### PR TITLE
Initial support for lifetimes in macro + `Self` param support

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -37,7 +37,7 @@ impl Method {
     pub fn from_syn(
         m: &ImplItemMethod,
         self_path_type: PathType,
-        mut introduced_lifetimes: Vec<LifetimeDef>,
+        impl_introduced_lifetimes: Vec<LifetimeDef>,
     ) -> Method {
         let self_ident = self_path_type.path.elements.last().unwrap();
         let method_ident = &m.sig.ident;
@@ -50,6 +50,7 @@ impl Method {
         // so we introduce every lifetime introduced in both the impl and the method to ensure we have everything.
         // This will look idiomatic in 99% of cases, and won't even break the wack cases where
         // a lifetime is introduced in the impl but not used in the method.
+        let mut introduced_lifetimes = impl_introduced_lifetimes;
         introduced_lifetimes.extend(m.sig.generics.lifetimes().map(Into::into));
 
         let all_params = m

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use syn::*;
 
 use super::docs::Docs;
-use super::{Lifetime, Path, PathType, TypeName, ValidityError};
+use super::{Lifetime, LifetimeDef, Path, PathType, TypeName, ValidityError};
 use crate::Env;
 
 /// A method declared in the `impl` associated with an FFI struct.
@@ -28,32 +28,29 @@ pub struct Method {
     /// The return type of the method, if any.
     pub return_type: Option<TypeName>,
 
-    /// The lifetimes introduced in this method, e.g. `'a` in `fn make_foo<'a>(&self, x: &'a u8) -> Foo<'a>`
-    pub introduced_lifetimes: Vec<Lifetime>,
+    /// The lifetimes introduced in this method and surrounding impl block.
+    pub introduced_lifetimes: Vec<LifetimeDef>,
 }
 
 impl Method {
     /// Extracts a [`Method`] from an AST node inside an `impl`.
-    pub fn from_syn(m: &ImplItemMethod, self_path: &Path) -> Method {
-        let self_ident = self_path.elements.last().unwrap();
+    pub fn from_syn(
+        m: &ImplItemMethod,
+        self_path_type: PathType,
+        mut introduced_lifetimes: Vec<LifetimeDef>,
+    ) -> Method {
+        let self_ident = self_path_type.path.elements.last().unwrap();
         let method_ident = &m.sig.ident;
         let extern_ident = Ident::new(
             format!("{}_{}", self_ident, method_ident).as_str(),
             m.sig.ident.span(),
         );
 
-        let introduced_lifetimes = m
-            .sig
-            .generics
-            .lifetimes()
-            .map(|lt| {
-                if !lt.bounds.is_empty() {
-                    panic!("Bounds on lifetimes currently unsupported");
-                }
-
-                Lifetime::from(&lt.lifetime)
-            })
-            .collect();
+        // It doesn't matter if we introduce lifetimes in a method that doesn't use them,
+        // so we introduce every lifetime introduced in both the impl and the method to ensure we have everything.
+        // This will look idiomatic in 99% of cases, and won't even break the wack cases where
+        // a lifetime is introduced in the impl but not used in the method.
+        introduced_lifetimes.extend(m.sig.generics.lifetimes().map(Into::into));
 
         let all_params = m
             .sig
@@ -61,7 +58,7 @@ impl Method {
             .iter()
             .filter_map(|a| match a {
                 FnArg::Receiver(_) => None,
-                FnArg::Typed(t) => Some(t.into()),
+                FnArg::Typed(t) => Some(Param::from_syn(t, self_path_type.clone())),
             })
             .collect::<Vec<_>>();
 
@@ -70,19 +67,22 @@ impl Method {
                 name: "self".to_string(),
                 ty: if let Some(ref reference) = rec.reference {
                     TypeName::Reference(
-                        Box::new(TypeName::Named(PathType::new(self_path.clone()))),
+                        Box::new(TypeName::Named(self_path_type.clone())),
                         rec.mutability.is_some(),
                         Lifetime::from(&reference.1),
                     )
                 } else {
-                    TypeName::Named(PathType::new(self_path.clone()))
+                    TypeName::Named(self_path_type.clone())
                 },
             },
             _ => panic!("Unexpected self param type"),
         });
 
         let return_ty = match &m.sig.output {
-            ReturnType::Type(_, return_typ) => Some(return_typ.as_ref().into()),
+            ReturnType::Type(_, return_typ) => Some(TypeName::from_syn(
+                return_typ.as_ref(),
+                Some(self_path_type),
+            )),
             ReturnType::Default => None,
         };
 
@@ -161,10 +161,8 @@ impl Param {
             _ => false,
         }
     }
-}
 
-impl From<&syn::PatType> for Param {
-    fn from(t: &PatType) -> Param {
+    pub fn from_syn(t: &PatType, self_path_type: PathType) -> Self {
         let ident = match t.pat.as_ref() {
             Pat::Ident(ident) => ident.clone(),
             _ => panic!("Unexpected param type"),
@@ -172,7 +170,7 @@ impl From<&syn::PatType> for Param {
 
         Param {
             name: ident.ident.to_string(),
-            ty: t.ty.as_ref().into(),
+            ty: TypeName::from_syn(&t.ty, Some(self_path_type)),
         }
     }
 }
@@ -183,7 +181,7 @@ mod tests {
 
     use syn;
 
-    use super::{Method, Path};
+    use super::{Method, Path, PathType};
 
     #[test]
     fn static_methods() {
@@ -195,7 +193,8 @@ mod tests {
 
                 }
             },
-            &Path::empty().sub_path("MyStructContainingMethod".to_string())
+            PathType::new(Path::empty().sub_path("MyStructContainingMethod".to_string())),
+            vec![]
         ));
 
         insta::assert_yaml_snapshot!(Method::from_syn(
@@ -209,7 +208,8 @@ mod tests {
                     x
                 }
             },
-            &Path::empty().sub_path("MyStructContainingMethod".to_string())
+            PathType::new(Path::empty().sub_path("MyStructContainingMethod".to_string())),
+            vec![]
         ));
     }
 
@@ -221,7 +221,8 @@ mod tests {
 
                 }
             },
-            &Path::empty().sub_path("MyStructContainingMethod".to_string())
+            PathType::new(Path::empty().sub_path("MyStructContainingMethod".to_string())),
+            vec![]
         ));
 
         insta::assert_yaml_snapshot!(Method::from_syn(
@@ -231,7 +232,8 @@ mod tests {
                     x
                 }
             },
-            &Path::empty().sub_path("MyStructContainingMethod".to_string())
+            PathType::new(Path::empty().sub_path("MyStructContainingMethod".to_string())),
+            vec![]
         ));
     }
 }

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -15,7 +15,7 @@ mod enums;
 pub use enums::Enum;
 
 mod types;
