### PR TITLE
Support mutable primitive types slices parameters

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -6,12 +6,16 @@ use diplomat_core::ast;
 
 fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) {
     match &param.ty {
-        ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_) => {
-            let data_type = if let ast::TypeName::PrimitiveSlice(ref prim) = param.ty {
-                ast::TypeName::Primitive(*prim).to_syn().to_token_stream()
-            } else {
-                quote! { u8 }
-            };
+        ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_, _) => {
+            let (data_type, mutable_slice) =
+                if let ast::TypeName::PrimitiveSlice(prim, mutable) = &param.ty {
+                    (
+                        ast::TypeName::Primitive(*prim).to_syn().to_token_stream(),
+                        *mutable,
+                    )
+                } else {
+                    (quote! { u8 }, false)
+                };
             expanded_params.push(FnArg::Typed(PatType {
                 attrs: vec![],
                 pat: Box::new(Pat::Ident(PatIdent {
@@ -25,12 +29,21 @@ fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) 
                     subpat: None,
                 })),
                 colon_token: syn::token::Colon(Span::call_site()),
-                ty: Box::new(
-                    parse2(quote! {
-                        *const #data_type
-                    })
-                    .unwrap(),
-                ),
+                ty: if mutable_slice {
+                    Box::new(
+                        parse2(quote! {
+                            *mut #data_type
+                        })
+                        .unwrap(),
+                    )
+                } else {
+                    Box::new(
+                        parse2(quote! {
+                            *const #data_type
+                        })
+                        .unwrap(),
+                    )
+                },
             }));
 
             expanded_params.push(FnArg::Typed(PatType {
@@ -73,7 +86,7 @@ fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) 
 
 fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
     match &param.ty {
-        ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_) => {
+        ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_, _) => {
             let data_ident = Ident::new(
                 (param.name.clone() + "_diplomat_data").as_str(),
                 Span::call_site(),
@@ -83,17 +96,25 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
                 Span::call_site(),
             );
 
-            let tokens = if param.ty == ast::TypeName::StrReference {
+            let tokens = if let ast::TypeName::PrimitiveSlice(_, mutable) = &param.ty {
+                if *mutable {
+                    quote! {
+                        unsafe {
+                            core::slice::from_raw_parts_mut(#data_ident, #len_ident)
+                        }
+                    }
+                } else {
+                    quote! {
+                        unsafe {
+                            core::slice::from_raw_parts(#data_ident, #len_ident)
+                        }
+                    }
+                }
+            } else {
                 // TODO(#57): don't just unwrap? or should we assume that the other side gives us a good value?
                 quote! {
                     unsafe {
                         core::str::from_utf8(core::slice::from_raw_parts(#data_ident, #len_ident)).unwrap()
-                    }
-                }
-            } else {
-                quote! {
-                    unsafe {
-                        core::slice::from_raw_parts(#data_ident, #len_ident)
                     }
                 }
             };
@@ -322,6 +343,25 @@ mod tests {
 
                     impl Foo {
                         pub fn from_slice(s: &[f64]) {
+                            unimplemented!()
+                        }
+                    }
+                }
+            })
+            .to_token_stream()
+            .to_string()
+        ));
+    }
+
+    #[test]
+    fn method_taking_mutable_slice() {
+        insta::assert_display_snapshot!(rustfmt_code(
+            &gen_bridge(parse_quote! {
+                mod ffi {
+                    struct Foo {}
+
+                    impl Foo {
+                        pub fn fill_slice(s: &mut [f64]) {
                             unimplemented!()
                         }
                     }

--- a/macro/src/snapshots/diplomat__tests__method_taking_mutable_slice.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_mutable_slice.snap
@@ -1,0 +1,23 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                             mod ffi\n                             {\n                                 struct Foo { } impl Foo\n                                 {\n                                     pub fn fill_slice(s : & mut [f64])\n                                     { unimplemented! () }\n                                 }\n                             }\n                         }).to_token_stream().to_string())"
+
+---
+mod ffi {
+    #[repr(C)]
+    struct Foo {}
+    impl Foo {
+        pub fn fill_slice(s: &mut [f64]) {
+            unimplemented!()
+        }
+    }
+    #[no_mangle]
+    extern "C" fn Foo_fill_slice(s_diplomat_data: *mut f64, s_diplomat_len: usize) {
+        Foo::fill_slice(unsafe {
+            core::slice::from_raw_parts_mut(s_diplomat_data, s_diplomat_len)
+        });
+    }
+    #[no_mangle]
+    extern "C" fn Foo_destroy(this: Box<Foo>) {}
+}
+

--- a/macro/src/snapshots/diplomat__tests__method_taking_mutable_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_mutable_str.snap
@@ -1,0 +1,27 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                             mod ffi\n                             {\n                                 struct Foo { } impl Foo\n                                 {\n                                     pub fn make_uppercase(s : & mut str)\n                                     { unimplemented! () }\n                                 }\n                             }\n                         }).to_token_stream().to_string())"
+
+---
+mod ffi {
+    #[repr(C)]
+    struct Foo {}
+    impl Foo {
+        pub fn make_uppercase(s: &mut str) {
+            unimplemented!()
+        }
+    }
+    #[no_mangle]
+    extern "C" fn Foo_make_uppercase(s_diplomat_data: *mut u8, s_diplomat_len: usize) {
+        Foo::make_uppercase(unsafe {
+            core::str::from_utf8_mut(core::slice::from_raw_parts_mut(
+                s_diplomat_data,
+                s_diplomat_len,
+            ))
+            .unwrap()
+        });
+    }
+    #[no_mangle]
+    extern "C" fn Foo_destroy(this: Box<Foo>) {}
+}
+

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -302,7 +302,7 @@ pub fn gen_includes<W: fmt::Write>(
         }
         ast::TypeName::Writeable => {}
         ast::TypeName::StrReference => {}
-        ast::TypeName::PrimitiveSlice(_) => {}
+        ast::TypeName::PrimitiveSlice(..) => {}
         ast::TypeName::Unit => {}
     }
 

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -301,7 +301,7 @@ pub fn gen_includes<W: fmt::Write>(
             }
         }
         ast::TypeName::Writeable => {}
-        ast::TypeName::StrReference => {}
+        ast::TypeName::StrReference(..) => {}
         ast::TypeName::PrimitiveSlice(..) => {}
         ast::TypeName::Unit => {}
     }

--- a/tool/src/c/results.rs
+++ b/tool/src/c/results.rs
@@ -36,7 +36,7 @@ pub fn collect_results<'a>(
             }
         }
         ast::TypeName::Writeable => {}
