### PR TITLE
Js inline struct fields

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -298,11 +298,28 @@ impl Param {
 pub struct BorrowedParams<'a>(pub Option<&'a SelfParam>, pub Vec<&'a Param>);
 
 impl BorrowedParams<'_> {
+    /// Returns an [`Iterator`] through the names of the borrowed parameters,
+    /// accepting a `&str` that the `self` param will be called if present.
     pub fn names<'a>(&'a self, self_name: &'a str) -> impl Iterator<Item = &'a str> {
         self.0
             .iter()
             .map(move |_| self_name)
             .chain(self.1.iter().map(|param| param.name.as_str()))
+    }
+
+    /// Returns `true` if there are no borrowed parameters, otherwise `false`.
+    pub fn is_empty(&self) -> bool {
+        !self.borrows_self() && !self.borrows_params()
+    }
+
+    /// Returns `true` if the `self` param is borrowed, otherwise `false`.
+    pub fn borrows_self(&self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Returns `true` if there are any borrowed params, otherwise `false`.
+    pub fn borrows_params(&self) -> bool {
+        !self.1.is_empty()
     }
 }
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -569,6 +569,42 @@ impl TypeName {
         }
     }
 
+    /// Returns `true` if any lifetime satisfies a predicate, otherwise `false`.
+    ///
+    /// This method is short-circuiting, meaning that if the predicate ever succeeds,
+    /// it will return immediately.
+    pub fn any_lifetime<'a, F>(&'a self, mut f: F) -> bool
+    where
+        F: FnMut(&'a Lifetime, LifetimeOrigin) -> bool,
+    {
+        self.visit_lifetimes(&mut |lifetime, origin| {
+            if f(lifetime, origin) {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .is_break()
+    }
+
+    /// Returns `true` if all lifetimes satisfy a predicate, otherwise `false`.
+    ///
+    /// This method is short-circuiting, meaning that if the predicate ever fails,
+    /// it will return immediately.
+    pub fn all_lifetimes<'a, F>(&'a self, mut f: F) -> bool
+    where
+        F: FnMut(&'a Lifetime, LifetimeOrigin) -> bool,
+    {
+        self.visit_lifetimes(&mut |lifetime, origin| {
+            if f(lifetime, origin) {
+                ControlFlow::Continue(())
+            } else {
+                ControlFlow::Break(())
+            }
+        })
+        .is_continue()
+    }
+
     fn check_opaque<'a>(
         &'a self,
         in_path: &Path,

--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -11,18 +11,11 @@ const ICU4XDataProvider_box_destroy_registry = new FinalizationRegistry(underlyi
 export class ICU4XDataProvider {
   constructor(underlying) {
     this.underlying = underlying;
+    ICU4XDataProvider_box_destroy_registry.register(this, underlying);
   }
 
   static new_static() {
-    const diplomat_out = (() => {
-      const out = (() => {
-        const out = new ICU4XDataProvider(wasm.ICU4XDataProvider_new_static());
-        out.owner = null;
-        return out;
-      })();
-      ICU4XDataProvider_box_destroy_registry.register(out, out.underlying)
-      return out;
-    })();
+    const diplomat_out = new ICU4XDataProvider(wasm.ICU4XDataProvider_new_static());
     return diplomat_out;
   }
 
@@ -44,18 +37,11 @@ const ICU4XFixedDecimal_box_destroy_registry = new FinalizationRegistry(underlyi
 export class ICU4XFixedDecimal {
   constructor(underlying) {
     this.underlying = underlying;
+    ICU4XFixedDecimal_box_destroy_registry.register(this, underlying);
   }
 
   static new(v) {
-    const diplomat_out = (() => {
-      const out = (() => {
-        const out = new ICU4XFixedDecimal(wasm.ICU4XFixedDecimal_new(v));
-        out.owner = null;
-        return out;
-      })();
-      ICU4XFixedDecimal_box_destroy_registry.register(out, out.underlying)
-      return out;
-    })();
+    const diplomat_out = new ICU4XFixedDecimal(wasm.ICU4XFixedDecimal_new(v));
     return diplomat_out;
   }
 
@@ -87,6 +73,7 @@ const ICU4XFixedDecimalFormat_box_destroy_registry = new FinalizationRegistry(un
 export class ICU4XFixedDecimalFormat {
   constructor(underlying) {
     this.underlying = underlying;
+    ICU4XFixedDecimalFormat_box_destroy_registry.register(this, underlying);
   }
 
   static try_new(locale, provider, options) {
@@ -96,18 +83,7 @@ export class ICU4XFixedDecimalFormat {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.ICU4XFixedDecimalFormat_try_new(diplomat_receive_buffer, locale.underlying, provider.underlying, ICU4XFixedDecimalGroupingStrategy_js_to_rust[diplomat_ICU4XFixedDecimalFormatOptions_extracted_grouping_strategy], ICU4XFixedDecimalSignDisplay_js_to_rust[diplomat_ICU4XFixedDecimalFormatOptions_extracted_sign_display]);
       const out = new ICU4XFixedDecimalFormatResult(diplomat_receive_buffer);
-      if (out.fdf.underlying !== 0) {
-        const out_fdf_value = out.fdf;
-        ICU4XFixedDecimalFormat_box_destroy_registry.register(out_fdf_value, out_fdf_value.underlying);
-        Object.defineProperty(out, "fdf", { value: out_fdf_value });
-      } else {
-        Object.defineProperty(out, "fdf", { value: null });
-      }
-      diplomat_alloc_destroy_registry.register(out, {
-        ptr: out.underlying,
-        size: 5,
-        align: 4,
-      });
+      wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
       return out;
     })();
     return diplomat_out;
@@ -121,13 +97,10 @@ export class ICU4XFixedDecimalFormat {
   }
 }
 
-const ICU4XFixedDecimalFormatOptions_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.ICU4XFixedDecimalFormatOptions_destroy(underlying);
-});
-
 export class ICU4XFixedDecimalFormatOptions {
   constructor(underlying) {
-    this.underlying = underlying;
+    this.grouping_strategy = new ICU4XFixedDecimalGroupingStrategy_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, underlying + 0)];
+    this.sign_display = new ICU4XFixedDecimalSignDisplay_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, underlying + 4)];
   }
 
   static default() {
@@ -135,44 +108,20 @@ export class ICU4XFixedDecimalFormatOptions {
       const diplomat_receive_buffer = wasm.diplomat_alloc(8, 4);
       wasm.ICU4XFixedDecimalFormatOptions_default(diplomat_receive_buffer);
       const out = new ICU4XFixedDecimalFormatOptions(diplomat_receive_buffer);
-      diplomat_alloc_destroy_registry.register(out, {
-        ptr: out.underlying,
-        size: 8,
-        align: 4,
-      });
+      wasm.diplomat_free(diplomat_receive_buffer, 8, 4);
       return out;
     })();
     return diplomat_out;
   }
-
-  get grouping_strategy() {
-    return ICU4XFixedDecimalGroupingStrategy_rust_to_js[(new Int32Array(wasm.memory.buffer, this.underlying + 0, 1))[0]];
-  }
-
-  get sign_display() {
-    return ICU4XFixedDecimalSignDisplay_rust_to_js[(new Int32Array(wasm.memory.buffer, this.underlying + 4, 1))[0]];
-  }
 }
-
-const ICU4XFixedDecimalFormatResult_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.ICU4XFixedDecimalFormatResult_destroy(underlying);
-});
 
 export class ICU4XFixedDecimalFormatResult {
   constructor(underlying) {
-    this.underlying = underlying;
-  }
-
-  get fdf() {
-    return (() => {
-      const out = new ICU4XFixedDecimalFormat((new Uint32Array(wasm.memory.buffer, this.underlying + 0, 1))[0]);
-      out.owner = null;
-      return out;
+    this.fdf = (() => {
+      const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 0);
+      return (option_ptr == 0) ? null : new ICU4XFixedDecimalFormat(option_ptr);
     })();
-  }
-
-  get success() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 4, 1))[0] == 1;
+    this.success = (new Uint8Array(wasm.memory.buffer, underlying + 4, 1))[0] == 1;
   }
 }
 
