### PR TITLE
Don't pull in uchar.h in C++ mode

### DIFF
--- a/example/c/ICU4XDataProvider.h
+++ b/example/c/ICU4XDataProvider.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XDataProvider_H
 #define ICU4XDataProvider_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/c/ICU4XFixedDecimal.h
+++ b/example/c/ICU4XFixedDecimal.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimal_H
 #define ICU4XFixedDecimal_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/c/ICU4XFixedDecimalFormat.h
+++ b/example/c/ICU4XFixedDecimalFormat.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalFormat_H
 #define ICU4XFixedDecimalFormat_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/c/ICU4XFixedDecimalFormatOptions.h
+++ b/example/c/ICU4XFixedDecimalFormatOptions.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalFormatOptions_H
 #define ICU4XFixedDecimalFormatOptions_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/c/ICU4XFixedDecimalFormatResult.h
+++ b/example/c/ICU4XFixedDecimalFormatResult.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalFormatResult_H
 #define ICU4XFixedDecimalFormatResult_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/c/ICU4XFixedDecimalGroupingStrategy.h
+++ b/example/c/ICU4XFixedDecimalGroupingStrategy.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalGroupingStrategy_H
 #define ICU4XFixedDecimalGroupingStrategy_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/c/ICU4XFixedDecimalSignDisplay.h
+++ b/example/c/ICU4XFixedDecimalSignDisplay.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalSignDisplay_H
 #define ICU4XFixedDecimalSignDisplay_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/c/ICU4XLocale.h
+++ b/example/c/ICU4XLocale.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XLocale_H
 #define ICU4XLocale_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/c/diplomat_runtime.h
+++ b/example/c/diplomat_runtime.h
@@ -5,6 +5,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+// uchar.h doesn't always exist, but char32_t is always available
+// in C++ anyway
+#ifndef __cplusplus
+#include<uchar.h>
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/example/cpp/include/ICU4XDataProvider.h
+++ b/example/cpp/include/ICU4XDataProvider.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XDataProvider_H
 #define ICU4XDataProvider_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/cpp/include/ICU4XFixedDecimal.h
+++ b/example/cpp/include/ICU4XFixedDecimal.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimal_H
 #define ICU4XFixedDecimal_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/cpp/include/ICU4XFixedDecimalFormat.h
+++ b/example/cpp/include/ICU4XFixedDecimalFormat.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalFormat_H
 #define ICU4XFixedDecimalFormat_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/cpp/include/ICU4XFixedDecimalFormatOptions.h
+++ b/example/cpp/include/ICU4XFixedDecimalFormatOptions.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalFormatOptions_H
 #define ICU4XFixedDecimalFormatOptions_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/cpp/include/ICU4XFixedDecimalFormatResult.h
+++ b/example/cpp/include/ICU4XFixedDecimalFormatResult.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalFormatResult_H
 #define ICU4XFixedDecimalFormatResult_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/cpp/include/ICU4XFixedDecimalGroupingStrategy.h
+++ b/example/cpp/include/ICU4XFixedDecimalGroupingStrategy.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalGroupingStrategy_H
 #define ICU4XFixedDecimalGroupingStrategy_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/cpp/include/ICU4XFixedDecimalSignDisplay.h
+++ b/example/cpp/include/ICU4XFixedDecimalSignDisplay.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XFixedDecimalSignDisplay_H
 #define ICU4XFixedDecimalSignDisplay_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/cpp/include/ICU4XLocale.h
+++ b/example/cpp/include/ICU4XLocale.h
@@ -1,7 +1,6 @@
 #ifndef ICU4XLocale_H
 #define ICU4XLocale_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/example/cpp/include/diplomat_runtime.h
+++ b/example/cpp/include/diplomat_runtime.h
@@ -5,6 +5,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+// uchar.h doesn't always exist, but char32_t is always available
+// in C++ anyway
+#ifndef __cplusplus
+#include<uchar.h>
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/feature_tests/c/ErrorEnum.h
+++ b/feature_tests/c/ErrorEnum.h
@@ -1,7 +1,6 @@
 #ifndef ErrorEnum_H
 #define ErrorEnum_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/c/ErrorStruct.h
+++ b/feature_tests/c/ErrorStruct.h
@@ -1,7 +1,6 @@
 #ifndef ErrorStruct_H
 #define ErrorStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/c/MyStruct.h
+++ b/feature_tests/c/MyStruct.h
@@ -1,7 +1,6 @@
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/c/Opaque.h
+++ b/feature_tests/c/Opaque.h
@@ -1,7 +1,6 @@
 #ifndef Opaque_H
 #define Opaque_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/c/OptionOpaque.h
+++ b/feature_tests/c/OptionOpaque.h
@@ -1,7 +1,6 @@
 #ifndef OptionOpaque_H
 #define OptionOpaque_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/c/OptionOpaqueChar.h