-        ast::TypeName::StrReference => {}
+        ast::TypeName::StrReference(..) => {}
         ast::TypeName::PrimitiveSlice(..) => {}
         ast::TypeName::Unit => {}
     }

--- a/tool/src/c/results.rs
+++ b/tool/src/c/results.rs
@@ -37,7 +37,7 @@ pub fn collect_results<'a>(
         }
         ast::TypeName::Writeable => {}
         ast::TypeName::StrReference => {}
-        ast::TypeName::PrimitiveSlice(_) => {}
+        ast::TypeName::PrimitiveSlice(..) => {}
         ast::TypeName::Unit => {}
     }
 }

--- a/tool/src/c/snapshots/diplomat_tool__c__structs__tests__method_taking_slice@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__structs__tests__method_taking_slice@MyStruct.h.snap
@@ -19,6 +19,8 @@ typedef struct MyStruct MyStruct;
 
 MyStruct* MyStruct_new_slice(const double* v_data, size_t v_len);
 
+void MyStruct_fill_slice(double* v_data, size_t v_len);
+
 void MyStruct_set_slice(MyStruct* self, const double* new_slice_data, size_t new_slice_len);
 void MyStruct_destroy(MyStruct* self);
 

--- a/tool/src/c/snapshots/diplomat_tool__c__structs__tests__method_taking_str@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__structs__tests__method_taking_str@MyStruct.h.snap
@@ -20,6 +20,8 @@ typedef struct MyStruct MyStruct;
 MyStruct* MyStruct_new_str(const char* v_data, size_t v_len);
 
 void MyStruct_set_str(MyStruct* self, const char* new_str_data, size_t new_str_len);
+
+void MyStruct_make_uppercase(MyStruct* self, char* some_str_data, size_t some_str_len);
 void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -82,10 +82,11 @@ pub fn gen_method<W: fmt::Write>(
                 "const char* {}_data, size_t {}_len",
                 param.name, param.name
             )?;
