### PR TITLE
Hide resolution environment behind "Env", swap out hashmap with BTreeMap

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 use syn::*;
 
-use super::{utils::get_doc_lines, ModSymbol};
+use super::utils::get_doc_lines;
 use super::{Path, TypeName, ValidityError};
+use crate::Env;
 
 /// A method declared in the `impl` associated with an FFI struct.
 /// Includes both static and non-static methods, which can be distinguished
@@ -85,12 +84,7 @@ impl Method {
     /// references or boxes.
     ///
     /// Errors are pushed into the `errors` vector.
-    pub fn check_opaque<'a>(
-        &'a self,
-        in_path: &Path,
-        env: &HashMap<Path, HashMap<String, ModSymbol>>,
-        errors: &mut Vec<ValidityError>,
-    ) {
+    pub fn check_opaque<'a>(&'a self, in_path: &Path, env: &Env, errors: &mut Vec<ValidityError>) {
         self.self_param
             .iter()
             .for_each(|m| m.ty.check_opaque(in_path, env, errors));

--- a/core/src/ast/paths.rs
+++ b/core/src/ast/paths.rs
@@ -2,7 +2,7 @@ use proc_macro2::Span;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Hash, Eq, PartialEq, Deserialize, Serialize, Clone, Debug)]
+#[derive(Hash, Eq, PartialEq, Deserialize, Serialize, Clone, Debug, Ord, PartialOrd)]
 pub struct Path {
     pub elements: Vec<String>,
 }

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__zst_non_opaque.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__zst_non_opaque.snap
@@ -3,6 +3,6 @@ source: core/src/ast/validity.rs
 expression: output
 
 ---
-A non-opaque zero-sized struct or enum has been defined: ffi::OpaqueEnum
 A non-opaque zero-sized struct or enum has been defined: ffi::OpaqueStruct
+A non-opaque zero-sized struct or enum has been defined: ffi::OpaqueEnum
 

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__zst_non_opaque.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__zst_non_opaque.snap
@@ -3,6 +3,6 @@ source: core/src/ast/validity.rs
 expression: output
 
 ---
-A non-opaque zero-sized struct or enum has been defined: ffi::OpaqueStruct
 A non-opaque zero-sized struct or enum has been defined: ffi::OpaqueEnum