@@ -211,6 +160,7 @@ const ICU4XLocale_box_destroy_registry = new FinalizationRegistry(underlying => 
 export class ICU4XLocale {
   constructor(underlying) {
     this.underlying = underlying;
+    ICU4XLocale_box_destroy_registry.register(this, underlying);
   }
 
   static new(name) {
@@ -218,15 +168,7 @@ export class ICU4XLocale {
     let name_diplomat_ptr = wasm.diplomat_alloc(name_diplomat_bytes.length, 1);
     let name_diplomat_buf = new Uint8Array(wasm.memory.buffer, name_diplomat_ptr, name_diplomat_bytes.length);
     name_diplomat_buf.set(name_diplomat_bytes, 0);
-    const diplomat_out = (() => {
-      const out = (() => {
-        const out = new ICU4XLocale(wasm.ICU4XLocale_new(name_diplomat_ptr, name_diplomat_bytes.length));
-        out.owner = null;
-        return out;
-      })();
-      ICU4XLocale_box_destroy_registry.register(out, out.underlying)
-      return out;
-    })();
+    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new(name_diplomat_ptr, name_diplomat_bytes.length));
     wasm.diplomat_free(name_diplomat_ptr, name_diplomat_bytes.length, 1);
     return diplomat_out;
   }
@@ -236,15 +178,7 @@ export class ICU4XLocale {
     let bytes_diplomat_ptr = wasm.diplomat_alloc(bytes_diplomat_bytes.length, 1);
     let bytes_diplomat_buf = new Uint8Array(wasm.memory.buffer, bytes_diplomat_ptr, bytes_diplomat_bytes.length);
     bytes_diplomat_buf.set(bytes_diplomat_bytes, 0);
-    const diplomat_out = (() => {
-      const out = (() => {
-        const out = new ICU4XLocale(wasm.ICU4XLocale_new_from_bytes(bytes_diplomat_ptr, bytes_diplomat_bytes.length));
-        out.owner = null;
-        return out;
-      })();
-      ICU4XLocale_box_destroy_registry.register(out, out.underlying)
-      return out;
-    })();
+    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new_from_bytes(bytes_diplomat_ptr, bytes_diplomat_bytes.length));
     wasm.diplomat_free(bytes_diplomat_ptr, bytes_diplomat_bytes.length, 1);
     return diplomat_out;
   }

--- a/example/js/diplomat-runtime.mjs
+++ b/example/js/diplomat-runtime.mjs
@@ -29,3 +29,27 @@ export function extractCodePoint(str, param) {
   }
   return cp;
 }