-pub use types::{CustomType, Lifetime, ModSymbol, PathType, PrimitiveType, TypeName};
+pub use types::{CustomType, Lifetime, LifetimeDef, ModSymbol, PathType, PrimitiveType, TypeName};
 
 mod paths;
 pub use paths::Path;

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
@@ -13,6 +13,7 @@ modules:
           docs:
             - ""
             - ~
+          lifetimes: []
           fields: []
           methods: []
     sub_modules: []

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
@@ -11,6 +11,7 @@ declared_types:
       docs:
         - ""
         - ~
+      lifetimes: []
       fields: []
       methods:
         - name: pub_fn

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -11,6 +11,7 @@ declared_types:
       docs:
         - ""
         - ~
+      lifetimes: []
       fields:
         - - a
           - Primitive: i32
@@ -71,6 +72,7 @@ declared_types:
       docs:
         - ""
         - ~
+      lifetimes: []
       methods:
         - name: new
           docs:

--- a/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
@@ -10,6 +10,7 @@ docs:
         - foo
         - Bar
     typ: Struct
+lifetimes: []
 fields:
   - - a
     - Primitive: i32

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-3.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-3.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! {\n                :: core :: my_type :: Foo < 'test, MyType >\n            })"
+expression: "TypeName::from(&syn::parse_quote! { :: core :: my_type :: Foo < 'test > })"
 ---
 Named:
   path:

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use proc_macro2::Span;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use serde::{Deserialize, Serialize};
 use syn::{punctuated::Punctuated, *};
 
@@ -53,6 +53,15 @@ impl CustomType {
 
     pub fn self_path(&self, in_path: &Path) -> Path {
         in_path.sub_path(self.name().clone())
+    }
+
+    /// Get the lifetimes of the custom type.
+    pub fn lifetimes(&self) -> Option<&[LifetimeDef]> {
+        match self {
+            CustomType::Struct(strct) => Some(&strct.lifetimes[..]),
+            CustomType::Opaque(strct) => Some(&strct.lifetimes[..]),
+            CustomType::Enum(_) => None,
+        }
     }
 
     /// Performs various validity checks:
@@ -109,7 +118,7 @@ pub enum ModSymbol {
     CustomType(CustomType),
 }
 
-/// A named type that is just a path
+/// A named type that is just a path, e.g. `std::borrow::Cow<'a, T>`.
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
 pub struct PathType {
     pub path: Path,
@@ -118,16 +127,36 @@ pub struct PathType {
 
 impl PathType {
     pub fn to_syn(&self) -> syn::TypePath {
-        syn::TypePath {
-            qself: None,
-            path: self.path.to_syn(),
+        let mut path = self.path.to_syn();
+
+        if !self.lifetimes.is_empty() {
+            if let Some(seg) = path.segments.last_mut() {
+                let lifetimes = &self.lifetimes;
+                seg.arguments =
+                    syn::PathArguments::AngleBracketed(syn::parse_quote! { <#(#lifetimes),*> });
+            }
         }
+
+        syn::TypePath { qself: None, path }
     }
 
     pub fn new(path: Path) -> Self {
         Self {
             path,
             lifetimes: vec![],
+        }
+    }
+
+    pub fn extract_self_type(strct: &syn::ItemStruct) -> Self {
+        PathType {
+            path: Path {
+                elements: vec![strct.ident.to_string()],
+            },
+            lifetimes: strct
+                .generics
+                .lifetimes()
+                .map(|lt_def| (&lt_def.lifetime).into())
+                .collect(),
         }
     }
 }
@@ -144,9 +173,9 @@ impl From<&syn::TypePath> for PathType {
                         angle_generics
                             .args
                             .iter()
-                            .filter_map(|generic_arg| match generic_arg {
-                                GenericArgument::Lifetime(lifetime) => Some(lifetime.into()),
-                                _ => None,
+                            .map(|generic_arg| match generic_arg {
+                                GenericArgument::Lifetime(lifetime) => lifetime.into(),
+                                _ => panic!("generic type arguments are unsupported"),
                             })
                             .collect(),
                     )
@@ -287,6 +316,9 @@ impl TypeName {
                 &str
             },
             TypeName::PrimitiveSlice(name, mutable) => {
+                // Do we need a lifetime here?
+                // What if we have `&'a [u8]`?
+                // I think this would involve a new field on `TypeName::PrimitiveSlice`
                 let primitive_name = PRIMITIVE_TO_STRING.get(name).unwrap();
                 let formatted_str = format!(
                     "&{}[{}]",
@@ -298,6 +330,109 @@ impl TypeName {
             TypeName::Unit => syn::parse_quote! {
                 ()
             },
+        }
+    }
+
+    /// Extract a [`TypeName`] from a [`syn::Type`] AST node.
+    /// The following rules are used to infer [`TypeName`] variants:
+    /// - If the type is a path with a single element that is the name of a Rust primitive, returns a [`TypeName::Primitive`]
+    /// - If the type is a path with a single element [`Box`], returns a [`TypeName::Box`] with the type parameter recursively converted
+    /// - If the type is a path with a single element [`Option`], returns a [`TypeName::Option`] with the type parameter recursively converted
+    /// - If the type is a path with a single element `Self` and `self_path_type` is provided, returns a [`TypeName::Named`]
+    /// - If the type is a path equal to [`diplomat_runtime::DiplomatResult`], returns a [`TypeName::Result`] with the type parameters recursively converted
+    /// - If the type is a path equal to [`diplomat_runtime::DiplomatWriteable`], returns a [`TypeName::Writeable`]
+    /// - If the type is a reference to `str`, returns a [`TypeName::StrReference`]
+    /// - If the type is a reference to a slice of a Rust primitive, returns a [`TypeName::PrimitiveSlice`]
+    /// - If the type is a reference (`&` or `&mut`), returns a [`TypeName::Reference`] with the referenced type recursively converted
+    /// - Otherwise, assume that the reference is to a [`CustomType`] in either the current module or another one, returns a [`TypeName::Named`]
+    pub fn from_syn(ty: &syn::Type, self_path_type: Option<PathType>) -> TypeName {
+        match ty {
+            syn::Type::Reference(r) => {
+                if r.elem.to_token_stream().to_string() == "str" {
+                    return TypeName::StrReference(r.mutability.is_some());
+                }
+                if let syn::Type::Slice(slice) = &*r.elem {
+                    if let syn::Type::Path(p) = &*slice.elem {
+                        if let Some(primitive) = p
+                            .path
+                            .get_ident()
+                            .and_then(|i| STRING_TO_PRIMITIVE.get(i.to_string().as_str()))
+                        {
+                            return TypeName::PrimitiveSlice(*primitive, r.mutability.is_some());
+                        }
+                    }
+                }
+                TypeName::Reference(
+                    Box::new(TypeName::from_syn(r.elem.as_ref(), self_path_type)),
+                    r.mutability.is_some(),
+                    Lifetime::from(&r.lifetime),
+                )
+            }
+            syn::Type::Path(p) => {
+                if let Some(primitive) = p
+                    .path
+                    .get_ident()
+                    .and_then(|i| STRING_TO_PRIMITIVE.get(i.to_string().as_str()))
+                {
+                    TypeName::Primitive(*primitive)
+                } else if p.path.segments.len() == 1 && p.path.segments[0].ident == "Box" {
+                    if let PathArguments::AngleBracketed(type_args) = &p.path.segments[0].arguments
+                    {
+                        if let GenericArgument::Type(tpe) = &type_args.args[0] {
+                            TypeName::Box(Box::new(TypeName::from_syn(tpe, self_path_type)))
+                        } else {
+                            panic!("Expected first type argument for Box to be a type")
+                        }
+                    } else {
+                        panic!("Expected angle brackets for Box type")
+                    }
+                } else if p.path.segments.len() == 1 && p.path.segments[0].ident == "Option" {
+                    if let PathArguments::AngleBracketed(type_args) = &p.path.segments[0].arguments
+                    {
+                        if let GenericArgument::Type(tpe) = &type_args.args[0] {
+                            TypeName::Option(Box::new(TypeName::from_syn(tpe, self_path_type)))
+                        } else {
+                            panic!("Expected first type argument for Option to be a type")
+                        }
+                    } else {
+                        panic!("Expected angle brackets for Option type")
+                    }
+                } else if p.path.segments.len() == 1 && p.path.segments[0].ident == "Self" {
+                    if let Some(self_path_type) = self_path_type {
+                        TypeName::Named(self_path_type)
+                    } else {
+                        panic!("Cannot have `Self` type outside of a method");
+                    }
+                } else if is_runtime_type(p, "DiplomatResult") {
+                    if let PathArguments::AngleBracketed(type_args) =
+                        &p.path.segments.last().unwrap().arguments
+                    {
+                        if let (GenericArgument::Type(ok), GenericArgument::Type(err)) =
+                            (&type_args.args[0], &type_args.args[1])
+                        {
+                            let ok = TypeName::from_syn(ok, self_path_type.clone());
+                            let err = TypeName::from_syn(err, self_path_type);
+                            TypeName::Result(Box::new(ok), Box::new(err))
+                        } else {
+                            panic!("Expected both type arguments for Result to be a type")
+                        }
+                    } else {
+                        panic!("Expected angle brackets for Result type")
+                    }
+                } else if is_runtime_type(p, "DiplomatWriteable") {
+                    TypeName::Writeable
+                } else {
+                    TypeName::Named(PathType::from(p))
+                }
+            }
+            syn::Type::Tuple(tup) => {
+                if tup.elems.is_empty() {
+                    TypeName::Unit
+                } else {
+                    todo!("Tuples are not currently supported")
+                }
+            }
+            other => panic!("Unsupported type: {}", other.to_token_stream()),
         }
     }
 
@@ -444,102 +579,6 @@ impl TypeName {
     }
 }
 
-impl From<&syn::Type> for TypeName {
-    /// Extract a [`TypeName`] from a [`syn::Type`] AST node.
-    /// The following rules are used to infer [`TypeName`] variants:
-    /// - If the type is a path with a single element that is the name of a Rust primitive, returns a [`TypeName::Primitive`]
-    /// - If the type is a path with a single element [`Box`], returns a [`TypeName::Box`] with the type parameter recursively converted
-    /// - If the type is a path with a single element [`Option`], returns a [`TypeName::Option`] with the type parameter recursively converted
-    /// - If the type is a path equal to [`diplomat_runtime::DiplomatResult`], returns a [`TypeName::Result`] with the type parameters recursively converted
-    /// - If the type is a path equal to [`diplomat_runtime::DiplomatWriteable`], returns a [`TypeName::Writeable`]
-    /// - If the type is a reference to `str`, returns a [`TypeName::StrReference`]
-    /// - If the type is a reference to a slice of a Rust primitive, returns a [`TypeName::PrimitiveSlice`]
-    /// - If the type is a reference (`&` or `&mut`), returns a [`TypeName::Reference`] with the referenced type recursively converted
-    /// - Otherwise, assume that the reference is to a [`CustomType`] in either the current module or another one, returns a [`TypeName::Named`]
-    fn from(ty: &syn::Type) -> TypeName {
-        match ty {
-            syn::Type::Reference(r) => {
-                if r.elem.to_token_stream().to_string() == "str" {
-                    return TypeName::StrReference(r.mutability.is_some());
-                }
-                if let syn::Type::Slice(slice) = &*r.elem {
-                    if let syn::Type::Path(p) = &*slice.elem {
-                        if let Some(primitive) = p
-                            .path
-                            .get_ident()
-                            .and_then(|i| STRING_TO_PRIMITIVE.get(i.to_string().as_str()))
-                        {
-                            return TypeName::PrimitiveSlice(*primitive, r.mutability.is_some());
-                        }
-                    }
-                }
-                TypeName::Reference(
-                    Box::new(r.elem.as_ref().into()),
-                    r.mutability.is_some(),
-                    Lifetime::from(&r.lifetime),
-                )
-            }
-            syn::Type::Path(p) => {
-                if let Some(primitive) = p
-                    .path
-                    .get_ident()
-                    .and_then(|i| STRING_TO_PRIMITIVE.get(i.to_string().as_str()))
-                {
-                    TypeName::Primitive(*primitive)
-                } else if p.path.segments.len() == 1 && p.path.segments[0].ident == "Box" {
-                    if let PathArguments::AngleBracketed(type_args) = &p.path.segments[0].arguments
-                    {
-                        if let GenericArgument::Type(tpe) = &type_args.args[0] {
-                            TypeName::Box(Box::new(tpe.into()))
-                        } else {
-                            panic!("Expected first type argument for Box to be a type")
-                        }
-                    } else {
-                        panic!("Expected angle brackets for Box type")
-                    }
-                } else if p.path.segments.len() == 1 && p.path.segments[0].ident == "Option" {
-                    if let PathArguments::AngleBracketed(type_args) = &p.path.segments[0].arguments
-                    {
-                        if let GenericArgument::Type(tpe) = &type_args.args[0] {
-                            TypeName::Option(Box::new(tpe.into()))
-                        } else {
-                            panic!("Expected first type argument for Option to be a type")
-                        }
-                    } else {
-                        panic!("Expected angle brackets for Option type")
-                    }
-                } else if is_runtime_type(p, "DiplomatResult") {
-                    if let PathArguments::AngleBracketed(type_args) =
-                        &p.path.segments.last().unwrap().arguments
-                    {
-                        if let (GenericArgument::Type(ok), GenericArgument::Type(err)) =
-                            (&type_args.args[0], &type_args.args[1])
-                        {
-                            TypeName::Result(Box::new(ok.into()), Box::new(err.into()))
-                        } else {
-                            panic!("Expected both type arguments for Result to be a type")
-                        }
-                    } else {
-                        panic!("Expected angle brackets for Result type")
-                    }
-                } else if is_runtime_type(p, "DiplomatWriteable") {
-                    TypeName::Writeable
-                } else {
-                    TypeName::Named(PathType::from(p))
-                }
-            }
-            syn::Type::Tuple(tup) => {
-                if tup.elems.is_empty() {
-                    TypeName::Unit
-                } else {
-                    todo!("Tuples are not currently supported")
-                }
-            }
-            other => panic!("Unsupported type: {}", other.to_token_stream()),
-        }
-    }
-}
-
 fn is_runtime_type(p: &TypePath, name: &str) -> bool {
     (p.path.segments.len() == 1 && p.path.segments[0].ident == name)
         || (p.path.segments.len() == 2
@@ -552,10 +591,8 @@ impl fmt::Display for TypeName {
         match self {
             TypeName::Primitive(p) => p.fmt(f),
             TypeName::Named(p) => p.fmt(f),
-            TypeName::Reference(ty, mutable, lifetime) if *mutable => {
-                write!(f, "&{} mut {}", lifetime, ty)
-            }
-            TypeName::Reference(ty, _, lifetime) => write!(f, "&{} {}", lifetime, ty),
+            TypeName::Reference(ty, true, lifetime) => write!(f, "&{} mut {}", lifetime, ty),
+            TypeName::Reference(ty, false, lifetime) => write!(f, "&{} {}", lifetime, ty),
             TypeName::Box(ty) => write!(f, "Box<{}>", ty),
             TypeName::Option(ty) => write!(f, "Option<{}>", ty),
             TypeName::Result(ty, ty2) => write!(f, "Result<{}, {}>", ty, ty2),
@@ -571,9 +608,48 @@ impl fmt::Display for TypeName {
 
 impl fmt::Display for PathType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.path.fmt(f)
+        self.path.fmt(f)?;
+
+        if let Some((first, rest)) = self.lifetimes.split_first() {
+            write!(f, "<{}", first)?;
+            for lt in rest {
+                write!(f, ", {}", lt)?;
+            }
+            '>'.fmt(f)?;
+        }
+        Ok(())
     }
 }
+
+/// A lifetime as a generic parameter, potentially with bounds.
+///
+/// The `'a` and `'b: 'a` in `Foo<'a, 'b: 'a>`.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LifetimeDef {
+    pub lifetime: Lifetime,
+    pub bounds: Vec<Lifetime>,
+}
+
+impl From<&syn::LifetimeDef> for LifetimeDef {
+    fn from(lifetime_def: &syn::LifetimeDef) -> Self {
+        Self {
+            lifetime: (&lifetime_def.lifetime).into(),
+            bounds: lifetime_def.bounds.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl ToTokens for LifetimeDef {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let LifetimeDef { lifetime, bounds } = self;
+        tokens.extend(if bounds.is_empty() {
+            quote! { #lifetime }
+        } else {
+            quote! { #lifetime: #(#bounds)+* }
+        })
+    }
+}
+
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Lifetime {
     /// Kept separate because it doesn't matter as much when tracking lifetimes but it'll still need
@@ -585,11 +661,25 @@ pub enum Lifetime {
 
 impl fmt::Display for Lifetime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Self::Static => f.write_str("'static"),
-            Self::Named(ref s) => write!(f, "'{}", s),
-            Self::Anonymous => f.write_str("'_"),
+        match self {
+            Lifetime::Static => "'static".fmt(f),
+            Lifetime::Named(ref s) => write!(f, "'{}", s),
+            Lifetime::Anonymous => "'_".fmt(f),
         }
+    }
+}
+
+impl ToTokens for Lifetime {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let mut lt = |name| {
+            syn::Lifetime::new(name, Span::call_site()).to_tokens(tokens);
+        };
+
+        match self {
+            Lifetime::Static => lt("'static"),
+            Lifetime::Named(ref s) => lt(&format!("'{}", s)),
+            Lifetime::Anonymous => lt("'_"),
+        };
     }
 }
 
@@ -615,7 +705,7 @@ impl Lifetime {
         match *self {
             Self::Static => Some(syn::Lifetime::new("'static", Span::call_site())),
             Self::Anonymous => None,
-            Self::Named(ref s) => Some(syn::Lifetime::new(s, Span::call_site())),
+            Self::Named(ref s) => Some(syn::Lifetime::new(&format!("'{}", s), Span::call_site())),
         }
     }
 }
@@ -700,98 +790,155 @@ mod tests {
 
     #[test]
     fn typename_primitives() {
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            i32
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                i32
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            usize
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                usize
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            bool
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                bool
+            },
+            None
+        ));
     }
 
     #[test]
     fn typename_named() {
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            MyLocalStruct
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                MyLocalStruct
+            },
+            None
+        ));
     }
 
     #[test]
     fn typename_references() {
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            &i32
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                &i32
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            &mut MyLocalStruct
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                &mut MyLocalStruct
+            },
+            None
+        ));
     }
 
     #[test]
     fn typename_boxes() {
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            Box<i32>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                Box<i32>
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            Box<MyLocalStruct>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                Box<MyLocalStruct>
+            },
+            None
+        ));
     }
 
     #[test]
     fn typename_option() {
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            Option<i32>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                Option<i32>
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            Option<MyLocalStruct>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                Option<MyLocalStruct>
+            },
+            None
+        ));
     }
 
     #[test]
     fn typename_result() {
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            DiplomatResult<MyLocalStruct, i32>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                DiplomatResult<MyLocalStruct, i32>
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            DiplomatResult<(), MyLocalStruct>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                DiplomatResult<(), MyLocalStruct>
+            },
+            None
+        ));
     }
 
     #[test]
     fn lifetimes() {
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            Foo<'a, 'b>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                Foo<'a, 'b>
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            ::core::my_type::Foo
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                ::core::my_type::Foo
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            ::core::my_type::Foo<'test>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                ::core::my_type::Foo<'test>
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            Option<Ref<'object>>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                Option<Ref<'object>>
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            Foo<'a, 'b, 'c, 'd>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                Foo<'a, 'b, 'c, 'd>
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            very::long::path::to::my::Type<'x, 'y, 'z>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                very::long::path::to::my::Type<'x, 'y, 'z>
+            },
+            None
+        ));
 
