### PR TITLE
Track lifetimes in `ast::types::PathType`

### DIFF
--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -20,6 +20,7 @@ self_param:
           path:
             elements:
               - MyStructContainingMethod
+          lifetimes: []
       - true
       - Anonymous
 params:
@@ -32,6 +33,7 @@ params:
         path:
           elements:
             - MyCustomStruct
+        lifetimes: []
 return_type:
   Primitive: u64
 introduced_lifetimes: []

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -15,6 +15,7 @@ self_param:
           path:
             elements:
               - MyStructContainingMethod
+          lifetimes: []
       - false
       - Anonymous
 params:
@@ -27,6 +28,7 @@ params:
         path:
           elements:
             - MyCustomStruct
+        lifetimes: []
 return_type: ~
 introduced_lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
@@ -23,6 +23,7 @@ params:
         path:
           elements:
             - MyCustomStruct
+        lifetimes: []
 return_type:
   Primitive: u64
 introduced_lifetimes: []

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
@@ -23,6 +23,7 @@ params:
         path:
           elements:
             - MyCustomStruct
+        lifetimes: []
 return_type: ~
 introduced_lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -22,6 +22,7 @@ declared_types:
                 path:
                   elements:
                     - NonOpaqueStruct
+                lifetimes: []
           - - ""
             - ~
       methods:
@@ -40,6 +41,7 @@ declared_types:
               path:
                 elements:
                   - NonOpaqueStruct
+              lifetimes: []
           introduced_lifetimes: []
         - name: set_a
           docs:
@@ -54,6 +56,7 @@ declared_types:
                     path:
                       elements:
                         - NonOpaqueStruct
+                    lifetimes: []
                 - true
                 - Anonymous
           params:
@@ -82,6 +85,7 @@ declared_types:
                 path:
                   elements:
                     - OpaqueStruct
+                lifetimes: []
           introduced_lifetimes: []
         - name: get_string
           docs:
@@ -96,6 +100,7 @@ declared_types:
                     path:
                       elements:
                         - OpaqueStruct
+                    lifetimes: []
                 - false
                 - Anonymous
           params: []
@@ -104,6 +109,7 @@ declared_types:
               path:
                 elements:
                   - String
+              lifetimes: []
           introduced_lifetimes: []
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
@@ -21,6 +21,7 @@ fields:
           path:
             elements:
               - MyLocalStruct
+          lifetimes: []
     - - ""
       - ~
 methods: []

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-2.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! { :: core :: my_type :: Foo })"
+---
+Named:
+  path:
+    elements:
+      - core
+      - my_type
+      - Foo
+  lifetimes: []
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-3.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-3.snap
@@ -1,0 +1,13 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! {\n                :: core :: my_type :: Foo < 'test, MyType >\n            })"
+---
+Named:
+  path:
+    elements:
+      - core
+      - my_type
+      - Foo
+  lifetimes:
+    - Named: test
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-4.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-4.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! { Option < Ref < 'object >> })"
+---
+Option:
+  Named:
+    path:
+      elements:
+        - Ref
+    lifetimes:
+      - Named: object
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-5.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-5.snap
@@ -1,0 +1,14 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! { Foo < 'a, 'b, 'c, 'd > })"
+---
+Named:
+  path:
+    elements:
+      - Foo
+  lifetimes:
+    - Named: a
+    - Named: b
+    - Named: c
+    - Named: d
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-6.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-6.snap
@@ -1,0 +1,18 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! {\n                very :: long :: path :: to :: my :: Type < 'x, 'y, 'z >\n            })"
+---
+Named:
+  path:
+    elements:
+      - very
+      - long
+      - path
+      - to
+      - my
+      - Type
+  lifetimes:
+    - Named: x
+    - Named: y
+    - Named: z
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-7.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-7.snap
@@ -1,0 +1,19 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! {\n                DiplomatResult < OkRef < 'a, 'b >, ErrRef < 'c >>\n            })"
+---
+Result:
+  - Named:
+      path:
+        elements:
+          - OkRef
+      lifetimes:
+        - Named: a
+        - Named: b
+  - Named:
+      path:
+        elements:
+          - ErrRef
+      lifetimes:
+        - Named: c
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from(&syn::parse_quote! { Foo < 'a, 'b > })"
+---
+Named:
+  path:
+    elements:
+      - Foo
+  lifetimes:
+    - Named: a
+    - Named: b
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes-2.snap
@@ -7,4 +7,5 @@ Box:
     path:
       elements:
         - MyLocalStruct
+    lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_named.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_named.snap
@@ -6,4 +6,5 @@ Named:
   path:
     elements:
       - MyLocalStruct
+  lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
@@ -7,4 +7,5 @@ Option:
     path:
       elements:
         - MyLocalStruct
+    lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_references-2.snap
@@ -7,6 +7,7 @@ Reference:
       path:
         elements:
           - MyLocalStruct
+      lifetimes: []
   - true
   - Anonymous
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
@@ -8,4 +8,5 @@ Result:
       path:
         elements:
           - MyLocalStruct
+      lifetimes: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
@@ -7,5 +7,6 @@ Result:
       path:
         elements:
           - MyLocalStruct
+      lifetimes: []
   - Primitive: i32
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -140,14 +140,16 @@ impl From<&syn::TypePath> for PathType {
             .last()
             .and_then(|last| {
                 if let PathArguments::AngleBracketed(angle_generics) = &last.arguments {
-                    Some(angle_generics
-                        .args
-                        .iter()
-                        .filter_map(|generic_arg| match generic_arg {
-                            GenericArgument::Lifetime(lifetime) => Some(lifetime.into()),
-                            _ => None,
-                        })
-                        .collect())
+                    Some(
+                        angle_generics
+                            .args
+                            .iter()
+                            .filter_map(|generic_arg| match generic_arg {
+                                GenericArgument::Lifetime(lifetime) => Some(lifetime.into()),
+                                _ => None,
+                            })
+                            .collect(),
+                    )
                 } else {
                     None
                 }


### PR DESCRIPTION
This (very minor) PR adds support for tracking lifetimes in the `ast::types::PathType`s