### PR TITLE
Throw exceptions when returning Result::Err in JS

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -112,8 +112,8 @@ impl Method {
     pub fn is_writeable_out(&self) -> bool {
         let return_compatible = self.return_type.is_none()
             || match self.return_type.as_ref().unwrap() {
-                TypeName::Void => true,
-                TypeName::Result(ok, _) => matches!(ok.as_ref(), TypeName::Void),
+                TypeName::Unit => true,
+                TypeName::Result(ok, _) => matches!(ok.as_ref(), TypeName::Unit),
                 _ => false,
             };
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
@@ -1,10 +1,10 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Result < (), MyLocalStruct > })"
+expression: "TypeName::from(&syn::parse_quote! { DiplomatResult < (), MyLocalStruct > })"
 
 ---
 Result:
-  - Void
+  - Unit
   - Named:
       elements:
         - MyLocalStruct

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -109,7 +109,7 @@ pub enum TypeName {
     /// A `&str` type.
     StrReference,
     /// The `()` type.
-    Void,
+    Unit,
 }
 
 impl TypeName {
@@ -199,7 +199,7 @@ impl TypeName {
             TypeName::StrReference => syn::parse_quote! {
                 &str
             },
-            TypeName::Void => syn::parse_quote! {
+            TypeName::Unit => syn::parse_quote! {
                 ()
             },
         }
@@ -304,7 +304,7 @@ impl TypeName {
             }
             TypeName::Writeable => {}
             TypeName::StrReference => {}
-            TypeName::Void => {}
+            TypeName::Unit => {}
         }
     }
 
