### PR TITLE
Parse lifetimes in diplomat

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use syn::*;
 
 use super::utils::get_doc_lines;
-use super::{Path, TypeName, ValidityError};
+use super::{Lifetime, Path, TypeName, ValidityError};
 use crate::Env;
 
 /// A method declared in the `impl` associated with an FFI struct.
@@ -56,6 +56,7 @@ impl Method {
                     TypeName::Reference(
                         Box::new(TypeName::Named(self_path.clone())),
                         rec.mutability.is_some(),
+                        Lifetime::Named,
                     )
                 } else {
                     TypeName::Named(self_path.clone())
@@ -138,7 +139,10 @@ pub struct Param {
 impl Param {
     /// Check if this parameter is a Writeable
     pub fn is_writeable(&self) -> bool {
-        self.ty == TypeName::Reference(Box::new(TypeName::Writeable), true)
+        match self.ty {
+            TypeName::Reference(ref w, true, _lt) => **w == TypeName::Writeable,
+            _ => false,
+        }
     }
 }
 

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -15,7 +15,7 @@ mod enums;
 pub use enums::Enum;
 
 mod types;
-pub use types::{CustomType, ModSymbol, PrimitiveType, TypeName};
+pub use types::{CustomType, Lifetime, ModSymbol, PrimitiveType, TypeName};
 
 mod paths;
 pub use paths::Path;

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                                  fn\n                                  foo(& mut self, x : u64, y : MyCustomStruct)\n                                  -> u64 { x }\n                              }).unwrap(),\n                 &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
+expression: "Method::from_syn(&syn::parse_quote! {\n                      fn foo(& mut self, x : u64, y : MyCustomStruct) -> u64\n                      { x }\n                  },\n                 &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
 
 ---
 name: foo
@@ -14,6 +14,7 @@ self_param:
           elements:
             - MyStructContainingMethod
       - true
+      - Named
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                                  fn foo(& self, x : u64, y : MyCustomStruct)\n                                  { }\n                              }).unwrap(),\n                 &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
+expression: "Method::from_syn(&syn::parse_quote! {\n                      fn foo(& self, x : u64, y : MyCustomStruct) {}\n                  },\n                 &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
 
 ---
 name: foo
@@ -14,6 +14,7 @@ self_param:
           elements:
             - MyStructContainingMethod
       - false
+      - Named
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/modules.rs
-expression: "Module::from_syn(&syn::parse_quote! {\n                                  mod ffi\n                                  {\n                                      struct NonOpaqueStruct\n                                      { a : i32, b : Box < NonOpaqueStruct > }\n                                      impl NonOpaqueStruct\n                                      {\n                                          fn new(x : i32) -> NonOpaqueStruct\n                                          { unimplemented ! () ; } fn\n                                          set_a(& mut self, new_a : i32)\n                                          { self . a = new_a ; }\n                                      } #[diplomat :: opaque] struct\n                                      OpaqueStruct { a : SomeExternalType }\n                                      impl OpaqueStruct\n                                      {\n                                          fn new() -> Box < OpaqueStruct >\n                                          { unimplemented ! () ; } fn\n                                          get_string(& self) -> String\n                                          { unimplemented ! () }\n                                      }\n                                  }\n                              }).unwrap(), true)"
+expression: "Module::from_syn(&syn::parse_quote! {\n                      mod ffi\n                      {\n                          struct NonOpaqueStruct\n                          { a : i32, b : Box < NonOpaqueStruct > } impl\n                          NonOpaqueStruct\n                          {\n                              pub fn new(x : i32) -> NonOpaqueStruct\n                              { unimplemented! () ; } pub fn\n                              set_a(& mut self, new_a : i32)\n                              { self.a = new_a ; }\n                          } #[diplomat :: opaque] struct OpaqueStruct\n                          { a : SomeExternalType } impl OpaqueStruct\n                          {\n                              pub fn new() -> Box < OpaqueStruct >\n                              { unimplemented! () ; } pub fn\n                              get_string(& self) -> String\n                              { unimplemented! () }\n                          }\n                      }\n                  }, true)"
 
 ---
 name: ffi
@@ -44,6 +44,7 @@ declared_types:
                     elements:
                       - NonOpaqueStruct
                 - true
+                - Named
           params:
             - name: new_a
               ty:
@@ -75,6 +76,7 @@ declared_types:
                     elements:
                       - OpaqueStruct
                 - false
+                - Named
           params: []
           return_type:
             Named:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { & mut MyLocalStruct }).unwrap())"
+expression: "TypeName::from(&syn::parse_quote! { & mut MyLocalStruct })"
 
 ---
 Reference:
@@ -8,4 +8,5 @@ Reference:
       elements:
         - MyLocalStruct
   - true
+  - Named
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references.snap
@@ -1,9 +1,10 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { & i32 }).unwrap())"
+expression: "TypeName::from(&syn::parse_quote! { & i32 })"
 
 ---
 Reference:
   - Primitive: i32
   - false
+  - Named
 

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -270,7 +270,7 @@ pub fn gen_includes<W: fmt::Write>(
                 out,
             )?;
         }
