### PR TITLE
Update diplomat::result to use std::variant

### DIFF
--- a/example/cpp/ICU4XFixedDecimal.hpp
+++ b/example/cpp/ICU4XFixedDecimal.hpp
@@ -48,9 +48,6 @@ template<typename W> inline diplomat::result<std::monostate, std::monostate> ICU
   capi::DiplomatWriteable to_writer = diplomat::WriteableTrait<W>::Construct(to);
   auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimal_to_string(this->inner.get(), &to_writer);
   diplomat::result<std::monostate, std::monostate> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
-  if (diplomat_result_raw_out_value.is_ok) {
-  } else {
-  }
   return diplomat_result_out_value;
 }
 inline diplomat::result<std::string, std::monostate> ICU4XFixedDecimal::to_string() {
@@ -58,9 +55,6 @@ inline diplomat::result<std::string, std::monostate> ICU4XFixedDecimal::to_strin
   capi::DiplomatWriteable diplomat_writeable_out = diplomat::WriteableFromString(diplomat_writeable_string);
   auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimal_to_string(this->inner.get(), &diplomat_writeable_out);
   diplomat::result<std::monostate, std::monostate> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
-  if (diplomat_result_raw_out_value.is_ok) {
-  } else {
-  }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
 #endif

--- a/example/cpp/ICU4XFixedDecimal.hpp
+++ b/example/cpp/ICU4XFixedDecimal.hpp
@@ -47,8 +47,7 @@ inline void ICU4XFixedDecimal::negate() {
 template<typename W> inline diplomat::result<std::monostate, std::monostate> ICU4XFixedDecimal::to_string_to_writeable(W& to) {
   capi::DiplomatWriteable to_writer = diplomat::WriteableTrait<W>::Construct(to);
   auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimal_to_string(this->inner.get(), &to_writer);
-  diplomat::result<std::monostate, std::monostate> diplomat_result_out_value;
-  diplomat_result_out_value.is_ok = diplomat_result_raw_out_value.is_ok;
+  diplomat::result<std::monostate, std::monostate> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
   }
@@ -58,16 +57,10 @@ inline diplomat::result<std::string, std::monostate> ICU4XFixedDecimal::to_strin
   std::string diplomat_writeable_string;
   capi::DiplomatWriteable diplomat_writeable_out = diplomat::WriteableFromString(diplomat_writeable_string);
   auto diplomat_result_raw_out_value = capi::ICU4XFixedDecimal_to_string(this->inner.get(), &diplomat_writeable_out);
-  diplomat::result<std::monostate, std::monostate> diplomat_result_out_value;
-  diplomat_result_out_value.is_ok = diplomat_result_raw_out_value.is_ok;
+  diplomat::result<std::monostate, std::monostate> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
   }
-  diplomat::result<std::monostate, std::monostate> out_value = diplomat_result_out_value;
-  if (out_value.is_ok) {
-    return diplomat::result<std::string, std::monostate>::new_ok(diplomat_writeable_string);
-  } else {
-    return diplomat::result<std::string, std::monostate>::new_err_void();
-  }
+  return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
 #endif

--- a/example/cpp/diplomat_runtime.hpp
+++ b/example/cpp/diplomat_runtime.hpp
@@ -47,49 +47,65 @@ template<> struct WriteableTrait<std::string> {
   }
 };
 