@@ -393,7 +393,7 @@ impl From<&syn::Type> for TypeName {
             }
             syn::Type::Tuple(tup) => {
                 if tup.elems.is_empty() {
-                    TypeName::Void
+                    TypeName::Unit
                 } else {
                     todo!("Tuples are not currently supported")
                 }

--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -17,6 +17,7 @@ export class ICU4XDataProvider {
     const diplomat_out = (() => {
       const out = (() => {
         const out = new ICU4XDataProvider(wasm.ICU4XDataProvider_new_static());
+        out.owner = null;
         return out;
       })();
       ICU4XDataProvider_box_destroy_registry.register(out, out.underlying)
@@ -39,6 +40,7 @@ export class ICU4XFixedDecimal {
     const diplomat_out = (() => {
       const out = (() => {
         const out = new ICU4XFixedDecimal(wasm.ICU4XFixedDecimal_new(v));
+        out.owner = null;
         return out;
       })();
       ICU4XFixedDecimal_box_destroy_registry.register(out, out.underlying)
@@ -59,8 +61,9 @@ export class ICU4XFixedDecimal {
     const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
       return (() => {
         const is_ok = wasm.ICU4XFixedDecimal_to_string(this.underlying, writeable) == 1;
-        const out = { is_ok: is_ok };
-        return out;
+        if (!is_ok) {
+          throw undefined;
+        }
       })();
     });
     return diplomat_out;
@@ -147,6 +150,7 @@ export class ICU4XFixedDecimalFormatResult {
   get fdf() {
     return (() => {
       const out = new ICU4XFixedDecimalFormat((new Uint32Array(wasm.memory.buffer, this.underlying + 0, 1))[0]);
+      out.owner = null;
       return out;
     })();
   }
@@ -201,6 +205,7 @@ export class ICU4XLocale {
     const diplomat_out = (() => {
       const out = (() => {
         const out = new ICU4XLocale(wasm.ICU4XLocale_new(name_diplomat_ptr, name_diplomat_bytes.length));
+        out.owner = null;
         return out;
       })();
       ICU4XLocale_box_destroy_registry.register(out, out.underlying)

--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -62,7 +62,7 @@ export class ICU4XFixedDecimal {
       return (() => {
         const is_ok = wasm.ICU4XFixedDecimal_to_string(this.underlying, writeable) == 1;
         if (!is_ok) {
-          throw undefined;
+          throw {};
         }
       })();
     });

--- a/example/js/diplomat-runtime.mjs
+++ b/example/js/diplomat-runtime.mjs
@@ -6,20 +6,10 @@ function readString(wasm, ptr, len) {
 export function withWriteable(wasm, callback) {
   const writeable = wasm.diplomat_buffer_writeable_create(0);
   try {
-    const callbackOut = callback(writeable);
-    if (typeof callbackOut  === "object" && callbackOut.hasOwnProperty("is_ok")) {
-      if (callbackOut.is_ok) {
-        const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
-        const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
-        return { is_ok: true, ok: readString(wasm, outStringPtr, outStringLen) };
-      } else {
-        return callbackOut;
-      }
-    } else {
-      const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
-      const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
-      return readString(wasm, outStringPtr, outStringLen);
-    }
+    callback(writeable);
+    const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
+    const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
+    return readString(wasm, outStringPtr, outStringLen);
   } finally {
     wasm.diplomat_buffer_writeable_destroy(writeable);
   }

--- a/example/js/main.mjs
+++ b/example/js/main.mjs
@@ -2,12 +2,12 @@ import { ICU4XFixedDecimal, ICU4XLocale, ICU4XDataProvider, ICU4XFixedDecimalFor
 
 const my_decimal = ICU4XFixedDecimal.new(123);
 
-console.log(my_decimal.to_string().ok);
+console.log(my_decimal.to_string());
 
 my_decimal.multiply_pow10(-1);
 console.log("multiplied by 0.1");
 
-console.log(my_decimal.to_string().ok);
+console.log(my_decimal.to_string());
 
 const locale = ICU4XLocale.new("bn");
 

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -227,7 +227,7 @@ fn collect_results<'a, 'b>(
         }
         ast::TypeName::Writeable => {}
         ast::TypeName::StrReference => {}
-        ast::TypeName::Void => {}
+        ast::TypeName::Unit => {}
     }
 }
 
@@ -244,7 +244,7 @@ fn gen_result<W: fmt::Write>(
         writeln!(&mut result_indent, "union {{")?;
         let mut union_indent = indented(&mut result_indent).with_str("    ");
 
-        if let ast::TypeName::Void = ok.as_ref() {
+        if let ast::TypeName::Unit = ok.as_ref() {
             writeln!(&mut union_indent, "uint8_t ok[0];")?;
         } else {
             gen_type(
@@ -256,7 +256,7 @@ fn gen_result<W: fmt::Write>(
             writeln!(&mut union_indent, " ok;")?;
         }
 
-        if let ast::TypeName::Void = err.as_ref() {
+        if let ast::TypeName::Unit = err.as_ref() {
             writeln!(&mut union_indent, "uint8_t err[0];")?;
         } else {
             gen_type(
@@ -369,7 +369,7 @@ pub fn gen_type<W: fmt::Write>(
 
         ast::TypeName::Writeable => write!(out, "DiplomatWriteable")?,
         ast::TypeName::StrReference => panic!(),
-        ast::TypeName::Void => write!(out, "void")?,
+        ast::TypeName::Unit => write!(out, "void")?,
     }
 
     Ok(())
@@ -397,7 +397,7 @@ fn name_for_type(typ: &ast::TypeName) -> String {
         }
         ast::TypeName::Writeable => "writeable".to_string(),
         ast::TypeName::StrReference => "str_ref".to_string(),
-        ast::TypeName::Void => "void".to_string(),
+        ast::TypeName::Unit => "void".to_string(),
     }
 }
 

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -200,7 +200,7 @@ fn return_type_form(
 
         ast::TypeName::Option(underlying) => return_type_form(underlying, in_path, env),
 
-        ast::TypeName::Void => ReturnTypeForm::Empty,
+        ast::TypeName::Unit => ReturnTypeForm::Empty,
 
         ast::TypeName::Box(_) => ReturnTypeForm::Scalar,
 
@@ -300,7 +300,7 @@ fn gen_method<W: fmt::Write>(
     }
 
     match &method.return_type {
-        None | Some(ast::TypeName::Void) => {
+        None | Some(ast::TypeName::Unit) => {
             write!(&mut maybe_writeable_indent, "{}", invocation_expr)?;
         }
 
@@ -584,7 +584,7 @@ fn gen_value_rust_to_js<W: fmt::Write>(
             } else {
                 writeln!(&mut iife_indent, "if (!is_ok) {{")?;
                 let mut err_indent = indented(&mut iife_indent).with_str("  ");
-                writeln!(&mut err_indent, "throw undefined;")?;
+                writeln!(&mut err_indent, "throw {{}};")?;
             }
 
             writeln!(&mut iife_indent, "}}")?;
@@ -603,7 +603,7 @@ fn gen_value_rust_to_js<W: fmt::Write>(
         }
         ast::TypeName::Writeable => todo!(),
         ast::TypeName::StrReference => todo!(),
-        ast::TypeName::Void => value_expr(out)?,
+        ast::TypeName::Unit => value_expr(out)?,
     }
 
     Ok(())
@@ -770,8 +770,8 @@ fn gen_rust_reference_to_js<W: fmt::Write>(
             }
         }
 
-        ast::TypeName::Void => {
-            write!(out, "undefined")?;
+        ast::TypeName::Unit => {
+            write!(out, "{{}}")?;
         }
 
         _ => todo!(),

--- a/tool/src/js/runtime.mjs
+++ b/tool/src/js/runtime.mjs
@@ -6,20 +6,10 @@ function readString(wasm, ptr, len) {
 export function withWriteable(wasm, callback) {
   const writeable = wasm.diplomat_buffer_writeable_create(0);
   try {
-    const callbackOut = callback(writeable);
-    if (typeof callbackOut  === "object" && callbackOut.hasOwnProperty("is_ok")) {
-      if (callbackOut.is_ok) {
-        const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
-        const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
-        return { is_ok: true, ok: readString(wasm, outStringPtr, outStringLen) };
-      } else {
-        return callbackOut;
-      }
-    } else {
-      const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
-      const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
-      return readString(wasm, outStringPtr, outStringLen);
-    }
+    callback(writeable);
+    const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
+    const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
+    return readString(wasm, outStringPtr, outStringLen);
   } finally {
     wasm.diplomat_buffer_writeable_destroy(writeable);
   }

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -104,6 +104,6 @@ pub fn type_size_alignment(
         },
         ast::TypeName::StrReference => (4, 4),
         ast::TypeName::Writeable => panic!(),
-        ast::TypeName::Void => (0, 1),
+        ast::TypeName::Unit => (0, 1),
     }
 }


### PR DESCRIPTION
Also sets up a simple ownership system so that returning structs borrowed from the result functions properly.