### PR TITLE
Partial work for tracking lifetimes in the AST

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -27,6 +27,8 @@ pub struct Method {
 
     /// The return type of the method, if any.
     pub return_type: Option<TypeName>,
+
+    pub introduced_lifetimes: Vec<Lifetime>,
 }
 
 impl Method {
@@ -38,6 +40,19 @@ impl Method {
             format!("{}_{}", self_ident, method_ident).as_str(),
             m.sig.ident.span(),
         );
+
+        let introduced_lifetimes = m
+            .sig
+            .generics
+            .lifetimes()
+            .map(|lt| {
+                if !lt.bounds.is_empty() {
+                    panic!("Bounds on lifetimes currently unsupported");
+                }
+
+                Lifetime::from(&lt.lifetime)
+            })
+            .collect();
 
         let all_params = m
             .sig
@@ -52,11 +67,11 @@ impl Method {
         let self_param = m.sig.receiver().map(|rec| match rec {
             FnArg::Receiver(rec) => Param {
                 name: "self".to_string(),
-                ty: if rec.reference.is_some() {
+                ty: if let Some(ref reference) = rec.reference {
                     TypeName::Reference(
                         Box::new(TypeName::Named(self_path.clone())),
                         rec.mutability.is_some(),
-                        Lifetime::Anonymous,
+                        Lifetime::from(&reference.1),
                     )
                 } else {
                     TypeName::Named(self_path.clone())
@@ -77,6 +92,7 @@ impl Method {
             self_param,
             params: all_params,
             return_type: return_ty,
+            introduced_lifetimes,
         }
     }
 

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use syn::*;
 
 use super::docs::Docs;
-use super::{Lifetime, Path, TypeName, ValidityError};
+use super::{Lifetime, Path, PathType, TypeName, ValidityError};
 use crate::Env;
 
 /// A method declared in the `impl` associated with an FFI struct.
@@ -69,12 +69,12 @@ impl Method {
                 name: "self".to_string(),
                 ty: if let Some(ref reference) = rec.reference {
                     TypeName::Reference(
-                        Box::new(TypeName::Named(self_path.clone())),
+                        Box::new(TypeName::Named(PathType::new(self_path.clone()))),
                         rec.mutability.is_some(),
                         Lifetime::from(&reference.1),
                     )
                 } else {
-                    TypeName::Named(self_path.clone())
+                    TypeName::Named(PathType::new(self_path.clone()))
                 },
             },
             _ => panic!("Unexpected self param type"),

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -56,7 +56,7 @@ impl Method {
                     TypeName::Reference(
                         Box::new(TypeName::Named(self_path.clone())),
                         rec.mutability.is_some(),
-                        Lifetime::Named,
+                        Lifetime::Anonymous,
                     )
                 } else {
                     TypeName::Named(self_path.clone())
@@ -140,7 +140,7 @@ impl Param {
     /// Check if this parameter is a Writeable
     pub fn is_writeable(&self) -> bool {
         match self.ty {
-            TypeName::Reference(ref w, true, _lt) => **w == TypeName::Writeable,
+            TypeName::Reference(ref w, true, ref _lt) => **w == TypeName::Writeable,
             _ => false,
         }
     }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -28,6 +28,7 @@ pub struct Method {
     /// The return type of the method, if any.
     pub return_type: Option<TypeName>,
 
+    /// The lifetimes introduced in this method, e.g. `'a` in `fn make_foo<'a>(&self, x: &'a u8) -> Foo<'a>`
     pub introduced_lifetimes: Vec<Lifetime>,
 }
 

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -15,7 +15,7 @@ mod enums;
 pub use enums::Enum;
 
 mod types;
-pub use types::{CustomType, Lifetime, ModSymbol, PrimitiveType, TypeName};
+pub use types::{CustomType, Lifetime, ModSymbol, PathType, PrimitiveType, TypeName};
 
 mod paths;
 pub use paths::Path;

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                      #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)]\n                      fn foo(& mut self, x : u64, y : MyCustomStruct) -> u64\n                      { x }\n                  },\n                 &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
+expression: "Method::from_syn(&syn::parse_quote! {\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(& mut self, x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
 ---
 name: foo
 docs:
@@ -17,10 +17,11 @@ self_param:
   ty:
     Reference:
       - Named:
-          elements:
-            - MyStructContainingMethod
+          path:
+            elements:
+              - MyStructContainingMethod
       - true
-      - Named
+      - Anonymous
 params:
   - name: x
     ty:
@@ -28,8 +29,10 @@ params:
   - name: y
     ty:
       Named:
-        elements:
-          - MyCustomStruct
+        path:
+          elements:
+            - MyCustomStruct
 return_type:
   Primitive: u64
+introduced_lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -20,6 +20,7 @@ self_param:
           path:
             elements:
               - MyStructContainingMethod
+          lifetimes: []
       - true
       - Anonymous
 params:
@@ -32,6 +33,7 @@ params:
         path:
           elements:
             - MyCustomStruct
+        lifetimes: []
 return_type:
   Primitive: u64
 introduced_lifetimes: []

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                      fn foo(& self, x : u64, y : MyCustomStruct) {}\n                  },\n                 &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
+expression: "Method::from_syn(&syn::parse_quote! {\n                fn foo(& self, x : u64, y : MyCustomStruct) {}\n            },\n    &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
 ---
 name: foo
 docs:
@@ -12,10 +12,11 @@ self_param:
   ty:
     Reference:
       - Named:
-          elements:
-            - MyStructContainingMethod
+          path:
+            elements:
+              - MyStructContainingMethod
       - false
-      - Named
+      - Anonymous
 params:
   - name: x
     ty:
@@ -23,7 +24,9 @@ params:
   - name: y
     ty:
       Named:
-        elements:
-          - MyCustomStruct
+        path:
+          elements:
+            - MyCustomStruct
 return_type: ~
+introduced_lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -15,6 +15,7 @@ self_param:
           path:
             elements:
               - MyStructContainingMethod
+          lifetimes: []
       - false
       - Anonymous
 params:
@@ -27,6 +28,7 @@ params:
         path:
           elements:
             - MyCustomStruct
+        lifetimes: []
 return_type: ~
 introduced_lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                      /// Some docs.\n                      /// Some more docs.\n                      ///\n                      /// Even more docs.\n                      #[diplomat :: rust_link(foo :: Bar :: batz, FnInEnum)]\n                      fn foo(x : u64, y : MyCustomStruct) -> u64 { x }\n                  },\n                 &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
+expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                /// Some more docs.\n                ///\n                /// Even more docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInEnum)] fn\n                foo(x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
 ---
 name: foo
 docs:
@@ -20,8 +20,10 @@ params:
   - name: y
     ty:
       Named:
-        elements:
-          - MyCustomStruct
+        path:
+          elements:
+            - MyCustomStruct
 return_type:
   Primitive: u64
+introduced_lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
@@ -23,6 +23,7 @@ params:
         path:
           elements:
             - MyCustomStruct
+        lifetimes: []
 return_type:
   Primitive: u64
 introduced_lifetimes: []

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                      /// Some docs.\n                      #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)]\n                      fn foo(x : u64, y : MyCustomStruct) {}\n                  },\n                 &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
+expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    &Path::empty().sub_path(\"MyStructContainingMethod\".to_string()))"
 ---
 name: foo
 docs:
@@ -20,7 +20,9 @@ params:
   - name: y
     ty:
       Named:
-        elements:
-          - MyCustomStruct
+        path:
+          elements:
+            - MyCustomStruct
 return_type: ~
+introduced_lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
@@ -23,6 +23,7 @@ params:
         path:
           elements:
             - MyCustomStruct
+        lifetimes: []
 return_type: ~
 introduced_lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/modules.rs
-expression: "Module::from_syn(&syn::parse_quote! {\n                      #[diplomat :: bridge] mod ffi\n                      {\n                          struct Foo {} impl Foo\n                          {\n                              pub fn pub_fn() { unimplemented! () } pub(crate)\n                              fn pub_crate_fn() { unimplemented! () }\n                              pub(super) fn pub_super_fn()\n                              { unimplemented! () } fn priv_fn()\n                              { unimplemented! () }\n                          }\n                      }\n                  }, true)"
+expression: "Module::from_syn(&syn::parse_quote! {\n                #[diplomat :: bridge] mod ffi\n                {\n                    struct Foo {} impl Foo\n                    {\n                        pub fn pub_fn() { unimplemented! () } pub(crate) fn\n                        pub_crate_fn() { unimplemented! () } pub(super) fn\n                        pub_super_fn() { unimplemented! () } fn priv_fn()\n                        { unimplemented! () }\n                    }\n                }\n            }, true)"
 ---
 name: ffi
 imports: []
@@ -21,5 +21,6 @@ declared_types:
           self_param: ~
           params: []
           return_type: ~
+          introduced_lifetimes: []
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/modules.rs
-expression: "Module::from_syn(&syn::parse_quote! {\n                      mod ffi\n                      {\n                          struct NonOpaqueStruct\n                          { a : i32, b : Box < NonOpaqueStruct > } impl\n                          NonOpaqueStruct\n                          {\n                              pub fn new(x : i32) -> NonOpaqueStruct\n                              { unimplemented! () ; } pub fn\n                              set_a(& mut self, new_a : i32)\n                              { self.a = new_a ; }\n                          } #[diplomat :: opaque] struct OpaqueStruct\n                          { a : SomeExternalType } impl OpaqueStruct\n                          {\n                              pub fn new() -> Box < OpaqueStruct >\n                              { unimplemented! () ; } pub fn\n                              get_string(& self) -> String\n                              { unimplemented! () }\n                          }\n                      }\n                  }, true)"
+expression: "Module::from_syn(&syn::parse_quote! {\n                mod ffi\n                {\n                    struct NonOpaqueStruct\n                    { a : i32, b : Box < NonOpaqueStruct > } impl\n                    NonOpaqueStruct\n                    {\n                        pub fn new(x : i32) -> NonOpaqueStruct\n                        { unimplemented! () ; } pub fn\n                        set_a(& mut self, new_a : i32) { self.a = new_a ; }\n                    } #[diplomat :: opaque] struct OpaqueStruct\n                    { a : SomeExternalType } impl OpaqueStruct\n                    {\n                        pub fn new() -> Box < OpaqueStruct > { unimplemented! () ; }\n                        pub fn get_string(& self) -> String { unimplemented! () }\n                    }\n                }\n            }, true)"
 ---
 name: ffi
 imports: []
@@ -19,8 +19,9 @@ declared_types:
         - - b
           - Box:
               Named:
-                elements:
-                  - NonOpaqueStruct
+                path:
+                  elements:
+                    - NonOpaqueStruct
           - - ""
             - ~
       methods:
@@ -36,8 +37,10 @@ declared_types:
                 Primitive: i32
           return_type:
             Named:
-              elements:
-                - NonOpaqueStruct
+              path:
+                elements:
+                  - NonOpaqueStruct
+          introduced_lifetimes: []
         - name: set_a
           docs:
             - ""
@@ -48,15 +51,17 @@ declared_types:
             ty:
               Reference:
                 - Named:
-                    elements:
-                      - NonOpaqueStruct
+                    path:
+                      elements:
+                        - NonOpaqueStruct
                 - true
-                - Named
+                - Anonymous
           params:
             - name: new_a
               ty:
                 Primitive: i32
           return_type: ~
+          introduced_lifetimes: []
   OpaqueStruct:
     Opaque:
       name: OpaqueStruct
@@ -74,8 +79,10 @@ declared_types:
           return_type:
             Box:
               Named:
-                elements:
-                  - OpaqueStruct
+                path:
+                  elements:
+                    - OpaqueStruct
+          introduced_lifetimes: []
         - name: get_string
           docs:
             - ""
@@ -86,14 +93,17 @@ declared_types:
             ty:
               Reference:
                 - Named:
-                    elements:
-                      - OpaqueStruct
+                    path:
+                      elements:
+                        - OpaqueStruct
                 - false
-                - Named
+                - Anonymous
           params: []
           return_type:
             Named:
-              elements:
-                - String
+              path:
+                elements:
+                  - String
+          introduced_lifetimes: []
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -22,6 +22,7 @@ declared_types:
                 path:
                   elements:
                     - NonOpaqueStruct
+                lifetimes: []
           - - ""
             - ~
       methods:
@@ -40,6 +41,7 @@ declared_types:
               path:
                 elements:
                   - NonOpaqueStruct
+              lifetimes: []
           introduced_lifetimes: []
         - name: set_a
           docs:
@@ -54,6 +56,7 @@ declared_types:
                     path:
                       elements:
                         - NonOpaqueStruct
+                    lifetimes: []
                 - true
                 - Anonymous
           params:
@@ -82,6 +85,7 @@ declared_types:
                 path:
                   elements:
                     - OpaqueStruct
+                lifetimes: []
           introduced_lifetimes: []
         - name: get_string
           docs:
@@ -96,6 +100,7 @@ declared_types:
                     path:
                       elements:
                         - OpaqueStruct
+                    lifetimes: []
                 - false
                 - Anonymous
           params: []
@@ -104,6 +109,7 @@ declared_types:
               path:
                 elements:
                   - String
+              lifetimes: []
           introduced_lifetimes: []
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/structs.rs
-expression: "Struct::from(&syn::parse_quote! {\n                  /// Some docs.\n                  #[diplomat :: rust_link(foo :: Bar, Struct)] struct\n                  MyLocalStruct { a : i32, b : Box < MyLocalStruct > }\n              })"
+expression: "Struct::from(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Struct)] struct\n                MyLocalStruct { a : i32, b : Box < MyLocalStruct > }\n            })"
 ---
 name: MyLocalStruct
 docs:
@@ -18,8 +18,9 @@ fields:
   - - b
     - Box:
         Named:
-          elements:
-            - MyLocalStruct
+          path:
+            elements:
+              - MyLocalStruct
     - - ""
       - ~
 methods: []

--- a/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
@@ -21,6 +21,7 @@ fields:
           path:
             elements:
               - MyLocalStruct
+          lifetimes: []
     - - ""
       - ~
 methods: []

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-2.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! { :: core :: my_type :: Foo })"
+---
+Named:
+  path:
+    elements:
+      - core
+      - my_type
+      - Foo
+  lifetimes: []
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-3.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-3.snap
@@ -1,0 +1,13 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! {\n                :: core :: my_type :: Foo < 'test, MyType >\n            })"
+---
+Named:
+  path:
+    elements:
+      - core
+      - my_type
+      - Foo
+  lifetimes:
+    - Named: test
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-4.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-4.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! { Option < Ref < 'object >> })"
+---
+Option:
+  Named:
+    path:
+      elements:
+        - Ref
+    lifetimes:
+      - Named: object
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-5.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-5.snap
@@ -1,0 +1,14 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! { Foo < 'a, 'b, 'c, 'd > })"
+---
+Named:
+  path:
+    elements:
+      - Foo
+  lifetimes:
+    - Named: a
+    - Named: b
+    - Named: c
+    - Named: d
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-6.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-6.snap
@@ -1,0 +1,18 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! {\n                very :: long :: path :: to :: my :: Type < 'x, 'y, 'z >\n            })"
+---
+Named:
+  path:
+    elements:
+      - very
+      - long
+      - path
+      - to
+      - my
+      - Type
+  lifetimes:
+    - Named: x
+    - Named: y
+    - Named: z
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-7.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-7.snap
@@ -1,0 +1,19 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! {\n                DiplomatResult < OkRef < 'a, 'b >, ErrRef < 'c >>\n            })"
+---
+Result:
+  - Named:
+      path:
+        elements:
+          - OkRef
+      lifetimes:
+        - Named: a
+        - Named: b
+  - Named:
+      path:
+        elements:
+          - ErrRef
+      lifetimes:
+        - Named: c
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! { Foo < 'a, 'b > })"
+---
+Named:
+  path:
+    elements:
+      - Foo
+  lifetimes:
+    - Named: a
+    - Named: b
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes-2.snap
@@ -1,10 +1,10 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Box < MyLocalStruct > }).unwrap())"
-
+expression: "TypeName::from(&syn::parse_quote! { Box < MyLocalStruct > })"
 ---
 Box:
   Named:
-    elements:
-      - MyLocalStruct
+    path:
+      elements:
+        - MyLocalStruct
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes-2.snap
@@ -7,4 +7,5 @@ Box:
     path:
       elements:
         - MyLocalStruct
+    lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_named.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_named.snap
@@ -6,4 +6,5 @@ Named:
   path:
     elements:
       - MyLocalStruct
+  lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_named.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_named.snap
@@ -1,9 +1,9 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { MyLocalStruct }).unwrap())"
-
+expression: "TypeName::from(&syn::parse_quote! { MyLocalStruct })"
 ---
 Named:
-  elements:
-    - MyLocalStruct
+  path:
+    elements:
+      - MyLocalStruct
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
@@ -1,10 +1,10 @@
 ---
 source: core/src/ast/types.rs
 expression: "TypeName::from(&syn::parse_quote! { Option < MyLocalStruct > })"
-
 ---
 Option:
   Named:
-    elements:
-      - MyLocalStruct
+    path:
+      elements:
+        - MyLocalStruct
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
@@ -7,4 +7,5 @@ Option:
     path:
       elements:
         - MyLocalStruct
+    lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references-2.snap
@@ -7,6 +7,7 @@ Reference:
       path:
         elements:
           - MyLocalStruct
+      lifetimes: []
   - true
   - Anonymous
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references-2.snap
@@ -1,12 +1,12 @@
 ---
 source: core/src/ast/types.rs
 expression: "TypeName::from(&syn::parse_quote! { & mut MyLocalStruct })"
-
 ---
 Reference:
   - Named:
-      elements:
-        - MyLocalStruct
+      path:
+        elements:
+          - MyLocalStruct
   - true
-  - Named
+  - Anonymous
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references.snap
@@ -1,10 +1,9 @@
 ---
 source: core/src/ast/types.rs
 expression: "TypeName::from(&syn::parse_quote! { & i32 })"
-
 ---
 Reference:
   - Primitive: i32
   - false
-  - Named
+  - Anonymous
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
@@ -1,11 +1,11 @@
 ---
 source: core/src/ast/types.rs
 expression: "TypeName::from(&syn::parse_quote! { DiplomatResult < (), MyLocalStruct > })"
-
 ---
 Result:
   - Unit
   - Named:
-      elements:
-        - MyLocalStruct
+      path:
+        elements:
+          - MyLocalStruct
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
@@ -8,4 +8,5 @@ Result:
       path:
         elements:
           - MyLocalStruct
+      lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
@@ -7,5 +7,6 @@ Result:
       path:
         elements:
           - MyLocalStruct
+      lifetimes: []
   - Primitive: i32
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
@@ -1,11 +1,11 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Result < MyLocalStruct, i32 > })"
-
+expression: "TypeName::from(&syn::parse_quote! { DiplomatResult < MyLocalStruct, i32 > })"
 ---
 Result:
   - Named:
-      elements:
-        - MyLocalStruct
+      path:
+        elements:
+          - MyLocalStruct
   - Primitive: i32
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -136,6 +136,14 @@ impl From<&syn::TypePath> for PathType {
     }
 }
 
+impl From<Path> for PathType {
+    fn from(other: Path) -> Self {
+        Self {
+            path: other,
+        }
+    }
+}
+
 /// A local type reference, such as the type of a field, parameter, or return value.
 /// Unlike [`CustomType`], which represents a type declaration, [`TypeName`]s can compose
 /// types through references and boxing, and can also capture unresolved paths.

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -604,7 +604,7 @@ impl From<&syn::Lifetime> for Lifetime {
 
 impl From<&Option<syn::Lifetime>> for Lifetime {
     fn from(lt: &Option<syn::Lifetime>) -> Self {
-        lt.as_ref().map(|lt| lt.into()).unwrap_or(Self::Anonymous)
+        lt.as_ref().map(Into::into).unwrap_or(Self::Anonymous)
     }
 }
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -559,7 +559,7 @@ impl fmt::Display for Lifetime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Static => f.write_str("'static"),
-            Self::Named(ref s) => f.write_str(&s),
+            Self::Named(ref s) => f.write_str(s),
             Self::Anonymous => f.write_str("_"),
         }
     }
