### PR TITLE
Switch to storing types through enums with variants for special types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ name = "diplomat_core"
 version = "0.1.0"
 dependencies = [
  "impls",
+ "lazy_static",
  "proc-macro2",
  "quote",
  "syn",
@@ -169,6 +170,12 @@ name = "impls"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "litemap"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,3 +12,4 @@ syn = { version = "1.0", features = [ "full", "extra-traits" ] }
 quote = "1.0"
 impls = "1"
 proc-macro2 = "1.0.27"
+lazy_static = "1.4.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,5 @@
-use syn::*;
 use quote::ToTokens;
+use syn::*;
 
 pub mod meta;
 
@@ -45,7 +45,7 @@ pub fn extract_from_file(file: File) -> Vec<meta::Struct> {
                 .iter()
                 .any(|a| a.path.to_token_stream().to_string() == "diplomat :: bridge")
             {
-                out.append(&mut extract_from_mod(&item_mod));
+                out.append(&mut extract_from_mod(item_mod));
             }
         }
     });

--- a/core/src/meta.rs
+++ b/core/src/meta.rs
@@ -45,11 +45,11 @@ impl Method {
                 name: "self".to_string(),
                 ty: if rec.reference.is_some() {
                     Type::Reference(
-                        Box::new(Type::FFIStruct(self_ident.to_string())),
+                        Box::new(Type::Named(self_ident.to_string())),
                         rec.mutability.is_some(),
                     )
                 } else {
-                    Type::FFIStruct(self_ident.to_string())
+                    Type::Named(self_ident.to_string())
                 },
             },
             _ => panic!("Unexpected self param type"),
