### PR TITLE
Make `ast::Param` use `Ident`

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -22,7 +22,7 @@ pub struct Method {
     pub full_path_name: Ident,
 
     /// The `self` param of the method, if any.
-    pub self_param: Option<Param>,
+    pub self_param: Option<SelfParam>,
 
     /// All non-`self` params taken by the method.
     pub params: Vec<Param>,
@@ -66,18 +66,7 @@ impl Method {
             .collect::<Vec<_>>();
 
         let self_param = m.sig.receiver().map(|rec| match rec {
-            FnArg::Receiver(rec) => Param {
-                name: "self".to_string(),
-                ty: if let Some(ref reference) = rec.reference {
-                    TypeName::Reference(
-                        Lifetime::from(&reference.1),
-                        Mutability::from_syn(&rec.mutability),
-                        Box::new(TypeName::Named(self_path_type.clone())),
-                    )
-                } else {
-                    TypeName::Named(self_path_type.clone())
-                },
-            },
+            FnArg::Receiver(rec) => SelfParam::from_syn(rec, self_path_type.clone()),
             _ => panic!("Unexpected self param type"),
         });
 
@@ -123,7 +112,7 @@ impl Method {
     /// contain elided lifetimes that we depend on for this method. The validity
     /// checks ensure that the return type doesn't elide any lifetimes, ensuring
     /// that this method will produce correct results.
-    pub fn params_held_by_output(&self) -> Vec<&Param> {
+    pub fn params_held_by_output(&self) -> (Option<&SelfParam>, Vec<&Param>) {
         // To determine which params the return type is bound to, we just have to
         // find the params that contain a lifetime that's also in the return type.
         self.return_type
@@ -147,11 +136,27 @@ impl Method {
                     ControlFlow::Continue(())
                 });
 
+                let held_self_param = self.self_param.as_ref().filter(|self_param| {
+                    // Check if `self` is a reference with a lifetime in the return type.
+                    if let Some(Lifetime::Named(ref name)) = self_param.reference {
+                        if lifetimes.contains(name) {
+                            return true;
+                        }
+                    }
+                    self_param.path_type.lifetimes.iter().any(|lt| {
+                        if let Lifetime::Named(name) = lt {
+                            lifetimes.contains(name)
+                        } else {
+                            false
+                        }
+                    })
+                });
+
                 // Collect all the params that contain a named lifetime that's also
                 // in the return type.
-                self.self_param
+                let held_params = self
+                    .params
                     .iter()
-                    .chain(self.params.iter())
                     .filter(|param| {
                         param
                             .ty
@@ -168,7 +173,9 @@ impl Method {
                             })
                             .is_break()
                     })
-                    .collect()
+                    .collect();
+
+                (held_self_param, held_params)
             })
             .unwrap_or_default()
     }
