### PR TITLE
Omit zero-sized variants in DiplomatResult

### DIFF
--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -34,6 +34,17 @@ impl Module {
             .for_each(|m| m.check_opaque(&in_path.sub_path(self.name.clone()), env, errors));
     }
 
+    /// Ensures that we are not exporting any non-opaque zero-sized types
+    pub fn check_zst<'a>(&'a self, in_path: &Path, errors: &mut Vec<Path>) {
+        self.declared_types
+            .values()
+            .for_each(|t| t.check_zst(&in_path.sub_path(self.name.clone()), errors));
+
+        self.sub_modules
+            .iter()
+            .for_each(|m| m.check_zst(&in_path.sub_path(self.name.clone()), errors));
+    }
+
     fn insert_all_types(&self, in_path: Path, out: &mut HashMap<Path, HashMap<String, ModSymbol>>) {
         let mut mod_symbols = HashMap::new();
 
@@ -198,6 +209,13 @@ impl File {
         self.modules
             .values()
             .for_each(|t| t.check_opaque(&Path::empty(), env, errors));
+    }
+
+    /// Ensures that we are not exporting any non-opaque zero-sized types
+    pub fn check_zst(&self, errors: &mut Vec<Path>) {
+        self.modules
+            .values()
+            .for_each(|t| t.check_zst(&Path::empty(), errors));
     }
 
     /// Fuses all declared types into a single environment `HashMap`.

--- a/example/cpp/result_void_void.h
+++ b/example/cpp/result_void_void.h
@@ -10,10 +10,6 @@
 extern "C" {
 #endif
 typedef struct fixed_decimal_ffi_result_void_void {
-    union {
-        uint8_t ok[0];
-        uint8_t err[0];
-    };
     bool is_ok;
 } fixed_decimal_ffi_result_void_void;
 #ifdef __cplusplus

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@MyStruct.h.snap
@@ -1,0 +1,34 @@
+---
+source: tool/src/c/types.rs
+expression: out_texts.get(out).unwrap()
+
+---
+#ifndef MyStruct_H
+#define MyStruct_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "result_void_uint8_t.h"
+#include "result_void_void.h"
+#include "result_uint8_t_void.h"
+
+typedef struct MyStruct {
+    ffi_result_void_uint8_t a;
+    ffi_result_void_void b;
+    ffi_result_uint8_t_void c;
+} MyStruct;
+
+MyStruct MyStruct_new();
+void MyStruct_destroy(MyStruct* self);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@result_MyStruct_uint8_t.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@result_MyStruct_uint8_t.h.snap
@@ -1,0 +1,29 @@
+---
+source: tool/src/c/types.rs
+expression: out_texts.get(out).unwrap()
+
+---
+#ifndef result_MyStruct_uint8_t_H
+#define result_MyStruct_uint8_t_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "MyStruct.h"
+typedef struct ffi_result_MyStruct_uint8_t {
+    union {
+        MyStruct ok;
+        uint8_t err;
+    };
+    bool is_ok;
+} ffi_result_MyStruct_uint8_t;
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@result_uint8_t_void.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@result_uint8_t_void.h.snap
@@ -1,0 +1,27 @@
+---
+source: tool/src/c/types.rs
+expression: out_texts.get(out).unwrap()
+
+---
+#ifndef result_uint8_t_void_H
+#define result_uint8_t_void_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct ffi_result_uint8_t_void {
+    union {
+        uint8_t ok;
+    };
+    bool is_ok;
+} ffi_result_uint8_t_void;
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@result_void_uint8_t.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@result_void_uint8_t.h.snap
@@ -1,0 +1,27 @@
+---
+source: tool/src/c/types.rs
+expression: out_texts.get(out).unwrap()
+
+---
+#ifndef result_void_uint8_t_H
+#define result_void_uint8_t_H
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct ffi_result_void_uint8_t {
+    union {
+        uint8_t err;
+    };
+    bool is_ok;
+} ffi_result_void_uint8_t;
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@result_void_void.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@result_void_void.h.snap
@@ -1,3 +1,8 @@
+---
+source: tool/src/c/types.rs
+expression: out_texts.get(out).unwrap()
+
+---
 #ifndef result_void_void_H
 #define result_void_void_H
 #include <stdio.h>
@@ -9,10 +14,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-typedef struct fixed_decimal_ffi_result_void_void {
+typedef struct ffi_result_void_void {
     bool is_ok;
-} fixed_decimal_ffi_result_void_void;
+} ffi_result_void_void;
 #ifdef __cplusplus
 }
 #endif
 #endif