@@ -93,8 +93,8 @@ impl From<&syn::PatType> for Param {
 #[derive(Clone, Debug)]
 pub enum Type {
     Primitive(PrimitiveType),
-    FFIStruct(String),
-    Reference(Box<Type>, bool),
+    Named(String),
+    Reference(Box<Type>, /* mutable */ bool),
     Box(Box<Type>),
 }
 
@@ -104,7 +104,7 @@ impl Type {
             Type::Primitive(name) => {
                 syn::Type::Path(syn::parse_str(PRIMITIVE_TO_STRING.get(name).unwrap()).unwrap())
             }
-            Type::FFIStruct(name) => syn::Type::Path(syn::parse_str(name.as_str()).unwrap()),
+            Type::Named(name) => syn::Type::Path(syn::parse_str(name.as_str()).unwrap()),
             Type::Reference(underlying, mutable) => syn::Type::Reference(TypeReference {
                 and_token: syn::token::And(Span::call_site()),
                 lifetime: None,
@@ -209,7 +209,7 @@ impl From<&syn::Type> for Type {
                         panic!("Expected angle brackets for Box type")
                     }
                 } else {
-                    Type::FFIStruct(p.path.to_token_stream().to_string())
+                    Type::Named(p.path.to_token_stream().to_string())
                 }
             }
             _ => panic!(),

--- a/core/src/meta.rs
+++ b/core/src/meta.rs
@@ -1,6 +1,10 @@
 use proc_macro2::Span;
 use quote::ToTokens;
-use syn::*;
+use syn::{punctuated::Punctuated, *};
+
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use std::iter::FromIterator;
 
 #[derive(Debug)]
 pub struct Struct {
@@ -39,10 +43,13 @@ impl Method {
         let self_param = m.sig.receiver().map(|rec| match rec {
             FnArg::Receiver(rec) => Param {
                 name: "self".to_string(),
-                ty: Type {
-                    name: self_ident.to_string(),
-                    mutability: rec.mutability.is_some(),
-                    reference: rec.reference.is_some(),
+                ty: if rec.reference.is_some() {
+                    Type::Reference(
+                        Box::new(Type::FFIStruct(self_ident.to_string())),
+                        rec.mutability.is_some(),
+                    )
+                } else {
+                    Type::FFIStruct(self_ident.to_string())
                 },
             },
             _ => panic!("Unexpected self param type"),
@@ -84,52 +91,127 @@ impl From<&syn::PatType> for Param {
 }
 
 #[derive(Clone, Debug)]
-pub struct Type {
-    pub name: String,
-    pub reference: bool,
-    pub mutability: bool,
+pub enum Type {
+    Primitive(PrimitiveType),
+    FFIStruct(String),
+    Reference(Box<Type>, bool),
+    Box(Box<Type>),
 }
 
 impl Type {
     pub fn to_syn(&self) -> syn::Type {
-        if self.reference {
-            syn::Type::Reference(TypeReference {
+        match self {
+            Type::Primitive(name) => {
+                syn::Type::Path(syn::parse_str(PRIMITIVE_TO_STRING.get(name).unwrap()).unwrap())
+            }
+            Type::FFIStruct(name) => syn::Type::Path(syn::parse_str(name.as_str()).unwrap()),
+            Type::Reference(underlying, mutable) => syn::Type::Reference(TypeReference {
                 and_token: syn::token::And(Span::call_site()),
                 lifetime: None,
-                mutability: if self.mutability {
+                mutability: if *mutable {
                     Some(syn::token::Mut(Span::call_site()))
                 } else {
                     None
                 },
-                elem: Box::new(
-                    Type {
-                        name: self.name.clone(),
-                        reference: false,
-                        mutability: false,
-                    }
-                    .to_syn(),
-                ),
-            })
-        } else {
-            syn::Type::Path(syn::parse_str(self.name.as_str()).unwrap())
+                elem: Box::new(underlying.to_syn()),
+            }),
+            Type::Box(underlying) => syn::Type::Path(TypePath {
+                qself: None,
+                path: Path {
+                    leading_colon: None,
+                    segments: Punctuated::from_iter(vec![PathSegment {
+                        ident: Ident::new("Box", Span::call_site()),
+                        arguments: PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                            colon2_token: None,
+                            lt_token: syn::token::Lt(Span::call_site()),
+                            args: Punctuated::from_iter(vec![GenericArgument::Type(
+                                underlying.to_syn(),
+                            )]),
+                            gt_token: syn::token::Gt(Span::call_site()),
+                        }),
+                    }]),
+                },
+            }),
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[allow(non_camel_case_types)]
+pub enum PrimitiveType {
+    i8,
+    u8,
+    i16,
+    u16,
+    i32,
+    u32,
+    i64,
+    u64,
+    i128,
+    u128,
+    isize,
+    usize,
+    f32,
+    f64,
+    bool,
+    char,
+}
+
+lazy_static! {
+    static ref PRIMITIVES_MAPPING: [(&'static str, PrimitiveType); 16] = [
+        ("i8", PrimitiveType::i8),
+        ("u8", PrimitiveType::u8),
+        ("i16", PrimitiveType::i16),
+        ("u16", PrimitiveType::u16),
+        ("i32", PrimitiveType::i32),
+        ("u32", PrimitiveType::u32),
+        ("i64", PrimitiveType::i64),
+        ("u64", PrimitiveType::u64),
+        ("i128", PrimitiveType::i128),
+        ("u128", PrimitiveType::u128),
+        ("isize", PrimitiveType::isize),
+        ("usize", PrimitiveType::usize),
+        ("f32", PrimitiveType::f32),
+        ("f64", PrimitiveType::f64),
+        ("bool", PrimitiveType::bool),
+        ("char", PrimitiveType::char),
+    ];
+    static ref STRING_TO_PRIMITIVE: HashMap<&'static str, PrimitiveType> =
+        PRIMITIVES_MAPPING.iter().cloned().collect();
+    static ref PRIMITIVE_TO_STRING: HashMap<PrimitiveType, &'static str> = PRIMITIVES_MAPPING
+        .iter()
+        .map(|t| (t.1.clone(), t.0))
+        .collect();
 }
 
 impl From<&syn::Type> for Type {
     fn from(ty: &syn::Type) -> Type {
         match ty {
             syn::Type::Reference(r) => {
-                let mut without_ref: Type = r.elem.as_ref().into();
-                without_ref.reference = true;
-                without_ref.mutability = r.mutability.is_some();
-                without_ref
+                Type::Reference(Box::new(r.elem.as_ref().into()), r.mutability.is_some())
             }
-            syn::Type::Path(p) => Type {
-                name: p.path.to_token_stream().to_string(),
-                reference: false,
-                mutability: false,
-            },
+            syn::Type::Path(p) => {
+                if let Some(primitive) = p
+                    .path
+                    .get_ident()
+                    .and_then(|i| STRING_TO_PRIMITIVE.get(i.to_string().as_str()))
+                {
+                    Type::Primitive(primitive.clone())
+                } else if p.path.segments.len() == 1 && p.path.segments[0].ident == "Box" {
+                    if let PathArguments::AngleBracketed(type_args) = &p.path.segments[0].arguments
+                    {
+                        if let GenericArgument::Type(tpe) = &type_args.args[0] {
+                            Type::Box(Box::new(tpe.into()))
+                        } else {
+                            panic!("Expected first type argument for Box to be a type")
+                        }
+                    } else {
+                        panic!("Expected angle brackets for Box type")
+                    }
+                } else {
+                    Type::FFIStruct(p.path.to_token_stream().to_string())
+                }
+            }
             _ => panic!(),
         }
     }

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -37,6 +37,8 @@ fn gen_js(strcts: Vec<meta::Struct>) {
 }
 
 fn main() {
-    let lib_file = syn_inline_mod::parse_and_inline_modules(&Path::new("./src/main.rs"));
-    gen_js(extract_from_file(lib_file));
+    let lib_file = syn_inline_mod::parse_and_inline_modules(Path::new("./src/main.rs"));
+    let structs = extract_from_file(lib_file);
+    dbg!(&structs);
+    gen_js(structs);
 }


### PR DESCRIPTION
Right now, the only special types are scalar primitives and `Box`, but more variants like `Result` can be added in the future. Also, until support for internal references is implemented, any types that are not primitives or boxes are assumed to be internal references.

Will follow on with a PR for docs after a PR that adds struct attributes to the metadata.