+
+// Get the pointer returned by an FFI function
+//
+// It's tempting to call `(new Uint32Array(wasm.memory.buffer, FFI_func(), 1))[0]`.
+// However, there's a chance that `wasm.memory.buffer` will be resized between
+// the time it's accessed and the time it's used, invalidating the view.
+// This function ensures that the view into wasm memory is fresh.
+//
+// This is used for methods that return multiple types into a wasm buffer, where
+// one of those types is another ptr. Call this method to get access to the returned
+// ptr, so the return buffer can be freed.
+export function ptrRead(wasm, ptr) {
+  return (new Uint32Array(wasm.memory.buffer, ptr, 1))[0];
+}
+
+// Get the flag of a result type.
+export function resultFlag(wasm, ptr, offset) {
+  return (new Uint8Array(wasm.memory.buffer, ptr + offset, 1))[0];
+}
+
+// Get the discriminant of a Rust enum.
+export function enumDiscriminant(wasm, ptr) {
+  return (new Int32Array(wasm.memory.buffer, ptr, 1))[0]
+}

--- a/feature_tests/c/include/ErrorStruct.h
+++ b/feature_tests/c/include/ErrorStruct.h
@@ -12,6 +12,7 @@ extern "C" {
 
 typedef struct ErrorStruct {
     int32_t i;
+    int32_t j;
 } ErrorStruct;
 
 void ErrorStruct_destroy(ErrorStruct* self);

--- a/feature_tests/cpp/docs/result_ffi.rst
+++ b/feature_tests/cpp/docs/result_ffi.rst
@@ -11,6 +11,8 @@
 
     .. cpp:member:: int32_t i
 
+    .. cpp:member:: int32_t j
+
 .. cpp:class:: ResultOpaque
 
     .. cpp:function:: static diplomat::result<ResultOpaque, ErrorEnum> new_(int32_t i)

--- a/feature_tests/cpp/include/ErrorStruct.h
+++ b/feature_tests/cpp/include/ErrorStruct.h
@@ -12,6 +12,7 @@ extern "C" {
 
 typedef struct ErrorStruct {
     int32_t i;
+    int32_t j;
 } ErrorStruct;
 
 void ErrorStruct_destroy(ErrorStruct* self);

--- a/feature_tests/cpp/include/ErrorStruct.hpp
+++ b/feature_tests/cpp/include/ErrorStruct.hpp
@@ -25,6 +25,7 @@ struct ErrorStructDeleter {
 struct ErrorStruct {
  public:
   int32_t i;
+  int32_t j;
 };
 
 

--- a/feature_tests/cpp/include/ResultOpaque.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.hpp
@@ -94,7 +94,7 @@ inline diplomat::result<ResultOpaque, ErrorStruct> ResultOpaque::new_failing_str
     diplomat_result_out_value = diplomat::Ok(ResultOpaque(diplomat_result_raw_out_value.ok));
   } else {
   capi::ErrorStruct diplomat_raw_struct_out_value = diplomat_result_raw_out_value.err;
-    diplomat_result_out_value = diplomat::Err(ErrorStruct{ .i = std::move(diplomat_raw_struct_out_value.i) });
+    diplomat_result_out_value = diplomat::Err(ErrorStruct{ .i = std::move(diplomat_raw_struct_out_value.i), .j = std::move(diplomat_raw_struct_out_value.j) });
   }
   return diplomat_result_out_value;
 }

--- a/feature_tests/dotnet/Lib/Generated/ErrorStruct.cs
+++ b/feature_tests/dotnet/Lib/Generated/ErrorStruct.cs
@@ -33,6 +33,24 @@ public partial class ErrorStruct
         }
     }
 