-        insta::assert_yaml_snapshot!(TypeName::from(&syn::parse_quote! {
-            DiplomatResult<OkRef<'a, 'b>, ErrRef<'c>>
-        }));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                DiplomatResult<OkRef<'a, 'b>, ErrRef<'c>>
+            },
+            None
+        ));
     }
 }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -147,6 +147,23 @@ impl PathType {
         }
     }
 
+    /// Get the `Self` type from a struct declaration.
+    ///
+    /// Consider the following struct declaration:
+    /// ```
+    /// struct RefList<'a> {
+    ///     data: &'a i32,
+    ///     next: Option<Box<Self>>,
+    /// }
+    /// ```
+    /// When determining what type `Self` is in the `next` field, we would have to call
+    /// this method on the `syn::ItemStruct` that represents this struct declaration.
+    /// This method would then return a `PathType` representing `RefList<'a>`, so we
+    /// know that's what `Self` should refer to.
+    ///
+    /// The reason this function exists though is so when we convert the fields' types
+    /// to `PathType`s, we don't panic. We don't actually need to write the struct's
+    /// field types expanded in the macro, so this function is more for correctness,
     pub fn extract_self_type(strct: &syn::ItemStruct) -> Self {
         PathType {
             path: Path {

--- a/feature_tests/src/lib.rs
+++ b/feature_tests/src/lib.rs
@@ -3,7 +3,9 @@
 // We're not trying to write good code here, just tests
 #![allow(clippy::style)]
 
+pub mod lifetimes;
 pub mod option;
 pub mod result;
+pub mod selftype;
 pub mod slices;
 pub mod structs;

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -1,0 +1,18 @@
+#[diplomat::bridge]
+pub mod ffi {
+    #[diplomat::opaque]
+    pub struct Foo<'a>(&'a str);
+
+    #[diplomat::opaque]
+    pub struct Bar<'b, 'a: 'b>(&'b Foo<'a>);
+
+    impl<'a> Foo<'a> {
+        pub fn new(x: &'a str) -> Box<Self> {
+            Box::new(Foo(x))
+        }
+
+        pub fn get_bar<'b>(&'b self) -> Box<Bar<'b, 'a>> {
+            Box::new(Bar(self))
+        }
+    }
+}

--- a/feature_tests/src/selftype.rs
+++ b/feature_tests/src/selftype.rs
@@ -1,0 +1,20 @@
+#[diplomat::bridge]
+mod ffi {
+    struct RefList<'a> {
+        data: &'a i32,
+        next: Option<Box<Self>>,
+    }
+
+    impl<'b> RefList<'b> {
+        pub fn node(data: &'b i32) -> Self {
+            RefList { data, next: None }
+        }
+
+        pub fn extend(&mut self, other: Self) {
+            match self.next.as_mut() {
+                Some(tail) => tail.extend(other),
+                None => self.next = Some(Box::new(other)),
+            }
+        }
+    }
+}

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -169,37 +169,34 @@ fn gen_custom_type_method(strct: &ast::CustomType, m: &ast::Method) -> Item {
         );
     }
 
