### PR TITLE
Add a better error message when the path to the file is not found

### DIFF
--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -11,7 +11,16 @@ mod layout;
 mod util;
 
 fn main() -> std::io::Result<()> {
-    let lib_file = syn_inline_mod::parse_and_inline_modules(Path::new("./src/lib.rs"));
+    let path = Path::new("src/lib.rs");
+    if !path.exists() {
+        let current_dir = std::env::current_dir().expect("Could not find home directory.");
+        eprintln!(
+            "Could not find the lib.rs file to process: {:?}",
+            Path::new(&current_dir).join(path)
+        );
+        std::process::exit(1);
+    }
+    let lib_file = syn_inline_mod::parse_and_inline_modules(path);
     let custom_types = ast::File::from(&lib_file);
     let env = custom_types.all_types();
 


### PR DESCRIPTION
The error as it is:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })', /Users/greg/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-inline-mod-0.4.0/src/lib.rs:39:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The new error:

```
Could not find the lib.rs file to process: "/path/to/src/lib.rs"
```