+    public int J
+    {
+        get
+        {
+            unsafe
+            {
+                return _inner.j;
+            }
+        }
+        set
+        {
+            unsafe
+            {
+                _inner.j = value;
+            }
+        }
+    }
+
     /// <summary>
     /// Creates a managed <c>ErrorStruct</c> from the raw representation.
     /// </summary>

--- a/feature_tests/dotnet/Lib/Generated/RawErrorStruct.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawErrorStruct.cs
@@ -17,4 +17,6 @@ public partial struct ErrorStruct
     private const string NativeLib = "diplomat_feature_tests";
 
     public int i;
+
+    public int j;
 }

--- a/feature_tests/js/diplomat-runtime.mjs
+++ b/feature_tests/js/diplomat-runtime.mjs
@@ -29,3 +29,27 @@ export function extractCodePoint(str, param) {
   }
   return cp;
 }
+
+// Get the pointer returned by an FFI function
+//
+// It's tempting to call `(new Uint32Array(wasm.memory.buffer, FFI_func(), 1))[0]`.
+// However, there's a chance that `wasm.memory.buffer` will be resized between
+// the time it's accessed and the time it's used, invalidating the view.
+// This function ensures that the view into wasm memory is fresh.
+//
+// This is used for methods that return multiple types into a wasm buffer, where
+// one of those types is another ptr. Call this method to get access to the returned
+// ptr, so the return buffer can be freed.
+export function ptrRead(wasm, ptr) {
+  return (new Uint32Array(wasm.memory.buffer, ptr, 1))[0];
+}
+
+// Get the flag of a result type.
+export function resultFlag(wasm, ptr, offset) {
+  return (new Uint8Array(wasm.memory.buffer, ptr + offset, 1))[0];
+}
+
+// Get the discriminant of a Rust enum.
+export function enumDiscriminant(wasm, ptr) {
+  return (new Int32Array(wasm.memory.buffer, ptr, 1))[0]
+}

--- a/feature_tests/js/docs/result_ffi.rst
+++ b/feature_tests/js/docs/result_ffi.rst
@@ -7,6 +7,8 @@
 
     .. js:attribute:: i
 
+    .. js:attribute:: j
+
 .. js:class:: ResultOpaque
 
     .. js:staticfunction:: new(i)

--- a/feature_tests/src/result.rs
+++ b/feature_tests/src/result.rs
@@ -15,6 +15,7 @@ pub mod ffi {
     #[derive(Debug)]
     pub struct ErrorStruct {
         i: i32,
+        j: i32,
     }
     impl ResultOpaque {
         pub fn new(i: i32) -> DiplomatResult<Box<ResultOpaque>, ErrorEnum> {
@@ -34,7 +35,7 @@ pub mod ffi {
         }
 
         pub fn new_failing_struct(i: i32) -> DiplomatResult<Box<ResultOpaque>, ErrorStruct> {
-            Err(ErrorStruct { i }).into()
+            Err(ErrorStruct { i, j: 12 }).into()
         }
 
         pub fn new_in_err(i: i32) -> DiplomatResult<(), Box<ResultOpaque>> {

--- a/tool/src/js/display.rs
+++ b/tool/src/js/display.rs
@@ -99,3 +99,46 @@ where
         self.0(f)
     }
 }
+
+/// Write an immediately invoked function expression (IIFE).
+///
+/// This function accepts a closure that writes the contents of the IIFE,
+/// and generates the proper wrapping and indentation.
+///
+/// # Examples
+///
+/// ```ignore
+/// writeln!(f, "const out = {};", iife(|mut f| {
+///     writeln!(f, "const out = {{}};")?;
+///     writeln!(f, "out.a = 7;")?;
+///     writeln!(f, "return out;")?;
+/// }))?;
+/// ```
+/// This generates
+/// ```js
+/// const out = (() => {
+///   const out = {};
+///   out.a = 7;
+///   return out;
+/// })();
+/// ```
+pub fn iife<F>(f: F) -> IIFE<F>
+where
+    F: Fn(Indented<Formatter>) -> Result,
+{
+    IIFE(f)
+}
+
+/// An `fmt::Display` type returned by [`iife`].
+pub struct IIFE<F>(F)
+where
+    F: Fn(Indented<Formatter>) -> Result;
+
+impl<F> Display for IIFE<F>
+where
+    F: Fn(Indented<Formatter>) -> Result,
+{
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "(() => {})()", block(&self.0))
+    }
+}

