### PR TITLE
Fix failure to generate feature_tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
       run: cd example && ./gen_all.sh
     - name: Test example is fresh
       run: git diff --exit-code
+    - name: Generate feature tests
+      run: cd feature_tests && ./gen_all.sh
+    - name: Test example is fresh
+      run: git diff --exit-code
   tests-and-example:
     runs-on: ubuntu-latest
     steps:

--- a/feature_tests/cpp/docs/index.rst
+++ b/feature_tests/cpp/docs/index.rst
@@ -5,8 +5,10 @@ Documentation
    :maxdepth: 3
    :caption: Modules:
 
+   lifetimes_ffi
    option_ffi
    result_ffi
+   selftype_ffi
    slices_ffi
    structs_ffi
 

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -4,6 +4,16 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
   wasm.diplomat_free(obj["ptr"], obj["size"], obj["align"]);
 });
 
+const Bar_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.Bar_destroy(underlying);
+});
+
+export class Bar {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+}
+
 const ErrorEnum_js_to_rust = {
   "Foo": 0,
   "Bar": 1,
@@ -70,6 +80,47 @@ export class Float64Vec {
     new_slice_diplomat_buf.set(new_slice_diplomat_bytes, 0);
     const diplomat_out = wasm.Float64Vec_set_value(this.underlying, new_slice_diplomat_ptr, new_slice_diplomat_bytes.length);
     wasm.diplomat_free(new_slice_diplomat_ptr, new_slice_diplomat_bytes.length, 8);
+  }
+}
+
+const Foo_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.Foo_destroy(underlying);
+});
+
+export class Foo {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  static new(x) {
+    let x_diplomat_bytes = (new TextEncoder()).encode(x);
+    let x_diplomat_ptr = wasm.diplomat_alloc(x_diplomat_bytes.length, 1);
+    let x_diplomat_buf = new Uint8Array(wasm.memory.buffer, x_diplomat_ptr, x_diplomat_bytes.length);
+    x_diplomat_buf.set(x_diplomat_bytes, 0);
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new Foo(wasm.Foo_new(x_diplomat_ptr, x_diplomat_bytes.length));
+        out.owner = null;
+        return out;
+      })();
+      Foo_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    wasm.diplomat_free(x_diplomat_ptr, x_diplomat_bytes.length, 1);
+    return diplomat_out;
+  }
+
+  get_bar() {
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new Bar(wasm.Foo_get_bar(this.underlying));
+        out.owner = null;
+        return out;
+      })();
+      Bar_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    return diplomat_out;
   }
 }
 
@@ -385,6 +436,29 @@ export class OptionStruct {
       out.owner = null;
       return out;
     })();
+  }
+}
+
+const RefList_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.RefList_destroy(underlying);
+});
+
+export class RefList {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+
+  static node(data) {
+    const diplomat_out = (() => {
+      const out = (() => {
+        const out = new RefList(wasm.RefList_node(data.underlying));
+        out.owner = null;
+        return out;
+      })();
+      RefList_box_destroy_registry.register(out, out.underlying)
+      return out;
+    })();
+    return diplomat_out;
   }
 }
 

--- a/feature_tests/js/docs/index.rst
+++ b/feature_tests/js/docs/index.rst
@@ -5,8 +5,10 @@ Documentation
    :maxdepth: 3
    :caption: Modules:
 
+   lifetimes_ffi
    option_ffi
    result_ffi
+   selftype_ffi
    slices_ffi
    structs_ffi
 

--- a/feature_tests/src/selftype.rs
+++ b/feature_tests/src/selftype.rs
@@ -1,14 +1,11 @@
 #[diplomat::bridge]
 mod ffi {
     #[diplomat::opaque]
-    struct RefList<'a> {
-        data: &'a i32,
-        next: Option<Box<Self>>,
-    }
+    struct RefList<'a>( (&'a i32, Option<Box<Self>>));
 
     impl<'b> RefList<'b> {
         pub fn node(data: &'b i32) -> Box<Self> {
-            Box::new(RefList { data, next: None })
+            Box::new(RefList((data, None)))
         }
 
         // pub fn extend(&mut self, other: Self) {

--- a/feature_tests/src/selftype.rs
+++ b/feature_tests/src/selftype.rs
@@ -1,7 +1,7 @@
 #[diplomat::bridge]
 mod ffi {
     #[diplomat::opaque]
-    struct RefList<'a>( (&'a i32, Option<Box<Self>>));
+    struct RefList<'a>((&'a i32, Option<Box<Self>>));
 
     impl<'b> RefList<'b> {
         pub fn node(data: &'b i32) -> Box<Self> {

--- a/feature_tests/src/selftype.rs
+++ b/feature_tests/src/selftype.rs
@@ -1,20 +1,21 @@
 #[diplomat::bridge]
 mod ffi {
+    #[diplomat::opaque]
     struct RefList<'a> {
         data: &'a i32,
         next: Option<Box<Self>>,
     }
 
     impl<'b> RefList<'b> {
-        pub fn node(data: &'b i32) -> Self {
-            RefList { data, next: None }
+        pub fn node(data: &'b i32) -> Box<Self> {
+            Box::new(RefList { data, next: None })
         }
 
-        pub fn extend(&mut self, other: Self) {
-            match self.next.as_mut() {
-                Some(tail) => tail.extend(other),
-                None => self.next = Some(Box::new(other)),
-            }
-        }
+        // pub fn extend(&mut self, other: Self) {
+        //     match self.next.as_mut() {
+        //         Some(tail) => tail.extend(other),
+        //         None => self.next = Some(Box::new(other)),
+        //     }
+        // }
     }
 }


### PR DESCRIPTION
we weren't testing that feature_tests was appropriately generated in CI, and it was failing since the selftype test was referring to non-opaque structs behind references. It's worth rewriting the test, but I don't want to do that here