+

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -154,6 +154,26 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_result_types() {
+        test_file! {
+            #[diplomat::bridge]
+            mod ffi {
+                struct MyStruct {
+                    a: DiplomatResult<(), u8>,
+                    b: DiplomatResult<(), ()>,
+                    c: DiplomatResult<u8, ()>,
+                }
+
+                impl MyStruct {
+                    pub fn new() -> MyStruct {
+                        unimplemented!()
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_writeable_out() {
         test_file! {
             #[diplomat::bridge]

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -94,9 +94,9 @@ pub fn gen_rust_to_cpp<W: Write>(
             super::types::gen_type(typ, in_path, None, env, out).unwrap();
             writeln!(out, " {}({}.is_ok);", wrapped_value_id, raw_value_id).unwrap();
 
-            if ok.as_ref() != &ast::TypeName::Unit || err.as_ref() != &ast::TypeName::Unit {
+            if !ok.is_zst() || !err.is_zst() {
                 writeln!(out, "if ({}.is_ok) {{", raw_value_id).unwrap();
-                if ok.as_ref() != &ast::TypeName::Unit {
+                if !ok.is_zst() {
                     let ok_expr = gen_rust_to_cpp(
                         &format!("{}.ok", raw_value_id),
                         path,
@@ -113,7 +113,7 @@ pub fn gen_rust_to_cpp<W: Write>(
                     .unwrap();
                 }
                 writeln!(out, "}} else {{").unwrap();
-                if err.as_ref() != &ast::TypeName::Unit {
+                if !err.is_zst() {
                     let err_expr = gen_rust_to_cpp(
                         &format!("{}.err", raw_value_id),
                         path,

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -281,7 +281,7 @@ pub fn gen_method_interface<W: fmt::Write>(
     if rearranged_writeable {
         if let Some(ast::TypeName::Result(_, err)) = &method.return_type {
             write!(out, "diplomat::result<std::string, ")?;
-            if err.as_ref() == &ast::TypeName::Unit {
+            if err.is_zst() {
                 write!(out, "std::monostate")?;
             } else {
                 gen_type(err, in_path, None, env, out)?;

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -59,14 +59,14 @@ pub fn gen_type<W: fmt::Write>(
 
         ast::TypeName::Result(ok, err) => {
             write!(out, "diplomat::result<")?;
-            if let ast::TypeName::Unit = ok.as_ref() {
+            if ok.is_zst() {
                 write!(out, "std::monostate")?;
             } else {
                 gen_type(ok, in_path, behind_ref, env, out)?;
             }
 
             write!(out, ", ")?;
-            if let ast::TypeName::Unit = err.as_ref() {
+            if err.is_zst() {
                 write!(out, "std::monostate")?;
             } else {
                 gen_type(err, in_path, behind_ref, env, out)?;

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -81,11 +81,19 @@ fn main() -> std::io::Result<()> {
     let env = custom_types.all_types();
 
     let mut opaque_errors = vec![];
+    let mut zst_errors = vec![];
     custom_types.check_opaque(&env, &mut opaque_errors);
-    if !opaque_errors.is_empty() {
+    custom_types.check_zst(&mut zst_errors);
+    if !opaque_errors.is_empty() || !zst_errors.is_empty() {
         opaque_errors.iter().for_each(|e| {
             eprintln!(
                 "An opaque type crossed the FFI boundary as a value: {:?}",
+                e
+            )
+        });
+        zst_errors.iter().for_each(|e| {
+            eprintln!(
+                "A non-opaque zero-sized struct or enum has been defined: {:?}",
                 e
             )
         });


### PR DESCRIPTION
Fixes https://github.com/rust-diplomat/diplomat/issues/74

We also now verify that people are not producing other zero-sized structs or enums, the only ZST allowed in our FFI is `()` which we can handle specially.