### PR TITLE
Fix `Method::params_held_by_output` ignoring lifetime bounds

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -52,6 +52,10 @@ impl Method {
         // a lifetime is introduced in the impl but not used in the method.
         let mut introduced_lifetimes = impl_introduced_lifetimes;
         introduced_lifetimes.extend(m.sig.generics.lifetimes().map(Into::into));
+        assert!(
+            m.sig.generics.where_clause.is_none(),
+            "where bounds aren't yet supported"
+        );
 
         let all_params = m
             .sig
@@ -503,16 +507,6 @@ mod tests {
         assert_params_held_by_output! { [a, b, c, d] =>
             #[diplomat::rust_link(Foo, FnInStruct)]
             fn diamond_and_nested_types<'b: 'a, 'c: 'b, 'd: 'b + 'c, 'x, 'y>(a: &'x One<'a>, b: &'y One<'b>, c: &One<'c>, d: &One<'d>, nohold: &One<'x>) -> Box<Foo<'a>> {
-                unimplemented!()
-            }
-        }
-
-        assert_params_held_by_output! { [hold] =>
-            #[diplomat::rust_link(Foo, FnInStruct)]
-            fn where_clause<'b>(hold: One<'b>) -> Box<Foo<'a>>
-            where
-                'b: 'a,
-            {
                 unimplemented!()
             }
         }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -98,11 +98,12 @@ impl Method {
     ///
     /// Given the following method:
     /// ```ignore
-    /// fn foo<'a, 'b, 'c>(&'a self, bar: Bar<'b>, baz: Baz<'c>) -> FooBar<'a, 'b> { ... }
+    /// fn foo<'a, 'b: 'a, 'c>(&'a self, bar: Bar<'b>, baz: Baz<'c>) -> FooBar<'a> { ... }
     /// ```
     /// Then this method would return the `&'a self` and `bar: Bar<'b>` params
-    /// because they contain lifetimes that are in the return type. It wouldn't
-    /// include `baz: Baz<'c>` though, because the return type isn't bound by `'c`.
+    /// because `'a` is in the return type, and `'b` must live at least as long
+    /// as `'a`. It wouldn't include `baz: Baz<'c>` though, because the return
+    /// type isn't bound by `'c` in any way.
     ///
     /// # Panics
     ///
@@ -117,8 +118,6 @@ impl Method {
         self.return_type
             .as_ref()
             .map(|return_type| {
-                // if it's the static lifetime, is it even our responsibility to
-                // hold it? I don't really think so.
                 // Collect all lifetimes that the return type might care about,
                 // including the lifetimes it contains, as well as the lifetimes
                 // that must live as long as the lifetimes it contains.

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -439,7 +439,7 @@ mod tests {
 
         assert_params_held_by_output! { [hold] =>
             #[diplomat::rust_link(Foo, FnInStruct)]
-            fn transitivity<'a, 'b: 'a, 'c: 'b, 'd>(hold: &'c Bar, nohold: &'d Bar) -> Box<Foo<'a>> {
+            fn transitivity<'a, 'b: 'a, 'c: 'b, 'd: 'c, 'e: 'd, 'x>(hold: &'x One<'e>, nohold: &One<'x>) -> Box<Foo<'a>> {
                 unimplemented!()
             }
         }
@@ -451,37 +451,68 @@ mod tests {
             }
         }
 
+        assert_params_held_by_output! { [a, b, c, d] =>
+            #[diplomat::rust_link(Foo, FnInStruct)]
+            fn many_dependents<'a, 'b: 'a, 'c: 'a, 'd: 'b, 'x, 'y>(a: &'x One<'a>, b: &'b One<'x>, c: &Two<'x, 'c>, d: &'x Two<'d, 'y>, nohold: &'x Two<'x, 'y>) -> Box<Foo<'a>> {
+                unimplemented!()
+            }
+        }
+
         assert_params_held_by_output! { [hold] =>
             #[diplomat::rust_link(Foo, FnInStruct)]
-            fn transitivity_long<'a, 'b: 'a, 'c: 'b, 'd: 'c, 'e: 'd>(hold: &'e Bar, nohold: &'f Bar) -> Box<Foo<'a>> {
+            fn return_outlives_param<'short, 'long: 'short>(hold: &Two<'long, 'short>, nohold: &'short One<'short>) -> Box<Foo<'long>> {
+                unimplemented!()
+            }
+        }
+
+        assert_params_held_by_output! { [hold] =>
+            #[diplomat::rust_link(Foo, FnInStruct)]
+            fn transitivity_deep_types<'a, 'b: 'a, 'c: 'b, 'd: 'c>(hold: Option<Box<Bar<'d>>>, nohold: &'a Box<Option<Baz<'a>>>) -> DiplomatResult<Box<Foo<'b>>, Error> {
+                unimplemented!()
+            }
+        }
+
+        assert_params_held_by_output! { [top, left, right, bottom] =>
+            #[diplomat::rust_link(Foo, FnInStruct)]
+            fn diamond_top<'top, 'left: 'top, 'right: 'top, 'bottom: 'left + 'right>(top: One<'top>, left: One<'left>, right: One<'right>, bottom: One<'bottom>) -> Box<Foo<'top>> {
+                unimplemented!()
+            }
+        }
+
+        assert_params_held_by_output! { [left, bottom] =>
+            #[diplomat::rust_link(Foo, FnInStruct)]
+            fn diamond_left<'top, 'left: 'top, 'right: 'top, 'bottom: 'left + 'right>(top: One<'top>, left: One<'left>, right: One<'right>, bottom: One<'bottom>) -> Box<Foo<'left>> {
+                unimplemented!()
+            }
+        }
+
+        assert_params_held_by_output! { [right, bottom] =>
+            #[diplomat::rust_link(Foo, FnInStruct)]
+            fn diamond_right<'top, 'left: 'top, 'right: 'top, 'bottom: 'left + 'right>(top: One<'top>, left: One<'left>, right: One<'right>, bottom: One<'bottom>) -> Box<Foo<'right>> {
+                unimplemented!()
+            }
+        }
+
+        assert_params_held_by_output! { [bottom] =>
+            #[diplomat::rust_link(Foo, FnInStruct)]
+            fn diamond_bottom<'top, 'left: 'top, 'right: 'top, 'bottom: 'left + 'right>(top: One<'top>, left: One<'left>, right: One<'right>, bottom: One<'bottom>) -> Box<Foo<'bottom>> {
                 unimplemented!()
             }
         }
 
         assert_params_held_by_output! { [a, b, c, d] =>
             #[diplomat::rust_link(Foo, FnInStruct)]
-            fn many_dependents<'a, 'b: 'a, 'c: 'a, 'd: 'a>(a: &'a A, b: &'b B, c: &'c C, d: &'d D, nohold: &'e Bar) -> Box<Foo<'a>> {
+            fn diamond_and_nested_types<'b: 'a, 'c: 'b, 'd: 'b + 'c, 'x, 'y>(a: &'x One<'a>, b: &'y One<'b>, c: &One<'c>, d: &One<'d>, nohold: &One<'x>) -> Box<Foo<'a>> {
                 unimplemented!()
             }
         }
 
         assert_params_held_by_output! { [hold] =>
             #[diplomat::rust_link(Foo, FnInStruct)]
-            fn other_way<'a, 'b: 'a>(hold: &'b Bar, nohold: &'a Bar) -> Box<Foo<'b>> {
-                unimplemented!()
-            }
-        }
-
-        assert_params_held_by_output! { [hold] =>
-            #[diplomat::rust_link(Foo, FnInStruct)]
-            fn transitivity_but_deep<'a, 'b: 'a, 'c: 'b, 'd: 'c>(hold: Option<Box<Bar<'d>>>, nohold: &'a Box<Option<Baz<'a>>>) -> DiplomatResult<Box<Foo<'b>>, Error> {
-                unimplemented!()
-            }
-        }
-
-        assert_params_held_by_output! { [hold] =>
-            #[diplomat::rust_link(Foo, FnInStruct)]
-            fn transitivity_but_deep<'a, 'b: 'a, 'c: 'a>(hold: &'c Bar, nohold: &'d Bar) -> Foo<'a, 'b> {
+            fn where_clause<'b>(hold: One<'b>) -> Box<Foo<'a>>
+            where
+                'b: 'a,
+            {
                 unimplemented!()
             }
         }


### PR DESCRIPTION
Fixes #163 

I implemented a basic lifetime dependency resolution algorithm that collects _all_ lifetimes in a `Method` that must live at least as long as the output type. It does this by doing DFS on the lifetime tree. My implementation is a little naive because it linearly scans through every unused lifetime relationship for each lifetime to determine how to traverse down the tree, but it should be fine because we're not expecting that many lifetimes or lifetime bounds.

The theoretically optimal solution would be to instead create a map from `'a` to a vec of `'b` for all `'b` such that `'b: 'a`, allowing us to traverse each edge of the tree in constant (or logn) time, but this introduces a lot of allocations when we're not expecting that many lifetimes bounds in the first place, so I'm not sure if this is worth it.

Since this was kinda cognitively complex, I added a lot of tests and comments walking through the code.

Thanks to @Manishearth for implementation help.