-    let method_invocation = match &m.self_param {
-        Some(_) => {
-            quote! {
-                #this_ident.#method_ident
-            }
-        }
-        None => {
-            quote! {
-                #self_ident::#method_ident
-            }
+    let lifetimes = {
+        let lifetimes = &m.introduced_lifetimes;
+        if lifetimes.is_empty() {
+            quote! {}
+        } else {
+            quote! { <#(#lifetimes),*> }
         }
     };
 
-    match &m.return_type {
-        None => Item::Fn(syn::parse_quote! {
-            #[no_mangle]
-            extern "C" fn #extern_ident(#(#all_params),*) {
-                #method_invocation(#(#all_params_invocation),*);
-            }
-        }),
-        Some(return_typ) => {
-            let return_typ_syn = return_typ.to_syn();
+    let method_invocation = if m.self_param.is_some() {
+        quote! { #this_ident.#method_ident }
+    } else {
+        quote! { #self_ident::#method_ident }
+    };
 
-            Item::Fn(syn::parse_quote! {
-                #[no_mangle]
-                extern "C" fn #extern_ident(#(#all_params),*) -> #return_typ_syn {
-                    #method_invocation(#(#all_params_invocation),*)
-                }
-            })
+    let return_tokens = if let Some(return_type) = &m.return_type {
+        let return_type_syn = return_type.to_syn();
+        quote! { -> #return_type_syn }
+    } else {
+        quote! {}
+    };
+
+    Item::Fn(syn::parse_quote! {
+        #[no_mangle]
+        extern "C" fn #extern_ident#lifetimes(#(#all_params),*) #return_tokens {
+            #method_invocation(#(#all_params_invocation),*)
         }
-    }
+    })
 }
 
 struct AttributeInfo {
@@ -290,16 +287,27 @@ fn gen_bridge(input: ItemMod) -> ItemMod {
             .for_each(|m| new_contents.push(gen_custom_type_method(custom_type, m)));
 
         let destroy_ident = Ident::new(
-            (custom_type.name().to_string() + "_destroy").as_str(),
+            format!("{}_destroy", custom_type.name()).as_str(),
             Span::call_site(),
         );
+
         let type_ident = Ident::new(custom_type.name(), Span::call_site());
+
+        let (lifetime_defs, lifetimes) = if let Some(lifetime_defs) = custom_type.lifetimes() {
+            let lifetimes = lifetime_defs.iter().map(|lt| &lt.lifetime);
+            (
+                quote! { <#(#lifetime_defs),*> }, // with bounds
+                quote! { <#(#lifetimes),*> },     // without bounds
+            )
+        } else {
+            (quote! {}, quote! {})
+        };
 
         // for now, body is empty since all we need to do is drop the box
         // TODO(#13): change to take a `*mut` and handle DST boxes appropriately
         new_contents.push(Item::Fn(syn::parse_quote! {
             #[no_mangle]
-            extern "C" fn #destroy_ident(this: Box<#type_ident>) {}
+            extern "C" fn #destroy_ident#lifetime_defs(this: Box<#type_ident#lifetimes>) {}
         }));
     }
 
@@ -465,6 +473,56 @@ mod tests {
 
                     impl Foo {
                         pub fn to_string(&self, to: &mut DiplomatWriteable) -> DiplomatResult<(), ()> {
+                            unimplemented!()
+                        }
+                    }
+                }
+            })
+            .to_token_stream()
+            .to_string()
+        ));
+    }
+
+    #[test]
+    fn multilevel_borrows() {
+        insta::assert_display_snapshot!(rustfmt_code(
+            &gen_bridge(parse_quote! {
+                mod ffi {
+                    #[diplomat::opaque]
+                    struct Foo<'a>(&'a str);
+
+                    #[diplomat::opaque]
+                    struct Bar<'b, 'a: 'b>(&'b Foo<'a>);
+
+                    impl<'a> Foo<'a> {
+                        pub fn new(x: &'a str) -> Box<Foo<'a>> {
+                            unimplemented!()
+                        }
+
+                        pub fn get_bar<'b>(&'b self) -> Box<Bar<'b, 'a>> {
+                            unimplemented!()
+                        }
+                    }
+                }
+            })
+            .to_token_stream()
+            .to_string()
+        ));
+    }
+
+    #[test]
+    fn self_params() {
+        insta::assert_display_snapshot!(rustfmt_code(
+            &gen_bridge(parse_quote! {
+                mod ffi {
+                    #[diplomat::opaque]
+                    struct RefList<'a> {
+                        data: &'a i32,
+                        next: Option<Box<Self>>,
+                    }
+
+                    impl<'b> RefList<'b> {
+                        pub fn extend(&mut self, other: &Self) -> Self {
                             unimplemented!()
                         }
                     }

--- a/macro/src/snapshots/diplomat__tests__method_taking_mutable_slice.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_mutable_slice.snap
@@ -1,7 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                             mod ffi\n                             {\n                                 struct Foo { } impl Foo\n                                 {\n                                     pub fn fill_slice(s : & mut [f64])\n                                     { unimplemented! () }\n                                 }\n                             }\n                         }).to_token_stream().to_string())"
-
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn fill_slice(s : & mut [f64]) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -13,9 +12,7 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Foo_fill_slice(s_diplomat_data: *mut f64, s_diplomat_len: usize) {
-        Foo::fill_slice(unsafe {
-            core::slice::from_raw_parts_mut(s_diplomat_data, s_diplomat_len)
-        });
+        Foo::fill_slice(unsafe { core::slice::from_raw_parts_mut(s_diplomat_data, s_diplomat_len) })
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/macro/src/snapshots/diplomat__tests__method_taking_mutable_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_mutable_str.snap
@@ -1,7 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                             mod ffi\n                             {\n                                 struct Foo { } impl Foo\n                                 {\n                                     pub fn make_uppercase(s : & mut str)\n                                     { unimplemented! () }\n                                 }\n                             }\n                         }).to_token_stream().to_string())"
-
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn make_uppercase(s : & mut str) { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -19,7 +18,7 @@ mod ffi {
                 s_diplomat_len,
             ))
             .unwrap()