--- a/tool/src/js/runtime.mjs
+++ b/tool/src/js/runtime.mjs
@@ -29,3 +29,27 @@ export function extractCodePoint(str, param) {
   }
   return cp;
 }
+
+// Get the pointer returned by an FFI function
+//
+// It's tempting to call `(new Uint32Array(wasm.memory.buffer, FFI_func(), 1))[0]`.
+// However, there's a chance that `wasm.memory.buffer` will be resized between
+// the time it's accessed and the time it's used, invalidating the view.
+// This function ensures that the view into wasm memory is fresh.
+//
+// This is used for methods that return multiple types into a wasm buffer, where
+// one of those types is another ptr. Call this method to get access to the returned
+// ptr, so the return buffer can be freed.
+export function ptrRead(wasm, ptr) {
+  return (new Uint32Array(wasm.memory.buffer, ptr, 1))[0];
+}
+
+// Get the flag of a result type.
+export function resultFlag(wasm, ptr, offset) {
+  return (new Uint8Array(wasm.memory.buffer, ptr + offset, 1))[0];
+}
+
+// Get the discriminant of a Rust enum.
+export function enumDiscriminant(wasm, ptr) {
+  return (new Int32Array(wasm.memory.buffer, ptr, 1))[0]
+}

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_returning_struct@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_returning_struct@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/structs.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -16,6 +15,7 @@ const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
 export class MyStruct {
   constructor(underlying) {
     this.underlying = underlying;
+    MyStruct_box_destroy_registry.register(this, underlying);
   }
 
   get_non_opaque() {
@@ -23,36 +23,18 @@ export class MyStruct {
       const diplomat_receive_buffer = wasm.diplomat_alloc(8, 4);
       wasm.MyStruct_get_non_opaque(diplomat_receive_buffer, this.underlying);
       const out = new NonOpaqueStruct(diplomat_receive_buffer);
-      diplomat_alloc_destroy_registry.register(out, {
-        ptr: out.underlying,
-        size: 8,
-        align: 4,
-      });
+      wasm.diplomat_free(diplomat_receive_buffer, 8, 4);
       return out;
     })();
     return diplomat_out;
   }
 }
 
