### PR TITLE
Add check for non-opaque types being passed by move

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -81,9 +81,10 @@ impl Method {
     }
 
     /// Checks that any references to opaque structs in parameters or return values
-    /// are always behind a box or reference.
+    /// are always behind a box or reference, and that non-opaque custom types are *never* behind
+    /// references or boxes.
     ///
-    /// Any references to opaque structs that are invalid are pushed into the `errors` vector.
+    /// Errors are pushed into the `errors` vector.
     pub fn check_opaque<'a>(
         &'a self,
         in_path: &Path,
@@ -100,6 +101,7 @@ impl Method {
             .iter()
             .for_each(|t| t.check_opaque(in_path, env, errors));
     }
+
 
     /// Checks whether the method qualifies for special writeable handling.
     /// To qualify, a method must:

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -102,7 +102,6 @@ impl Method {
             .for_each(|t| t.check_opaque(in_path, env, errors));
     }
 
-
     /// Checks whether the method qualifies for special writeable handling.
     /// To qualify, a method must:
     ///  - not return any value

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__non_opaque_move.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__non_opaque_move.snap
@@ -1,0 +1,10 @@
+---
+source: core/src/ast/validity.rs
+expression: output
+
+---
+A non-opaque type was found behind a Box or reference, these can only be handled by-move as they get converted at the FFI boundary: NonOpaque
+A non-opaque type was found behind a Box or reference, these can only be handled by-move as they get converted at the FFI boundary: NonOpaque
+A non-opaque type was found behind a Box or reference, these can only be handled by-move as they get converted at the FFI boundary: NonOpaque
+A non-opaque type was found behind a Box or reference, these can only be handled by-move as they get converted at the FFI boundary: NonOpaque
+

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -55,7 +55,8 @@ impl CustomType {
 
     /// Checks that any references to opaque structs in parameters or return values
     /// are always behind a box or reference, and that non-opaque custom types are *never* behind
-    /// references or boxes.
+    /// references or boxes. The latter check is needed because non-opaque custom types typically get
+    /// *converted* at the FFI boundary.
     ///
     /// Errors are pushed into the `errors` vector.
     pub fn check_opaque<'a>(
@@ -330,7 +331,7 @@ impl TypeName {
                         errors.push(ValidityError::OpaqueAsValue(self.clone()))
                     }
                 } else if behind_reference {
-                        errors.push(ValidityError::NonOpaqueBehindRef(self.clone()))
+                    errors.push(ValidityError::NonOpaqueBehindRef(self.clone()))
                 }
             }
             TypeName::Writeable => {}

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -54,9 +54,10 @@ impl CustomType {
     }
 
     /// Checks that any references to opaque structs in parameters or return values
-    /// are always behind a box or reference.
+    /// are always behind a box or reference, and that non-opaque custom types are *never* behind
+    /// references or boxes.
     ///
-    /// Any references to opaque structs that are invalid are pushed into the `errors` vector.
+    /// Errors are pushed into the `errors` vector.
     pub fn check_opaque<'a>(
         &'a self,
         in_path: &Path,
@@ -328,6 +329,8 @@ impl TypeName {
                     if !behind_reference {
                         errors.push(ValidityError::OpaqueAsValue(self.clone()))
                     }
+                } else if behind_reference {
+                        errors.push(ValidityError::NonOpaqueBehindRef(self.clone()))
                 }
             }
             TypeName::Writeable => {}
@@ -338,9 +341,10 @@ impl TypeName {
     }
 
     /// Checks that any references to opaque structs in parameters or return values
-    /// are always behind a box or reference.
+    /// are always behind a box or reference, and that non-opaque custom types are *never* behind
+    /// references or boxes.
     ///
-    /// Any references to opaque structs that are invalid are pushed into the `errors` vector.
+    /// Errors are pushed into the `errors` vector.
     pub fn check_opaque<'a>(
         &'a self,
         in_path: &Path,

--- a/core/src/ast/validity.rs
+++ b/core/src/ast/validity.rs
@@ -13,6 +13,11 @@ pub enum ValidityError {
         doc = "A non-opaque zero-sized struct or enum has been defined: {0}"
     )]
     NonOpaqueZST(Path),
+    #[cfg_attr(
+        feature = "displaydoc",
+        doc = "A non-opaque type was found behind a Box or reference, these can only be handled by-move: {0}"
+    )]
+    NonOpaqueBehindRef(TypeName),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
fixes https://github.com/rust-diplomat/diplomat/issues/97

Somewhat progress towards https://github.com/rust-diplomat/diplomat/milestone/1 because I don't want to start writing the tests until validity is properly handled (otherwise the process of writing the tests is just downright annoying; since things start failing in C++ code in gnarly ways)

Turned out to be much much cleaner now that #112 exists