-        });
+        })
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/macro/src/snapshots/diplomat__tests__method_taking_slice.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_slice.snap
@@ -1,7 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                             mod ffi\n                             {\n                                 struct Foo { } impl Foo\n                                 {\n                                     pub fn from_slice(s : & [f64])\n                                     { unimplemented! () }\n                                 }\n                             }\n                         }).to_token_stream().to_string())"
-
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn from_slice(s : & [f64]) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -13,7 +12,7 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Foo_from_slice(s_diplomat_data: *const f64, s_diplomat_len: usize) {
-        Foo::from_slice(unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) });
+        Foo::from_slice(unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) })
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/macro/src/snapshots/diplomat__tests__method_taking_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_str.snap
@@ -1,7 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                             mod ffi\n                             {\n                                 struct Foo { } impl Foo\n                                 {\n                                     pub fn from_str(s : & str)\n                                     { unimplemented! () }\n                                 }\n                             }\n                         }).to_token_stream().to_string())"
-
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn from_str(s : & str) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -16,7 +15,7 @@ mod ffi {
         Foo::from_str(unsafe {
             core::str::from_utf8(core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len))
                 .unwrap()
-        });
+        })
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/macro/src/snapshots/diplomat__tests__mod_with_enum.snap
+++ b/macro/src/snapshots/diplomat__tests__mod_with_enum.snap
@@ -1,7 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                             mod ffi\n                             {\n                                 enum Abc { A, B = 123, } impl Abc\n                                 {\n                                     pub fn do_something(& self)\n                                     { unimplemented! () }\n                                 }\n                             }\n                         }).to_token_stream().to_string())"
-
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                enum Abc { A, B = 123, } impl Abc\n                                { pub fn do_something(& self) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -16,7 +15,7 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Abc_do_something(this: &Abc) {
-        this.do_something();
+        this.do_something()
     }
     #[no_mangle]
     extern "C" fn Abc_destroy(this: Box<Abc>) {}

--- a/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
+++ b/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
@@ -1,0 +1,34 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                #[diplomat :: opaque] struct Foo < 'a > (& 'a str) ;\n                                #[diplomat :: opaque] struct Bar < 'b, 'a : 'b >\n                                (& 'b Foo < 'a >) ; impl < 'a > Foo < 'a >\n                                {\n                                    pub fn new(x : & 'a str) -> Box < Foo < 'a >>\n                                    { unimplemented! () } pub fn get_bar < 'b > (& 'b self) ->\n                                    Box < Bar < 'b, 'a >> { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+---
+mod ffi {
+    #[repr(transparent)]
+    struct Foo<'a>(&'a str);
+    #[repr(transparent)]
+    struct Bar<'b, 'a: 'b>(&'b Foo<'a>);
+    impl<'a> Foo<'a> {
+        pub fn new(x: &'a str) -> Box<Foo<'a>> {
+            unimplemented!()
+        }
+        pub fn get_bar<'b>(&'b self) -> Box<Bar<'b, 'a>> {
+            unimplemented!()
+        }
+    }
+    #[no_mangle]
+    extern "C" fn Bar_destroy<'b, 'a: 'b>(this: Box<Bar<'b, 'a>>) {}
+    #[no_mangle]
+    extern "C" fn Foo_new<'a>(x_diplomat_data: *const u8, x_diplomat_len: usize) -> Box<Foo<'a>> {
+        Foo::new(unsafe {
+            core::str::from_utf8(core::slice::from_raw_parts(x_diplomat_data, x_diplomat_len))
+                .unwrap()
+        })
+    }
+    #[no_mangle]
+    extern "C" fn Foo_get_bar<'a, 'b>(this: &'b Foo<'a>) -> Box<Bar<'b, 'a>> {
+        this.get_bar()
+    }
+    #[no_mangle]
+    extern "C" fn Foo_destroy<'a>(this: Box<Foo<'a>>) {}
+}
+