-const NonOpaqueStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.NonOpaqueStruct_destroy(underlying);
-});
-
 export class NonOpaqueStruct {
   constructor(underlying) {
-    this.underlying = underlying;
-  }
-
-  get a() {
-    return (new Uint16Array(wasm.memory.buffer, this.underlying + 0, 1))[0];
-  }
-
-  get b() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 2, 1))[0];
-  }
-
-  get c() {
-    return (new Uint32Array(wasm.memory.buffer, this.underlying + 4, 1))[0];
+    this.a = (new Uint16Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.b = (new Uint8Array(wasm.memory.buffer, underlying + 2, 1))[0];
+    this.c = (new Uint32Array(wasm.memory.buffer, underlying + 4, 1))[0];
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/structs.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -16,6 +15,7 @@ const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
 export class MyStruct {
   constructor(underlying) {
     this.underlying = underlying;
+    MyStruct_box_destroy_registry.register(this, underlying);
   }
 
   static new_str(v) {
@@ -23,15 +23,7 @@ export class MyStruct {
     let v_diplomat_ptr = wasm.diplomat_alloc(v_diplomat_bytes.length, 1);
     let v_diplomat_buf = new Uint8Array(wasm.memory.buffer, v_diplomat_ptr, v_diplomat_bytes.length);
     v_diplomat_buf.set(v_diplomat_bytes, 0);
-    const diplomat_out = (() => {
-      const out = (() => {
-        const out = new MyStruct(wasm.MyStruct_new_str(v_diplomat_ptr, v_diplomat_bytes.length));
-        out.owner = null;
-        return out;
-      })();
-      MyStruct_box_destroy_registry.register(out, out.underlying)
-      return out;
-    })();
+    const diplomat_out = new MyStruct(wasm.MyStruct_new_str(v_diplomat_ptr, v_diplomat_bytes.length));
     wasm.diplomat_free(v_diplomat_ptr, v_diplomat_bytes.length, 1);
     return diplomat_out;
   }

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_writeable_out@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_writeable_out@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/structs.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -16,6 +15,7 @@ const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
 export class MyStruct {
   constructor(underlying) {
     this.underlying = underlying;
+    MyStruct_box_destroy_registry.register(this, underlying);
   }
 
   write() {
@@ -36,19 +36,15 @@ export class MyStruct {
     const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
       return (() => {
         const diplomat_receive_buffer = wasm.diplomat_alloc(2, 1);
-        const result_tag = {};
-        diplomat_alloc_destroy_registry.register(result_tag, {
-          ptr: diplomat_receive_buffer,
-          size: 2,
-          align: 1,
-        });
         wasm.MyStruct_write_result(diplomat_receive_buffer, this.underlying, writeable);
-        const is_ok = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 1, 1))[0] == 1;
+        const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 1);
         if (is_ok) {
           const ok_value = {};
+          wasm.diplomat_free(diplomat_receive_buffer, 2, 1)
           return ok_value;
         } else {
-          const throw_value = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
+          const throw_value = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 0, 1))[0];
+          wasm.diplomat_free(diplomat_receive_buffer, 2, 1)
           throw new diplomatRuntime.FFIError(throw_value);
         }
       })();

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_non_opaque_struct@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_non_opaque_struct@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/structs.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -9,13 +8,10 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
   wasm.diplomat_free(obj["ptr"], obj["size"], obj["align"]);
 });
 
