### PR TITLE
JS codegen cleanup

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -125,16 +125,17 @@ impl Method {
     /// method that doesn't take the writeable as an argument but instead creates
     /// one locally and just returns the final string.
     pub fn is_writeable_out(&self) -> bool {
-        let return_compatible = self.return_type.is_none()
-            || match self.return_type.as_ref().unwrap() {
+        let return_compatible = self
+            .return_type
+            .as_ref()
+            .map(|return_type| match return_type {
                 TypeName::Unit => true,
                 TypeName::Result(ok, _) => matches!(ok.as_ref(), TypeName::Unit),
                 _ => false,
-            };
+            })
+            .unwrap_or(true);
 
-        return_compatible
-            && !self.params.is_empty()
-            && self.params[self.params.len() - 1].is_writeable()
+        return_compatible && self.params.last().map(Param::is_writeable).unwrap_or(false)
     }
 
     /// Checks if any parameters are writeable (regardless of other compatibilities for writeable output)

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -8,6 +8,7 @@ use indenter::indented;
 use super::types::{return_type_form, ReturnTypeForm};
 use crate::layout;
 
+/// TODO: docs
 #[allow(clippy::ptr_arg)] // false positive, rust-clippy#8463, fixed in 1.61
 pub fn gen_value_js_to_rust(
     param_name: String,
@@ -103,6 +104,7 @@ pub fn gen_value_js_to_rust(
     }
 }
 
+/// TODO: docs
 pub fn gen_value_rust_to_js<W: fmt::Write>(
     value_expr: &str,
     typ: &ast::TypeName,
@@ -346,6 +348,7 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
     Ok(())
 }
 
+/// TODO: docs
 fn gen_box_destructor<W: fmt::Write>(
     name: &ast::Ident,
     typ: &ast::TypeName,
@@ -409,6 +412,7 @@ fn gen_box_destructor<W: fmt::Write>(
     Ok(())
 }
 
+/// TODO: docs
 fn gen_rust_reference_to_js<W: fmt::Write>(
     underlying: &ast::TypeName,
     in_path: &ast::Path,

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -253,9 +253,6 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
                             result_size_align.size(),
                             result_size_align.align()
                         )?;
-                    }
-
-                    if needs_buffer {
                         writeln!(f, "const result_tag = {{}};")?;
                         writeln!(
                             f,
@@ -266,11 +263,6 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
                                 writeln!(f, "align: {},", result_size_align.align())
                             })
                         )?;
-                    }
-
-                    if !needs_buffer {
-                        writeln!(f, "const is_ok = {} == 1;", value_expr)?;
-                    } else {
                         writeln!(f, "{};", value_expr)?;
                         writeln!(
                             f,
@@ -286,11 +278,8 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
                                 )
                             })
                         )?;