+A non-opaque zero-sized struct or enum has been defined: ffi::OpaqueStruct
 

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -32,7 +32,7 @@ impl Env {
     pub fn iter_items(&self) -> impl Iterator<Item = (&Path, &String, &ModSymbol)> + '_ {
         self.env
             .iter()
-            .flat_map(|(k, ref v)| v.module.iter().map(move |v2| (k, v2.0, v2.1)))
+            .flat_map(|(k, v)| v.module.iter().map(move |v2| (k, v2.0, v2.1)))
     }
 
     /// Iterate over all modules

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -44,8 +44,8 @@ impl Env {
 }
 
 impl ModuleEnv {
-    pub(crate) fn insert(&mut self, name: String, symbol: ModSymbol) {
-        self.module.insert(name, symbol);
+    pub(crate) fn insert(&mut self, name: String, symbol: ModSymbol) -> Option<ModSymbol> {
+        self.module.insert(name, symbol)
     }
 
     /// Given an item name, fetch it

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -1,5 +1,5 @@
 use crate::ast::*;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::ops::Index;
 
 /// The type resolution environment
@@ -7,13 +7,13 @@ use std::ops::Index;
 /// Also contains the entire module structure
 #[derive(Default, Clone)]
 pub struct Env {
-    pub(crate) env: HashMap<Path, ModuleEnv>,
+    pub(crate) env: BTreeMap<Path, ModuleEnv>,
 }
 
 /// The type resolution environment within a specific module
 #[derive(Default, Clone)]
 pub struct ModuleEnv {
-    pub(crate) module: HashMap<String, ModSymbol>,
+    pub(crate) module: BTreeMap<String, ModSymbol>,
 }
 
 impl Env {

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -1,0 +1,88 @@
+use crate::ast::*;
+use std::collections::HashMap;
+use std::ops::Index;
+
+/// The type resolution environment
+///
+/// Also contains the entire module structure
+#[derive(Default, Clone)]
+pub struct Env {
+    pub(crate) env: HashMap<Path, ModuleEnv>,
+}
+
+/// The type resolution environment within a specific module
+#[derive(Default, Clone)]
+pub struct ModuleEnv {
+    pub(crate) module: HashMap<String, ModSymbol>,
+}
+
+impl Env {
+    pub(crate) fn insert(&mut self, path: Path, module: ModuleEnv) {
+        self.env.insert(path, module);
+    }
+
+    /// Given a path to a module and a name, get the item, if any
+    pub fn get(&self, path: &Path, name: &str) -> Option<&ModSymbol> {
+        self.env.get(path).and_then(|m| m.module.get(name))
+    }
+
+    /// Iterate over all items in the environment
+    ///
+    /// This will occur in a stable lexically sorted order by path and then name
+    pub fn iter_items(&self) -> impl Iterator<Item = (&Path, &String, &ModSymbol)> + '_ {
+        self.env
+            .iter()
+            .flat_map(|(k, ref v)| v.module.iter().map(move |v2| (k, v2.0, v2.1)))
+    }
+
+    /// Iterate over all modules
+    ///
+    /// This will occur in a stable lexically sorted order by path
+    pub fn iter_modules(&self) -> impl Iterator<Item = (&Path, &ModuleEnv)> + '_ {
+        self.env.iter()
+    }
+}
+
+impl ModuleEnv {
+    pub(crate) fn insert(&mut self, name: String, symbol: ModSymbol) {
+        self.module.insert(name, symbol);
+    }
+
+    /// Given an item name, fetch it
+    pub fn get(&self, name: &str) -> Option<&ModSymbol> {
+        self.module.get(name)
+    }
+
+    /// Iterate over all name-item pairs in this module
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &ModSymbol)> + '_ {
+        self.module.iter()
+    }
+
+    /// Iterate over all names in this module
+    ///
+    /// This will occur in a stable lexically sorted order by name
+    pub fn names(&self) -> impl Iterator<Item = &String> + '_ {
+        self.module.keys()
+    }
+
+    /// Iterate over all items in this module
+    ///
+    /// This will occur in a stable lexically sorted order by name
+    pub fn items(&self) -> impl Iterator<Item = &ModSymbol> + '_ {
+        self.module.values()
+    }
+}
+
+impl Index<&Path> for Env {
+    type Output = ModuleEnv;
+    fn index(&self, i: &Path) -> &ModuleEnv {
+        &self.env[i]
+    }
+}
+
+impl Index<&str> for ModuleEnv {
+    type Output = ModSymbol;
+    fn index(&self, i: &str) -> &ModSymbol {
+        &self.module[i]
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,3 +3,7 @@
 /// is primarily the AST types that Diplomat generates while
 /// extracting APIs.
 pub mod ast;
+
+mod environment;
+
+pub use environment::{Env, ModuleEnv};

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -24,7 +24,7 @@ use results::*;
 static RUNTIME_H: &str = include_str!("runtime.h");
 
 pub fn gen_bindings(
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     outs: &mut HashMap<String, String>,
 ) -> fmt::Result {
     let diplomat_runtime_out = outs
@@ -53,7 +53,7 @@ fn gen_struct_header<'a>(
     seen_results: &mut HashSet<(ast::Path, &'a ast::TypeName)>,
     all_results: &mut Vec<(ast::Path, &'a ast::TypeName)>,
     outs: &mut HashMap<String, String>,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> Result<(), fmt::Error> {
     let out = outs
         .entry(format!("{}.h", typ.name()))
@@ -163,7 +163,7 @@ fn gen_result_header(
     typ: &ast::TypeName,
     in_path: &ast::Path,
     outs: &mut HashMap<String, String>,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> fmt::Result {
     if let ast::TypeName::Result(ok, err) = typ {
         let out = outs
@@ -220,7 +220,7 @@ pub fn gen_includes<W: fmt::Write>(
     in_path: &ast::Path,
     pre_struct: bool,
     behind_ref: bool,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     seen_includes: &mut HashSet<String>,
     out: &mut W,
 ) -> fmt::Result {

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::fmt::Write;
 
 use diplomat_core::ast;
+use diplomat_core::Env;
 use indenter::indented;
 
 use crate::util;
@@ -23,10 +24,7 @@ use results::*;
 
 static RUNTIME_H: &str = include_str!("runtime.h");
 
-pub fn gen_bindings(
-    env: &Env,
-    outs: &mut HashMap<String, String>,
-) -> fmt::Result {
+pub fn gen_bindings(env: &Env, outs: &mut HashMap<String, String>) -> fmt::Result {
     let diplomat_runtime_out = outs
         .entry("diplomat_runtime.h".to_string())
         .or_insert_with(String::new);

--- a/tool/src/c/results.rs
+++ b/tool/src/c/results.rs
@@ -1,8 +1,5 @@
 use std::fmt::Write;
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-};
+use std::{collections::HashSet, fmt};
 
 use diplomat_core::ast;
 use diplomat_core::Env;

--- a/tool/src/c/results.rs
+++ b/tool/src/c/results.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use diplomat_core::ast;
+use diplomat_core::Env;
 use indenter::indented;
 
 use super::types::{gen_type, name_for_type};

--- a/tool/src/c/results.rs
+++ b/tool/src/c/results.rs
@@ -12,7 +12,7 @@ use super::types::{gen_type, name_for_type};
 pub fn collect_results<'a>(
     typ: &'a ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     seen: &mut HashSet<(ast::Path, &'a ast::TypeName)>,
     results: &mut Vec<(ast::Path, &'a ast::TypeName)>,
 ) {
@@ -47,7 +47,7 @@ pub fn collect_results<'a>(
 pub fn gen_result<W: fmt::Write>(
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     if let ast::TypeName::Result(ok, err) = typ {

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -1,3 +1,4 @@
+use diplomat_core::Env;
 use std::fmt::Write;
 use std::{collections::HashMap, fmt};
 

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -10,7 +10,7 @@ use super::types::gen_type;
 pub fn gen_struct<W: fmt::Write>(
     custom_type: &ast::CustomType,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     match custom_type {
@@ -39,7 +39,7 @@ pub fn gen_field<W: fmt::Write>(
     name: &str,
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     gen_type(typ, in_path, env, out)?;
@@ -51,7 +51,7 @@ pub fn gen_field<W: fmt::Write>(
 pub fn gen_method<W: fmt::Write>(
     method: &ast::Method,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     match &method.return_type {

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -1,6 +1,6 @@
 use diplomat_core::Env;
+use std::fmt;
 use std::fmt::Write;
-use std::{collections::HashMap, fmt};
 
 use diplomat_core::ast;
 use indenter::indented;

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -5,7 +5,7 @@ use diplomat_core::ast::{self, PrimitiveType};
 pub fn gen_type<W: fmt::Write>(
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     match typ {

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -1,3 +1,4 @@
+use diplomat_core::Env;
 use std::{collections::HashMap, fmt};
 
 use diplomat_core::ast::{self, PrimitiveType};

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -1,5 +1,5 @@
 use diplomat_core::Env;
-use std::{collections::HashMap, fmt};
+use std::fmt;
 
 use diplomat_core::ast::{self, PrimitiveType};
 

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -9,7 +9,7 @@ pub fn gen_rust_to_cpp<W: Write>(
     path: &str,
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config: &LibraryConfig,
     out: &mut W,
 ) -> String {
@@ -207,7 +207,7 @@ pub fn gen_cpp_to_rust<W: Write>(
     behind_ref: Option<ReferenceMeta>,
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     is_self: bool,
     out: &mut W,
 ) -> String {

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Write};
+use std::fmt::Write;
 
 use diplomat_core::ast;
 use diplomat_core::Env;

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fmt::Write};
 
 use diplomat_core::ast;
+use diplomat_core::Env;
 
 use crate::cpp::config::LibraryConfig;
 

--- a/tool/src/cpp/docs.rs
+++ b/tool/src/cpp/docs.rs
@@ -1,4 +1,5 @@
 use colored::*;
+use diplomat_core::Env;
 use std::fmt::Write;
 use std::fs;
 use std::path::PathBuf;

--- a/tool/src/cpp/docs.rs
+++ b/tool/src/cpp/docs.rs
@@ -50,9 +50,9 @@ pub fn gen_docs(
     writeln!(&mut toctree_indent, ":caption: Modules:")?;
     writeln!(&mut toctree_indent)?;
     let mut sorted_keys: Vec<String> = env
-        .iter()
+        .iter_modules()
         .filter(|(_, s)| {
-            s.values()
+            s.items()
                 .any(|k| matches!(k, ast::ModSymbol::CustomType(_)))
         })
         .map(|(p, _)| p.elements.join("_"))
@@ -68,9 +68,9 @@ pub fn gen_docs(
     writeln!(index_out, "* :ref:`genindex`")?;
     writeln!(index_out, "* :ref:`search`")?;
 
-    for (in_path, mod_symbols) in env.iter() {
-        if mod_symbols
-            .values()
+    for (in_path, module) in env.iter_modules() {
+        if module
+            .items()
             .any(|k| matches!(k, ast::ModSymbol::CustomType(_)))
         {
             let out = outs
@@ -81,12 +81,12 @@ pub fn gen_docs(
             writeln!(out, "{}", title)?;
             writeln!(out, "{}", "=".repeat(title.len()))?;
 
-            let mut sorted_symbols: Vec<&String> = mod_symbols.keys().collect();
+            let mut sorted_symbols: Vec<&String> = module.names().collect();
             sorted_symbols.sort();
 
             for symbol_name in sorted_symbols {
-                let custom_type = &mod_symbols[symbol_name];
-                if let ast::ModSymbol::CustomType(typ) = custom_type {
+                let custom_type = &module[symbol_name];
+                if let ast::ModSymbol::CustomType(ref typ) = custom_type {
                     writeln!(out)?;
                     gen_custom_type_docs(out, typ, in_path, env, &library_config)?;
                 }

--- a/tool/src/cpp/docs.rs
+++ b/tool/src/cpp/docs.rs
@@ -14,7 +14,7 @@ use crate::{
 
 /// Generate RST-formatted Sphinx docs for all FFI types.
 pub fn gen_docs(
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config_path: &Option<PathBuf>,
     outs: &mut HashMap<String, String>,
 ) -> fmt::Result {
@@ -100,7 +100,7 @@ pub fn gen_custom_type_docs<W: fmt::Write>(
     out: &mut W,
     typ: &ast::CustomType,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config: &LibraryConfig,
 ) -> fmt::Result {
     match typ {
@@ -162,7 +162,7 @@ pub fn gen_method_docs<W: fmt::Write>(
     enclosing_type: &ast::CustomType,
     in_path: &ast::Path,
     writeable_to_string: bool,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config: &LibraryConfig,
     out: &mut W,
 ) -> fmt::Result {
@@ -230,7 +230,7 @@ pub fn gen_field_docs<W: fmt::Write>(
     out: &mut W,
     field: &(String, ast::TypeName, String),
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config: &LibraryConfig,
 ) -> fmt::Result {
     write!(out, ".. cpp:member:: ")?;
@@ -258,7 +258,7 @@ pub fn gen_enum_variant_docs<W: fmt::Write>(
     out: &mut W,
     variant: &(String, isize, String),
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> fmt::Result {
     write!(out, ".. cpp:enumerator:: {}", variant.0)?;
 

--- a/tool/src/cpp/docs.rs
+++ b/tool/src/cpp/docs.rs
@@ -49,17 +49,14 @@ pub fn gen_docs(
     writeln!(&mut toctree_indent, ":maxdepth: 3")?;
     writeln!(&mut toctree_indent, ":caption: Modules:")?;
     writeln!(&mut toctree_indent)?;
-    let mut sorted_keys: Vec<String> = env
-        .iter_modules()
-        .filter(|(_, s)| {
-            s.items()
-                .any(|k| matches!(k, ast::ModSymbol::CustomType(_)))
-        })
-        .map(|(p, _)| p.elements.join("_"))
-        .collect();
-    sorted_keys.sort();
-    for in_path in sorted_keys {
-        writeln!(&mut toctree_indent, "{}", in_path)?;
+
+    for (in_path, module) in env.iter_modules() {
+        if module
+            .items()
+            .any(|k| matches!(k, ast::ModSymbol::CustomType(_)))
+        {
+            writeln!(&mut toctree_indent, "{}", in_path.elements.join("_"))?;
+        }
     }
     writeln!(index_out)?;
     writeln!(index_out, "Indices and tables")?;
@@ -81,12 +78,8 @@ pub fn gen_docs(
             writeln!(out, "{}", title)?;
             writeln!(out, "{}", "=".repeat(title.len()))?;
 
-            let mut sorted_symbols: Vec<&String> = module.names().collect();
-            sorted_symbols.sort();
-
-            for symbol_name in sorted_symbols {
-                let custom_type = &module[symbol_name];
-                if let ast::ModSymbol::CustomType(ref typ) = custom_type {
+            for item in module.items() {
+                if let ast::ModSymbol::CustomType(ref typ) = item {
                     writeln!(out)?;
                     gen_custom_type_docs(out, typ, in_path, env, &library_config)?;
                 }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -30,7 +30,7 @@ mod util;
 static RUNTIME_HPP: &str = include_str!("runtime.hpp");
 
 pub fn gen_bindings(
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config_path: &Option<PathBuf>,
     outs: &mut HashMap<String, String>,
 ) -> fmt::Result {
@@ -222,7 +222,7 @@ fn gen_includes<W: fmt::Write>(
     pre_struct: bool,
     behind_ref: bool,
     for_field: bool,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     seen_includes: &mut HashSet<String>,
     out: &mut W,
 ) -> fmt::Result {

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use diplomat_core::ast;
+use diplomat_core::Env;
 use indenter::indented;
 
 #[cfg(test)]

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -1,3 +1,4 @@
+use diplomat_core::Env;
 use std::fmt::Write;
 use std::{collections::HashMap, fmt};
 

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -14,7 +14,7 @@ pub fn gen_struct<W: fmt::Write>(
     custom_type: &ast::CustomType,
     in_path: &ast::Path,
     is_header: bool,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config: &LibraryConfig,
     out: &mut W,
 ) -> fmt::Result {
@@ -151,7 +151,7 @@ fn gen_method<W: fmt::Write>(
     is_header: bool,
     // should it convert writeables to string as an additional method?
     writeable_to_string: bool,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config: &LibraryConfig,
     out: &mut W,
 ) -> fmt::Result {
@@ -293,7 +293,7 @@ pub fn gen_method_interface<W: fmt::Write>(
     is_header: bool,
     has_writeable_param: bool,
     rearranged_writeable: bool,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config: &LibraryConfig,
     out: &mut W,
     writeable_to_string: bool,

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -1,6 +1,6 @@
 use diplomat_core::Env;
+use std::fmt;
 use std::fmt::Write;
-use std::{collections::HashMap, fmt};
 
 use diplomat_core::ast;
 use indenter::indented;

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use diplomat_core::Env;
 use std::collections::HashMap;
 
 use diplomat_core::ast;

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -9,7 +9,7 @@ pub fn gen_type<W: fmt::Write>(
     typ: &ast::TypeName,
     in_path: &ast::Path,
     behind_ref: Option<bool>, // owned?
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     library_config: &LibraryConfig,
     out: &mut W,
 ) -> fmt::Result {

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 use diplomat_core::Env;
-use std::collections::HashMap;
 
 use diplomat_core::ast;
 

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -1,3 +1,4 @@
+use diplomat_core::Env;
 use std::fmt::Write;
 use std::{collections::HashMap, fmt};
 

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -11,7 +11,7 @@ pub fn gen_value_js_to_rust(
     param_name: String,
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     pre_logic: &mut Vec<String>,
     invocation_params: &mut Vec<String>,
     post_logic: &mut Vec<String>,
@@ -97,7 +97,7 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
     value_expr: &dyn Fn(&mut dyn fmt::Write) -> fmt::Result,
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     match typ {
@@ -313,7 +313,7 @@ fn gen_box_destructor<W: fmt::Write>(
     name: &str,
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> Result<(), fmt::Error> {
     match typ {
@@ -353,7 +353,7 @@ fn gen_rust_reference_to_js<W: fmt::Write>(
     in_path: &ast::Path,
     value_expr: &dyn Fn(&mut dyn fmt::Write) -> fmt::Result,
     owner: &str,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     match underlying {

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -1,6 +1,6 @@
 use diplomat_core::Env;
+use std::fmt;
 use std::fmt::Write;
-use std::{collections::HashMap, fmt};
 
 use diplomat_core::ast::{self, PrimitiveType};
 use indenter::indented;

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -1,3 +1,4 @@
+use diplomat_core::Env;
 use std::fmt::Write;
 use std::{collections::HashMap, fmt};
 
@@ -7,10 +8,7 @@ use indenter::indented;
 use crate::docs_util::markdown_to_rst;
 
 /// Generate RST-formatted Sphinx docs for all FFI types. Currently assumes a JS target.
-pub fn gen_docs(
-    env: &Env,
-    outs: &mut HashMap<String, String>,
-) -> fmt::Result {
+pub fn gen_docs(env: &Env, outs: &mut HashMap<String, String>) -> fmt::Result {
     let index_out = outs
         .entry("index.rst".to_string())
         .or_insert_with(String::new);

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -20,17 +20,13 @@ pub fn gen_docs(env: &Env, outs: &mut HashMap<String, String>) -> fmt::Result {
     writeln!(&mut toctree_indent, ":maxdepth: 3")?;
     writeln!(&mut toctree_indent, ":caption: Modules:")?;
     writeln!(&mut toctree_indent)?;
-    let mut sorted_keys: Vec<String> = env
-        .iter_modules()
-        .filter(|(_, s)| {
-            s.items()
-                .any(|k| matches!(k, ast::ModSymbol::CustomType(_)))
-        })
-        .map(|(p, _)| p.elements.join("_"))
-        .collect();
-    sorted_keys.sort();
-    for in_path in sorted_keys {
-        writeln!(&mut toctree_indent, "{}", in_path)?;
+    for (in_path, module) in env.iter_modules() {
+        if module
+            .items()
+            .any(|k| matches!(k, ast::ModSymbol::CustomType(_)))
+        {
+            writeln!(&mut toctree_indent, "{}", in_path.elements.join("_"))?;
+        }
     }
     writeln!(index_out)?;
     writeln!(index_out, "Indices and tables")?;
@@ -55,9 +51,8 @@ pub fn gen_docs(env: &Env, outs: &mut HashMap<String, String>) -> fmt::Result {
             let mut sorted_symbols: Vec<&String> = module.names().collect();
             sorted_symbols.sort();
 
-            for symbol_name in sorted_symbols {
-                let custom_type = &module[symbol_name];
-                if let ast::ModSymbol::CustomType(ref typ) = custom_type {
+            for item in module.items() {
+                if let ast::ModSymbol::CustomType(ref typ) = item {
                     writeln!(out)?;
                     gen_custom_type_docs(out, typ, in_path, env)?;
                 }

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -8,7 +8,7 @@ use crate::docs_util::markdown_to_rst;
 
 /// Generate RST-formatted Sphinx docs for all FFI types. Currently assumes a JS target.
 pub fn gen_docs(
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     outs: &mut HashMap<String, String>,
 ) -> fmt::Result {
     let index_out = outs
@@ -74,7 +74,7 @@ pub fn gen_custom_type_docs<W: fmt::Write>(
     out: &mut W,
     typ: &ast::CustomType,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> fmt::Result {
     writeln!(out, ".. js:class:: {}", typ.name())?;
 
@@ -110,7 +110,7 @@ pub fn gen_method_docs<W: fmt::Write>(
     out: &mut W,
     method: &ast::Method,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> fmt::Result {
     let mut param_names: Vec<String> = method.params.iter().map(|p| p.name.clone()).collect();
     if method.is_writeable_out() {
@@ -167,7 +167,7 @@ pub fn gen_field_docs<W: fmt::Write>(
     out: &mut W,
     field: &(String, ast::TypeName, String),
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> fmt::Result {
     writeln!(out, ".. js:attribute:: {}", field.0)?;
 

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -21,9 +21,9 @@ pub fn gen_docs(env: &Env, outs: &mut HashMap<String, String>) -> fmt::Result {
     writeln!(&mut toctree_indent, ":caption: Modules:")?;
     writeln!(&mut toctree_indent)?;
     let mut sorted_keys: Vec<String> = env
-        .iter()
+        .iter_modules()
         .filter(|(_, s)| {
-            s.values()
+            s.items()
                 .any(|k| matches!(k, ast::ModSymbol::CustomType(_)))
         })
         .map(|(p, _)| p.elements.join("_"))
@@ -39,9 +39,9 @@ pub fn gen_docs(env: &Env, outs: &mut HashMap<String, String>) -> fmt::Result {
     writeln!(index_out, "* :ref:`genindex`")?;
     writeln!(index_out, "* :ref:`search`")?;
 
-    for (in_path, mod_symbols) in env.iter() {
-        if mod_symbols
-            .values()
+    for (in_path, module) in env.iter_modules() {
+        if module
+            .items()
             .any(|k| matches!(k, ast::ModSymbol::CustomType(_)))
         {
             let out = outs
@@ -52,12 +52,12 @@ pub fn gen_docs(env: &Env, outs: &mut HashMap<String, String>) -> fmt::Result {
             writeln!(out, "{}", title)?;
             writeln!(out, "{}", "=".repeat(title.len()))?;
 
-            let mut sorted_symbols: Vec<&String> = mod_symbols.keys().collect();
+            let mut sorted_symbols: Vec<&String> = module.names().collect();
             sorted_symbols.sort();
 
             for symbol_name in sorted_symbols {
-                let custom_type = &mod_symbols[symbol_name];
-                if let ast::ModSymbol::CustomType(typ) = custom_type {
+                let custom_type = &module[symbol_name];
+                if let ast::ModSymbol::CustomType(ref typ) = custom_type {
                     writeln!(out)?;
                     gen_custom_type_docs(out, typ, in_path, env)?;
                 }

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -2,7 +2,6 @@ use diplomat_core::Env;
 use std::fmt::Write;
 use std::{collections::HashMap, fmt};
 
-use diplomat_core::ast;
 use indenter::indented;
 
 use crate::util;

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -22,7 +22,7 @@ pub mod conversions;
 static RUNTIME_MJS: &str = include_str!("runtime.mjs");
 
 pub fn gen_bindings(
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     outs: &mut HashMap<String, String>,
 ) -> fmt::Result {
     let diplomat_runtime_out = outs

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -1,3 +1,4 @@
+use diplomat_core::Env;
 use std::fmt::Write;
 use std::{collections::HashMap, fmt};
 
@@ -21,10 +22,7 @@ pub mod conversions;
 
 static RUNTIME_MJS: &str = include_str!("runtime.mjs");
 
-pub fn gen_bindings(
-    env: &Env,
-    outs: &mut HashMap<String, String>,
-) -> fmt::Result {
+pub fn gen_bindings(env: &Env, outs: &mut HashMap<String, String>) -> fmt::Result {
     let diplomat_runtime_out = outs
         .entry("diplomat-runtime.mjs".to_string())
         .or_insert_with(String::new);

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -12,7 +12,7 @@ pub fn gen_struct<W: fmt::Write>(
     out: &mut W,
     custom_type: &ast::CustomType,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> fmt::Result {
     if let ast::CustomType::Enum(enm) = custom_type {
         writeln!(out, "const {}_js_to_rust = {{", enm.name)?;
@@ -77,7 +77,7 @@ fn gen_field<W: fmt::Write>(
     typ: &ast::TypeName,
     in_path: &ast::Path,
     offset: usize,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     writeln!(out, "get {}() {{", name)?;
@@ -98,7 +98,7 @@ fn gen_field<W: fmt::Write>(
 fn gen_method<W: fmt::Write>(
     method: &ast::Method,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
     out: &mut W,
 ) -> fmt::Result {
     let is_writeable = method.is_writeable_out();

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -1,3 +1,4 @@
+use diplomat_core::Env;
 use std::fmt::Write;
 use std::{collections::HashMap, fmt};
 

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -1,6 +1,6 @@
 use diplomat_core::Env;
+use std::fmt;
 use std::fmt::Write;
-use std::{collections::HashMap, fmt};
 
 use diplomat_core::ast;
 use indenter::indented;

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -1,5 +1,4 @@
 use diplomat_core::Env;
-use std::collections::HashMap;
 
 use diplomat_core::ast;
 

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -1,3 +1,4 @@
+use diplomat_core::Env;
 use std::collections::HashMap;
 
 use diplomat_core::ast;
@@ -18,11 +19,7 @@ pub enum ReturnTypeForm {
 /// in the WASM ABI.
 ///
 /// See https://github.com/WebAssembly/tool-conventions/blob/master/BasicCABI.md#function-signatures.
-pub fn return_type_form(
-    typ: &ast::TypeName,
-    in_path: &ast::Path,
-    env: &Env,
-) -> ReturnTypeForm {
+pub fn return_type_form(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> ReturnTypeForm {
     match typ {
         ast::TypeName::Named(_) => match typ.resolve(in_path, env) {
             ast::CustomType::Struct(strct) => {

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -21,7 +21,7 @@ pub enum ReturnTypeForm {
 pub fn return_type_form(
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> ReturnTypeForm {
     match typ {
         ast::TypeName::Named(_) => match typ.resolve(in_path, env) {

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -3,6 +3,7 @@ use std::alloc::Layout;
 use std::{cmp::max, collections::HashMap};
 
 use diplomat_core::ast::{self, PrimitiveType, TypeName};
+use diplomat_core::Env;
 
 // TODO(#58): support non-32-bit platforms
 use u32 as usize_target;
@@ -65,11 +66,7 @@ pub fn result_ok_offset_size_align(
     (offsets[1], size_max_align)
 }
 
-pub fn type_size_alignment(
-    typ: &ast::TypeName,
-    in_path: &ast::Path,
-    env: &Env,
-) -> Layout {
+pub fn type_size_alignment(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> Layout {
     match typ {
         // TODO(#58): support non-32-bit platforms
         // Actual:

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -10,7 +10,7 @@ use u32 as usize_target;
 pub fn struct_offsets_size_max_align(
     strct: &ast::Struct,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> (Vec<usize>, Layout) {
     let mut max_align = 0;
     let mut next_offset = 0;
@@ -37,7 +37,7 @@ pub fn result_ok_offset_size_align(
     ok: &TypeName,
     err: &TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> (usize, Layout) {
     let ok_size_align = type_size_alignment(ok, in_path, env);
     let err_size_align = type_size_alignment(err, in_path, env);
@@ -68,7 +68,7 @@ pub fn result_ok_offset_size_align(
 pub fn type_size_alignment(
     typ: &ast::TypeName,
     in_path: &ast::Path,
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> Layout {
     match typ {
         // TODO(#58): support non-32-bit platforms

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -1,6 +1,6 @@
 use core::panic;
 use std::alloc::Layout;
-use std::{cmp::max, collections::HashMap};
+use std::cmp::max;
 
 use diplomat_core::ast::{self, PrimitiveType, TypeName};
 use diplomat_core::Env;

--- a/tool/src/util.rs
+++ b/tool/src/util.rs
@@ -1,15 +1,14 @@
 use diplomat_core::Env;
-use std::collections::HashMap;
 
 use diplomat_core::ast;
 
 pub fn get_all_custom_types(env: &Env) -> Vec<(&ast::Path, &ast::CustomType)> {
     let mut all_types: Vec<(&ast::Path, &ast::CustomType)> = vec![];
 
-    for (path, name, symbol) in env.iter_items() {
-            if let ast::ModSymbol::CustomType(c) = symbol {
-                all_types.push((path, c));
-            }
+    for (path, _name, symbol) in env.iter_items() {
+        if let ast::ModSymbol::CustomType(c) = symbol {
+            all_types.push((path, c));
+        }
     }
 
     all_types

--- a/tool/src/util.rs
+++ b/tool/src/util.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use diplomat_core::ast;
 
 pub fn get_all_custom_types(
-    env: &HashMap<ast::Path, HashMap<String, ast::ModSymbol>>,
+    env: &Env,
 ) -> Vec<(&ast::Path, &ast::CustomType)> {
     let mut all_types: Vec<(&ast::Path, &ast::CustomType)> = vec![];
 

--- a/tool/src/util.rs
+++ b/tool/src/util.rs
@@ -1,10 +1,9 @@
+use diplomat_core::Env;
 use std::collections::HashMap;
 
 use diplomat_core::ast;
 
-pub fn get_all_custom_types(
-    env: &Env,
-) -> Vec<(&ast::Path, &ast::CustomType)> {
+pub fn get_all_custom_types(env: &Env) -> Vec<(&ast::Path, &ast::CustomType)> {
     let mut all_types: Vec<(&ast::Path, &ast::CustomType)> = vec![];
 
     for (path, mod_symbols) in env {

--- a/tool/src/util.rs
+++ b/tool/src/util.rs
@@ -6,12 +6,10 @@ use diplomat_core::ast;
 pub fn get_all_custom_types(env: &Env) -> Vec<(&ast::Path, &ast::CustomType)> {
     let mut all_types: Vec<(&ast::Path, &ast::CustomType)> = vec![];
 
-    for (path, mod_symbols) in env {
-        for symbol in mod_symbols.values() {
+    for (path, name, symbol) in env.iter_items() {
             if let ast::ModSymbol::CustomType(c) = symbol {
                 all_types.push((path, c));
             }
-        }
     }
 
     all_types


### PR DESCRIPTION
Some of our tests rely on iteration order and that gets flaky with hashmaps.

This gives us a stable iteration order

This PR is built on top of https://github.com/rust-diplomat/diplomat/pull/113 to reduce churn.