-const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.MyStruct_destroy(underlying);
-});
-
 export class MyStruct {
   constructor(underlying) {
-    this.underlying = underlying;
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   static new(a, b) {
@@ -23,11 +19,7 @@ export class MyStruct {
       const diplomat_receive_buffer = wasm.diplomat_alloc(2, 1);
       wasm.MyStruct_new(diplomat_receive_buffer, a, b);
       const out = new MyStruct(diplomat_receive_buffer);
-      diplomat_alloc_destroy_registry.register(out, {
-        ptr: out.underlying,
-        size: 2,
-        align: 1,
-      });
+      wasm.diplomat_free(diplomat_receive_buffer, 2, 1);
       return out;
     })();
     return diplomat_out;
@@ -40,14 +32,6 @@ export class MyStruct {
 
   set_b(b) {
     const diplomat_out = wasm.MyStruct_set_b(this.underlying, b);
-  }
-
-  get a() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 0, 1))[0];
-  }
-
-  get b() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 1, 1))[0];
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_opaque_struct@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_opaque_struct@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/structs.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -16,18 +15,11 @@ const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
 export class MyStruct {
   constructor(underlying) {
     this.underlying = underlying;
+    MyStruct_box_destroy_registry.register(this, underlying);
   }
 
   static new(a, b) {
-    const diplomat_out = (() => {
-      const out = (() => {
-        const out = new MyStruct(wasm.MyStruct_new(a, b));
-        out.owner = null;
-        return out;
-      })();
-      MyStruct_box_destroy_registry.register(out, out.underlying)
-      return out;
-    })();
+    const diplomat_out = new MyStruct(wasm.MyStruct_new(a, b));
     return diplomat_out;
   }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__option_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__option_types@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/types.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -16,23 +15,15 @@ const MyOpaqueStruct_box_destroy_registry = new FinalizationRegistry(underlying 
 export class MyOpaqueStruct {
   constructor(underlying) {
     this.underlying = underlying;
+    MyOpaqueStruct_box_destroy_registry.register(this, underlying);
   }
 }
 
-const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.MyStruct_destroy(underlying);
-});
-
 export class MyStruct {
   constructor(underlying) {
-    this.underlying = underlying;
-  }
-
-  get a() {
-    return (() => {
-      const out = new MyOpaqueStruct((new Uint32Array(wasm.memory.buffer, this.underlying + 0, 1))[0]);
-      out.owner = null;
-      return out;
+    this.a = (() => {
+      const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 0);
+      return (option_ptr == 0) ? null : new MyOpaqueStruct(option_ptr);
     })();
   }
 }

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/types.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -16,16 +15,18 @@ const MyOpaqueStruct_box_destroy_registry = new FinalizationRegistry(underlying 
 export class MyOpaqueStruct {
   constructor(underlying) {
     this.underlying = underlying;
+    MyOpaqueStruct_box_destroy_registry.register(this, underlying);
   }
 }
 
-const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.MyStruct_destroy(underlying);
-});
-
 export class MyStruct {
   constructor(underlying) {
-    this.underlying = underlying;
+    this.a = (() => {
+      const out = new MyOpaqueStruct(diplomatRuntime.ptrRead(wasm, underlying + 0));
+      out.__this_lifetime_guard = this;
+      return out;
+    })();
+    this.b = (new Uint8Array(wasm.memory.buffer, underlying + 4, 1))[0];
   }
 
   static new(foo, bar) {
@@ -33,26 +34,10 @@ export class MyStruct {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.MyStruct_new(diplomat_receive_buffer, foo.underlying, bar.underlying);
       const out = new MyStruct(diplomat_receive_buffer);
-      diplomat_alloc_destroy_registry.register(out, {
-        ptr: out.underlying,
-        size: 5,
-        align: 4,
-      });
+      wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
       return out;
     })();
     return diplomat_out;
-  }
-
-  get a() {
-    return (() => {
-      const out = new MyOpaqueStruct((new Uint32Array(wasm.memory.buffer, this.underlying + 0, 1))[0]);
-      out.owner = null;
-      return out;
-    })();
-  }
-
-  get b() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 4, 1))[0];
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__result_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__result_types@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/types.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -16,50 +15,32 @@ const MyOpaqueStruct_box_destroy_registry = new FinalizationRegistry(underlying 
 export class MyOpaqueStruct {
   constructor(underlying) {
     this.underlying = underlying;
+    MyOpaqueStruct_box_destroy_registry.register(this, underlying);
   }
 }
 
-const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.MyStruct_destroy(underlying);
-});
-
 export class MyStruct {
   constructor(underlying) {
-    this.underlying = underlying;
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   static new() {
     const diplomat_out = (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(3, 1);
-      const result_tag = {};
-      diplomat_alloc_destroy_registry.register(result_tag, {
-        ptr: diplomat_receive_buffer,
-        size: 3,
-        align: 1,
-      });
       wasm.MyStruct_new(diplomat_receive_buffer);
-      const is_ok = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 2, 1))[0] == 1;
+      const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 2);
       if (is_ok) {
-        const ok_value = (() => {
-          const out = new MyStruct(diplomat_receive_buffer);
-          out.owner = result_tag;
-          return out;
-        })();
+        const ok_value = new MyStruct(diplomat_receive_buffer);
+        wasm.diplomat_free(diplomat_receive_buffer, 3, 1)
         return ok_value;
       } else {
-        const throw_value = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
+        const throw_value = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 0, 1))[0];
+        wasm.diplomat_free(diplomat_receive_buffer, 3, 1)
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
     return diplomat_out;
-  }
-
-  get a() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 0, 1))[0];
-  }
-
-  get b() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 1, 1))[0];
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__string_reference@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__string_reference@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/types.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -9,13 +8,10 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
   wasm.diplomat_free(obj["ptr"], obj["size"], obj["align"]);
 });
 
-const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.MyStruct_destroy(underlying);
-});
-
 export class MyStruct {
   constructor(underlying) {
-    this.underlying = underlying;
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   static new(v) {
@@ -27,23 +23,11 @@ export class MyStruct {
       const diplomat_receive_buffer = wasm.diplomat_alloc(2, 1);
       wasm.MyStruct_new(diplomat_receive_buffer, v_diplomat_ptr, v_diplomat_bytes.length);
       const out = new MyStruct(diplomat_receive_buffer);
-      diplomat_alloc_destroy_registry.register(out, {
-        ptr: out.underlying,
-        size: 2,
-        align: 1,
-      });
+      wasm.diplomat_free(diplomat_receive_buffer, 2, 1);
       return out;
     })();
     wasm.diplomat_free(v_diplomat_ptr, v_diplomat_bytes.length, 1);
     return diplomat_out;
-  }
-
-  get a() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 0, 1))[0];
-  }
-
-  get b() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 1, 1))[0];
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/types.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -9,26 +8,17 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
   wasm.diplomat_free(obj["ptr"], obj["size"], obj["align"]);
 });
 