@@ -180,8 +187,12 @@ impl Method {
         env: &Env,
         errors: &mut Vec<ValidityError>,
     ) {
-        if let Some(ref m) = self.self_param {
-            m.ty.check_validity(in_path, env, errors);
+        // validity check that if the self type is nonopaque, that it is
+        // behind a reference
+        if let Some(ref self_param) = self.self_param {
+            self_param
+                .to_typename()
+                .check_validity(in_path, env, errors);
         }
         for m in self.params.iter() {
             m.ty.check_validity(in_path, env, errors);
@@ -218,14 +229,45 @@ impl Method {
     }
 }
 
-/// A parameter taken by a [`Method`], including `self`.
+/// The `self` parameter taken by a [`Method`].
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+pub struct SelfParam {
+    /// The lifetime of the `self` param, if it's a reference.
+    pub reference: Option<Lifetime>,
+
+    /// The mutability of the `self` param.
+    pub mutability: Mutability,
+
+    /// The type of the parameter, which will be a named reference to
+    /// the associated struct,
+    pub path_type: PathType,
+}
+
+impl SelfParam {
+    pub fn to_typename(&self) -> TypeName {
+        let typ = TypeName::Named(self.path_type.clone());
+        if let Some(ref lt) = self.reference {
+            return TypeName::Reference(lt.clone(), self.mutability.clone(), Box::new(typ));
+        }
+        typ
+    }
+
+    pub fn from_syn(rec: &syn::Receiver, path_type: PathType) -> Self {
+        SelfParam {
+            reference: rec.reference.as_ref().map(|(_, lt)| lt.into()),
+            mutability: Mutability::from_syn(&rec.mutability),
+            path_type,
+        }
+    }
+}
+
+/// A parameter taken by a [`Method`], not including `self`.
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
 pub struct Param {
     /// The name of the parameter in the original method declaration.
-    pub name: String,
+    pub name: Ident,
 
-    /// The type of the parameter, which will be a named reference to
-    /// the associated struct if this is the `self` parameter.
+    /// The type of the parameter.
     pub ty: TypeName,
 }
 
@@ -240,12 +282,12 @@ impl Param {
 
     pub fn from_syn(t: &PatType, self_path_type: PathType) -> Self {
         let ident = match t.pat.as_ref() {
-            Pat::Ident(ident) => ident.clone(),
+            Pat::Ident(ident) => ident,
             _ => panic!("Unexpected param type"),
         };
 
         Param {
-            name: ident.ident.to_string(),
+            name: (&ident.ident).into(),
             ty: TypeName::from_syn(&t.ty, Some(self_path_type)),
         }
     }
@@ -316,25 +358,47 @@ mod tests {
     }
 
     macro_rules! assert_params_held_by_output {
-        ([$($lt:expr),*] => $($tokens:tt)* ) => {{
+        ([self $(,$($param:ident),+)?] => $($tokens:tt)* ) => {{
             let method = Method::from_syn(
                 &syn::parse_quote! { $($tokens)* },
                 PathType::new(Path::empty().sub_path(Ident::from("MyStructContainingMethod"))),
                 vec![],
             );
 
-            let actual = method
-                .params_held_by_output()
+            let (self_param, params) = method.params_held_by_output();
+            assert!(self_param.is_some(), "expected `self` param to be held");
+
+            let actual: Vec<&str> = params
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect();
+
+            let expected: &[&str] = &[$($(stringify!($param)),*)?];
+
+            assert_eq!(actual, expected);
+        }};
+        ([$($param:ident),*] => $($tokens:tt)* ) => {{
+            let method = Method::from_syn(
+                &syn::parse_quote! { $($tokens)* },
+                PathType::new(Path::empty().sub_path(Ident::from("MyStructContainingMethod"))),
+                vec![],
+            );
+
+            let (self_param, params) = method.params_held_by_output();
+            assert!(self_param.is_none(), "didn't expect `self` param to be held");
+
+            let actual = params
                 .iter()
                 .map(|p| p.name.as_str())
                 .collect::<Vec<_>>();
-            assert_eq!(actual, [$($lt),*]);
+
+            assert_eq!(actual, [$(stringify!($param)),*]);
         }};
     }
 
     #[test]
     fn static_params_held_by_return_type() {
-        assert_params_held_by_output! { ["first", "second"] =>
+        assert_params_held_by_output! { [first, second] =>
             #[diplomat::rust_link(foo::Bar::batz, FnInStruct)]
             fn foo<'a, 'b>(first: &'a First, second: &'b Second, third: &Third) -> Foo<'a, 'b> {
                 unimplemented!()
@@ -344,21 +408,21 @@ mod tests {
 
     #[test]
     fn nonstatic_params_held_by_return_type() {
-        assert_params_held_by_output! { ["self"] =>
+        assert_params_held_by_output! { [self] =>
             #[diplomat::rust_link(foo::Bar::batz, FnInStruct)]
             fn foo<'a>(&'a self) -> Foo<'a> {
                 unimplemented!()
             }
         }
 
-        assert_params_held_by_output! { ["self", "foo", "bar"] =>
+        assert_params_held_by_output! { [self, foo, bar] =>
             #[diplomat::rust_link(foo::Bar::batz, FnInStruct)]
             fn foo<'x, 'y>(&'x self, foo: &'x Foo, bar: &Bar<'y>, baz: &Baz) -> Foo<'x, 'y> {
                 unimplemented!()
             }
         }
 
-        assert_params_held_by_output! { ["self", "bar"] =>
+        assert_params_held_by_output! { [self, bar] =>
             #[diplomat::rust_link(foo::Bar::batz, FnInStruct)]
             fn foo<'a, 'b>(&'a self, bar: Bar<'b>) -> Foo<'a, 'b> {
                 unimplemented!()
@@ -366,7 +430,7 @@ mod tests {
         }
 
         // Test that being dependent on 'static doesn't make you dependent on 'static params.
-        assert_params_held_by_output! { ["self", "bar"] =>
+        assert_params_held_by_output! { [self, bar] =>
             #[diplomat::rust_link(foo::Bar::batz, FnInStruct)]
             fn foo<'a, 'b>(&'a self, bar: Bar<'b>, baz: &'static str) -> Foo<'a, 'b, 'static> {
                 unimplemented!()

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -13,16 +13,13 @@ docs:
     typ: FnInStruct
 full_path_name: MyStructContainingMethod_foo
 self_param:
-  name: self
-  ty:
-    Reference:
-      - Anonymous
-      - Mutable
-      - Named:
-          path:
-            elements:
-              - MyStructContainingMethod
-          lifetimes: []
+  reference: Anonymous
+  mutability: Mutable
+  path_type:
+    path:
+      elements:
+        - MyStructContainingMethod
+    lifetimes: []
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -13,8 +13,9 @@ docs:
     typ: FnInStruct
 full_path_name: MyStructContainingMethod_foo
 self_param:
-  reference: Anonymous
-  mutability: Mutable
+  reference:
+    - Anonymous
+    - Mutable
   path_type:
     path:
       elements:

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -8,16 +8,13 @@ docs:
   - ~
 full_path_name: MyStructContainingMethod_foo
 self_param:
-  name: self
-  ty:
-    Reference:
-      - Anonymous
-      - Immutable
-      - Named:
-          path:
-            elements:
-              - MyStructContainingMethod
-          lifetimes: []
+  reference: Anonymous
+  mutability: Immutable
+  path_type:
+    path:
+      elements:
+        - MyStructContainingMethod
+    lifetimes: []
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -8,8 +8,9 @@ docs:
   - ~
 full_path_name: MyStructContainingMethod_foo
 self_param:
-  reference: Anonymous
-  mutability: Immutable
+  reference:
+    - Anonymous
+    - Immutable
   path_type:
     path:
       elements:

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -50,8 +50,9 @@ declared_types:
             - ~
           full_path_name: NonOpaqueStruct_set_a
           self_param:
-            reference: Anonymous
-            mutability: Mutable
+            reference:
+              - Anonymous
+              - Mutable
             path_type:
               path:
                 elements:
@@ -92,8 +93,9 @@ declared_types:
             - ~
           full_path_name: OpaqueStruct_get_string
           self_param:
-            reference: Anonymous
-            mutability: Immutable
+            reference:
+              - Anonymous
+              - Immutable
             path_type:
               path:
                 elements:

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -50,16 +50,13 @@ declared_types:
             - ~
           full_path_name: NonOpaqueStruct_set_a
           self_param:
-            name: self
-            ty:
-              Reference:
-                - Anonymous
-                - Mutable
-                - Named:
-                    path:
-                      elements:
-                        - NonOpaqueStruct
-                    lifetimes: []
+            reference: Anonymous
+            mutability: Mutable
+            path_type:
+              path:
+                elements:
+                  - NonOpaqueStruct
+              lifetimes: []
           params:
             - name: new_a
               ty:
@@ -95,16 +92,13 @@ declared_types:
             - ~
           full_path_name: OpaqueStruct_get_string
           self_param:
-            name: self
-            ty:
-              Reference:
-                - Anonymous
-                - Immutable
-                - Named:
-                    path:
-                      elements:
-                        - OpaqueStruct
-                    lifetimes: []
+            reference: Anonymous
+            mutability: Immutable
+            path_type:
+              path:
+                elements:
+                  - OpaqueStruct
+              lifetimes: []
           params: []
           return_type:
             Named:

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -18,10 +18,7 @@ fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) 
                     attrs: vec![],
                     by_ref: None,
                     mutability: None,
-                    ident: Ident::new(
-                        (param.name.clone() + "_diplomat_data").as_str(),
-                        Span::call_site(),
-                    ),
+                    ident: Ident::new(&format!("{}_diplomat_data", param.name), Span::call_site()),
                     subpat: None,
                 })),
                 colon_token: syn::token::Colon(Span::call_site()),
@@ -45,10 +42,7 @@ fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) 
                     attrs: vec![],
                     by_ref: None,
                     mutability: None,
-                    ident: Ident::new(
-                        (param.name.clone() + "_diplomat_len").as_str(),
-                        Span::call_site(),
-                    ),
+                    ident: Ident::new(&format!("{}_diplomat_len", param.name), Span::call_site()),
                     subpat: None,
                 })),
                 colon_token: syn::token::Colon(Span::call_site()),
@@ -80,14 +74,9 @@ fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) 
 fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
     match &param.ty {
         ast::TypeName::StrReference(_) | ast::TypeName::PrimitiveSlice(..) => {
-            let data_ident = Ident::new(
-                (param.name.clone() + "_diplomat_data").as_str(),
-                Span::call_site(),
-            );
-            let len_ident = Ident::new(
-                (param.name.clone() + "_diplomat_len").as_str(),
-                Span::call_site(),
-            );
+            let data_ident =
+                Ident::new(&format!("{}_diplomat_data", param.name), Span::call_site());
+            let len_ident = Ident::new(&format!("{}_diplomat_len", param.name), Span::call_site());
 
             let tokens = if let ast::TypeName::PrimitiveSlice(_, mutability, _) = &param.ty {
                 match mutability {
@@ -148,7 +137,7 @@ fn gen_custom_type_method(strct: &ast::CustomType, m: &ast::Method) -> Item {
                 attrs: vec![],
                 pat: Box::new(this_ident.clone()),
                 colon_token: syn::token::Colon(Span::call_site()),
-                ty: Box::new(self_param.ty.to_syn()),
+                ty: Box::new(self_param.to_typename().to_syn()),
             }),
         );
     }

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -66,13 +66,18 @@ pub fn gen_method<W: fmt::Write>(
     }
 
     write!(out, " {}(", method.full_path_name)?;
-    let mut params_to_gen = method.params.clone();
-    if let Some(param) = &method.self_param {
-        params_to_gen.insert(0, param.clone());
+
+    let mut first = true;
+    if let Some(self_param) = &method.self_param {
+        gen_type(&self_param.to_typename(), in_path, env, out)?;
+        write!(out, " self")?;
+        first = false;
     }
 
-    for (i, param) in params_to_gen.iter().enumerate() {
-        if i != 0 {
+    for param in method.params.iter() {
+        if first {
+            first = false;
+        } else {
             write!(out, ", ")?;
         }
 

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -319,7 +319,7 @@ pub fn gen_method_interface<W: fmt::Write>(
 
     let mut is_const = false;
     if let Some(ref self_param) = method.self_param {
-        // If it's pass-by-value, we assume mutability.
+        // If it's pass-by-value, mutability doesn't matter.
         if let Some((_, ref mutability)) = self_param.reference {
             is_const = mutability.is_immutable();
         }

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -211,12 +211,12 @@ fn gen_method<W: fmt::Write>(
 
         let mut all_params_invocation = vec![];
 
-        if let Some(param) = &method.self_param {
+        if let Some(self_param) = &method.self_param {
             let invocation_expr = gen_cpp_to_rust(
                 "this",
                 "this",
                 None,
-                &param.ty,
+                &self_param.to_typename(),
                 in_path,
                 env,
                 true,
@@ -233,13 +233,13 @@ fn gen_method<W: fmt::Write>(
                 }
                 _ => {
                     let invocation_expr = gen_cpp_to_rust(
-                        &param.name,
-                        &param.name,
+                        param.name.as_str(),
+                        param.name.as_str(),
                         None,
                         &param.ty,
                         in_path,
                         env,
-                        param.name == "self",
+                        false,
                         &mut method_body,
                     );
                     all_params_invocation.push(invocation_expr);
@@ -318,9 +318,10 @@ pub fn gen_method_interface<W: fmt::Write>(
     }
 
     let mut is_const = false;
-    if let Some(ref param) = method.self_param {
-        if let ast::TypeName::Reference(_, mutable, _lt) = &param.ty {
-            is_const = mutable.is_immutable();
+    if let Some(ref self_param) = method.self_param {
+        // QUESTION: What if we have mutable pass-by-value?
+        if self_param.reference.is_some() {
+            is_const = self_param.mutability.is_immutable();
         }
     } else if is_header {
         write!(out, "static ")?;

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -319,9 +319,9 @@ pub fn gen_method_interface<W: fmt::Write>(
 
     let mut is_const = false;
     if let Some(ref self_param) = method.self_param {
-        // QUESTION: What if we have mutable pass-by-value?
-        if self_param.reference.is_some() {
-            is_const = self_param.mutability.is_immutable();
+        // If it's pass-by-value, we assume mutability.
+        if let Some((_, ref mutability)) = self_param.reference {
+            is_const = mutability.is_immutable();
         }
     } else if is_header {
         write!(out, "static ")?;

--- a/tool/src/dotnet/idiomatic.rs
+++ b/tool/src/dotnet/idiomatic.rs
@@ -362,7 +362,7 @@ fn gen_method(
             write!(out, ", ")?;
         }
 
-        let name = param.name.to_lower_camel_case();
+        let name = param.name.as_str().to_lower_camel_case();
 
         if let ast::TypeName::StrReference(..) = param.ty {
             params_str_ref.push(name.clone());
@@ -419,7 +419,7 @@ fn gen_method(
             }
 
             for param in &params_custom_types {
-                let param_name = param.name.to_lower_camel_case();
+                let param_name = param.name.as_str().to_lower_camel_case();
                 let raw_var_name = format!("{}Raw", param_name);
                 let mut raw_type_name = String::new();
                 gen_raw_conversion_type_name_decl_position(

--- a/tool/src/dotnet/raw.rs
+++ b/tool/src/dotnet/raw.rs
@@ -177,16 +177,21 @@ fn gen_method(
             .replace(&format!("{}_", typ.name()), "")
             .to_upper_camel_case()
     )?;
-    let mut params_to_gen = method.params.clone();
-    if let Some(param) = &method.self_param {
-        params_to_gen.insert(0, param.clone());
+
+    let mut first = true;
+    if let Some(ref self_param) = method.self_param {
+        gen_param("self", &self_param.to_typename(), false, in_path, env, out)?;
+        first = false;
     }
 
-    for (i, param) in params_to_gen.iter().enumerate() {
-        if i != 0 {
+    for param in method.params.iter() {
+        if first {
+            first = false;
+        } else {
             write!(out, ", ")?;
         }
-        let name = param.name.to_lower_camel_case();
+
+        let name = param.name.as_str().to_lower_camel_case();
         gen_param(&name, &param.ty, param.is_writeable(), in_path, env, out)?;
     }
 

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -10,7 +10,7 @@ use crate::layout;
 
 #[allow(clippy::ptr_arg)] // false positive, rust-clippy#8463, fixed in 1.61
 pub fn gen_value_js_to_rust(
-    param_name: String,
+    param_name: &ast::Ident,
     typ: &ast::TypeName,
     in_path: &ast::Path,
     env: &Env,
@@ -73,14 +73,14 @@ pub fn gen_value_js_to_rust(
             ast::CustomType::Struct(struct_type) => {
                 for (field_name, field_type, _) in struct_type.fields.iter() {
                     let field_extracted_name =
-                        format!("diplomat_{}_extracted_{}", struct_type.name, field_name);
+                        format!("diplomat_{}_extracted_{}", struct_type.name, field_name).into();
                     pre_logic.push(format!(
                         "const {} = {}[\"{}\"];",
                         field_extracted_name, param_name, field_name
                     ));
 
                     gen_value_js_to_rust(
-                        field_extracted_name,
+                        &field_extracted_name,
                         field_type,
                         in_path,
                         env,
@@ -99,7 +99,7 @@ pub fn gen_value_js_to_rust(
                 panic!("Opaque types cannot be sent as values");
             }
         },
-        _ => invocation_params.push(param_name),
+        _ => invocation_params.push(param_name.to_string()),
     }
 }
 

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -109,7 +109,11 @@ pub fn gen_method_docs<W: fmt::Write>(
     docs_url_gen: &ast::DocsUrlGenerator,
     env: &Env,
 ) -> fmt::Result {
-    let mut param_names: Vec<String> = method.params.iter().map(|p| p.name.clone()).collect();
+    let mut param_names = method
+        .params
+        .iter()
+        .map(|p| p.name.as_str())
+        .collect::<Vec<_>>();
     if method.is_writeable_out() {
         param_names.remove(param_names.len() - 1);
     }

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -118,7 +118,7 @@ fn gen_method<W: fmt::Write>(
 
     method.params.iter().for_each(|p| {
         gen_value_js_to_rust(
-            p.name.clone(),
+            &p.name,
             &p.ty,
             in_path,
             env,
@@ -131,8 +131,8 @@ fn gen_method<W: fmt::Write>(
     let mut all_params = method
         .params
         .iter()
-        .map(|p| p.name.clone())
-        .collect::<Vec<String>>();
+        .map(|p| p.name.as_str())
+        .collect::<Vec<_>>();
 
     if is_writeable {
         let last_index_exprs = all_param_exprs.len() - 1;


### PR DESCRIPTION
I keep getting distracted and wanting to change little things that bother me so here we are.

This PR does two things: Changes the `name` field of `Param` to be of type `Ident`, and introduces the new `SelfParam` type which distinguishes at the type level between ordinary function parameters and the special `self` parameter. It is defined as follows:
```rust
pub struct SelfParam {
    pub reference: Option<Lifetime>,
    pub mutability: Mutability,
    pub path_type: PathType,
}
```
The new type is introduced because `self` is an invalid identifier. Because of this, I've had to change the type signatures of a couple methods, but I've updated everything accordingly and all the tests pass. 