+++ b/feature_tests/c/OptionOpaqueChar.h
@@ -1,7 +1,6 @@
 #ifndef OptionOpaqueChar_H
 #define OptionOpaqueChar_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/c/OptionStruct.h
+++ b/feature_tests/c/OptionStruct.h
@@ -1,7 +1,6 @@
 #ifndef OptionStruct_H
 #define OptionStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/c/ResultOpaque.h
+++ b/feature_tests/c/ResultOpaque.h
@@ -1,7 +1,6 @@
 #ifndef ResultOpaque_H
 #define ResultOpaque_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/c/diplomat_runtime.h
+++ b/feature_tests/c/diplomat_runtime.h
@@ -5,6 +5,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+// uchar.h doesn't always exist, but char32_t is always available
+// in C++ anyway
+#ifndef __cplusplus
+#include<uchar.h>
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/feature_tests/cpp/include/ErrorEnum.h
+++ b/feature_tests/cpp/include/ErrorEnum.h
@@ -1,7 +1,6 @@
 #ifndef ErrorEnum_H
 #define ErrorEnum_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/cpp/include/ErrorStruct.h
+++ b/feature_tests/cpp/include/ErrorStruct.h
@@ -1,7 +1,6 @@
 #ifndef ErrorStruct_H
 #define ErrorStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/cpp/include/MyStruct.h
+++ b/feature_tests/cpp/include/MyStruct.h
@@ -1,7 +1,6 @@
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/cpp/include/Opaque.h
+++ b/feature_tests/cpp/include/Opaque.h
@@ -1,7 +1,6 @@
 #ifndef Opaque_H
 #define Opaque_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/cpp/include/OptionOpaque.h
+++ b/feature_tests/cpp/include/OptionOpaque.h
@@ -1,7 +1,6 @@
 #ifndef OptionOpaque_H
 #define OptionOpaque_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/cpp/include/OptionOpaqueChar.h
+++ b/feature_tests/cpp/include/OptionOpaqueChar.h
@@ -1,7 +1,6 @@
 #ifndef OptionOpaqueChar_H
 #define OptionOpaqueChar_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/cpp/include/OptionStruct.h
+++ b/feature_tests/cpp/include/OptionStruct.h
@@ -1,7 +1,6 @@
 #ifndef OptionStruct_H
 #define OptionStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/cpp/include/ResultOpaque.h
+++ b/feature_tests/cpp/include/ResultOpaque.h
@@ -1,7 +1,6 @@
 #ifndef ResultOpaque_H
 #define ResultOpaque_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/feature_tests/cpp/include/diplomat_runtime.h
+++ b/feature_tests/cpp/include/diplomat_runtime.h
@@ -5,6 +5,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+// uchar.h doesn't always exist, but char32_t is always available
+// in C++ anyway
+#ifndef __cplusplus
+#include<uchar.h>
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -59,7 +59,6 @@ fn gen_struct_header<'a>(
     writeln!(out, "#ifndef {}_H", typ.name())?;
     writeln!(out, "#define {}_H", typ.name())?;
     writeln!(out, "#include <stdio.h>")?;
-    writeln!(out, "#include <uchar.h>")?;
     writeln!(out, "#include <stdint.h>")?;
     writeln!(out, "#include <stddef.h>")?;
     writeln!(out, "#include <stdbool.h>")?;

--- a/tool/src/c/runtime.h
+++ b/tool/src/c/runtime.h
@@ -5,6 +5,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+// uchar.h doesn't always exist, but char32_t is always available
+// in C++ anyway
+#ifndef __cplusplus
+#include<uchar.h>
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tool/src/c/snapshots/diplomat_tool__c__structs__tests__method_taking_slice@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__structs__tests__method_taking_slice@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__structs__tests__method_taking_str@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__structs__tests__method_taking_str@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__structs__tests__simple_non_opaque_struct@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__structs__tests__simple_non_opaque_struct@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__structs__tests__simple_opaque_struct@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__structs__tests__simple_opaque_struct@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Bar.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Bar.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef Bar_H
 #define Bar_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Foo.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Foo.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef Foo_H
 #define Foo_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__option_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__option_types@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__pointer_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__pointer_types@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__result_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__result_types@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__unit_type@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__unit_type@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__writeable_out@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__writeable_out@MyStruct.h.snap
@@ -6,7 +6,6 @@ expression: out_texts.get(out).unwrap()
 #ifndef MyStruct_H
 #define MyStruct_H
 #include <stdio.h>
-#include <uchar.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>


### PR DESCRIPTION
uchar.h is part of the C standard, but some toolchains seem to not include it (like MacOS). However, char32_t exists in C++ anyway so this is only a problem for C build systems. This can be fixed by finding a header and pulling it in, but it's better if C++ doesn't have to care about this.