-const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.MyStruct_destroy(underlying);
-});
-
 export class MyStruct {
   constructor(underlying) {
-    this.underlying = underlying;
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   something() {
-    const diplomat_out = wasm.MyStruct_something(this.underlying);
+    const diplomat_MyStruct_extracted_a = this["a"];
+    const diplomat_MyStruct_extracted_b = this["b"];
+    const diplomat_out = wasm.MyStruct_something(diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b);
     return diplomat_out;
-  }
-
-  get a() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 0, 1))[0];
-  }
-
-  get b() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 1, 1))[0];
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@api.mjs.snap
@@ -1,7 +1,6 @@
 ---
 source: tool/src/js/types.rs
 expression: out_texts.get(out).unwrap()
-
 ---
 import wasm from "./wasm.mjs"
 import * as diplomatRuntime from "./diplomat-runtime.mjs"
@@ -9,28 +8,19 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
   wasm.diplomat_free(obj["ptr"], obj["size"], obj["align"]);
 });
 
-const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
-  wasm.MyStruct_destroy(underlying);
-});
-
 export class MyStruct {
   constructor(underlying) {
-    this.underlying = underlying;
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   write() {
+    const diplomat_MyStruct_extracted_a = this["a"];
+    const diplomat_MyStruct_extracted_b = this["b"];
     const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
-      return wasm.MyStruct_write(this.underlying, writeable);
+      return wasm.MyStruct_write(diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b, writeable);
     });
     return diplomat_out;
-  }
-
-  get a() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 0, 1))[0];
-  }
-
-  get b() {
-    return (new Uint8Array(wasm.memory.buffer, this.underlying + 1, 1))[0];
   }
 }
 

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -176,6 +176,18 @@ fn gen_method<W: fmt::Write>(
     let mut all_param_exprs = vec![];
     let mut post_stmts = vec![];
 
+    if let Some(ref self_param) = method.self_param {
+        gen_value_js_to_rust(
+            &ast::Ident::from("this"),
+            &self_param.to_typename(),
+            in_path,
+            env,
+            &mut pre_stmts,
+            &mut all_param_exprs,
+            &mut post_stmts,
+        );
+    }
+
     for p in method.params.iter() {
         gen_value_js_to_rust(
             &p.name,
@@ -201,10 +213,6 @@ fn gen_method<W: fmt::Write>(
     }
 
     let all_params_invocation = {
-        if method.self_param.is_some() {
-            all_param_exprs.insert(0, "this.underlying".to_string());
-        }
-
         if let Some(ref return_type) = method.return_type {
             if let ReturnTypeForm::Complex = return_type_form(return_type, in_path, env) {
                 all_param_exprs.insert(0, "diplomat_receive_buffer".to_string());
@@ -242,9 +250,9 @@ fn gen_method<W: fmt::Write>(
                             ValueIntoJs {
                                 value_expr: &invocation_expr,
                                 typ,
-                                in_path,
                                 borrows_self: borrowed_params.borrows_self(),
                                 borrowed_params: &borrowed_params.1[..],
+                                in_path,
                                 env,
                             }
                             .fmt(f)

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -170,7 +170,7 @@ mod tests {
                 }
 
                 impl MyStruct {
-                    pub fn write(&self, to: &mut DiplomatWriteable) {
+                    pub fn write(self, to: &mut DiplomatWriteable) {
                         unimplemented!()
                     }
                 }
@@ -189,7 +189,7 @@ mod tests {
                 }
 
                 impl MyStruct {
-                    pub fn something(&self) -> () {
+                    pub fn something(self) -> () {
                         unimplemented!()
                     }
                 }


### PR DESCRIPTION
#172 attempted to do way too many things at once, and introduced a lot of bugs. Therefore, I'm redoing all of it in smaller parts for easier review and bug-hunting along the way.

This first part attempts to remove the underlying buffer from non-opaque structs in JS by having them eagerly load all fields from the underlying buffer in the constructor, and so the buffer can be freed right afterwards. This removes the requirement for non-opaque structs to have a `FinalizationRegistry` and custom `get` methods.

Additionally, it moves the `FinalizationRegistry` registration for opaque type into the constructor, allowing us to drastically clean up generated boilerplate code. One of the caveats of this is that `Option<Box<T>>` fields are now checked to be non-null before throwing them into a constructor, which makes the code _much_ more readable.

I've also added some helper functions in `diplomatRuntime` which make it easier for us to reason about the generated code, as well as avoid the detach error with array views and the wasm buffer being updated.