### PR TITLE
Don't include `<span>` by default

### DIFF
--- a/example/cpp/ICU4XDataProvider.hpp
+++ b/example/cpp/ICU4XDataProvider.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/ICU4XFixedDecimal.hpp
+++ b/example/cpp/ICU4XFixedDecimal.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/ICU4XFixedDecimalFormat.hpp
+++ b/example/cpp/ICU4XFixedDecimalFormat.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/ICU4XFixedDecimalFormatOptions.hpp
+++ b/example/cpp/ICU4XFixedDecimalFormatOptions.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/ICU4XFixedDecimalFormatResult.hpp
+++ b/example/cpp/ICU4XFixedDecimalFormatResult.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/ICU4XFixedDecimalGroupingStrategy.hpp
+++ b/example/cpp/ICU4XFixedDecimalGroupingStrategy.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/ICU4XFixedDecimalSignDisplay.hpp
+++ b/example/cpp/ICU4XFixedDecimalSignDisplay.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/ICU4XLocale.hpp
+++ b/example/cpp/ICU4XLocale.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/MyStruct.hpp
+++ b/example/cpp/MyStruct.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/example/cpp/Opaque.hpp
+++ b/example/cpp/Opaque.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/config.rs
+++ b/tool/src/cpp/config.rs
@@ -27,7 +27,7 @@ pub struct LibraryConfig {
 impl LibraryConfig {
     pub fn default() -> LibraryConfig {
         LibraryConfig {
-            headers: vec!["#include <optional>".into(), "#include <span>".into()],
+            headers: vec!["#include <optional>".into()],
             nullopt: CallableLibraryType {
                 name: "std::nullopt".into(),
                 expr: "std::nullopt".into(),

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__enum_conversion@Foo.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__enum_conversion@Foo.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__enum_conversion@MyEnum.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__enum_conversion@MyEnum.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__enum_conversion@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__enum_conversion@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__option_conversion@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__option_conversion@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_slice@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_slice@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_str@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_str@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_writeable_out@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_writeable_out@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__simple_non_opaque_struct@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__simple_non_opaque_struct@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__simple_opaque_struct@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__simple_opaque_struct@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__struct_documentation@Foo.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__struct_documentation@Foo.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_fields@Bar.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_fields@Bar.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_fields@Foo.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_fields@Foo.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_methods@Bar.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_methods@Bar.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_methods@Foo.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_methods@Foo.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__enum_documentation@MyEnum.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__enum_documentation@MyEnum.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__option_types@MyOpaqueStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__option_types@MyOpaqueStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__option_types@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__option_types@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__pointer_types@MyOpaqueStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__pointer_types@MyOpaqueStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__pointer_types@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__pointer_types@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyOpaqueStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyOpaqueStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__string_reference@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__string_reference@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__unit_type@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__unit_type@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__writeable_out@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__writeable_out@MyStruct.hpp.snap
@@ -12,7 +12,6 @@ expression: out_texts.get(out).unwrap()
 #include <memory>
 #include <variant>
 #include <optional>
-#include <span>
 #include "diplomat_runtime.hpp"
 
 namespace capi {


### PR DESCRIPTION
We don't actually use the header, but it turns out that this works fine on systems where the header is present (but unusable due to C++ version).

We shouldn't include it at all.