### PR TITLE
Don't assume that repr(C) enums are ssize

### DIFF
--- a/example/c/api.h
+++ b/example/c/api.h
@@ -32,8 +32,8 @@ typedef enum ICU4XFixedDecimalSignDisplay {
 typedef struct ICU4XLocale ICU4XLocale;
 
 typedef struct ICU4XFixedDecimalFormatOptions {
-    ssize_t grouping_strategy;
-    ssize_t sign_display;
+    ICU4XFixedDecimalGroupingStrategy grouping_strategy;
+    ICU4XFixedDecimalSignDisplay sign_display;
 } ICU4XFixedDecimalFormatOptions;
 
 typedef struct ICU4XFixedDecimalFormatResult {
@@ -71,9 +71,9 @@ void ICU4XFixedDecimalFormatOptions_destroy(ICU4XFixedDecimalFormatOptions* self
 
 void ICU4XFixedDecimalFormatResult_destroy(ICU4XFixedDecimalFormatResult* self);
 
-void ICU4XFixedDecimalGroupingStrategy_destroy(ssize_t* self);
+void ICU4XFixedDecimalGroupingStrategy_destroy(ICU4XFixedDecimalGroupingStrategy* self);
 
-void ICU4XFixedDecimalSignDisplay_destroy(ssize_t* self);
+void ICU4XFixedDecimalSignDisplay_destroy(ICU4XFixedDecimalSignDisplay* self);
 
 ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
 void ICU4XLocale_destroy(ICU4XLocale* self);

--- a/example/cpp/api.h
+++ b/example/cpp/api.h
@@ -32,8 +32,8 @@ typedef enum ICU4XFixedDecimalSignDisplay {
 typedef struct ICU4XLocale ICU4XLocale;
 
 typedef struct ICU4XFixedDecimalFormatOptions {
-    ssize_t grouping_strategy;
-    ssize_t sign_display;
+    ICU4XFixedDecimalGroupingStrategy grouping_strategy;
+    ICU4XFixedDecimalSignDisplay sign_display;
 } ICU4XFixedDecimalFormatOptions;
 
 typedef struct ICU4XFixedDecimalFormatResult {
@@ -71,9 +71,9 @@ void ICU4XFixedDecimalFormatOptions_destroy(ICU4XFixedDecimalFormatOptions* self
 
 void ICU4XFixedDecimalFormatResult_destroy(ICU4XFixedDecimalFormatResult* self);
 
-void ICU4XFixedDecimalGroupingStrategy_destroy(ssize_t* self);
+void ICU4XFixedDecimalGroupingStrategy_destroy(ICU4XFixedDecimalGroupingStrategy* self);
 
-void ICU4XFixedDecimalSignDisplay_destroy(ssize_t* self);
+void ICU4XFixedDecimalSignDisplay_destroy(ICU4XFixedDecimalSignDisplay* self);
 
 ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
 void ICU4XLocale_destroy(ICU4XLocale* self);

--- a/example/cpp/api.hpp
+++ b/example/cpp/api.hpp
@@ -18,14 +18,14 @@ struct ICU4XFixedDecimalFormatOptions;
 
 struct ICU4XFixedDecimalFormatResult;
 
-enum struct ICU4XFixedDecimalGroupingStrategy : ssize_t {
+enum struct ICU4XFixedDecimalGroupingStrategy {
   Auto = 0,
   Never = 1,
   Always = 2,
   Min2 = 3,
 };
 
-enum struct ICU4XFixedDecimalSignDisplay : ssize_t {
+enum struct ICU4XFixedDecimalSignDisplay {
   Auto = 0,
   Never = 1,
   Always = 2,
@@ -154,7 +154,7 @@ diplomat::result<std::string, std::monostate> ICU4XFixedDecimal::to_string() {
 
 ICU4XFixedDecimalFormatResult ICU4XFixedDecimalFormat::try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XFixedDecimalFormatOptions options) {
   ICU4XFixedDecimalFormatOptions diplomat_wrapped_struct_options = options;
-  capi::ICU4XFixedDecimalFormatResult diplomat_raw_struct_out_value = capi::ICU4XFixedDecimalFormat_try_new(locale.AsFFI(), provider.AsFFI(), capi::ICU4XFixedDecimalFormatOptions{ .grouping_strategy = static_cast<ssize_t>(diplomat_wrapped_struct_options.grouping_strategy), .sign_display = static_cast<ssize_t>(diplomat_wrapped_struct_options.sign_display) });
+  capi::ICU4XFixedDecimalFormatResult diplomat_raw_struct_out_value = capi::ICU4XFixedDecimalFormat_try_new(locale.AsFFI(), provider.AsFFI(), capi::ICU4XFixedDecimalFormatOptions{ .grouping_strategy = static_cast<capi::ICU4XFixedDecimalGroupingStrategy>(diplomat_wrapped_struct_options.grouping_strategy), .sign_display = static_cast<capi::ICU4XFixedDecimalSignDisplay>(diplomat_wrapped_struct_options.sign_display) });
   auto diplomat_optional_raw_out_value_fdf = diplomat_raw_struct_out_value.fdf;
   std::optional<ICU4XFixedDecimalFormat> diplomat_optional_out_value_fdf;
   if (diplomat_optional_raw_out_value_fdf != nullptr) {

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -333,9 +333,8 @@ pub fn gen_type<W: fmt::Write>(
                 write!(out, "{}", r.name())?;
             }
 
-            ast::CustomType::Enum(_) => {
-                // repr(C) fieldless enums use the default platform representation: isize
-                write!(out, "ssize_t")?;
+            ast::CustomType::Enum(enm) => {
+                write!(out, "{}", enm.name)?;
             }
         },
 

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -43,7 +43,7 @@ pub fn gen_bindings(
             }
 
             ast::CustomType::Enum(enm) => {
-                writeln!(out, "enum struct {} : ssize_t {{", enm.name)?;
+                writeln!(out, "enum struct {} {{", enm.name)?;
                 let mut enm_indent = indented(out).with_str("  ");
                 for (name, discriminant, _) in enm.variants.iter() {
                     writeln!(&mut enm_indent, "{} = {},", name, discriminant)?;
@@ -716,7 +716,7 @@ fn gen_cpp_to_rust<W: Write>(
                 }
             }
 
-            ast::CustomType::Enum(_) => format!("static_cast<ssize_t>({})", cpp),
+            ast::CustomType::Enum(enm) => format!("static_cast<capi::{}>({})", enm.name, cpp),
         },
         ast::TypeName::Writeable => {
             if behind_ref


### PR DESCRIPTION
Rust actually just uses the platform default.