-        } else if let ast::TypeName::PrimitiveSlice(ref prim) = param.ty {
+        } else if let ast::TypeName::PrimitiveSlice(ref prim, mutable) = param.ty {
             write!(
                 out,
-                "const {}* {}_data, size_t {}_len",
+                "{}{}* {}_data, size_t {}_len",
+                if mutable { "" } else { "const " },
                 c_type_for_prim(prim),
                 param.name,
                 param.name
@@ -186,6 +187,10 @@ mod tests {
 
                 impl MyStruct {
                     pub fn new_slice(v: &[f64]) -> Box<MyStruct> {
+                        unimplemented!()
+                    }
+
+                    pub fn fill_slice(v: &mut [f64]) {
                         unimplemented!()
                     }
 

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -76,20 +76,20 @@ pub fn gen_method<W: fmt::Write>(
             write!(out, ", ")?;
         }
 
-        if param.ty == ast::TypeName::StrReference {
+        if let ast::TypeName::StrReference(mutable) = param.ty {
             write!(
                 out,
-                "const char* {}_data, size_t {}_len",
-                param.name, param.name
+                "{0}char* {1}_data, size_t {1}_len",
+                if mutable { "" } else { "const " },
+                param.name
             )?;
         } else if let ast::TypeName::PrimitiveSlice(ref prim, mutable) = param.ty {
             write!(
                 out,
-                "{}{}* {}_data, size_t {}_len",
+                "{0}{1}* {2}_data, size_t {2}_len",
                 if mutable { "" } else { "const " },
                 c_type_for_prim(prim),
                 param.name,
-                param.name
             )?;
         } else {
             gen_type(&param.ty, in_path, env, out)?;
@@ -170,6 +170,10 @@ mod tests {
                     }
 
                     pub fn set_str(&mut self, new_str: &str) {
+                        unimplemented!()
+                    }
+
+                    pub fn make_uppercase(&mut self, some_str: &mut str) {
                         unimplemented!()
                     }
                 }

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -50,7 +50,7 @@ pub fn gen_type<W: fmt::Write>(
         }
 
         ast::TypeName::Writeable => write!(out, "DiplomatWriteable")?,
-        ast::TypeName::StrReference => unreachable!("Strings handled in structs.rs"),
+        ast::TypeName::StrReference(..) => unreachable!("Strings handled in structs.rs"),
         ast::TypeName::PrimitiveSlice(..) => unreachable!("Slices handled in structs.rs"),
         ast::TypeName::Unit => write!(out, "void")?,
     }
@@ -79,7 +79,8 @@ pub fn name_for_type(typ: &ast::TypeName) -> String {
             format!("result_{}_{}", name_for_type(ok), name_for_type(err))
         }
         ast::TypeName::Writeable => "writeable".to_string(),
-        ast::TypeName::StrReference => "str_ref".to_string(),
+        ast::TypeName::StrReference(true) => "str_mut_ref".to_string(),
+        ast::TypeName::StrReference(false) => "str_ref".to_string(),
         ast::TypeName::PrimitiveSlice(prim, true) => {
             format!("ref_mut_prim_slice_{}", c_type_for_prim(prim))
         }

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -51,7 +51,7 @@ pub fn gen_type<W: fmt::Write>(
 
         ast::TypeName::Writeable => write!(out, "DiplomatWriteable")?,
         ast::TypeName::StrReference => unreachable!("Strings handled in structs.rs"),
-        ast::TypeName::PrimitiveSlice(_) => unreachable!("Slices handled in structs.rs"),
+        ast::TypeName::PrimitiveSlice(..) => unreachable!("Slices handled in structs.rs"),
         ast::TypeName::Unit => write!(out, "void")?,
     }
 
@@ -80,7 +80,12 @@ pub fn name_for_type(typ: &ast::TypeName) -> String {
         }
         ast::TypeName::Writeable => "writeable".to_string(),
         ast::TypeName::StrReference => "str_ref".to_string(),
-        ast::TypeName::PrimitiveSlice(prim) => format!("ref_prim_slice_{}", c_type_for_prim(prim)),
+        ast::TypeName::PrimitiveSlice(prim, true) => {
+            format!("ref_mut_prim_slice_{}", c_type_for_prim(prim))
+        }
+        ast::TypeName::PrimitiveSlice(prim, false) => {
+            format!("ref_prim_slice_{}", c_type_for_prim(prim))
+        }
         ast::TypeName::Unit => "void".to_string(),
     }
 }

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -177,7 +177,7 @@ pub fn gen_rust_to_cpp<W: Write>(
             todo!("Returning references from Rust to C++ is not currently supported")
         }
         ast::TypeName::Writeable => panic!("Returning writeables is not supported"),
-        ast::TypeName::StrReference => {
+        ast::TypeName::StrReference(..) => {
             todo!("Returning &str from Rust to C++ is not currently supported")
         }
         ast::TypeName::PrimitiveSlice(..) => {

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -180,7 +180,7 @@ pub fn gen_rust_to_cpp<W: Write>(
         ast::TypeName::StrReference => {
             todo!("Returning &str from Rust to C++ is not currently supported")
         }
-        ast::TypeName::PrimitiveSlice(_) => {
+        ast::TypeName::PrimitiveSlice(..) => {
             todo!("Returning &[T] from Rust to C++ is not currently supported")
         }
         ast::TypeName::Unit => cpp.to_string(),

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -330,7 +330,7 @@ fn gen_includes<W: fmt::Write>(
         }
         ast::TypeName::Writeable => {}
         ast::TypeName::StrReference => {}
-        ast::TypeName::PrimitiveSlice(_) => {}
+        ast::TypeName::PrimitiveSlice(..) => {}
         ast::TypeName::Unit => {}
     }
 

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -329,7 +329,7 @@ fn gen_includes<W: fmt::Write>(
             )?;
         }
         ast::TypeName::Writeable => {}
-        ast::TypeName::StrReference => {}
+        ast::TypeName::StrReference(..) => {}
         ast::TypeName::PrimitiveSlice(..) => {}
         ast::TypeName::Unit => {}
     }

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__string_reference@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__string_reference@MyStruct.hpp.snap
@@ -31,12 +31,16 @@ struct MyStructDeleter {
 struct MyStruct {
  public:
   static MyStruct new_(const std::string_view v);
+  static void make_uppercase(std::string_view v);
 };
 
 
 inline MyStruct MyStruct::new_(const std::string_view v) {
   capi::MyStruct diplomat_raw_struct_out_value = capi::MyStruct_new(v.data(), v.size());
   return MyStruct{  };
+}
+inline void MyStruct::make_uppercase(std::string_view v) {
+  capi::MyStruct_make_uppercase(v.data(), v.size());
 }
 #endif
 

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -221,7 +221,7 @@ fn gen_method<W: fmt::Write>(
 
         for param in params_to_gen.iter() {
             match param.ty {
-                ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_) => {
+                ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_, _) => {
                     all_params_invocation.push(format!("{}.data()", param.name));
                     all_params_invocation.push(format!("{}.size()", param.name));
                 }

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -221,7 +221,7 @@ fn gen_method<W: fmt::Write>(
 
         for param in params_to_gen.iter() {
             match param.ty {
-                ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_, _) => {
+                ast::TypeName::StrReference(_) | ast::TypeName::PrimitiveSlice(_, _) => {
                     all_params_invocation.push(format!("{}.data()", param.name));
                     all_params_invocation.push(format!("{}.size()", param.name));
                 }

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -122,7 +122,16 @@ fn gen_type_inner<W: fmt::Write>(
             write!(out, "const {}", library_config.string_view.expr)?;
         }
 
-        ast::TypeName::PrimitiveSlice(prim) => {
+        ast::TypeName::PrimitiveSlice(prim, true) => {
+            write!(
+                out,
+                "{}<{}>",
+                library_config.span.expr,
+                crate::c::types::c_type_for_prim(prim)
+            )?;
+        }
+
+        ast::TypeName::PrimitiveSlice(prim, false) => {
             write!(
                 out,
                 "const {}<{}>",

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -118,7 +118,11 @@ fn gen_type_inner<W: fmt::Write>(
             write!(out, "capi::DiplomatWriteable")?;
         }
 
-        ast::TypeName::StrReference => {
+        ast::TypeName::StrReference(true) => {
+            write!(out, "{}", library_config.string_view.expr)?;
+        }
+
+        ast::TypeName::StrReference(false) => {
             write!(out, "const {}", library_config.string_view.expr)?;
         }
 
@@ -241,6 +245,10 @@ mod tests {
 
                 impl MyStruct {
                     pub fn new(v: &str) -> MyStruct {
+                        unimplemented!()
+                    }
+
+                    pub fn make_uppercase(v: &mut str) {
                         unimplemented!()
                     }
                 }

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -18,7 +18,7 @@ pub fn gen_value_js_to_rust(
     post_logic: &mut Vec<String>,
 ) {
     match typ {
-        ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_) => {
+        ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_, _) => {
             // TODO(#61): consider extracting into runtime function
             if *typ == ast::TypeName::StrReference {
                 pre_logic.push(format!(
@@ -31,7 +31,7 @@ pub fn gen_value_js_to_rust(
                     param_name, param_name
                 ));
             }
-            let align = if let ast::TypeName::PrimitiveSlice(prim) = typ {
+            let align = if let ast::TypeName::PrimitiveSlice(prim, _) = typ {
                 layout::primitive_size_alignment(*prim).align()
             } else {
                 1
@@ -338,7 +338,7 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
         }
         ast::TypeName::Writeable => todo!(),
         ast::TypeName::StrReference => todo!(),
-        ast::TypeName::PrimitiveSlice(_) => todo!(),
+        ast::TypeName::PrimitiveSlice(..) => todo!(),
         ast::TypeName::Unit => write!(out, "{}", value_expr)?,
     }
 

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -18,9 +18,9 @@ pub fn gen_value_js_to_rust(
     post_logic: &mut Vec<String>,
 ) {
     match typ {
-        ast::TypeName::StrReference | ast::TypeName::PrimitiveSlice(_, _) => {
+        ast::TypeName::StrReference(_) | ast::TypeName::PrimitiveSlice(_, _) => {
             // TODO(#61): consider extracting into runtime function
-            if *typ == ast::TypeName::StrReference {
+            if let ast::TypeName::StrReference(_) = typ {
                 pre_logic.push(format!(
                     "let {}_diplomat_bytes = (new TextEncoder()).encode({});",
                     param_name, param_name
@@ -337,7 +337,7 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
             gen_rust_reference_to_js(underlying.as_ref(), in_path, value_expr, "null", env, out)?;
         }
         ast::TypeName::Writeable => todo!(),
-        ast::TypeName::StrReference => todo!(),
+        ast::TypeName::StrReference(_) => todo!(),
         ast::TypeName::PrimitiveSlice(..) => todo!(),
         ast::TypeName::Unit => write!(out, "{}", value_expr)?,
     }

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -143,7 +143,7 @@ pub fn gen_method_docs<W: fmt::Write>(
     for p in method
         .params
         .iter()
-        .filter(|p| matches!(p.ty, ast::TypeName::PrimitiveSlice(_)))
+        .filter(|p| matches!(p.ty, ast::TypeName::PrimitiveSlice(..)))
     {
         writeln!(out)?;
         writeln!(

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -71,7 +71,7 @@ pub fn return_type_form(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> 
 
         ast::TypeName::StrReference => ReturnTypeForm::Scalar,
 
-        ast::TypeName::PrimitiveSlice(_) => ReturnTypeForm::Scalar,
+        ast::TypeName::PrimitiveSlice(..) => ReturnTypeForm::Scalar,
 
         ast::TypeName::Primitive(_) => ReturnTypeForm::Scalar,
 

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -69,7 +69,7 @@ pub fn return_type_form(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> 
 
         ast::TypeName::Reference(_, _mut, _lt) => ReturnTypeForm::Scalar,
 
-        ast::TypeName::StrReference => ReturnTypeForm::Scalar,
+        ast::TypeName::StrReference(..) => ReturnTypeForm::Scalar,
 
         ast::TypeName::PrimitiveSlice(..) => ReturnTypeForm::Scalar,
 

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -106,7 +106,7 @@ pub fn type_size_alignment(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) 
         // ast::TypeName::StrReference => Layout::new::<&str>(),
         // ast::TypeName::PrimitiveSlice(_) => Layout::new::<&[u8]>(),
         // Temporary:
-        ast::TypeName::StrReference => Layout::new::<(usize_target, usize_target)>(),
+        ast::TypeName::StrReference(_) => Layout::new::<(usize_target, usize_target)>(),
         ast::TypeName::PrimitiveSlice(_, _) => Layout::new::<(usize_target, usize_target)>(),
         ast::TypeName::Writeable => panic!(),
         ast::TypeName::Unit => Layout::new::<()>(),

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -107,7 +107,7 @@ pub fn type_size_alignment(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) 
         // ast::TypeName::PrimitiveSlice(_) => Layout::new::<&[u8]>(),
         // Temporary:
         ast::TypeName::StrReference => Layout::new::<(usize_target, usize_target)>(),
-        ast::TypeName::PrimitiveSlice(_) => Layout::new::<(usize_target, usize_target)>(),
+        ast::TypeName::PrimitiveSlice(_, _) => Layout::new::<(usize_target, usize_target)>(),
         ast::TypeName::Writeable => panic!(),
         ast::TypeName::Unit => Layout::new::<()>(),
     }


### PR DESCRIPTION
Sometimes it's desirable to send a fixed-size array allocated by host language to be filled on Rust side (this can save us from copying bytes around, for instance my colleagues developing [`devolutions-crypto`](https://github.com/Devolutions/devolutions-crypto) use [this pattern](https://github.com/Devolutions/devolutions-crypto/blob/master/wrappers/csharp/src/Managed.cs#L35) extensively).

cc @pdugre