-template<class T, class E>
-struct result
-{
-  union {
-    T ok;
-    E err;
-  };
-  bool is_ok;
+template<class T> struct Ok {
+  T inner;
+  Ok(T&& i): inner(i) {}
+  explicit Ok() {}
+};
 
-  ~result() {
+template<class T> struct Err {
+  T inner;
+  Err(T&& i): inner(i) {}
+  explicit Err() {}
+};
+
+template<class T, class E>
+class result {
+private:
+    std::variant<Ok<T>, Err<E>> val;
+public:
+  result(bool is_ok) {
     if (is_ok) {
-      ok.~T();
+      this->val = std::variant<Ok<T>, Err<E>>(Ok<T>());
     } else {
-      err.~E();
+      this->val = std::variant<Ok<T>, Err<E>>(Err<E>());
     }
   }
+  result(Ok<T>&& v): val(std::move(v)) {}
+  result(Err<E>&& v): val(std::move(v)) {}
+  result(const result &) = default;
+  result(result &&) noexcept = default;
+  ~result() = default;
+  bool is_ok() const {
+    return std::holds_alternative<Ok<T>>(this->val);
+  };
+  bool is_err() const {
+    return std::holds_alternative<Err<E>>(this->val);
+  };
 
-  static result<T, E> new_ok(T x) {
-    return {
-      .ok = x,
-      .is_ok = true
-    };
+  std::optional<T> ok() const {
+    if (!this->is_ok()) {
+      return std::nullopt;
+    }
+    return std::make_optional(std::get<Ok<T>>(this->val).inner);
+  };
+  std::optional<E> err() const {
+    if (!this->is_err()) {
+      return std::nullopt;
+    }
+    return std::make_optional(std::get<Err<E>>(this->val).inner);
   }
 
-  static result<std::monostate, E> new_ok_void() {
-    return {
-      .is_ok = true
-    };
-  }
-
-  static result<T, E> new_err(E x) {
-    return {
-      .err = x,
-      .is_ok = false
-    };
-  }
-
-  static result<T, std::monostate> new_err_void() {
-    return {
-      .is_ok = false
-    };
+  template<typename T2>
+  result<T2, E> replace_ok(T2&& t) {
+    if (this->is_err()) {
+      return result<T2, E>(Err<T>(std::get<Err<E>>(this->val)));
+    } else {
+      return result<T2, E>(Ok<T2>(std::move(t)));
+    }
   }
 };
+
 
 }
 

--- a/example/cpp/diplomat_runtime.hpp
+++ b/example/cpp/diplomat_runtime.hpp
@@ -96,10 +96,18 @@ public:
     return std::make_optional(std::get<Err<E>>(this->val).inner);
   }
 
+  void set_ok(T&& t) {
+    this->val = Ok<T>(std::move(t));
+  }
+
+  void set_err(E&& e) {
+    this->val = Err<E>(std::move(e));
+  }
+
   template<typename T2>
   result<T2, E> replace_ok(T2&& t) {
     if (this->is_err()) {
-      return result<T2, E>(Err<T>(std::get<Err<E>>(this->val)));
+      return result<T2, E>(Err<E>(std::get<Err<E>>(this->val)));
     } else {
       return result<T2, E>(Ok<T2>(std::move(t)));
     }

--- a/example/cpp/main.cpp
+++ b/example/cpp/main.cpp
@@ -4,12 +4,17 @@
 int main(int argc, char *argv[]) {
     ICU4XFixedDecimal fd = ICU4XFixedDecimal::new_(123);
 
-    std::cout << fd.to_string().ok << std::endl;
+    std::cout << "ok" << fd.to_string().is_err() << std::endl;
+
+    std::string fd_out = fd.to_string().ok().value();
+
+    std::cout << fd_out << std::endl;
 
     fd.multiply_pow10(-1);
     std::cout << "multiplied by 0.1" << std::endl;
 
-    std::cout << fd.to_string().ok << std::endl;
+    fd_out = fd.to_string().ok().value();
+    std::cout << fd_out << std::endl;
 
     std::string out;
 

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -99,7 +99,7 @@ pub fn gen_rust_to_cpp<W: Write>(
                 if ok.as_ref() != &ast::TypeName::Unit {
                     let ok_expr =
                         gen_rust_to_cpp(&format!("{}.ok", raw_value_id), path, ok, in_path, env, out);
-                    writeln!(out, "  {} = diplomat::Ok(std::move({}));", wrapped_value_id, ok_expr).unwrap();
+                    writeln!(out, "  {}.set_ok((std::move({})));", wrapped_value_id, ok_expr).unwrap();
                 }
                 writeln!(out, "}} else {{").unwrap();
                 if err.as_ref() != &ast::TypeName::Unit {
@@ -111,7 +111,7 @@ pub fn gen_rust_to_cpp<W: Write>(
                         env,
                         out,
                     );
-                    writeln!(out, "  {} = diplomat::Err(std::move({}));", wrapped_value_id, err_expr).unwrap();
+                    writeln!(out, "  {}.set_err((std::move({})));", wrapped_value_id, err_expr).unwrap();
                 }
                 writeln!(out, "}}").unwrap();
             }

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -92,14 +92,13 @@ pub fn gen_rust_to_cpp<W: Write>(
 
             let wrapped_value_id = format!("diplomat_result_{}", path);
             super::types::gen_type(typ, in_path, None, env, out).unwrap();
-            writeln!(out, " {};", wrapped_value_id).unwrap();
+            writeln!(out, " {}({}.is_ok);", wrapped_value_id, raw_value_id).unwrap();
 
-            writeln!(out, "{}.is_ok = {}.is_ok;", wrapped_value_id, raw_value_id).unwrap();
             writeln!(out, "if ({}.is_ok) {{", raw_value_id).unwrap();
             if ok.as_ref() != &ast::TypeName::Unit {
                 let ok_expr =
                     gen_rust_to_cpp(&format!("{}.ok", raw_value_id), path, ok, in_path, env, out);
-                writeln!(out, "  {}.ok = {};", wrapped_value_id, ok_expr).unwrap();
+                writeln!(out, "  {} = diplomat::Ok(std::move({}));", wrapped_value_id, ok_expr).unwrap();
             }
             writeln!(out, "}} else {{").unwrap();
             if err.as_ref() != &ast::TypeName::Unit {
@@ -111,7 +110,7 @@ pub fn gen_rust_to_cpp<W: Write>(
                     env,
                     out,
                 );
-                writeln!(out, "  {}.err = {};", wrapped_value_id, err_expr).unwrap();
+                writeln!(out, "  {} = diplomat::Err(std::move({}));", wrapped_value_id, err_expr).unwrap();
             }
             writeln!(out, "}}").unwrap();
 

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -94,25 +94,27 @@ pub fn gen_rust_to_cpp<W: Write>(
             super::types::gen_type(typ, in_path, None, env, out).unwrap();
             writeln!(out, " {}({}.is_ok);", wrapped_value_id, raw_value_id).unwrap();
 
-            writeln!(out, "if ({}.is_ok) {{", raw_value_id).unwrap();
-            if ok.as_ref() != &ast::TypeName::Unit {
-                let ok_expr =
-                    gen_rust_to_cpp(&format!("{}.ok", raw_value_id), path, ok, in_path, env, out);
-                writeln!(out, "  {} = diplomat::Ok(std::move({}));", wrapped_value_id, ok_expr).unwrap();
+            if ok.as_ref() != &ast::TypeName::Unit || err.as_ref() != &ast::TypeName::Unit {
+                writeln!(out, "if ({}.is_ok) {{", raw_value_id).unwrap();
+                if ok.as_ref() != &ast::TypeName::Unit {
+                    let ok_expr =
+                        gen_rust_to_cpp(&format!("{}.ok", raw_value_id), path, ok, in_path, env, out);
+                    writeln!(out, "  {} = diplomat::Ok(std::move({}));", wrapped_value_id, ok_expr).unwrap();
+                }
+                writeln!(out, "}} else {{").unwrap();
+                if err.as_ref() != &ast::TypeName::Unit {
+                    let err_expr = gen_rust_to_cpp(
+                        &format!("{}.err", raw_value_id),
+                        path,
+                        err,
+                        in_path,
+                        env,
+                        out,
+                    );
+                    writeln!(out, "  {} = diplomat::Err(std::move({}));", wrapped_value_id, err_expr).unwrap();
+                }
+                writeln!(out, "}}").unwrap();
             }
-            writeln!(out, "}} else {{").unwrap();
-            if err.as_ref() != &ast::TypeName::Unit {
-                let err_expr = gen_rust_to_cpp(
-                    &format!("{}.err", raw_value_id),
-                    path,
-                    err,
-                    in_path,
-                    env,
-                    out,
-                );
-                writeln!(out, "  {} = diplomat::Err(std::move({}));", wrapped_value_id, err_expr).unwrap();
-            }
-            writeln!(out, "}}").unwrap();
 
             wrapped_value_id
         }

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -97,9 +97,20 @@ pub fn gen_rust_to_cpp<W: Write>(
             if ok.as_ref() != &ast::TypeName::Unit || err.as_ref() != &ast::TypeName::Unit {
                 writeln!(out, "if ({}.is_ok) {{", raw_value_id).unwrap();
                 if ok.as_ref() != &ast::TypeName::Unit {
-                    let ok_expr =
-                        gen_rust_to_cpp(&format!("{}.ok", raw_value_id), path, ok, in_path, env, out);
-                    writeln!(out, "  {}.set_ok((std::move({})));", wrapped_value_id, ok_expr).unwrap();
+                    let ok_expr = gen_rust_to_cpp(
+                        &format!("{}.ok", raw_value_id),
+                        path,
+                        ok,
+                        in_path,
+                        env,
+                        out,
+                    );
+                    writeln!(
+                        out,
+                        "  {}.set_ok((std::move({})));",
+                        wrapped_value_id, ok_expr
+                    )
+                    .unwrap();
                 }
                 writeln!(out, "}} else {{").unwrap();
                 if err.as_ref() != &ast::TypeName::Unit {
@@ -111,7 +122,12 @@ pub fn gen_rust_to_cpp<W: Write>(
                         env,
                         out,
                     );
-                    writeln!(out, "  {}.set_err((std::move({})));", wrapped_value_id, err_expr).unwrap();
+                    writeln!(
+                        out,
+                        "  {}.set_err((std::move({})));",
+                        wrapped_value_id, err_expr
+                    )
+                    .unwrap();
                 }
                 writeln!(out, "}}").unwrap();
             }

--- a/tool/src/cpp/runtime.hpp
+++ b/tool/src/cpp/runtime.hpp
@@ -96,6 +96,14 @@ public:
     return std::make_optional(std::get<Err<E>>(this->val).inner);
   }
 
+  void set_ok(T&& t) {
+    this->val = Ok<T>(std::move(t));
+  }
+
+  void set_err(E&& e) {
+    this->val = Err<E>(std::move(e));
+  }
+
   template<typename T2>
   result<T2, E> replace_ok(T2&& t) {
     if (this->is_err()) {

--- a/tool/src/cpp/runtime.hpp
+++ b/tool/src/cpp/runtime.hpp
@@ -47,49 +47,65 @@ template<> struct WriteableTrait<std::string> {
   }
 };
 
-template<class T, class E>
-struct result
-{
-  union {
-    T ok;
-    E err;
-  };
-  bool is_ok;
+template<class T> struct Ok {
+  T inner;
+  Ok(T&& i): inner(i) {}
+  explicit Ok() {}
+};
 
-  ~result() {
+template<class T> struct Err {
+  T inner;
+  Err(T&& i): inner(i) {}
+  explicit Err() {}
+};
+
+template<class T, class E>
+class result {
+private:
+    std::variant<Ok<T>, Err<E>> val;
+public:
+  result(bool is_ok) {
     if (is_ok) {
-      ok.~T();
+      this->val = std::variant<Ok<T>, Err<E>>(Ok<T>());
     } else {
-      err.~E();
+      this->val = std::variant<Ok<T>, Err<E>>(Err<E>());
     }
   }
+  result(Ok<T>&& v): val(std::move(v)) {}
+  result(Err<E>&& v): val(std::move(v)) {}
+  result(const result &) = default;
+  result(result &&) noexcept = default;
+  ~result() = default;
+  bool is_ok() const {
+    return std::holds_alternative<Ok<T>>(this->val);
+  };
+  bool is_err() const {
+    return std::holds_alternative<Err<E>>(this->val);
+  };
 
-  static result<T, E> new_ok(T x) {
-    return {
-      .ok = x,
-      .is_ok = true
-    };
+  std::optional<T> ok() const {
+    if (!this->is_ok()) {
+      return std::nullopt;
+    }
+    return std::make_optional(std::get<Ok<T>>(this->val).inner);
+  };
+  std::optional<E> err() const {
+    if (!this->is_err()) {
+      return std::nullopt;
+    }
+    return std::make_optional(std::get<Err<E>>(this->val).inner);
   }
 
-  static result<std::monostate, E> new_ok_void() {
-    return {
-      .is_ok = true
-    };
-  }
-
-  static result<T, E> new_err(E x) {
-    return {
-      .err = x,
-      .is_ok = false
-    };
-  }
-
-  static result<T, std::monostate> new_err_void() {
-    return {
-      .is_ok = false
-    };
+  template<typename T2>
+  result<T2, E> replace_ok(T2&& t) {
+    if (this->is_err()) {
+      return result<T2, E>(Err<E>(std::get<Err<E>>(this->val)));
+    } else {
+      return result<T2, E>(Ok<T2>(std::move(t)));
+    }
   }
 };
+
 
 }
 

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_writeable_out@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_writeable_out@MyStruct.hpp.snap
@@ -67,7 +67,7 @@ template<typename W> inline diplomat::result<std::monostate, uint8_t> MyStruct::
   diplomat::result<std::monostate, uint8_t> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value = diplomat::Err(std::move(diplomat_result_raw_out_value.err));
+    diplomat_result_out_value.set_err((std::move(diplomat_result_raw_out_value.err)));
   }
   return diplomat_result_out_value;
 }
@@ -78,7 +78,7 @@ inline diplomat::result<std::string, uint8_t> MyStruct::write_result() {
   diplomat::result<std::monostate, uint8_t> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value = diplomat::Err(std::move(diplomat_result_raw_out_value.err));
+    diplomat_result_out_value.set_err((std::move(diplomat_result_raw_out_value.err)));
   }
   return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_writeable_out@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_writeable_out@MyStruct.hpp.snap
@@ -64,11 +64,10 @@ inline std::string MyStruct::write_unit() {
 template<typename W> inline diplomat::result<std::monostate, uint8_t> MyStruct::write_result_to_writeable(W& out) {
   capi::DiplomatWriteable out_writer = diplomat::WriteableTrait<W>::Construct(out);
   auto diplomat_result_raw_out_value = capi::MyStruct_write_result(this->inner.get(), &out_writer);
-  diplomat::result<std::monostate, uint8_t> diplomat_result_out_value;
-  diplomat_result_out_value.is_ok = diplomat_result_raw_out_value.is_ok;
+  diplomat::result<std::monostate, uint8_t> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.err = diplomat_result_raw_out_value.err;
+    diplomat_result_out_value = diplomat::Err(std::move(diplomat_result_raw_out_value.err));
   }
   return diplomat_result_out_value;
 }
@@ -76,18 +75,12 @@ inline diplomat::result<std::string, uint8_t> MyStruct::write_result() {
   std::string diplomat_writeable_string;
   capi::DiplomatWriteable diplomat_writeable_out = diplomat::WriteableFromString(diplomat_writeable_string);
   auto diplomat_result_raw_out_value = capi::MyStruct_write_result(this->inner.get(), &diplomat_writeable_out);
-  diplomat::result<std::monostate, uint8_t> diplomat_result_out_value;
-  diplomat_result_out_value.is_ok = diplomat_result_raw_out_value.is_ok;
+  diplomat::result<std::monostate, uint8_t> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   } else {
-    diplomat_result_out_value.err = diplomat_result_raw_out_value.err;
+    diplomat_result_out_value = diplomat::Err(std::move(diplomat_result_raw_out_value.err));
   }
-  diplomat::result<std::monostate, uint8_t> out_value = diplomat_result_out_value;
-  if (out_value.is_ok) {
-    return diplomat::result<std::string, uint8_t>::new_ok(diplomat_writeable_string);
-  } else {
-    return diplomat::result<std::string, uint8_t>::new_err(out_value.err);
-  }
+  return diplomat_result_out_value.replace_ok(std::move(diplomat_writeable_string));
 }
 inline uint8_t MyStruct::write_no_rearrange(capi::DiplomatWriteable& out) {
   capi::DiplomatWriteable out_writer = diplomat::WriteableTrait<W>::Construct(out);

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyStruct.hpp.snap
@@ -41,13 +41,13 @@ inline diplomat::result<MyStruct, uint8_t> MyStruct::new_() {
   auto diplomat_result_raw_out_value_a = diplomat_raw_struct_out_value.a;
   diplomat::result<MyOpaqueStruct, uint8_t> diplomat_result_out_value_a(diplomat_result_raw_out_value_a.is_ok);
   if (diplomat_result_raw_out_value_a.is_ok) {
-    diplomat_result_out_value_a = diplomat::Ok(std::move(MyOpaqueStruct(diplomat_result_raw_out_value_a.ok)));
+    diplomat_result_out_value_a.set_ok((std::move(MyOpaqueStruct(diplomat_result_raw_out_value_a.ok))));
   } else {
-    diplomat_result_out_value_a = diplomat::Err(std::move(diplomat_result_raw_out_value_a.err));
+    diplomat_result_out_value_a.set_err((std::move(diplomat_result_raw_out_value_a.err)));
   }
-    diplomat_result_out_value = diplomat::Ok(std::move(MyStruct{ .a = std::move(diplomat_result_out_value_a) }));
+    diplomat_result_out_value.set_ok((std::move(MyStruct{ .a = std::move(diplomat_result_out_value_a) })));
   } else {
-    diplomat_result_out_value = diplomat::Err(std::move(diplomat_result_raw_out_value.err));
+    diplomat_result_out_value.set_err((std::move(diplomat_result_raw_out_value.err)));
   }
   return diplomat_result_out_value;
 }

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyStruct.hpp.snap
@@ -35,21 +35,19 @@ struct MyStruct {
 
 inline diplomat::result<MyStruct, uint8_t> MyStruct::new_() {
   auto diplomat_result_raw_out_value = capi::MyStruct_new();
-  diplomat::result<MyStruct, uint8_t> diplomat_result_out_value;
-  diplomat_result_out_value.is_ok = diplomat_result_raw_out_value.is_ok;
+  diplomat::result<MyStruct, uint8_t> diplomat_result_out_value(diplomat_result_raw_out_value.is_ok);
   if (diplomat_result_raw_out_value.is_ok) {
   capi::MyStruct diplomat_raw_struct_out_value = diplomat_result_raw_out_value.ok;
   auto diplomat_result_raw_out_value_a = diplomat_raw_struct_out_value.a;
-  diplomat::result<MyOpaqueStruct, uint8_t> diplomat_result_out_value_a;
-  diplomat_result_out_value_a.is_ok = diplomat_result_raw_out_value_a.is_ok;
+  diplomat::result<MyOpaqueStruct, uint8_t> diplomat_result_out_value_a(diplomat_result_raw_out_value_a.is_ok);
   if (diplomat_result_raw_out_value_a.is_ok) {
-    diplomat_result_out_value_a.ok = MyOpaqueStruct(diplomat_result_raw_out_value_a.ok);
+    diplomat_result_out_value_a = diplomat::Ok(std::move(MyOpaqueStruct(diplomat_result_raw_out_value_a.ok)));
   } else {
-    diplomat_result_out_value_a.err = diplomat_result_raw_out_value_a.err;
+    diplomat_result_out_value_a = diplomat::Err(std::move(diplomat_result_raw_out_value_a.err));
   }
-    diplomat_result_out_value.ok = MyStruct{ .a = std::move(diplomat_result_out_value_a) };
+    diplomat_result_out_value = diplomat::Ok(std::move(MyStruct{ .a = std::move(diplomat_result_out_value_a) }));
   } else {
-    diplomat_result_out_value.err = diplomat_result_raw_out_value.err;
+    diplomat_result_out_value = diplomat::Err(std::move(diplomat_result_raw_out_value.err));
   }
   return diplomat_result_out_value;
 }

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -341,7 +341,11 @@ fn gen_writeable_out_value<W: fmt::Write>(
     method_body: &mut W,
 ) -> fmt::Result {
     if let ast::TypeName::Result(_, _) = ret_typ {
-        writeln!(method_body, "return {}.replace_ok(std::move(diplomat_writeable_string));", out_expr)?;
+        writeln!(
+            method_body,
+            "return {}.replace_ok(std::move(diplomat_writeable_string));",
+            out_expr
+        )?;
     } else {
         panic!("Not in writeable out form")
     }

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -241,7 +241,7 @@ fn gen_method<W: fmt::Write>(
                 );
 
                 if rearranged_writeable {
-                    gen_writeable_out_value(&out_expr, ret_typ, in_path, env, &mut method_body)?;
+                    gen_writeable_out_value(&out_expr, ret_typ, &mut method_body)?;
                 } else {
                     writeln!(&mut method_body, "return {};", out_expr)?;
                 }
@@ -338,34 +338,10 @@ pub fn gen_method_interface<W: fmt::Write>(
 fn gen_writeable_out_value<W: fmt::Write>(
     out_expr: &str,
     ret_typ: &ast::TypeName,
-    in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
     method_body: &mut W,
 ) -> fmt::Result {
-    if let ast::TypeName::Result(_, err) = ret_typ {
-        gen_type(ret_typ, in_path, None, env, method_body)?;
-        writeln!(method_body, " out_value = {};", out_expr)?;
-
-        writeln!(method_body, "if (out_value.is_ok) {{")?;
-
-        write!(method_body, "  return diplomat::result<std::string, ")?;
-        if err.as_ref() == &ast::TypeName::Unit {
-            write!(method_body, "std::monostate")?;
-        } else {
-            gen_type(err, in_path, None, env, method_body)?;
-        }
-        writeln!(method_body, ">::new_ok(diplomat_writeable_string);")?;
-
-        writeln!(method_body, "}} else {{")?;
-        write!(method_body, "  return diplomat::result<std::string, ")?;
-        if err.as_ref() == &ast::TypeName::Unit {
-            writeln!(method_body, "std::monostate>::new_err_void();")?;
-        } else {
-            gen_type(err, in_path, None, env, method_body)?;
-            writeln!(method_body, ">::new_err(out_value.err);")?;
-        }
-
-        writeln!(method_body, "}}")?;
+    if let ast::TypeName::Result(_, _) = ret_typ {
+        writeln!(method_body, "return {}.replace_ok(std::move(diplomat_writeable_string));", out_expr)?;
     } else {
         panic!("Not in writeable out form")
     }


### PR DESCRIPTION
The previous version did not conform to the Rule of Five and was unsound. Furthermore it would fail to compile under emcc.

Fixes https://github.com/rust-diplomat/diplomat/issues/42

cc @shadaj