### PR TITLE
Dereference box fields when receiving structs by value

### DIFF
--- a/example/js/diplomat-runtime.mjs
+++ b/example/js/diplomat-runtime.mjs
@@ -14,3 +14,7 @@ export function withWriteable(wasm, callback) {
     wasm.diplomat_buffer_writeable_destroy(writeable);
   }
 }
+
+export const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
+  wasm.diplomat_free(obj["ptr"], obj["size"]);
+});

--- a/example/js/diplomat-runtime.mjs
+++ b/example/js/diplomat-runtime.mjs
@@ -14,7 +14,3 @@ export function withWriteable(wasm, callback) {
     wasm.diplomat_buffer_writeable_destroy(writeable);
   }
 }
-
-export const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
-  wasm.diplomat_free(obj["ptr"], obj["size"]);
-});

--- a/example/js/high-level.mjs
+++ b/example/js/high-level.mjs
@@ -5,11 +5,6 @@ const ICU4XDataProvider_box_destroy_registry = new FinalizationRegistry(underlyi
   wasm.ICU4XDataProvider_destroy(underlying);
 });
 
-const ICU4XDataProvider_alloc_destroy_registry = new FinalizationRegistry(obj => {
-  wasm.ICU4XDataProvider_drop_ptr(obj["ptr"]);
-  wasm.diplomat_free(obj["ptr"], obj["size"]);
-});
-
 export class ICU4XDataProvider {
   constructor(underlying) {
     this.underlying = underlying;
@@ -30,11 +25,6 @@ export class ICU4XDataProvider {
 
 const ICU4XFixedDecimal_box_destroy_registry = new FinalizationRegistry(underlying => {
   wasm.ICU4XFixedDecimal_destroy(underlying);
-});
-
-const ICU4XFixedDecimal_alloc_destroy_registry = new FinalizationRegistry(obj => {
-  wasm.ICU4XFixedDecimal_drop_ptr(obj["ptr"]);
-  wasm.diplomat_free(obj["ptr"], obj["size"]);
 });
 
 export class ICU4XFixedDecimal {
@@ -72,11 +62,6 @@ const ICU4XFixedDecimalFormat_box_destroy_registry = new FinalizationRegistry(un
   wasm.ICU4XFixedDecimalFormat_destroy(underlying);
 });
 
-const ICU4XFixedDecimalFormat_alloc_destroy_registry = new FinalizationRegistry(obj => {
-  wasm.ICU4XFixedDecimalFormat_drop_ptr(obj["ptr"]);
-  wasm.diplomat_free(obj["ptr"], obj["size"]);
-});
-
 export class ICU4XFixedDecimalFormat {
   constructor(underlying) {
     this.underlying = underlying;
@@ -87,7 +72,10 @@ export class ICU4XFixedDecimalFormat {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5);
       wasm.ICU4XFixedDecimalFormat_try_new(diplomat_receive_buffer, locale.underlying, provider.underlying);
       const out = new ICU4XFixedDecimalFormatResult(diplomat_receive_buffer);
-      ICU4XFixedDecimalFormatResult_alloc_destroy_registry.register(out, {
+      const out_fdf_value = out.fdf();
+      ICU4XFixedDecimalFormat_box_destroy_registry.register(out_fdf_value, out_fdf_value.underlying)
+      out.fdf = () => out_fdf_value;
+      diplomatRuntime.diplomat_alloc_destroy_registry.register(out, {
         ptr: out.underlying,
         size: 5
       });
@@ -104,11 +92,6 @@ export class ICU4XFixedDecimalFormat {
 
 const ICU4XFixedDecimalFormatResult_box_destroy_registry = new FinalizationRegistry(underlying => {
   wasm.ICU4XFixedDecimalFormatResult_destroy(underlying);
-});
-
-const ICU4XFixedDecimalFormatResult_alloc_destroy_registry = new FinalizationRegistry(obj => {
-  wasm.ICU4XFixedDecimalFormatResult_drop_ptr(obj["ptr"]);
-  wasm.diplomat_free(obj["ptr"], obj["size"]);
 });
 
 export class ICU4XFixedDecimalFormatResult {
@@ -130,11 +113,6 @@ export class ICU4XFixedDecimalFormatResult {
 
 const ICU4XLocale_box_destroy_registry = new FinalizationRegistry(underlying => {
   wasm.ICU4XLocale_destroy(underlying);
-});
-
-const ICU4XLocale_alloc_destroy_registry = new FinalizationRegistry(obj => {
-  wasm.ICU4XLocale_drop_ptr(obj["ptr"]);
-  wasm.diplomat_free(obj["ptr"], obj["size"]);
 });
 
 export class ICU4XLocale {

--- a/example/js/high-level.mjs
+++ b/example/js/high-level.mjs
@@ -1,5 +1,8 @@
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
+const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
+  wasm.diplomat_free(obj["ptr"], obj["size"]);
+});
 
 const ICU4XDataProvider_box_destroy_registry = new FinalizationRegistry(underlying => {
   wasm.ICU4XDataProvider_destroy(underlying);
@@ -75,7 +78,7 @@ export class ICU4XFixedDecimalFormat {
       const out_fdf_value = out.fdf();
       ICU4XFixedDecimalFormat_box_destroy_registry.register(out_fdf_value, out_fdf_value.underlying)
       out.fdf = () => out_fdf_value;
-      diplomatRuntime.diplomat_alloc_destroy_registry.register(out, {
+      diplomat_alloc_destroy_registry.register(out, {
         ptr: out.underlying,
         size: 5
       });

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -208,21 +208,6 @@ fn gen_bridge(input: ItemMod) -> ItemMod {
             })
             .unwrap(),
         ));
-
-        let drop_ptr_ident = Ident::new(
-            (custom_type.name().to_string() + "_drop_ptr").as_str(),
-            Span::call_site(),
-        );
-
-        new_contents.push(Item::Fn(
-            syn::parse2(quote! {
-                #[no_mangle]
-                pub unsafe extern "C" fn #drop_ptr_ident(this: *mut #type_ident) {
-                    std::ptr::drop_in_place(this);
-                }
-            })
-            .unwrap(),
-        ));
     }
 
     ItemMod {

--- a/macro/src/snapshots/diplomat__tests__method_taking_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_str.snap
@@ -20,9 +20,5 @@ mod ffi {
     }
     #[no_mangle]
     pub extern "C" fn Foo_destroy(this: Box<Foo>) {}
-    #[no_mangle]
-    pub unsafe extern "C" fn Foo_drop_ptr(this: *mut Foo) {
-        std::ptr::drop_in_place(this);
-    }
 }
 

--- a/tool/src/js.rs
+++ b/tool/src/js.rs
@@ -17,6 +17,16 @@ pub fn gen_bindings<W: fmt::Write>(
         "import * as diplomatRuntime from \"./diplomat-runtime.mjs\""
     )?;
 
+    writeln!(
+        out,
+        "const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {{"
+    )?;
+    writeln!(
+        indented(out).with_str("  "),
+        "wasm.diplomat_free(obj[\"ptr\"], obj[\"size\"]);"
+    )?;
+    writeln!(out, "}});")?;
+
     let mut all_types: Vec<&ast::CustomType> = env.values().collect();
     all_types.sort_by_key(|t| t.name());
     for custom_type in all_types {
@@ -287,7 +297,7 @@ fn gen_value_rust_to_js<W: fmt::Write>(
 
                     writeln!(
                         &mut iife_indent,
-                        "diplomatRuntime.diplomat_alloc_destroy_registry.register(out, {{"
+                        "diplomat_alloc_destroy_registry.register(out, {{"
                     )?;
 
                     let mut alloc_dict_indent = indented(&mut iife_indent).with_str("  ");

--- a/tool/src/js.rs
+++ b/tool/src/js.rs
@@ -45,23 +45,6 @@ fn gen_struct<W: fmt::Write>(
     writeln!(out, "}});")?;
     writeln!(out)?;
 
-    writeln!(
-        out,
-        "const {}_alloc_destroy_registry = new FinalizationRegistry(obj => {{",
-        custom_type.name()
-    )?;
-    writeln!(
-        indented(out).with_str("  "),
-        "wasm.{}_drop_ptr(obj[\"ptr\"]);",
-        custom_type.name()
-    )?;
-    writeln!(
-        indented(out).with_str("  "),
-        "wasm.diplomat_free(obj[\"ptr\"], obj[\"size\"]);"
-    )?;
-    writeln!(out, "}});")?;
-    writeln!(out)?;
-
     writeln!(out, "export class {} {{", custom_type.name())?;
 
     let mut class_body_out = indented(out).with_str("  ");
@@ -281,10 +264,30 @@ fn gen_value_rust_to_js<W: fmt::Write>(
                         "const out = new {}(diplomat_receive_buffer);",
                         strct.name
                     )?;
+
+                    for (name, typ) in strct.fields.iter() {
+                        if let ast::TypeName::Box(underlying) = typ {
+                            writeln!(
+                                &mut iife_indent,
+                                "const out_{}_value = out.{}();",
+                                name, name
+                            )?;
+                            // TODO(shadaj): delete back-references when we start generating them
+                            // since the function is generated assuming that back references are needed
+                            if let ast::TypeName::Named(_) = underlying.as_ref() {
+                                writeln!(
+                                    &mut iife_indent,
+                                    "{}_box_destroy_registry.register(out_{}_value, out_{}_value.underlying)",
+                                    underlying.resolve(env).name(), name, name
+                                )?;
+                            }
+                            writeln!(&mut iife_indent, "out.{} = () => out_{}_value;", name, name)?;
+                        }
+                    }
+
                     writeln!(
                         &mut iife_indent,
-                        "{}_alloc_destroy_registry.register(out, {{",
-                        strct.name
+                        "diplomatRuntime.diplomat_alloc_destroy_registry.register(out, {{"
                     )?;
 
                     let mut alloc_dict_indent = indented(&mut iife_indent).with_str("  ");


### PR DESCRIPTION
Since custom drops are only available on opaque types, which must be behind a `Box` if they are owned by a non-opaque FFI struct, this lets us simplify the destructor logic for structs received by value to just free the memory instead of calling struct-specific drop logic.

Fixes #17