### PR TITLE
Improve the DX on the diplomat-tool 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30302dda7a66f8c55932ebf208f7def840743ff64d495e9ceffcd97c18f11d39"
 dependencies = [
  "cortex-m",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -87,6 +107,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,11 +177,13 @@ version = "0.2.0"
 name = "diplomat-tool"
 version = "0.2.0"
 dependencies = [
+ "colored",
  "diplomat_core",
  "indenter",
  "insta",
  "pulldown-cmark",
  "quote",
+ "structopt",
  "syn",
  "syn-inline-mod",
 ]
@@ -265,6 +313,24 @@ dependencies = [
  "hash32",
  "serde",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -577,6 +643,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +858,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +942,15 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -889,6 +1018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +1046,12 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ diplomat-tool cpp cpp/
 
 If we want to generate Sphinx documentation to `cpp-docs`, we can run with that as an additional parameter:
 ```bash
-$ diplomat-tool cpp cpp/ cpp-docs/
+$ diplomat-tool cpp cpp/ --docs cpp-docs/
 ```
 
 ## Core Concepts

--- a/example/gen_all.sh
+++ b/example/gen_all.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-../target/debug/diplomat-tool js js/ js/docs/
+../target/debug/diplomat-tool js js/ --docs js/docs/
 ../target/debug/diplomat-tool c c/
-../target/debug/diplomat-tool cpp cpp/ cpp/docs/
+../target/debug/diplomat-tool cpp cpp/ --docs cpp/docs/

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -16,6 +16,8 @@ syn-inline-mod = "0.4.0"
 quote = "1.0"
 indenter = "0.3.3"
 pulldown-cmark = "0.8.0"
+structopt = "0.3"
+colored = "2.0"
 
 [dev-dependencies]
 insta = { version = "1.7.1", features = [ "backtrace" ] }

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -1,5 +1,12 @@
+use colored::*;
 use core::panic;
-use std::{collections::HashMap, env, fs::File, io::Write, path::Path};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
+use structopt::StructOpt;
 
 use diplomat_core::ast;
 
@@ -10,17 +17,66 @@ mod js;
 mod layout;
 mod util;
 
-fn main() -> std::io::Result<()> {
-    let path = Path::new("src/lib.rs");
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "diplomat-tool",
+    about = "Generate bindings to a target language"
+)]
+struct Opt {
+    /// The target language, "js", "c", or "cpp".
+    #[structopt()]
+    target_language: String,
+
+    /// The folder that stores the bindings.
+    #[structopt(parse(from_os_str))]
+    out_folder: PathBuf,
+
+    #[structopt(short, long, parse(from_os_str))]
+    docs: Option<PathBuf>,
+
+    /// The path to the lib.rs file. Defaults to src/lib.rs
+    #[structopt(short, long, parse(from_os_str))]
+    entry: Option<PathBuf>,
+}
+
+/// Provide nice error messages if a folder doesn't exist.
+fn exit_if_path_missing(path: &Path, message: &str) {
     if !path.exists() {
-        let current_dir = std::env::current_dir().expect("Could not find home directory.");
+        let current_dir = std::env::current_dir().expect("Filed to load current directory.");
         eprintln!(
-            "Could not find the lib.rs file to process: {:?}",
-            Path::new(&current_dir).join(path)
+            "{}{}\n{}",
+            "Error: ".red().bold(),
+            message,
+            format!("{}", Path::new(&current_dir).join(path).display()).red()
         );
         std::process::exit(1);
     }
-    let lib_file = syn_inline_mod::parse_and_inline_modules(path);
+}
+
+fn main() -> std::io::Result<()> {
+    let opt = Opt::from_args();
+    let is_custom_entry = opt.entry.is_some();
+    let path = opt.entry.unwrap_or_else(|| PathBuf::from("src/lib.rs"));
+
+    // Check that user-provided paths exist. Exit early with a nice error message
+    // if anything doesn't exist.
+    exit_if_path_missing(
+        &path,
+        if is_custom_entry {
+            "The entry file specified by --entry does not exist."
+        } else {
+            "Could not find the lib.rs file to process. Set it manually with the --entry option."
+        },
+    );
+    exit_if_path_missing(
+        &opt.out_folder,
+        "The out folder (the second argument) does not exist.",
+    );
+    if let Some(ref docs) = opt.docs {
+        exit_if_path_missing(docs, "The docs folder specified by --docs does not exist.");
+    }
+
+    let lib_file = syn_inline_mod::parse_and_inline_modules(path.as_path());
     let custom_types = ast::File::from(&lib_file);
     let env = custom_types.all_types();
 
@@ -28,7 +84,7 @@ fn main() -> std::io::Result<()> {
     custom_types.check_opaque(&env, &mut opaque_errors);
     if !opaque_errors.is_empty() {
         opaque_errors.iter().for_each(|e| {
-            println!(
+            eprintln!(
                 "An opaque type crossed the FFI boundary as a value: {:?}",
                 e
             )
@@ -36,38 +92,50 @@ fn main() -> std::io::Result<()> {
         panic!();
     }
 
-    let args: Vec<String> = env::args().collect();
-    let target = args[1].as_str();
-
     let mut out_texts: HashMap<String, String> = HashMap::new();
 
-    match target {
+    match opt.target_language.as_str() {
         "js" => js::gen_bindings(&env, &mut out_texts).unwrap(),
         "c" => c::gen_bindings(&env, &mut out_texts).unwrap(),
         "cpp" => cpp::gen_bindings(&env, &mut out_texts).unwrap(),
         o => panic!("Unknown target: {}", o),
     }
 
-    let out_folder_path = Path::new(args[2].as_str());
+    println!(
+        "{}",
+        format!("Generating {} bindings:", opt.target_language)
+            .green()
+            .bold()
+    );
+
     for (subpath, text) in out_texts {
-        let mut out_file = File::create(out_folder_path.join(subpath))?;
+        let out_path = opt.out_folder.join(subpath);
+        let mut out_file = File::create(&out_path)?;
         out_file.write_all(text.as_bytes())?;
+        println!("{}", format!("  {}", out_path.display()).dimmed());
     }
 
-    if args.len() > 3 {
+    if let Some(docs) = opt.docs {
+        println!(
+            "{}",
+            format!("Generating {} docs:", opt.target_language)
+                .green()
+                .bold()
+        );
         let mut docs_out_texts: HashMap<String, String> = HashMap::new();
 
-        match target {
+        match opt.target_language.as_str() {
             "js" => js::docs::gen_docs(&env, &mut docs_out_texts).unwrap(),
             "cpp" => cpp::docs::gen_docs(&env, &mut docs_out_texts).unwrap(),
             "c" => todo!("Docs generation for C"),
             o => panic!("Unknown target: {}", o),
         }
 
-        let docs_out_folder_path = Path::new(args[3].as_str());
         for (subpath, text) in docs_out_texts {
-            let mut out_file = File::create(docs_out_folder_path.join(subpath))?;
+            let out_path = docs.join(subpath);
+            let mut out_file = File::create(&out_path)?;
             out_file.write_all(text.as_bytes())?;
+            println!("{}", format!("  {}", out_path.display()).dimmed());
         }
     }
 


### PR DESCRIPTION
This outputs the files that are being processed so it's clear what's going on.

<img width="569" alt="image" src="https://user-images.githubusercontent.com/1588648/128644246-31d49f97-90e7-4d11-8338-004d05f09737.png">

I also added the StructOpt library, which includes a help file:

<img width="589" alt="image" src="https://user-images.githubusercontent.com/1588648/128644280-5cea24a9-fe40-4870-9ee0-63c199957321.png">

And I improved the output of the missing files, as well as checked all inputs:

<img width="583" alt="image" src="https://user-images.githubusercontent.com/1588648/128644307-084afe56-40ea-4adf-a15e-8d9affc54f3b.png">

One of the dependencies includes an extraneous `eprintln` and outputs `src file "src/lib.rs"`. It's probably worth following up with seeing about removing it.