### PR TITLE
Introduce an `Ident` type

### DIFF
--- a/core/src/ast/idents.rs
+++ b/core/src/ast/idents.rs
@@ -1,0 +1,39 @@
+use proc_macro2::Span;
+use quote::{ToTokens, TokenStreamExt};
+use serde::{Deserialize, Serialize};
+use std::{borrow::Borrow, fmt};
+ 
+/// An identifier, analogous to `syn::Ident` and `proc_macro2::Ident`.
+#[derive(Hash, Eq, PartialEq, Deserialize, Serialize, Clone, Debug, Ord, PartialOrd)]
+pub struct Ident(String);
+ 
+impl Ident {
+   pub fn to_syn(&self) -> syn::Ident {
+       syn::Ident::new(&self.0, Span::call_site())
+   }
+}
+ 
+impl Borrow<str> for Ident {
+   fn borrow(&self) -> &str {
+       &self.0
+   }
+}
+ 
+impl fmt::Display for Ident {
+   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+       self.0.fmt(f)
+   }
+}
+ 
+impl From<&syn::Ident> for Ident {
+   fn from(ident: &syn::Ident) -> Self {
+       Ident(ident.to_string())
+   }
+}
+ 
+impl ToTokens for Ident {
+   fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+       tokens.append(proc_macro2::Ident::new(&self.0, Span::call_site()));
+   }
+}
+ 

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -22,6 +22,9 @@ pub use types::{
 mod paths;
 pub use paths::Path;
 
+mod idents;
+pub use idents::Ident;
+
 mod docs;
 pub use docs::{Docs, DocsUrlGenerator};
 


### PR DESCRIPTION
Currently, we use `String`s for identifiers, which can be confusing because identifiers require invariants that `String`s obviously don't support. For example, a `String` in a `Path` refers to an identifier, while a `String` in a `Docs` refers to arbitrary text.

This PR introduces the `Ident` type, which will be the Diplomat equivalent of `syn::Ident` and `proc_macro2::Ident`, and resolve these ambiguities in source code. It will guarantee the same invariants and also allow for easier modification later, like if we wanted to internally use `smartstring::SmartString` or something for performance gains.

Doing this in a draft PR to more easily track progress