### PR TITLE
Move `TypeName::resolve` -> `PathType::resolve`

### DIFF
--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -230,8 +230,8 @@ pub fn gen_includes<W: fmt::Write>(
     out: &mut W,
 ) -> fmt::Result {
     match typ {
-        ast::TypeName::Named(_) => {
-            let (_, custom_typ) = typ.resolve_with_path(in_path, env);
+        ast::TypeName::Named(path_type) => {
+            let custom_typ = path_type.resolve(in_path, env);
             match (custom_typ, behind_ref) {
                 (ast::CustomType::Opaque(_) | ast::CustomType::Struct(_), true) => {
                     if pre_struct {

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -10,7 +10,7 @@ pub fn gen_type<W: fmt::Write>(
     out: &mut W,
 ) -> fmt::Result {
     match typ {
-        ast::TypeName::Named(_) => match typ.resolve(in_path, env) {
+        ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
             r @ ast::CustomType::Struct(_) | r @ ast::CustomType::Opaque(_) => {
                 write!(out, "{}", r.name())?;
             }

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -16,7 +16,7 @@ pub fn gen_rust_to_cpp<W: Write>(
 ) -> String {
     match typ {
         ast::TypeName::Box(underlying) => match underlying.as_ref() {
-            ast::TypeName::Named(_name) => match underlying.resolve(in_path, env) {
+            ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
                 ast::CustomType::Opaque(opaque) => {
                     format!("{}({})", opaque.name, cpp)
                 }
@@ -33,7 +33,7 @@ pub fn gen_rust_to_cpp<W: Write>(
             },
             _o => todo!(),
         },
-        ast::TypeName::Named(_) => match typ.resolve_with_path(in_path, env) {
+        ast::TypeName::Named(path_type) => match path_type.resolve_with_path(in_path, env) {
             (_, ast::CustomType::Opaque(_)) => {
                 panic!("Cannot handle opaque structs by value");
             }
@@ -221,7 +221,7 @@ pub fn gen_cpp_to_rust<W: Write>(
             is_self,
             out,
         ),
-        ast::TypeName::Named(_) => match typ.resolve(in_path, env) {
+        ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
             ast::CustomType::Opaque(_opaque) => {
                 if let Some(reference) = behind_ref {
                     if is_self {

--- a/tool/src/cpp/docs.rs
+++ b/tool/src/cpp/docs.rs
@@ -111,8 +111,7 @@ pub fn gen_custom_type_docs<W: fmt::Write>(
             &mut class_indented,
             &typ.docs().to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved =
-                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
+                let resolved = ast::PathType::new(shortcut_path.clone()).resolve(in_path, env);
                 match resolved {
                     ast::CustomType::Struct(_) => write!(to, ":cpp:struct:`{}`", resolved.name())?,
                     ast::CustomType::Enum(_) => {
@@ -217,8 +216,7 @@ pub fn gen_method_docs<W: fmt::Write>(
             &mut method_indented,
             &method.docs.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved =
-                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
+                let resolved = ast::PathType::new(shortcut_path.clone()).resolve(in_path, env);
                 match resolved {
                     ast::CustomType::Struct(_) => write!(to, ":cpp:struct:`{}`", resolved.name())?,
                     ast::CustomType::Enum(_) => {
@@ -266,8 +264,7 @@ pub fn gen_field_docs<W: fmt::Write>(
             &mut field_indented,
             &field.2.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved =
-                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
+                let resolved = ast::PathType::new(shortcut_path.clone()).resolve(in_path, env);
                 match resolved {
                     ast::CustomType::Struct(_) => write!(to, ":cpp:struct:`{}`", resolved.name())?,
                     ast::CustomType::Enum(_) => {
@@ -301,8 +298,7 @@ pub fn gen_enum_variant_docs<W: fmt::Write>(
             &mut enum_indented,
             &variant.2.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved =
-                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
+                let resolved = ast::PathType::new(shortcut_path.clone()).resolve(in_path, env);
                 match resolved {
                     ast::CustomType::Struct(_) => write!(to, ":cpp:struct:`{}`", resolved.name())?,
                     ast::CustomType::Enum(_) => {

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -225,8 +225,8 @@ fn gen_includes<W: fmt::Write>(
     out: &mut W,
 ) -> fmt::Result {
     match typ {
-        ast::TypeName::Named(_) => {
-            let (_, custom_typ) = typ.resolve_with_path(in_path, env);
+        ast::TypeName::Named(path_type) => {
+            let custom_typ = path_type.resolve(in_path, env);
             match custom_typ {
                 ast::CustomType::Opaque(_) => {
                     if pre_struct {

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -27,7 +27,7 @@ fn gen_type_inner<W: fmt::Write>(
 ) -> fmt::Result {
     let mut handled_ref = false;
     match typ {
-        ast::TypeName::Named(_) => match typ.resolve(in_path, env) {
+        ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
             ast::CustomType::Opaque(opaque) => {
                 if let Some(owned) = behind_ref {
                     if owned {

--- a/tool/src/dotnet/conversions.rs
+++ b/tool/src/dotnet/conversions.rs
@@ -68,13 +68,16 @@ pub fn to_idiomatic_object<W: fmt::Write>(
         }
         _ => {
             let name = gen_type_name_to_string(typ, in_path, env)?;
-            match typ.resolve(in_path, env) {
-                ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
-                    write!(out, "new {name}({input_var_name})")
-                }
-                ast::CustomType::Enum(_) => {
-                    write!(out, "({name}){input_var_name}")
-                }
+            match typ {
+                ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
+                    ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
+                        write!(out, "new {name}({input_var_name})")
+                    }
+                    ast::CustomType::Enum(_) => {
+                        write!(out, "({name}){input_var_name}")
+                    }
+                },
+                other => panic!("expected named type name, found `{}`", other),
             }
         }
     }
@@ -105,13 +108,16 @@ pub fn to_raw_object<W: fmt::Write>(
         }
         _ => {
             let name = gen_type_name_to_string(typ, in_path, env)?;
-            match typ.resolve(in_path, env) {
-                ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
-                    write!(out, "{input_var_name}.AsFFI()")
-                }
-                ast::CustomType::Enum(_) => {
-                    write!(out, "(Raw.{name}){input_var_name}")
-                }
+            match typ {
+                ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
+                    ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
+                        write!(out, "{input_var_name}.AsFFI()")
+                    }
+                    ast::CustomType::Enum(_) => {
+                        write!(out, "(Raw.{name}){input_var_name}")
+                    }
+                },
+                other => panic!("expected named type name, found `{}`", other),
             }
         }
     }

--- a/tool/src/dotnet/types.rs
+++ b/tool/src/dotnet/types.rs
@@ -20,7 +20,9 @@ pub fn gen_type_name(
     out: &mut dyn fmt::Write,
 ) -> fmt::Result {
     match typ {
-        ast::TypeName::Named(_) => write!(out, "{}", typ.resolve(in_path, env).name()),
+        ast::TypeName::Named(path_type) => {
+            write!(out, "{}", path_type.resolve(in_path, env).name())
+        }
 
         ast::TypeName::Box(underlying) => gen_type_name(underlying.as_ref(), in_path, env, out),
 

--- a/tool/src/dotnet/util.rs
+++ b/tool/src/dotnet/util.rs
@@ -102,9 +102,9 @@ fn collect_errors_impl<'ast>(
         ast::TypeName::Option(underlying) => {
             collect_errors_impl(underlying, in_path, env, errors, is_err_variant);
         }
-        ast::TypeName::Named(_) => {
+        ast::TypeName::Named(path_type) => {
             if is_err_variant {
-                let (custom_ty_path, _) = typ.resolve_with_path(in_path, env);
+                let (custom_ty_path, _) = path_type.resolve_with_path(in_path, env);
                 let key = (custom_ty_path, typ);
                 if !errors.contains(&key) {
                     errors.insert(key);

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -79,8 +79,7 @@ pub fn gen_custom_type_docs<W: fmt::Write>(
             &mut class_indented,
             &typ.docs().to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved =
-                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
+                let resolved = ast::PathType::new(shortcut_path.clone()).resolve(in_path, env);
                 write!(to, ":js:class:`{}`", resolved.name())?;
                 Ok(())
             },
@@ -140,8 +139,7 @@ pub fn gen_method_docs<W: fmt::Write>(
             &mut method_indented,
             &method.docs.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved =
-                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
+                let resolved = ast::PathType::new(shortcut_path.clone()).resolve(in_path, env);
                 write!(to, ":js:class:`{}`", resolved.name())?;
                 Ok(())
             },
@@ -180,8 +178,7 @@ pub fn gen_field_docs<W: fmt::Write>(
             &mut field_indented,
             &field.2.to_markdown(docs_url_gen),
             &|shortcut_path, to| {
-                let resolved =
-                    ast::TypeName::Named(shortcut_path.clone().into()).resolve(in_path, env);
+                let resolved = ast::PathType::new(shortcut_path.clone()).resolve(in_path, env);
                 write!(to, ":js:class:`{}`", resolved.name())?;
                 Ok(())
             },

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -20,7 +20,7 @@ pub enum ReturnTypeForm {
 /// See https://github.com/WebAssembly/tool-conventions/blob/master/BasicCABI.md#function-signatures.
 pub fn return_type_form(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> ReturnTypeForm {
     match typ {
-        ast::TypeName::Named(_) => match typ.resolve(in_path, env) {
+        ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
             ast::CustomType::Struct(strct) => {
                 let all_field_forms: Vec<ReturnTypeForm> = strct
                     .fields

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -77,7 +77,7 @@ pub fn type_size_alignment(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) 
             let (_, size_align) = result_ok_offset_size_align(ok, err, in_path, env);
             size_align
         }
-        ast::TypeName::Named(_) => match typ.resolve(in_path, env) {
+        ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
             ast::CustomType::Struct(strct) => {
                 let (_, size_max_align) = struct_offsets_size_max_align(
                     strct.fields.iter().map(|(_, typ, _)| typ),


### PR DESCRIPTION
Currently, `TypeName::resolve` only works if `self` is the `Named` variant, which wraps a `PathType` (which was added relatively recently), and panics otherwise. This PR refactors the logic of `TypeName::resolve` to `PathType::resolve`, making the code a lot more straightforward.