@@ -587,7 +587,7 @@ impl Lifetime {
         match *self {
             Self::Static => Some(syn::Lifetime::new("'static", Span::call_site())),
             Self::Anonymous => None,
-            Self::Named(ref s) => Some(syn::Lifetime::new(&s, Span::call_site())),
+            Self::Named(ref s) => Some(syn::Lifetime::new(s, Span::call_site())),
         }
     }
 }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -153,7 +153,8 @@ impl From<&syn::TypePath> for PathType {
                 } else {
                     None
                 }
-            }).unwrap_or_default();
+            })
+            .unwrap_or_default();
 
         Self {
             path: Path::from_syn(&other.path),

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -305,8 +305,8 @@ impl TypeName {
     /// the `env`, which contains all [`CustomType`]s across all FFI modules.
     pub fn resolve_with_path<'a>(&self, in_path: &Path, env: &'a Env) -> (Path, &'a CustomType) {
         match self {
-            TypeName::Named(local_path) => {
-                let local_path = &local_path.path;
+            TypeName::Named(local_path_type) => {
+                let local_path = &local_path_type.path;
                 let mut cur_path = in_path.clone();
                 for (i, elem) in local_path.elements.iter().enumerate() {
                     match elem.as_ref() {
@@ -576,9 +576,10 @@ impl fmt::Display for PathType {
 }
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Lifetime {
+    /// Kept separate because it doesn't matter as much when tracking lifetimes but it'll still need
+    /// to be mentioned in the type during codegen
     Static,
     Named(String),
-
     Anonymous,
 }
 
@@ -586,8 +587,8 @@ impl fmt::Display for Lifetime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Static => f.write_str("'static"),
-            Self::Named(ref s) => f.write_str(s),
-            Self::Anonymous => f.write_str("_"),
+            Self::Named(ref s) => write!(f, "'{}", s),
+            Self::Anonymous => f.write_str("'_"),
         }
     }
 }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -153,8 +153,7 @@ impl From<&syn::TypePath> for PathType {
                 } else {
                     None
                 }
-            })
-            .unwrap_or_else(Vec::new);
+            }).unwrap_or_default();
 
         Self {
             path: Path::from_syn(&other.path),

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -138,9 +138,7 @@ impl From<&syn::TypePath> for PathType {
 
 impl From<Path> for PathType {
     fn from(other: Path) -> Self {
-        Self {
-            path: other,
-        }
+        Self { path: other }
     }
 }
 

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -146,9 +146,9 @@ fn gen_struct_header<'a>(
 
     write!(out, "void {}_destroy(", typ.name())?;
     gen_type(
-        &ast::TypeName::Box(Box::new(ast::TypeName::Named(
+        &ast::TypeName::Box(Box::new(ast::TypeName::Named(ast::PathType::new(
             ast::Path::empty().sub_path(typ.name().clone()),
-        ))),
+        )))),
         in_path,
         env,
         out,

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -64,7 +64,7 @@ pub fn gen_type<W: fmt::Write>(
 /// which require one struct for each distinct instance.
 pub fn name_for_type(typ: &ast::TypeName) -> String {
     match typ {
-        ast::TypeName::Named(name) => name.elements.last().unwrap().clone(),
+        ast::TypeName::Named(name) => name.path.elements.last().unwrap().clone(),
         ast::TypeName::Box(underlying) => format!("box_{}", name_for_type(underlying)),
         ast::TypeName::Reference(underlying, mutable, _lt) => {
             if *mutable {

--- a/tool/src/cpp/docs.rs
+++ b/tool/src/cpp/docs.rs
@@ -111,7 +111,8 @@ pub fn gen_custom_type_docs<W: fmt::Write>(
             &mut class_indented,
             &typ.docs().to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved = ast::TypeName::Named(shortcut_path.clone()).resolve(in_path, env);
+                let resolved =
+                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
                 match resolved {
                     ast::CustomType::Struct(_) => write!(to, ":cpp:struct:`{}`", resolved.name())?,
                     ast::CustomType::Enum(_) => {
@@ -216,7 +217,8 @@ pub fn gen_method_docs<W: fmt::Write>(
             &mut method_indented,
             &method.docs.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved = ast::TypeName::Named(shortcut_path.clone()).resolve(in_path, env);
+                let resolved =
+                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
                 match resolved {
                     ast::CustomType::Struct(_) => write!(to, ":cpp:struct:`{}`", resolved.name())?,
                     ast::CustomType::Enum(_) => {
@@ -250,7 +252,8 @@ pub fn gen_field_docs<W: fmt::Write>(
             &mut field_indented,
             &field.2.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved = ast::TypeName::Named(shortcut_path.clone()).resolve(in_path, env);
+                let resolved =
+                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
                 match resolved {
                     ast::CustomType::Struct(_) => write!(to, ":cpp:struct:`{}`", resolved.name())?,
                     ast::CustomType::Enum(_) => {
@@ -284,7 +287,8 @@ pub fn gen_enum_variant_docs<W: fmt::Write>(
             &mut enum_indented,
             &variant.2.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved = ast::TypeName::Named(shortcut_path.clone()).resolve(in_path, env);
+                let resolved =
+                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
                 match resolved {
                     ast::CustomType::Struct(_) => write!(to, ":cpp:struct:`{}`", resolved.name())?,
                     ast::CustomType::Enum(_) => {

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -319,7 +319,7 @@ pub fn gen_method_interface<W: fmt::Write>(
 
     let mut is_const = false;
     if let Some(ref param) = method.self_param {
-        if let ast::TypeName::Reference(_, mutable, _lt) = param.ty {
+        if let ast::TypeName::Reference(_, mutable, ref _lt) = param.ty {
             is_const = !mutable;
         }
     } else if is_header {

--- a/tool/src/dotnet/types.rs
+++ b/tool/src/dotnet/types.rs
@@ -85,7 +85,7 @@ pub fn type_name_for_prim(prim: &ast::PrimitiveType) -> &str {
 /// Generates a struct name that uniquely identifies the given type.
 pub fn name_for_type(typ: &ast::TypeName) -> String {
     match typ {
-        ast::TypeName::Named(name) => name.elements.last().unwrap().clone(),
+        ast::TypeName::Named(name) => name.path.elements.last().unwrap().clone(),
         ast::TypeName::Box(underlying) => format!("Box{}", name_for_type(underlying)),
         ast::TypeName::Reference(underlying, mutable, _lt) => {
             if *mutable {

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -82,7 +82,8 @@ pub fn gen_custom_type_docs<W: fmt::Write>(
             &mut class_indented,
             &typ.docs().to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved = ast::TypeName::Named(shortcut_path.clone()).resolve(in_path, env);
+                let resolved =
+                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
                 write!(to, ":js:class:`{}`", resolved.name())?;
                 Ok(())
             },
@@ -138,7 +139,8 @@ pub fn gen_method_docs<W: fmt::Write>(
             &mut method_indented,
             &method.docs.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved = ast::TypeName::Named(shortcut_path.clone()).resolve(in_path, env);
+                let resolved =
+                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
                 write!(to, ":js:class:`{}`", resolved.name())?;
                 Ok(())
             },
@@ -177,7 +179,8 @@ pub fn gen_field_docs<W: fmt::Write>(
             &mut field_indented,
             &field.2.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved = ast::TypeName::Named(shortcut_path.clone()).resolve(in_path, env);
+                let resolved =
+                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
                 write!(to, ":js:class:`{}`", resolved.name())?;
                 Ok(())
             },

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -86,7 +86,7 @@ fn gen_field<W: fmt::Write>(
     write!(&mut method_body_out, "return ")?;
     gen_value_rust_to_js(
         &format!("this.underlying + {}", offset),
-        &ast::TypeName::Reference(Box::new(typ.clone()), true, ast::Lifetime::Named),
+        &ast::TypeName::Reference(Box::new(typ.clone()), true, ast::Lifetime::Anonymous),
         in_path,
         env,
         &mut method_body_out,


### PR DESCRIPTION
This expands our lifetime support and also maintains a difference between "paths" (`foo::bar::Baz`) and "path types" (`foo::bar::Baz<'a>`) so that we can track lifetime names. It does not yet track lifetimes in `PathType` but @QnnOkabayashi will likely be adding that part next.

Progress on #142 