--- a/macro/src/snapshots/diplomat__tests__self_params.snap
+++ b/macro/src/snapshots/diplomat__tests__self_params.snap
@@ -1,0 +1,23 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                #[diplomat :: opaque] struct RefList < 'a >\n                                { data : & 'a i32, next : Option < Box < Self >>, } impl <\n                                'b > RefList < 'b >\n                                {\n                                    pub fn extend(& mut self, other : & Self) -> Self\n                                    { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+---
+mod ffi {
+    #[repr(transparent)]
+    struct RefList<'a> {
+        data: &'a i32,
+        next: Option<Box<Self>>,
+    }
+    impl<'b> RefList<'b> {
+        pub fn extend(&mut self, other: &Self) -> Self {
+            unimplemented!()
+        }
+    }
+    #[no_mangle]
+    extern "C" fn RefList_extend<'b>(this: &mut RefList<'b>, other: &RefList<'b>) -> RefList<'b> {
+        this.extend(other)
+    }
+    #[no_mangle]
+    extern "C" fn RefList_destroy<'a>(this: Box<RefList<'a>>) {}
+}
+

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -46,7 +46,7 @@ pub fn result_ok_offset_size_align(
         &ast::Struct {
             name: "".to_string(),
             docs: Default::default(),
-            lifetimes: vec![], // I don't understand the context here, is `vec![]` correct?
+            lifetimes: vec![],
             fields: vec![
                 if ok_size_align.size() > err_size_align.size() {
                     ("".to_string(), ok.clone(), Default::default())

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -46,6 +46,7 @@ pub fn result_ok_offset_size_align(
         &ast::Struct {
             name: "".to_string(),
             docs: Default::default(),
+            lifetimes: vec![], // I don't understand the context here, is `vec![]` correct?
             fields: vec![
                 if ok_size_align.size() > err_size_align.size() {
                     ("".to_string(), ok.clone(), Default::default())


### PR DESCRIPTION
Please note that this is the initial implementation, and expect for there to be further PRs with more test coverage and refactoring.

Firstly, this fixes #142 by using the tracked lifetimes to annotate all the relevant lifetimes in the generated `extern "C"` code, including lifetime bounds and when the lifetimes are renamed between the declaration and the impl block. Here's an example:
```rust
mod ffi {
    #[repr(transparent)]
    struct Foo<'a>(&'a str);
    #[repr(transparent)]
    struct Bar<'b, 'a: 'b>(&'b Foo<'a>);
    impl<'a> Foo<'a> {
        pub fn new(x: &'a str) -> Box<Foo<'a>> {
            unimplemented!()
        }
        pub fn get_bar<'b>(&'b self) -> Box<Bar<'b, 'a>> {
            unimplemented!()
        }
    }
    #[no_mangle]
    extern "C" fn Bar_destroy<'b, 'a: 'b>(this: Box<Bar<'b, 'a>>) {}
    #[no_mangle]
    extern "C" fn Foo_new<'a>(x_diplomat_data: *const u8, x_diplomat_len: usize) -> Box<Foo<'a>> {
        Foo::new(unsafe {
            core::str::from_utf8(core::slice::from_raw_parts(x_diplomat_data, x_diplomat_len))
                .unwrap()
        })
    }
    #[no_mangle]
    extern "C" fn Foo_get_bar<'a, 'b>(this: &'b Foo<'a>) -> Box<Bar<'b, 'a>> {
        this.get_bar()
    }
    #[no_mangle]
    extern "C" fn Foo_destroy<'a>(this: Box<Foo<'a>>) {}
}
```
Secondly, now it also adds support for parameters of type `Self` by expanding to the full `PathType`, and this also works when the lifetimes are renamed. Here's an example:
```rust
mod ffi {
    #[repr(transparent)]
    struct RefList<'a> {
        data: &'a i32,
        next: Option<Box<Self>>,
    }
    impl<'b> RefList<'b> {
        pub fn extend(&mut self, other: &Self) -> Self {
            unimplemented!()
        }
    }
    #[no_mangle]
    extern "C" fn RefList_extend<'b>(this: &mut RefList<'b>, other: &RefList<'b>) -> RefList<'b> {
        this.extend(other)
    }
    #[no_mangle]
    extern "C" fn RefList_destroy<'a>(this: Box<RefList<'a>>) {}
}
```