-                    }
-
-                    if needs_buffer {
                         writeln!(
-                            &mut f,
+                            f,
                             "if (is_ok) {is_true} else {is_false}",
                             is_true = display::block(|mut f| {
                                 writeln!(
@@ -328,6 +317,7 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
                             })
                         )
                     } else {
+                        writeln!(f, "const is_ok = {} == 1;", value_expr)?;
                         writeln!(
                             f,
                             "if (!is_ok) {}",

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use std::fmt::Write;
 
 use diplomat_core::ast::{self, PrimitiveType};
-use indenter::indented;
 
+use super::display;
 use super::types::{return_type_form, ReturnTypeForm};
 use crate::layout;
 
@@ -123,41 +123,40 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
                         todo!("Receiving structs that don't need a buffer")
                     }
 
-                    writeln!(out, "(() => {{")?;
-                    let mut iife_indent = indented(out).with_str("  ");
-                    writeln!(
-                        &mut iife_indent,
-                        "const diplomat_receive_buffer = wasm.diplomat_alloc({}, {});",
-                        strct_size_align.size(),
-                        strct_size_align.align(),
-                    )?;
-                    writeln!(&mut iife_indent, "{};", value_expr)?;
-                    writeln!(
-                        &mut iife_indent,
-                        "const out = new {}(diplomat_receive_buffer);",
-                        strct.name
-                    )?;
+                    write!(
+                        out,
+                        "(() => {})()",
+                        display::block(|mut f| {
+                            writeln!(
+                                f,
+                                "const diplomat_receive_buffer = wasm.diplomat_alloc({}, {});",
+                                strct_size_align.size(),
+                                strct_size_align.align(),
+                            )?;
+                            writeln!(f, "{};", value_expr)?;
+                            writeln!(
+                                f,
+                                "const out = new {}(diplomat_receive_buffer);",
+                                strct.name
+                            )?;
 
-                    for (name, typ, _) in strct.fields.iter() {
-                        gen_box_destructor(name, typ, in_path, env, &mut iife_indent)?;
-                    }
+                            for (name, typ, _) in strct.fields.iter() {
+                                gen_box_destructor(name, typ, in_path, env, &mut f)?;
+                            }
 
-                    writeln!(
-                        &mut iife_indent,
-                        "diplomat_alloc_destroy_registry.register(out, {{"
-                    )?;
+                            writeln!(
+                                f,
+                                "diplomat_alloc_destroy_registry.register(out, {});",
+                                display::block(|mut f| {
+                                    writeln!(f, "ptr: out.underlying,")?;
+                                    writeln!(f, "size: {},", strct_size_align.size())?;
+                                    writeln!(f, "align: {},", strct_size_align.align())
+                                })
+                            )?;
 
-                    let mut alloc_dict_indent = indented(&mut iife_indent).with_str("  ");
-                    writeln!(&mut alloc_dict_indent, "ptr: out.underlying,")?;
-                    writeln!(&mut alloc_dict_indent, "size: {},", strct_size_align.size())?;
-                    writeln!(
-                        &mut alloc_dict_indent,
-                        "align: {},",
-                        strct_size_align.align()
+                            writeln!(f, "return out;")
+                        })
                     )?;
-                    writeln!(&mut iife_indent, "}});")?;
-                    writeln!(&mut iife_indent, "return out;")?;
-                    write!(out, "}})()")?;
                 }
 
                 ast::CustomType::Enum(enm) => {
@@ -171,29 +170,36 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
         }
 
         ast::TypeName::Box(underlying) => {
-            writeln!(out, "(() => {{")?;
-            let mut iife_indent = indented(out).with_str("  ");
-            write!(&mut iife_indent, "const out = ")?;
-            gen_rust_reference_to_js(
-                underlying.as_ref(),
-                in_path,
-                value_expr,
-                "null", // JS owns the box
-                env,
-                &mut iife_indent,
+            write!(
+                out,
+                "(() => {})()",
+                display::block(|mut f| {
+                    writeln!(
+                        f,
+                        "const out = {};",
+                        display::expr(|mut f| {
+                            gen_rust_reference_to_js(
+                                underlying.as_ref(),
+                                in_path,
+                                value_expr,
+                                "null", // JS owns the box
+                                env,
+                                &mut f,
+                            )
+                        })
+                    )?;
+
+                    if let ast::TypeName::Named(_) = underlying.as_ref() {
+                        writeln!(
+                            f,
+                            "{}_box_destroy_registry.register(out, out.underlying)",
+                            underlying.resolve(in_path, env).name()
+                        )?;
+                    }
+
+                    writeln!(f, "return out;")
+                })
             )?;
-            writeln!(&mut iife_indent, ";")?;
-
-            if let ast::TypeName::Named(_) = underlying.as_ref() {
-                writeln!(
-                    &mut iife_indent,
-                    "{}_box_destroy_registry.register(out, out.underlying)",
-                    underlying.resolve(in_path, env).name()
-                )?;
-            }
-
-            writeln!(&mut iife_indent, "return out;")?;
-            write!(out, "}})()")?;
         }
 
         ast::TypeName::Option(underlying) => {
@@ -201,133 +207,137 @@ pub fn gen_value_rust_to_js<W: fmt::Write>(
                 underlying.is_pointer(),
                 "Options must contain pointer types"
             );
-            writeln!(out, "(() => {{")?;
-            let mut iife_indent = indented(out).with_str("  ");
-            writeln!(&mut iife_indent, "const option_value = {}", value_expr)?;
-
-            writeln!(&mut iife_indent, "if (option_value !== 0) {{")?;
-
-            let mut if_indent = indented(&mut iife_indent).with_str("  ");
-            write!(&mut if_indent, "const inhabited_value = ")?;
-            // TODO(#62): actually return `null` if the option is `None`
-            gen_value_rust_to_js(
-                "option_value",
-                underlying.as_ref(),
-                in_path,
-                env,
-                &mut (&mut if_indent as &mut dyn fmt::Write),
+            write!(
+                out,
+                "(() => {})()",
+                display::block(|mut f| {
+                    writeln!(f, "const option_value = {}", value_expr)?;
+                    writeln!(
+                        f,
+                        "if (option_value !== 0) {if_true} else {if_false}",
+                        if_true = display::block(|mut f| {
+                            writeln!(
+                                f,
+                                "const inhabited_value = {};",
+                                display::expr(|mut f| {
+                                    // TODO(#62): actually return `null` if the option is `None`
+                                    gen_value_rust_to_js(
+                                        "option_value",
+                                        underlying.as_ref(),
+                                        in_path,
+                                        env,
+                                        &mut f,
+                                    )
+                                })
+                            )?;
+                            writeln!(f, "return inhabited_value;")
+                        }),
+                        if_false = display::block(|mut f| writeln!(f, "return null;"))
+                    )
+                })
             )?;
-            writeln!(&mut if_indent, ";")?;
-
-            writeln!(&mut if_indent, "return inhabited_value;")?;
-
-            writeln!(&mut iife_indent, "}} else {{")?;
-            writeln!(&mut iife_indent, "  return null;")?;
-            writeln!(&mut iife_indent, "}}")?;
-
-            write!(out, "}})()")?;
         }
 
         ast::TypeName::Result(ok, err) => {
             let (ok_offset, result_size_align) =
                 layout::result_ok_offset_size_align(ok, err, in_path, env);
             let needs_buffer = return_type_form(typ, in_path, env) == ReturnTypeForm::Complex;
-            writeln!(out, "(() => {{")?;
-            let mut iife_indent = indented(out).with_str("  ");
-            if needs_buffer {
-                writeln!(
-                    &mut iife_indent,
-                    "const diplomat_receive_buffer = wasm.diplomat_alloc({}, {});",
-                    result_size_align.size(),
-                    result_size_align.align()
-                )?;
-            }
+            write!(
+                out,
+                "(() => {})()",
+                display::block(|mut f| {
+                    if needs_buffer {
+                        writeln!(
+                            f,
+                            "const diplomat_receive_buffer = wasm.diplomat_alloc({}, {});",
+                            result_size_align.size(),
+                            result_size_align.align()
+                        )?;
+                    }
 
-            if needs_buffer {
-                writeln!(&mut iife_indent, "const result_tag = {{}};")?;
-                writeln!(
-                    &mut iife_indent,
-                    "diplomat_alloc_destroy_registry.register(result_tag, {{"
-                )?;
-                let mut alloc_dict_indent = indented(&mut iife_indent).with_str("  ");
-                writeln!(&mut alloc_dict_indent, "ptr: diplomat_receive_buffer,")?;
-                writeln!(
-                    &mut alloc_dict_indent,
-                    "size: {},",
-                    result_size_align.size()
-                )?;
-                writeln!(
-                    &mut alloc_dict_indent,
-                    "align: {},",
-                    result_size_align.align()
-                )?;
-                writeln!(&mut iife_indent, "}});")?;
-            }
+                    if needs_buffer {
+                        writeln!(f, "const result_tag = {{}};")?;
+                        writeln!(
+                            f,
+                            "diplomat_alloc_destroy_registry.register(result_tag, {});",
+                            display::block(|mut f| {
+                                writeln!(f, "ptr: diplomat_receive_buffer,")?;
+                                writeln!(f, "size: {},", result_size_align.size())?;
+                                writeln!(f, "align: {},", result_size_align.align())
+                            })
+                        )?;
+                    }
 
-            if !needs_buffer {
-                write!(&mut iife_indent, "const is_ok = ")?;
-                write!(&mut iife_indent, "{}", value_expr)?;
-                writeln!(&mut iife_indent, " == 1;")?;
-            } else {
-                write!(&mut iife_indent, "{}", value_expr)?;
-                writeln!(&mut iife_indent, ";")?;
-                write!(&mut iife_indent, "const is_ok = ")?;
-                gen_rust_reference_to_js(
-                    &ast::TypeName::Primitive(PrimitiveType::bool),
-                    in_path,
-                    &format!("diplomat_receive_buffer + {}", ok_offset),
-                    "result_tag",
-                    env,
-                    &mut ((&mut iife_indent) as &mut dyn fmt::Write),
-                )?;
-                writeln!(&mut iife_indent, ";")?;
-            }
+                    if !needs_buffer {
+                        writeln!(f, "const is_ok = {} == 1;", value_expr)?;
+                    } else {
+                        writeln!(f, "{};", value_expr)?;
+                        writeln!(
+                            f,
+                            "const is_ok = {};",
+                            display::expr(|mut f| {
+                                gen_rust_reference_to_js(
+                                    &ast::TypeName::Primitive(PrimitiveType::bool),
+                                    in_path,
+                                    &format!("diplomat_receive_buffer + {}", ok_offset),
+                                    "result_tag",
+                                    env,
+                                    &mut f,
+                                )
+                            })
+                        )?;
+                    }
 
-            if needs_buffer {
-                writeln!(&mut iife_indent, "if (is_ok) {{")?;
-
-                let mut ok_indent = indented(&mut iife_indent).with_str("  ");
-
-                write!(&mut ok_indent, "const ok_value = ")?;
-                gen_rust_reference_to_js(
-                    ok.as_ref(),
-                    in_path,
-                    "diplomat_receive_buffer",
-                    "result_tag",
-                    env,
-                    &mut ((&mut ok_indent) as &mut dyn fmt::Write),
-                )?;
-                writeln!(&mut ok_indent, ";")?;
-
-                writeln!(&mut ok_indent, "return ok_value;")?;
-
-                writeln!(&mut iife_indent, "}} else {{")?;
-                let mut err_indent = indented(&mut iife_indent).with_str("  ");
-
-                write!(&mut err_indent, "const throw_value = ")?;
-                gen_rust_reference_to_js(
-                    err.as_ref(),
-                    in_path,
-                    "diplomat_receive_buffer",
-                    "result_tag",
-                    env,
-                    &mut ((&mut err_indent) as &mut dyn fmt::Write),
-                )?;
-                writeln!(&mut err_indent, ";")?;
-
-                writeln!(
-                    &mut err_indent,
-                    "throw new diplomatRuntime.FFIError(throw_value);"
-                )?;
-            } else {
-                writeln!(&mut iife_indent, "if (!is_ok) {{")?;
-                let mut err_indent = indented(&mut iife_indent).with_str("  ");
-                writeln!(&mut err_indent, "throw new diplomatRuntime.FFIError({{}});")?;
-            }
-
-            writeln!(&mut iife_indent, "}}")?;
-
-            write!(out, "}})()")?;
+                    if needs_buffer {
+                        writeln!(
+                            &mut f,
+                            "if (is_ok) {is_true} else {is_false}",
+                            is_true = display::block(|mut f| {
+                                writeln!(
+                                    f,
+                                    "const ok_value = {};",
+                                    display::expr(|mut f| {
+                                        gen_rust_reference_to_js(
+                                            ok.as_ref(),
+                                            in_path,
+                                            "diplomat_receive_buffer",
+                                            "result_tag",
+                                            env,
+                                            &mut f,
+                                        )
+                                    })
+                                )?;
+                                writeln!(f, "return ok_value;")
+                            }),
+                            is_false = display::block(|mut f| {
+                                writeln!(
+                                    f,
+                                    "const throw_value = {};",
+                                    display::expr(|mut f| {
+                                        gen_rust_reference_to_js(
+                                            err.as_ref(),
+                                            in_path,
+                                            "diplomat_receive_buffer",
+                                            "result_tag",
+                                            env,
+                                            &mut f,
+                                        )
+                                    })
+                                )?;
+                                writeln!(f, "throw new diplomatRuntime.FFIError(throw_value);")
+                            })
+                        )
+                    } else {
+                        writeln!(
+                            f,
+                            "if (!is_ok) {}",
+                            display::block(|mut f| {
+                                writeln!(f, "throw new diplomatRuntime.FFIError({{}});")
+                            })
+                        )
+                    }
+                })
+            )?;
         }
 
         ast::TypeName::Primitive(_prim) => {
@@ -383,26 +393,21 @@ fn gen_box_destructor<W: fmt::Write>(
                 "Options must contain pointer types"
             );
 
-            writeln!(out, "if (out.{}.underlying !== 0) {{", name)?;
-
-            let mut if_indent = indented(out).with_str("  ");
-
-            gen_box_destructor(
-                name,
-                underlying.as_ref(),
-                in_path,
-                env,
-                &mut (&mut if_indent as &mut dyn fmt::Write),
-            )?;
-
-            writeln!(out, "}} else {{")?;
             writeln!(
                 out,
-                "  Object.defineProperty(out, \"{}\", {{ value: null }});",
-                name
+                "if (out.{}.underlying !== 0) {if_true} else {if_false}",
+                name,
+                if_true = display::block(|mut f| {
+                    gen_box_destructor(name, underlying.as_ref(), in_path, env, &mut f)
+                }),
+                if_false = display::block(|mut f| {
+                    writeln!(
+                        f,
+                        "Object.defineProperty(out, \"{}\", {{ value: null }});",
+                        name
+                    )
+                })
             )?;
-            writeln!(out, "}}")?;
-
             // TODO(#62): don't generate destructor if null
         }
 
@@ -484,19 +489,15 @@ fn gen_rust_reference_to_js<W: fmt::Write>(
                 )?;
                 write!(out, "]")?;
             } else {
-                writeln!(out, "(() => {{")?;
-                let mut iife_indent = indented(out).with_str("  ");
-                writeln!(
-                    &mut iife_indent,
-                    "const out = new {}({});",
-                    custom_type.name(),
-                    value_expr
+                write!(
+                    out,
+                    "(() => {})()",
+                    display::block(|mut f| {
+                        writeln!(f, "const out = new {}({});", custom_type.name(), value_expr)?;
+                        writeln!(f, "out.owner = {};", owner)?;
+                        writeln!(f, "return out;")
+                    })
                 )?;
-
-                writeln!(&mut iife_indent, "out.owner = {};", owner)?;
-
-                writeln!(&mut iife_indent, "return out;")?;
-                write!(out, "}})()")?;
             }
         }
 

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -468,16 +468,21 @@ fn gen_rust_reference_to_js<W: fmt::Write>(
             let custom_type = underlying.resolve(in_path, env);
 
             if let ast::CustomType::Enum(enm) = custom_type {
-                write!(out, "{}_rust_to_js[", enm.name)?;
-                gen_rust_reference_to_js(
-                    &ast::TypeName::Primitive(PrimitiveType::isize),
-                    in_path,
-                    value_expr,
-                    owner,
-                    env,
+                write!(
                     out,
+                    "{}_rust_to_js[{}]",
+                    enm.name,
+                    display::expr(|mut f| {
+                        gen_rust_reference_to_js(
+                            &ast::TypeName::Primitive(PrimitiveType::isize),
+                            in_path,
+                            value_expr,
+                            owner,
+                            env,
+                            &mut f,
+                        )
+                    })
                 )?;
-                write!(out, "]")?;
             } else {
                 write!(
                     out,

--- a/tool/src/js/display.rs
+++ b/tool/src/js/display.rs
@@ -4,9 +4,9 @@ use std::fmt::{Display, Formatter, Result};
 /// Print source code in a block.
 ///
 /// This function accepts a writing function, and returns a [`Block`]. When the `Block`
-/// is printed via the `fmt::Display` trait, it writes an open brace, indents the
-/// formatter, and calls the function to write the contents of the block. Then,
-/// it unindents the formatter and writes a close brace.
+/// is printed via the `fmt::Display` trait, it writes an open brace and new line,
+/// indents the formatter, and calls the function to write the contents of the block.
+/// Then, it unindents the formatter and writes a close brace.
 ///
 /// This allows for generating source code without having to manually insert
 /// opening/closing braces for blocks or worry about indentation.

--- a/tool/src/js/display.rs
+++ b/tool/src/js/display.rs
@@ -1,0 +1,101 @@
+use indenter::{indented, Indented};
+use std::fmt::{Display, Formatter, Result};
+
+/// Print source code in a block.
+///
+/// This function accepts a writing function, and returns a [`Block`]. When the `Block`
+/// is printed via the `fmt::Display` trait, it writes an open brace, indents the
+/// formatter, and calls the function to write the contents of the block. Then,
+/// it unindents the formatter and writes a close brace.
+///
+/// This allows for generating source code without having to manually insert
+/// opening/closing braces for blocks or worry about indentation.
+///
+/// # Examples
+///
+/// ```ignore
+/// writeln!(
+///     f,
+///     "if (ok) {if_true} else {if_false}"
+///     if_true = block(|mut f| {
+///         writeln!(f, "console.log(\"ok\");")
+///     }),
+///     if_false = block(|mut f| {
+///         writeln!(f, "console.log(\"err\");")
+///     })
+/// )?;
+/// ```
+/// This writes:
+/// ```js
+/// if (ok) {
+///   console.log("ok");
+/// } else {
+///   console.log("err");
+/// }
+/// ```
+pub fn block<F>(f: F) -> Block<F>
+where
+    F: Fn(Indented<Formatter>) -> Result,
+{
+    Block(f)
+}
+
+/// Generate source code in an indented block.
+///
+/// See [`block`] for more info.
+pub struct Block<F>(F)
+where
+    F: Fn(Indented<Formatter>) -> Result;
+
+impl<F> Display for Block<F>
+where
+    F: Fn(Indented<Formatter>) -> Result,
+{
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        writeln!(f, "{{")?;
+        self.0(indented(f).with_str("  "))?;
+        write!(f, "}}")
+    }
+}
+
+/// Write arbitrarily complex statements inline.
+///
+/// When generating source code, sometimes it's difficult to see where parantheses
+/// balance or remember to add a semicolon at the end of a long expression. This
+/// function allows you to wrap the display logic of a complex expression into
+/// a single type, making it easier to format the code around the expression.
+///
+/// # Examples
+///
+/// Variable assignment without forgetting the semicolon at the end.
+/// ```ignore
+/// writeln!(f, "const out = {};", expr(|mut f| {
+///     write!(f, "1 + 2")
+/// }))?;
+/// ```
+/// This writes:
+/// ```js
+/// const out = 1 + 2;
+/// ```
+pub fn expr<F>(f: F) -> Expr<F>
+where
+    F: Fn(&mut Formatter) -> Result,
+{
+    Expr(f)
+}
+
+/// Generate source code as an expression.
+///
+/// See [`expr`] for more info.
+pub struct Expr<F>(F)
+where
+    F: Fn(&mut Formatter) -> Result;
+
+impl<F> Display for Expr<F>
+where
+    F: Fn(&mut Formatter) -> Result,
+{
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        self.0(f)
+    }
+}

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -50,7 +50,7 @@ pub fn gen_struct<W: fmt::Write>(
             enm.name,
             display::block(|mut f| {
                 enm.variants.iter().try_for_each(|(name, discriminant, _)| {
-                    writeln!(f, "{}: \"{}\"", discriminant, name)
+                    writeln!(f, "{}: \"{}\",", discriminant, name)
                 })
             })
         )?;

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -74,7 +74,7 @@ pub fn gen_struct<W: fmt::Write>(
                 writeln!(
                     &mut f,
                     "constructor(underlying) {}",
-                    display::block(|mut f| { writeln!(f, "this.underlying = underlying;") })
+                    display::block(|mut f| writeln!(f, "this.underlying = underlying;"))
                 )?;
 
                 for method in custom_type.methods().iter() {
@@ -125,19 +125,23 @@ fn gen_field<W: fmt::Write>(
         "get {}() {}",
         name,
         display::block(|mut f| {
-            write!(f, "return ")?;
-            gen_value_rust_to_js(
-                &format!("this.underlying + {}", offset),
-                &ast::TypeName::Reference(
-                    ast::Lifetime::Anonymous,
-                    ast::Mutability::Mutable,
-                    Box::new(typ.clone()),
-                ),
-                in_path,
-                env,
-                &mut f,
-            )?;
-            writeln!(f, ";")
+            writeln!(
+                f,
+                "return {};",
+                display::expr(|mut f| {
+                    gen_value_rust_to_js(
+                        &format!("this.underlying + {}", offset),
+                        &ast::TypeName::Reference(
+                            ast::Lifetime::Anonymous,
+                            ast::Mutability::Mutable,
+                            Box::new(typ.clone()),
+                        ),
+                        in_path,
+                        env,
+                        &mut f,
+                    )
+                })
+            )
         })
     )
 }
@@ -166,7 +170,7 @@ fn gen_method<W: fmt::Write>(
     let mut all_param_exprs = vec![];
     let mut post_stmts = vec![];
 
-    method.params.iter().for_each(|p| {
+    for p in method.params.iter() {
         gen_value_js_to_rust(
             p.name.clone(),
             &p.ty,
@@ -175,8 +179,8 @@ fn gen_method<W: fmt::Write>(
             &mut pre_stmts,
             &mut all_param_exprs,
             &mut post_stmts,
-        )
-    });
+        );
+    }
 
     let mut all_params = method
         .params

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -9,6 +9,23 @@ use super::conversions::{gen_value_js_to_rust, gen_value_rust_to_js};
 use super::types::{return_type_form, ReturnTypeForm};
 use crate::layout;
 
+/// Generates a JS class declaration
+/// 
+/// # Examples
+/// 
+/// ```js
+/// const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
+///   wasm.MyStruct_destroy(underlying);
+/// })
+/// 
+/// export class MyStruct {
+///   constructor(underlying) {
+///     this.underlying = underlying;
+///   }
+/// 
+///   // snip
+/// }
+/// ```
 pub fn gen_struct<W: fmt::Write>(
     out: &mut W,
     custom_type: &ast::CustomType,
@@ -77,6 +94,17 @@ pub fn gen_struct<W: fmt::Write>(
     Ok(())
 }
 
+/// Generates a getter function for a field.
+/// 
+/// # Examples
+/// 
+/// ```js
+/// get a() {
+///   return (() => {
+///     // snip
+///   })();
+/// }
+/// ```
 fn gen_field<W: fmt::Write>(
     name: &ast::Ident,
     typ: &ast::TypeName,
@@ -104,6 +132,18 @@ fn gen_field<W: fmt::Write>(
     Ok(())
 }
 
+/// Generates the contents of a JS method.
+/// 
+/// # Examples
+/// 
+/// It could generate something like this
+/// ```js
+/// static node(data) {
+///   const diplomat_out = (() => {
+///     // snip
+///   })
+/// }
+/// ```
 fn gen_method<W: fmt::Write>(
     method: &ast::Method,
     in_path: &ast::Path,


### PR DESCRIPTION
** to be reviewed all at once, not commit-by-commit

This PR cleans up a lot of the codegen on the JS side by introducing a barebones tree-structured writing strategy with `display::block` and `display::expr`, which allow for writing things like:
```rust
writeln!(
    f,
    "diplomat_alloc_destroy_registry.register(out, {});",
    display::block(|mut f| {
        writeln!(f, "ptr: out.underlying,")?;
        writeln!(f, "size: {},", strct_size_align.size())?;
        writeln!(f, "align: {},", strct_size_align.align())
    })
)?;
```
The branch name is misleading because I originally intended to resolve #12. However, I couldn't understand the codegen in the current state, and so this cleanup was a necessary intermediate step.