-        ast::TypeName::Reference(underlying, _) => {
+        ast::TypeName::Reference(underlying, _, _lt) => {
             gen_includes(
                 underlying,
                 in_path,

--- a/tool/src/c/results.rs
+++ b/tool/src/c/results.rs
@@ -19,7 +19,7 @@ pub fn collect_results<'a>(
         ast::TypeName::Box(underlying) => {
             collect_results(underlying, in_path, env, seen, results);
         }
-        ast::TypeName::Reference(underlying, _) => {
+        ast::TypeName::Reference(underlying, _, _lt) => {
             collect_results(underlying, in_path, env, seen, results);
         }
         ast::TypeName::Primitive(_) => {}

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -25,7 +25,7 @@ pub fn gen_type<W: fmt::Write>(
             write!(out, "*")?;
         }
 
-        ast::TypeName::Reference(underlying, mutable) => {
+        ast::TypeName::Reference(underlying, mutable, _lt) => {
             if !mutable {
                 write!(out, "const ")?;
             }
@@ -66,7 +66,7 @@ pub fn name_for_type(typ: &ast::TypeName) -> String {
     match typ {
         ast::TypeName::Named(name) => name.elements.last().unwrap().clone(),
         ast::TypeName::Box(underlying) => format!("box_{}", name_for_type(underlying)),
-        ast::TypeName::Reference(underlying, mutable) => {
+        ast::TypeName::Reference(underlying, mutable, _lt) => {
             if *mutable {
                 return format!("ref_mut_{}", name_for_type(underlying));
             } else {

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -173,7 +173,7 @@ pub fn gen_rust_to_cpp<W: Write>(
         }
 
         ast::TypeName::Primitive(_) => cpp.to_string(),
-        ast::TypeName::Reference(_, _) => {
+        ast::TypeName::Reference(_, _, _) => {
             todo!("Returning references from Rust to C++ is not currently supported")
         }
         ast::TypeName::Writeable => panic!("Returning writeables is not supported"),
@@ -208,7 +208,7 @@ pub fn gen_cpp_to_rust<W: Write>(
     out: &mut W,
 ) -> String {
     match typ {
-        ast::TypeName::Reference(underlying, mutability) => gen_cpp_to_rust(
+        ast::TypeName::Reference(underlying, mutability, _lt) => gen_cpp_to_rust(
             cpp,
             path,
             Some(ReferenceMeta {

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -284,7 +284,7 @@ fn gen_includes<W: fmt::Write>(
                 out,
             )?;
         }
-        ast::TypeName::Reference(underlying, _) => {
+        ast::TypeName::Reference(underlying, _mut, _lt) => {
             gen_includes(
                 underlying,
                 in_path,

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -313,7 +313,7 @@ pub fn gen_method_interface<W: fmt::Write>(
 
     let mut is_const = false;
     if let Some(ref param) = method.self_param {
-        if let ast::TypeName::Reference(_, mutable) = param.ty {
+        if let ast::TypeName::Reference(_, mutable, _lt) = param.ty {
             is_const = !mutable;
         }
     } else if is_header {

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -62,7 +62,7 @@ fn gen_type_inner<W: fmt::Write>(
             )?;
         }
 
-        ast::TypeName::Reference(underlying, mutable) => {
+        ast::TypeName::Reference(underlying, mutable, _lt) => {
             if !mutable {
                 write!(out, "const ")?;
             }

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -65,7 +65,7 @@ pub fn gen_value_js_to_rust(
         ast::TypeName::Box(_) => {
             invocation_params.push(format!("{}.underlying", param_name));
         }
-        ast::TypeName::Reference(_, _) => {
+        ast::TypeName::Reference(_, _mut, _lt) => {
             invocation_params.push(format!("{}.underlying", param_name));
         }
         ast::TypeName::Named(_) => match typ.resolve(in_path, env) {
@@ -332,7 +332,7 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
             write!(out, "{}", value_expr)?;
         }
 
-        ast::TypeName::Reference(underlying, _mutability) => {
+        ast::TypeName::Reference(underlying, _mutability, _lt) => {
             // TODO(#12): pass in lifetime of the reference
             gen_rust_reference_to_js(underlying.as_ref(), in_path, value_expr, "null", env, out)?;
         }
@@ -431,7 +431,7 @@ fn gen_rust_reference_to_js<W: fmt::Write>(
             )?;
         }
 
-        ast::TypeName::Reference(typ, _) => {
+        ast::TypeName::Reference(typ, _mut, _lt) => {
             gen_rust_reference_to_js(
                 typ.as_ref(),
                 in_path,

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -86,7 +86,7 @@ fn gen_field<W: fmt::Write>(
     write!(&mut method_body_out, "return ")?;
     gen_value_rust_to_js(
         &format!("this.underlying + {}", offset),
-        &ast::TypeName::Reference(Box::new(typ.clone()), true),
+        &ast::TypeName::Reference(Box::new(typ.clone()), true, ast::Lifetime::Named),
         in_path,
         env,
         &mut method_body_out,

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -67,7 +67,7 @@ pub fn return_type_form(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> 
 
         ast::TypeName::Box(_) => ReturnTypeForm::Scalar,
 
-        ast::TypeName::Reference(_, _) => ReturnTypeForm::Scalar,
+        ast::TypeName::Reference(_, _mut, _lt) => ReturnTypeForm::Scalar,
 
         ast::TypeName::StrReference => ReturnTypeForm::Scalar,
 

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -74,7 +74,7 @@ pub fn type_size_alignment(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) 
         // ast::TypeName::Reference(_, _) => Layout::new::<&()>(),
         // Temporary:
         ast::TypeName::Box(_) => Layout::new::<usize_target>(),
-        ast::TypeName::Reference(_, _) => Layout::new::<usize_target>(),
+        ast::TypeName::Reference(_, _mut, _lt) => Layout::new::<usize_target>(),
         ast::TypeName::Option(underlying) => match underlying.as_ref() {
             ast::TypeName::Box(_) | ast::TypeName::Reference(..) => {
                 type_size_alignment(underlying, in_path, env)


### PR DESCRIPTION
This is a small step towards https://github.com/rust-diplomat/diplomat/issues/12, preparing the ground.

I was hoping to land support for returning static lifetimes here, however right now C++ needs a bit more work to support this, and there's design work to be done.