### PR TITLE
Strongly-typed JS codegen

### DIFF
--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -15,18 +15,16 @@ export class ICU4XDataProvider {
   }
 
   static new_static() {
-    const diplomat_out = new ICU4XDataProvider(wasm.ICU4XDataProvider_new_static());
-    return diplomat_out;
+    return new ICU4XDataProvider(wasm.ICU4XDataProvider_new_static());
   }
 
   static returns_result() {
-    const diplomat_out = (() => {
+    return (() => {
       const is_ok = wasm.ICU4XDataProvider_returns_result() == 1;
       if (!is_ok) {
         throw new diplomatRuntime.FFIError({});
       }
     })();
-    return diplomat_out;
   }
 }
 
@@ -41,20 +39,19 @@ export class ICU4XFixedDecimal {
   }
 
   static new(v) {
-    const diplomat_out = new ICU4XFixedDecimal(wasm.ICU4XFixedDecimal_new(v));
-    return diplomat_out;
+    return new ICU4XFixedDecimal(wasm.ICU4XFixedDecimal_new(v));
   }
 
   multiply_pow10(power) {
-    const diplomat_out = wasm.ICU4XFixedDecimal_multiply_pow10(this.underlying, power);
+    wasm.ICU4XFixedDecimal_multiply_pow10(this.underlying, power);
   }
 
   negate() {
-    const diplomat_out = wasm.ICU4XFixedDecimal_negate(this.underlying);
+    wasm.ICU4XFixedDecimal_negate(this.underlying);
   }
 
   to_string() {
-    const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
+    return diplomatRuntime.withWriteable(wasm, (writeable) => {
       return (() => {
         const is_ok = wasm.ICU4XFixedDecimal_to_string(this.underlying, writeable) == 1;
         if (!is_ok) {
@@ -62,7 +59,6 @@ export class ICU4XFixedDecimal {
         }
       })();
     });
-    return diplomat_out;
   }
 }
 
@@ -79,46 +75,43 @@ export class ICU4XFixedDecimalFormat {
   static try_new(locale, provider, options) {
     const diplomat_ICU4XFixedDecimalFormatOptions_extracted_grouping_strategy = options["grouping_strategy"];
     const diplomat_ICU4XFixedDecimalFormatOptions_extracted_sign_display = options["sign_display"];
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.ICU4XFixedDecimalFormat_try_new(diplomat_receive_buffer, locale.underlying, provider.underlying, ICU4XFixedDecimalGroupingStrategy_js_to_rust[diplomat_ICU4XFixedDecimalFormatOptions_extracted_grouping_strategy], ICU4XFixedDecimalSignDisplay_js_to_rust[diplomat_ICU4XFixedDecimalFormatOptions_extracted_sign_display]);
       const out = new ICU4XFixedDecimalFormatResult(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
       return out;
     })();
-    return diplomat_out;
   }
 
   format_write(value) {
-    const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
+    return diplomatRuntime.withWriteable(wasm, (writeable) => {
       return wasm.ICU4XFixedDecimalFormat_format_write(this.underlying, value.underlying, writeable);
     });
-    return diplomat_out;
   }
 }
 
 export class ICU4XFixedDecimalFormatOptions {
   constructor(underlying) {
-    this.grouping_strategy = ICU4XFixedDecimalGroupingStrategy_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, underlying + 0)];
+    this.grouping_strategy = ICU4XFixedDecimalGroupingStrategy_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, underlying)];
     this.sign_display = ICU4XFixedDecimalSignDisplay_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, underlying + 4)];
   }
 
   static default() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(8, 4);
       wasm.ICU4XFixedDecimalFormatOptions_default(diplomat_receive_buffer);
       const out = new ICU4XFixedDecimalFormatOptions(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 8, 4);
       return out;
     })();
-    return diplomat_out;
   }
 }
 
 export class ICU4XFixedDecimalFormatResult {
   constructor(underlying) {
     this.fdf = (() => {
-      const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 0);
+      const option_ptr = diplomatRuntime.ptrRead(wasm, underlying);
       return (option_ptr == 0) ? null : new ICU4XFixedDecimalFormat(option_ptr);
     })();
     this.success = (new Uint8Array(wasm.memory.buffer, underlying + 4, 1))[0] == 1;

--- a/feature_tests/c/include/MyStruct.h
+++ b/feature_tests/c/include/MyStruct.h
@@ -17,10 +17,9 @@ typedef struct MyStruct {
     uint64_t d;
     int32_t e;
     char32_t f;
-    DiplomatStringView g;
 } MyStruct;
 
-MyStruct MyStruct_new(const char* s_data, size_t s_len);
+MyStruct MyStruct_new();
 void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus

--- a/feature_tests/cpp/docs/structs_ffi.rst
+++ b/feature_tests/cpp/docs/structs_ffi.rst
@@ -15,11 +15,7 @@
 
     .. cpp:member:: char32_t f
 
-    .. cpp:member:: std::string_view g
-
-    .. cpp:function:: static MyStruct new_(const std::string_view s)
-
-        Lifetimes: ``s`` must live at least as long as the output.
+    .. cpp:function:: static MyStruct new_()
 
 .. cpp:class:: Opaque
 

--- a/feature_tests/cpp/include/MyStruct.h
+++ b/feature_tests/cpp/include/MyStruct.h
@@ -17,10 +17,9 @@ typedef struct MyStruct {
     uint64_t d;
     int32_t e;
     char32_t f;
-    DiplomatStringView g;
 } MyStruct;
 
-MyStruct MyStruct_new(const char* s_data, size_t s_len);
+MyStruct MyStruct_new();
 void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus

--- a/feature_tests/cpp/include/MyStruct.hpp
+++ b/feature_tests/cpp/include/MyStruct.hpp
@@ -31,15 +31,12 @@ struct MyStruct {
   uint64_t d;
   int32_t e;
   char32_t f;
-  std::string_view g;
-  static MyStruct new_(const std::string_view s);
+  static MyStruct new_();
 };
 
 
-inline MyStruct MyStruct::new_(const std::string_view s) {
-  capi::MyStruct diplomat_raw_struct_out_value = capi::MyStruct_new(s.data(), s.size());
-  capi::DiplomatStringView diplomat_str_raw_out_value_g = diplomat_raw_struct_out_value.g;
-  std::string_view str(diplomat_str_raw_out_value_g.data, diplomat_str_raw_out_value_g.len);
-  return MyStruct{ .a = std::move(diplomat_raw_struct_out_value.a), .b = std::move(diplomat_raw_struct_out_value.b), .c = std::move(diplomat_raw_struct_out_value.c), .d = std::move(diplomat_raw_struct_out_value.d), .e = std::move(diplomat_raw_struct_out_value.e), .f = std::move(diplomat_raw_struct_out_value.f), .g = std::move(str) };
+inline MyStruct MyStruct::new_() {
+  capi::MyStruct diplomat_raw_struct_out_value = capi::MyStruct_new();
+  return MyStruct{ .a = std::move(diplomat_raw_struct_out_value.a), .b = std::move(diplomat_raw_struct_out_value.b), .c = std::move(diplomat_raw_struct_out_value.c), .d = std::move(diplomat_raw_struct_out_value.d), .e = std::move(diplomat_raw_struct_out_value.e), .f = std::move(diplomat_raw_struct_out_value.f) };
 }
 #endif

--- a/feature_tests/cpp/include/Opaque.hpp
+++ b/feature_tests/cpp/include/Opaque.hpp
@@ -45,6 +45,6 @@ inline Opaque Opaque::new_() {
 }
 inline void Opaque::assert_struct(MyStruct s) const {
   MyStruct diplomat_wrapped_struct_s = s;
-  capi::Opaque_assert_struct(this->inner.get(), capi::MyStruct{ .a = diplomat_wrapped_struct_s.a, .b = diplomat_wrapped_struct_s.b, .c = diplomat_wrapped_struct_s.c, .d = diplomat_wrapped_struct_s.d, .e = diplomat_wrapped_struct_s.e, .f = diplomat_wrapped_struct_s.f, .g = { diplomat_wrapped_struct_s.g.data(), diplomat_wrapped_struct_s.g.size() } });
+  capi::Opaque_assert_struct(this->inner.get(), capi::MyStruct{ .a = diplomat_wrapped_struct_s.a, .b = diplomat_wrapped_struct_s.b, .c = diplomat_wrapped_struct_s.c, .d = diplomat_wrapped_struct_s.d, .e = diplomat_wrapped_struct_s.e, .f = diplomat_wrapped_struct_s.f });
 }
 #endif

--- a/feature_tests/cpp/tests/structs.cpp
+++ b/feature_tests/cpp/tests/structs.cpp
@@ -5,8 +5,7 @@
 
 int main(int argc, char *argv[]) {
     Opaque o = Opaque::new_();
-    std::string str = "hello";
-    MyStruct s = MyStruct::new_(str);
+    MyStruct s = MyStruct::new_();
 
     o.assert_struct(s);
 

--- a/feature_tests/dotnet/Lib/Generated/MyStruct.cs
+++ b/feature_tests/dotnet/Lib/Generated/MyStruct.cs
@@ -134,17 +134,12 @@ public partial class MyStruct
     /// <returns>
     /// A <c>MyStruct</c> allocated on C# side.
     /// </returns>
-    public static MyStruct New(string s)
+    public static MyStruct New()
     {
         unsafe
         {
-            byte[] sBuf = DiplomatUtils.StringToUtf8(s);
-            nuint sBufLength = (nuint)sBuf.Length;
-            fixed (byte* sBufPtr = sBuf)
-            {
-                Raw.MyStruct retVal = Raw.MyStruct.New(sBufPtr, sBufLength);
-                return new MyStruct(retVal);
-            }
+            Raw.MyStruct retVal = Raw.MyStruct.New();
+            return new MyStruct(retVal);
         }
     }
 

--- a/feature_tests/dotnet/Lib/Generated/RawMyStruct.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawMyStruct.cs
@@ -29,8 +29,6 @@ public partial struct MyStruct
 
     public uint f;
 
-    public string g;
-
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "MyStruct_new", ExactSpelling = true)]
-    public static unsafe extern MyStruct New(byte* s, nuint sSz);
+    public static unsafe extern MyStruct New();
 }

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -396,9 +396,9 @@ export class ResultOpaque {
       wasm.ResultOpaque_new(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
-        return out;
+        return ok_value;
       } else {
         const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
@@ -413,9 +413,9 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_foo(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
-        return out;
+        return ok_value;
       } else {
         const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
@@ -430,9 +430,9 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_bar(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
-        return out;
+        return ok_value;
       } else {
         const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
@@ -447,9 +447,9 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_unit(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
-        return out;
+        return ok_value;
       } else {
         const throw_value = {};
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
@@ -464,9 +464,9 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_struct(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 8);
       if (is_ok) {
-        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
         wasm.diplomat_free(diplomat_receive_buffer, 9, 4);
-        return out;
+        return ok_value;
       } else {
         const throw_value = new ErrorStruct(diplomat_receive_buffer);
         wasm.diplomat_free(diplomat_receive_buffer, 9, 4);
@@ -481,9 +481,9 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_in_err(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const out = {};
+        const ok_value = {};
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
-        return out;
+        return ok_value;
       } else {
         const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
@@ -498,9 +498,9 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_in_enum_err(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const out = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
+        const ok_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
-        return out;
+        return ok_value;
       } else {
         const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -26,7 +26,7 @@ const ErrorEnum_rust_to_js = {
 
 export class ErrorStruct {
   constructor(underlying) {
-    this.i = (new Int32Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.i = (new Int32Array(wasm.memory.buffer, underlying, 1))[0];
     this.j = (new Int32Array(wasm.memory.buffer, underlying + 4, 1))[0];
   }
 }
@@ -56,7 +56,7 @@ export class Float64Vec {
     let v_diplomat_ptr = wasm.diplomat_alloc(v_diplomat_bytes.length, 8);
     let v_diplomat_buf = new Uint8Array(wasm.memory.buffer, v_diplomat_ptr, v_diplomat_bytes.length);
     v_diplomat_buf.set(v_diplomat_bytes, 0);
-    const diplomat_out = wasm.Float64Vec_fill_slice(this.underlying, v_diplomat_ptr, v_diplomat_bytes.length);
+    wasm.Float64Vec_fill_slice(this.underlying, v_diplomat_ptr, v_diplomat_bytes.length);
     wasm.diplomat_free(v_diplomat_ptr, v_diplomat_bytes.length, 8);
   }
 
@@ -65,7 +65,7 @@ export class Float64Vec {
     let new_slice_diplomat_ptr = wasm.diplomat_alloc(new_slice_diplomat_bytes.length, 8);
     let new_slice_diplomat_buf = new Uint8Array(wasm.memory.buffer, new_slice_diplomat_ptr, new_slice_diplomat_bytes.length);
     new_slice_diplomat_buf.set(new_slice_diplomat_bytes, 0);
-    const diplomat_out = wasm.Float64Vec_set_value(this.underlying, new_slice_diplomat_ptr, new_slice_diplomat_bytes.length);
+    wasm.Float64Vec_set_value(this.underlying, new_slice_diplomat_ptr, new_slice_diplomat_bytes.length);
     wasm.diplomat_free(new_slice_diplomat_ptr, new_slice_diplomat_bytes.length, 8);
   }
 }
@@ -95,12 +95,11 @@ export class Foo {
   }
 
   get_bar() {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new Bar(wasm.Foo_get_bar(this.underlying));
       out.__this_lifetime_guard = this;
       return out;
     })();
-    return diplomat_out;
   }
 }
 
@@ -129,21 +128,20 @@ export class MyString {
     let new_str_diplomat_ptr = wasm.diplomat_alloc(new_str_diplomat_bytes.length, 1);
     let new_str_diplomat_buf = new Uint8Array(wasm.memory.buffer, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
     new_str_diplomat_buf.set(new_str_diplomat_bytes, 0);
-    const diplomat_out = wasm.MyString_set_str(this.underlying, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
+    wasm.MyString_set_str(this.underlying, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
     wasm.diplomat_free(new_str_diplomat_ptr, new_str_diplomat_bytes.length, 1);
   }
 
   get_str() {
-    const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
+    return diplomatRuntime.withWriteable(wasm, (writeable) => {
       return wasm.MyString_get_str(this.underlying, writeable);
     });
-    return diplomat_out;
   }
 }
 
 export class MyStruct {
   constructor(underlying) {
-    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying, 1))[0];
     this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0] == 1;
     this.c = (new Uint8Array(wasm.memory.buffer, underlying + 2, 1))[0];
     this.d = (new BigUint64Array(wasm.memory.buffer, underlying + 8, 1))[0];
@@ -152,14 +150,13 @@ export class MyStruct {
   }
 
   static new() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(24, 8);
       wasm.MyStruct_new(diplomat_receive_buffer);
       const out = new MyStruct(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 24, 8);
       return out;
     })();
-    return diplomat_out;
   }
 }
 
@@ -174,25 +171,23 @@ export class One {
   }
 
   static transitivity(hold, nohold) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_transitivity(hold.underlying, nohold.underlying));
       out.__hold_lifetime_guard = hold;
       return out;
     })();
-    return diplomat_out;
   }
 
   static cycle(hold, nohold) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_cycle(hold.underlying, nohold.underlying));
       out.__hold_lifetime_guard = hold;
       return out;
     })();
-    return diplomat_out;
   }
 
   static many_dependents(a, b, c, d, nohold) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_many_dependents(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying));
       out.__a_lifetime_guard = a;
       out.__b_lifetime_guard = b;
@@ -200,20 +195,18 @@ export class One {
       out.__d_lifetime_guard = d;
       return out;
     })();
-    return diplomat_out;
   }
 
   static return_outlives_param(hold, nohold) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_return_outlives_param(hold.underlying, nohold.underlying));
       out.__hold_lifetime_guard = hold;
       return out;
     })();
-    return diplomat_out;
   }
 
   static diamond_top(top, left, right, bottom) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_diamond_top(top.underlying, left.underlying, right.underlying, bottom.underlying));
       out.__top_lifetime_guard = top;
       out.__left_lifetime_guard = left;
@@ -221,40 +214,36 @@ export class One {
       out.__bottom_lifetime_guard = bottom;
       return out;
     })();
-    return diplomat_out;
   }
 
   static diamond_left(top, left, right, bottom) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_diamond_left(top.underlying, left.underlying, right.underlying, bottom.underlying));
       out.__left_lifetime_guard = left;
       out.__bottom_lifetime_guard = bottom;
       return out;
     })();
-    return diplomat_out;
   }
 
   static diamond_right(top, left, right, bottom) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_diamond_right(top.underlying, left.underlying, right.underlying, bottom.underlying));
       out.__right_lifetime_guard = right;
       out.__bottom_lifetime_guard = bottom;
       return out;
     })();
-    return diplomat_out;
   }
 
   static diamond_bottom(top, left, right, bottom) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_diamond_bottom(top.underlying, left.underlying, right.underlying, bottom.underlying));
       out.__bottom_lifetime_guard = bottom;
       return out;
     })();
-    return diplomat_out;
   }
 
   static diamond_and_nested_types(a, b, c, d, nohold) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new One(wasm.One_diamond_and_nested_types(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying));
       out.__a_lifetime_guard = a;
       out.__b_lifetime_guard = b;
@@ -262,7 +251,6 @@ export class One {
       out.__d_lifetime_guard = d;
       return out;
     })();
-    return diplomat_out;
   }
 }
 
@@ -277,8 +265,7 @@ export class Opaque {
   }
 
   static new() {
-    const diplomat_out = new Opaque(wasm.Opaque_new());
-    return diplomat_out;
+    return new Opaque(wasm.Opaque_new());
   }
 
   assert_struct(s) {
@@ -288,7 +275,7 @@ export class Opaque {
     const diplomat_MyStruct_extracted_d = s["d"];
     const diplomat_MyStruct_extracted_e = s["e"];
     const diplomat_MyStruct_extracted_f = s["f"];
-    const diplomat_out = wasm.Opaque_assert_struct(this.underlying, diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b, diplomat_MyStruct_extracted_c, diplomat_MyStruct_extracted_d, diplomat_MyStruct_extracted_e, diplomatRuntime.extractCodePoint(diplomat_MyStruct_extracted_f, 'diplomat_MyStruct_extracted_f'));
+    wasm.Opaque_assert_struct(this.underlying, diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b, diplomat_MyStruct_extracted_c, diplomat_MyStruct_extracted_d, diplomat_MyStruct_extracted_e, diplomatRuntime.extractCodePoint(diplomat_MyStruct_extracted_f, 'diplomat_MyStruct_extracted_f'));
   }
 }
 
@@ -303,45 +290,41 @@ export class OptionOpaque {
   }
 
   static new(i) {
-    const diplomat_out = (() => {
+    return (() => {
       const option_ptr = wasm.OptionOpaque_new(i);
       return (option_ptr == 0) ? null : new OptionOpaque(option_ptr);
     })();
-    return diplomat_out;
   }
 
   static new_none() {
-    const diplomat_out = (() => {
+    return (() => {
       const option_ptr = wasm.OptionOpaque_new_none();
       return (option_ptr == 0) ? null : new OptionOpaque(option_ptr);
     })();
-    return diplomat_out;
   }
 
   static new_struct() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(16, 4);
       wasm.OptionOpaque_new_struct(diplomat_receive_buffer);
       const out = new OptionStruct(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 16, 4);
       return out;
     })();
-    return diplomat_out;
   }
 
   static new_struct_nones() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(16, 4);
       wasm.OptionOpaque_new_struct_nones(diplomat_receive_buffer);
       const out = new OptionStruct(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 16, 4);
       return out;
     })();
-    return diplomat_out;
   }
 
   assert_integer(i) {
-    const diplomat_out = wasm.OptionOpaque_assert_integer(this.underlying, i);
+    wasm.OptionOpaque_assert_integer(this.underlying, i);
   }
 }
 
@@ -356,14 +339,14 @@ export class OptionOpaqueChar {
   }
 
   assert_char(ch) {
-    const diplomat_out = wasm.OptionOpaqueChar_assert_char(this.underlying, diplomatRuntime.extractCodePoint(ch, 'ch'));
+    wasm.OptionOpaqueChar_assert_char(this.underlying, diplomatRuntime.extractCodePoint(ch, 'ch'));
   }
 }
 
 export class OptionStruct {
   constructor(underlying) {
     this.a = (() => {
-      const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 0);
+      const option_ptr = diplomatRuntime.ptrRead(wasm, underlying);
       return (option_ptr == 0) ? null : new OptionOpaque(option_ptr);
     })();
     this.b = (() => {
@@ -389,12 +372,11 @@ export class RefList {
   }
 
   static node(data) {
-    const diplomat_out = (() => {
+    return (() => {
       const out = new RefList(wasm.RefList_node(data.underlying));
       out.__data_lifetime_guard = data;
       return out;
     })();
-    return diplomat_out;
   }
 }
 
@@ -409,133 +391,126 @@ export class ResultOpaque {
   }
 
   static new(i) {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.ResultOpaque_new(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer + 0));
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
-        return ok_value;
+        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
+        return out;
       } else {
-        const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer + 0)];
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
+        const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    return diplomat_out;
   }
 
   static new_failing_foo() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.ResultOpaque_new_failing_foo(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer + 0));
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
-        return ok_value;
+        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
+        return out;
       } else {
-        const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer + 0)];
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
+        const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    return diplomat_out;
   }
 
   static new_failing_bar() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.ResultOpaque_new_failing_bar(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer + 0));
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
-        return ok_value;
+        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
+        return out;
       } else {
-        const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer + 0)];
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
+        const throw_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    return diplomat_out;
   }
 
   static new_failing_unit() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.ResultOpaque_new_failing_unit(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer + 0));
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
-        return ok_value;
+        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
+        return out;
       } else {
         const throw_value = {};
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    return diplomat_out;
   }
 
   static new_failing_struct(i) {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(9, 4);
       wasm.ResultOpaque_new_failing_struct(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 8);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer + 0));
-        wasm.diplomat_free(diplomat_receive_buffer, 9, 4)
-        return ok_value;
+        const out = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        wasm.diplomat_free(diplomat_receive_buffer, 9, 4);
+        return out;
       } else {
         const throw_value = new ErrorStruct(diplomat_receive_buffer);
-        wasm.diplomat_free(diplomat_receive_buffer, 9, 4)
+        wasm.diplomat_free(diplomat_receive_buffer, 9, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    return diplomat_out;
   }
 
   static new_in_err(i) {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.ResultOpaque_new_in_err(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = {};
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
-        return ok_value;
+        const out = {};
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
+        return out;
       } else {
-        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer + 0));
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
+        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    return diplomat_out;
   }
 
   static new_in_enum_err(i) {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.ResultOpaque_new_in_enum_err(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer + 0)];
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
-        return ok_value;
+        const out = ErrorEnum_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, diplomat_receive_buffer)];
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
+        return out;
       } else {
-        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer + 0));
-        wasm.diplomat_free(diplomat_receive_buffer, 5, 4)
+        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    return diplomat_out;
   }
 
   assert_integer(i) {
-    const diplomat_out = wasm.ResultOpaque_assert_integer(this.underlying, i);
+    wasm.ResultOpaque_assert_integer(this.underlying, i);
   }
 }
 

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -4,14 +4,13 @@ pub mod ffi {
     #[diplomat::opaque]
     pub struct Opaque();
 
-    pub struct MyStruct<'a> {
+    pub struct MyStruct {
         a: u8,
         b: bool,
         c: u8,
         d: u64,
         e: i32,
         f: char,
-        g: &'a str,
     }
 
     impl Opaque {
@@ -24,8 +23,8 @@ pub mod ffi {
         }
     }
 
-    impl<'a> MyStruct<'a> {
-        pub fn new(s: &'a str) -> MyStruct<'a> {
+    impl MyStruct {
+        pub fn new() -> MyStruct {
             MyStruct {
                 a: 17,
                 b: true,
@@ -33,7 +32,6 @@ pub mod ffi {
                 d: 1234,
                 e: 5991,
                 f: '餐',
-                g: s,
             }
         }
 
@@ -44,7 +42,6 @@ pub mod ffi {
             assert_eq!(self.d, 1234);
             assert_eq!(self.e, 5991);
             assert_eq!(self.f, '餐');
-            assert_eq!(self.g, "hello");
         }
     }
 }

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -1,5 +1,7 @@
-use diplomat_core::{ast, Env};
+use diplomat_core::ast::{self, BorrowedParams};
+use diplomat_core::Env;
 use std::fmt::{self, Write as _};
+use std::num::NonZeroUsize;
 
 use super::display;
 use super::types::{return_type_form, ReturnTypeForm};
@@ -101,206 +103,406 @@ pub fn gen_value_js_to_rust(
     }
 }
 
-/// An [`fmt::Display`] type that writes the conversion from a Rust value into
-/// a JavaScript value.
-pub struct ValueIntoJs<'a> {
-    /// A JS expression that yields a Rust value through wasm.
-    pub value_expr: &'a str,
+/// Type alias for readability.
+type Offset = Option<NonZeroUsize>;
 
-    /// The type of the Rust value.
-    pub typ: &'a ast::TypeName,
+/// An [`fmt::Display`] type that represents an invocation of a WASM function.
+pub struct Invocation {
+    /// Name of the method in the WASM namespace.
+    full_path_name: ast::Ident,
 
-    /// A boolean determining if the value borrows from the object that created it.
-    pub borrows_self: bool,
-
-    /// A sequence of fields that the value borrows from.
-    pub borrowed_params: &'a [&'a ast::Param],
-
-    pub in_path: &'a ast::Path,
-    pub env: &'a Env,
+    /// Arguments to invoke the function with.
+    args: Vec<String>, // stringly typed for now...
 }
 
-impl<'a> fmt::Display for ValueIntoJs<'a> {
+impl Invocation {
+    /// Create a new [`Invocation`].
+    pub fn new(full_path_name: ast::Ident, args: Vec<String>) -> Self {
+        Invocation {
+            full_path_name,
+            args,
+        }
+    }
+
+    /// Invoke the function without passing in a return buffer.
+    pub fn scalar<'invoke>(&'invoke self) -> impl fmt::Display + 'invoke {
+        display::expr(move |f| {
+            write!(
+                f,
+                "wasm.{}({})",
+                self.full_path_name,
+                display::expr(|f| {
+                    if let Some((first, rest)) = self.args.split_first() {
+                        write!(f, "{}", first)?;
+                        for param in rest {
+                            write!(f, ", {param}")?;
+                        }
+                    }
+                    Ok(())
+                })
+            )
+        })
+    }
+
+    /// Invoke the function with a provided return buffer.
+    pub fn complex<'invoke>(
+        &'invoke self,
+        buf: &'invoke ast::Ident,
+    ) -> impl fmt::Display + 'invoke {
+        display::expr(move |f| {
+            write!(
+                f,
+                "wasm.{}({})",
+                self.full_path_name,
+                display::expr(|f| {
+                    write!(f, "{}", buf)?;
+                    for param in &self.args {
+                        write!(f, ", {param}")?;
+                    }
+                    Ok(())
+                })
+            )
+        })
+    }
+}
+
+/// Base information shared across the different conversion types.
+#[derive(Copy, Clone)]
+pub struct Base<'base> {
+    /// Scope of the Diplomat type environment.
+    pub in_path: &'base ast::Path,
+
+    /// Diplomat type environment.
+    pub env: &'base Env,
+
+    /// A boolean determining if the value borrows from the caller.
+    pub borrows_self: bool,
+
+    /// The params that the value borrows.
+    pub borrowed_params: &'base [&'base ast::Param],
+}
+
+impl<'base> Base<'base> {
+    /// Create a [`Base`] for a field.
+    pub fn new_field(in_path: &'base ast::Path, env: &'base Env, borrows_self: bool) -> Self {
+        Base {
+            in_path,
+            env,
+            borrows_self,
+            borrowed_params: &[],
+        }
+    }
+
+    /// Create a [`Base`] for a method.
+    pub fn new_method(
+        in_path: &'base ast::Path,
+        env: &'base Env,
+        borrowed_params: &'base BorrowedParams,
+    ) -> Self {
+        Base {
+            in_path,
+            env,
+            borrows_self: borrowed_params.0.is_some(),
+            borrowed_params: &borrowed_params.1[..],
+        }
+    }
+
+    fn resolve_type<'custom>(&'custom self, path_type: &ast::PathType) -> &'custom ast::CustomType {
+        path_type.resolve(self.in_path, self.env)
+    }
+
+    fn return_type_form(&self, typ: &ast::TypeName) -> ReturnTypeForm {
+        return_type_form(typ, self.in_path, self.env)
+    }
+
+    fn size_align(&self, typ: &ast::TypeName) -> (usize, usize) {
+        let layout = layout::type_size_alignment(typ, self.in_path, self.env);
+        (layout.size(), layout.align())
+    }
+
+    fn result_size_align(
+        &self,
+        ok: &ast::TypeName,
+        err: &ast::TypeName,
+    ) -> (usize, (usize, usize)) {
+        let (ok_offset, layout) =
+            layout::result_ok_offset_size_align(ok, err, self.in_path, self.env);
+        let (size, align) = (layout.size(), layout.align());
+        (ok_offset, (size, align))
+    }
+
+    fn borrows(&self) -> bool {
+        self.borrows_self || !self.borrowed_params.is_empty()
+    }
+}
+
+/// An [`fmt::Display`] type that represents a JS expression whose overall type
+/// is a pointer.
+#[derive(Copy, Clone)]
+pub enum Underlying<'base> {
+    /// A WASM invocation that evaluates to a pointer.
+    Invocation(&'base Invocation),
+
+    /// A binding that holds a pointer.
+    Binding(&'base ast::Ident),
+
+    /// Dereference a double pointer once, yielding the inside pointer.
+    PtrRead(&'base Underlying<'base>, Offset),
+}
+
+impl fmt::Display for Underlying<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Underlying::Invocation(invoke) => invoke.scalar().fmt(f),
+            Underlying::Binding(name) => name.fmt(f),
+            Underlying::PtrRead(name, offset) => {
+                write!(
+                    f,
+                    "diplomatRuntime.ptrRead(wasm, {})",
+                    display::expr(|f| match offset {
+                        Some(offset) => write!(f, "{name} + {offset}"),
+                        None => write!(f, "{name}"),
+                    })
+                )
+            }
+        }
+    }
+}
+
+/// An [`fmt::Display`] type for creating a JS value from a WASM invocation.
+pub struct InvocationIntoJs<'base> {
+    /// The type of the created value.
+    pub typ: &'base ast::TypeName,
+
+    /// The invocation that yields the value.
+    pub invocation: Invocation,
+
+    /// Base data.
+    pub base: Base<'base>,
+}
+
+impl fmt::Display for InvocationIntoJs<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.typ {
-            ast::TypeName::Named(path_type) => match path_type.resolve(self.in_path, self.env) {
+            ast::TypeName::Primitive(..) => self.invocation.scalar().fmt(f),
+            ast::TypeName::Named(path_type) => match self.base.resolve_type(path_type) {
                 ast::CustomType::Struct(strct) => {
-                    match return_type_form(self.typ, self.in_path, self.env) {
+                    // TODO: optimize `return_type_form` because we already know we're a non-opaque struct
+                    match self.base.return_type_form(self.typ) {
                         ReturnTypeForm::Scalar => {
-                            todo!("Recieving structs that don't need a buffer: {}", strct.name)
+                            todo!("#173: constructing a scalar struct")
                         }
-                        ReturnTypeForm::Complex => {
-                            let strct_layout = layout::type_size_alignment(self.typ, self.in_path, self.env);
-                            let (size, align) = (strct_layout.size(), strct_layout.align());
-                            display::iife(|mut f| {
-                                let buf_name = ast::Ident::from("diplomat_receive_buffer");
-                                writeln!(f, "const {buf_name} = wasm.diplomat_alloc({size}, {align});")?;
-                                writeln!(f, "{};", self.value_expr)?;
-                                writeln!(f, "const out = new {}({buf_name});", strct.name)?;
-                                writeln!(f, "wasm.diplomat_free({buf_name}, {size}, {align});")?;
-                                writeln!(f, "return out;")
-                            }).fmt(f)
-                        }
-                        ReturnTypeForm::Empty => panic!("How do we handle this case?"),
-                    }
-
-                }
-                ast::CustomType::Opaque(opaque) => {
-                    if !self.borrows_self && self.borrowed_params.is_empty() {
-                        write!(f, "new {}({})", opaque.name, self.value_expr)
-                    } else {
-                        display::iife(|mut f| {
-                            writeln!(f, "const out = new {}({});", opaque.name, self.value_expr)?;
-                            if self.borrows_self {
-                                writeln!(f, "out.__this_lifetime_guard = this;")?;
-                            }
-                            for param in self.borrowed_params {
-                                writeln!(f, "out.__{0}_lifetime_guard = {0};", param.name)?;
-                            }
+                        ReturnTypeForm::Complex => display::iife(|mut f| {
+                            let (size, align) = self.base.size_align(self.typ);
+                            let diplomat_receive_buffer: ast::Ident = "diplomat_receive_buffer".into();
+                            writeln!(f, "const {diplomat_receive_buffer} = wasm.diplomat_alloc({size}, {align});")?;
+                            writeln!(f, "{};", self.invocation.complex(&diplomat_receive_buffer))?;
+                            writeln!(f, "const out = new {}({diplomat_receive_buffer});", strct.name)?;
+                            writeln!(f, "wasm.diplomat_free({diplomat_receive_buffer}, {size}, {align});")?;
                             writeln!(f, "return out;")
-                        }).fmt(f)
+                        })
+                        .fmt(f),
+                        ReturnTypeForm::Empty => unreachable!(),
                     }
+                }
+                ast::CustomType::Opaque(_opaque) => {
+                    unreachable!("Cannot construct an opaque struct that's not borrowed")
                 }
                 ast::CustomType::Enum(enm) => {
-                    write!(f, "{}_rust_to_js[{}]", enm.name, ValueIntoJs {
-                        typ: &ast::TypeName::Primitive(ast::PrimitiveType::isize),
-                        ..*self
-                    })
+                    write!(f, "{}_rust_to_js[{}]", enm.name, self.invocation.scalar())
                 }
+            },
+            ast::TypeName::Reference(.., inner) | ast::TypeName::Box(inner) => Pointer {
+                inner,
+                underlying: Underlying::Invocation(&self.invocation),
+                base: self.base,
             }
-            ast::TypeName::Box(typ) | ast::TypeName::Reference(.., typ) => {
-                ValueIntoJs {
-                    typ: typ.as_ref(),
-                    ..*self
-                }
-                .fmt(f)
-            }
-            ast::TypeName::Option(typ) => match typ.as_ref() {
-                ptr_type @ (ast::TypeName::Box(..) | ast::TypeName::Reference(..)) => {
+            .fmt(f),
+            ast::TypeName::Option(inner) => match inner.as_ref() {
+                ast::TypeName::Box(inner) | ast::TypeName::Reference(.., inner) => {
                     display::iife(|mut f| {
+                        let option_ptr: ast::Ident = "option_ptr".into();
+                        writeln!(f, "const {option_ptr} = {};", self.invocation.scalar())?;
                         writeln!(
                             f,
-                            "const option_ptr = {};",
-                            self.value_expr
-                        )?;
-                        writeln!(
-                            f,
-                            "return (option_ptr == 0) ? null : {};",
-                            ValueIntoJs {
-                                value_expr: "option_ptr",
-                                typ: ptr_type,
-                                ..*self
+                            "return ({option_ptr} == 0) ? null : {};",
+                            Pointer {
+                                inner,
+                                underlying: Underlying::Binding(&option_ptr),
+                                base: self.base,
                             }
                         )
                     })
                     .fmt(f)
                 }
-                other @ (ast::TypeName::StrReference(..) | ast::TypeName::PrimitiveSlice(..)) => panic!("`{}` is a fat pointer (ptr, len), so it can't be stored behind an option", other),
-                other => panic!("`{0}` doesn't have the same layout guarantees as a ptr, so `Option<{0}>` is unsupported", other),
+                _ => unreachable!(),
             },
             ast::TypeName::Result(ok, err) => {
-                let (ok_offset, result_layout) = layout::result_ok_offset_size_align(ok, err, self.in_path, self.env);
-                let (size, align) = (result_layout.size(), result_layout.align());
-                let needs_buffer = matches!(return_type_form(self.typ, self.in_path, self.env), ReturnTypeForm::Complex);
-                display::iife(|mut f| {
-                    if needs_buffer {
-                        let buf_ident = ast::Ident::from("diplomat_receive_buffer");
-                        writeln!(f, "const {buf_ident} = wasm.diplomat_alloc({size}, {align});")?;
-                        writeln!(f, "{};", self.value_expr)?;
-                        writeln!(f, "const is_ok = diplomatRuntime.resultFlag(wasm, {buf_ident}, {ok_offset});")?;
-                        writeln!(f, "if (is_ok) {if_true} else {if_false}",
-                            if_true = display::block(|mut f| {
-                                writeln!(f, "const ok_value = {};", BufferedIntoJs {
-                                    buf_ptr: buf_ident.as_str(),
-                                    offset: 0,
-                                    typ: ok.as_ref(),
-                                    borrows_self: false,
-                                    borrowed_params: &[],
-                                    in_path: self.in_path,
-                                    env: self.env,
-                                })?;
-                                writeln!(f, "wasm.diplomat_free({buf_ident}, {size}, {align})")?;
-                                writeln!(f, "return ok_value;")
-                            }),
-                            if_false = display::block(|mut f| {
-                                writeln!(f, "const throw_value = {};", BufferedIntoJs {
-                                    buf_ptr: buf_ident.as_str(),
-                                    offset: 0,
-                                    typ: err.as_ref(),
-                                    borrows_self: false,
-                                    borrowed_params: &[],
-                                    in_path: self.in_path,
-                                    env: self.env,
-                                })?;
-                                writeln!(f, "wasm.diplomat_free({buf_ident}, {size}, {align})")?;
-                                writeln!(f, "throw new diplomatRuntime.FFIError(throw_value);")
-                            })
-                        )
-                    } else {
-                        writeln!(f, "const is_ok = {} == 1;", self.value_expr)?;
+                match self.base.return_type_form(self.typ) {
+                    ReturnTypeForm::Scalar => display::iife(|mut f| {
+                        writeln!(f, "const is_ok = {} == 1;", self.invocation.scalar())?;
                         writeln!(f, "if (!is_ok) {}", display::block(|mut f| {
                             writeln!(f, "throw new diplomatRuntime.FFIError({{}});")
                         }))
+                    })
+                    .fmt(f),
+                    ReturnTypeForm::Complex => {
+                        display::iife(|mut f| {
+                            let (flag_offset, (size, align)) = self.base.result_size_align(ok, err);
+                            let diplomat_receive_buffer: ast::Ident = "diplomat_receive_buffer".into();
+                            writeln!(f, "const {diplomat_receive_buffer} = wasm.diplomat_alloc({size}, {align});")?;
+                            writeln!(f, "{};", self.invocation.complex(&diplomat_receive_buffer))?;
+                            writeln!(f, "const is_ok = diplomatRuntime.resultFlag(wasm, {diplomat_receive_buffer}, {flag_offset});")?;
+                            writeln!(
+                                f,
+                                "if (is_ok) {if_true} else {if_false}",
+                                if_true = display::block(|mut f| {
+                                    writeln!(f, "const ok_value = {};", UnderlyingIntoJs {
+                                        typ: ok.as_ref(),
+                                        underlying: Underlying::Binding(&diplomat_receive_buffer),
+                                        offset: None,
+                                        base: self.base,
+                                    })?;
+                                    writeln!(f, "wasm.diplomat_free({diplomat_receive_buffer}, {size}, {align});")?;
+                                    writeln!(f, "return ok_value;")
+                                }),
+                                if_false = display::block(|mut f| {
+                                    writeln!(f, "const throw_value = {};", UnderlyingIntoJs {
+                                        typ: err.as_ref(),
+                                        underlying: Underlying::Binding(&diplomat_receive_buffer),
+                                        offset: None,
+                                        base: self.base,
+                                    })?;
+                                    writeln!(f, "wasm.diplomat_free({diplomat_receive_buffer}, {size}, {align});")?;
+                                    writeln!(f, "throw new diplomatRuntime.FFIError(throw_value);")
+                                })
+                            )
+                        })
+                        .fmt(f)
                     }
-                }).fmt(f)
+                    ReturnTypeForm::Empty => unreachable!(),
+                }
             }
-            ast::TypeName::Writeable => todo!("ast::TypeName::Writeable"),
-            ast::TypeName::StrReference(..) => todo!("ast::TypeName::StrReference(_)"),
-            ast::TypeName::PrimitiveSlice(..) => todo!("ast::TypeName::PrimitiveSlice(..)"),
-            ast::TypeName::Primitive(..) | ast::TypeName::Unit => self.value_expr.fmt(f),
+            ast::TypeName::Unit => self.invocation.scalar().fmt(f),
+            ast::TypeName::Writeable => todo!(),
+            ast::TypeName::StrReference(..) => todo!(),
+            ast::TypeName::PrimitiveSlice(..) => todo!(),
         }
     }
 }
 
-/// An [`fmt::Display`] type that writes the conversion from a Rust value in
-/// a buffer to a JavaScript value.
+/// An [`fmt::Display`] type for creating a JS value that's behind a pointer.
+struct Pointer<'base> {
+    /// The type behind the pointer.
+    inner: &'base ast::TypeName,
+
+    /// An expression that evaluates into the pointer.
+    underlying: Underlying<'base>,
+
+    /// Base data.
+    base: Base<'base>,
+}
+
+impl fmt::Display for Pointer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let ast::TypeName::Named(path_type) = self.inner {
+            if let ast::CustomType::Opaque(opaque) = self.base.resolve_type(path_type) {
+                if !self.base.borrows() {
+                    write!(f, "new {}({})", opaque.name, self.underlying)?;
+                } else {
+                    display::iife(|mut f| {
+                        writeln!(f, "const out = new {}({});", opaque.name, self.underlying)?;
+                        if self.base.borrows_self {
+                            writeln!(f, "out.__this_lifetime_guard = this;")?;
+                        }
+                        for param in self.base.borrowed_params {
+                            writeln!(f, "out.__{0}_lifetime_guard = {0};", param.name)?;
+                        }
+                        writeln!(f, "return out;")
+                    })
+                    .fmt(f)?;
+                }
+
+                return Ok(());
+            }
+        }
+
+        UnderlyingIntoJs {
+            typ: self.inner,
+            underlying: self.underlying,
+            offset: None,
+            base: self.base,
+        }
+        .fmt(f)
+    }
+}
+
+/// An [`fmt::Display`] type for creating a JS value from an underlying buffer.
 ///
-/// This method is useful for reading fields of a non-opaque struct from a buffer,
-/// and reading the `Ok` and `Err` values from a `DiplomatResult`.
-pub struct BufferedIntoJs<'a> {
-    /// The name of the buffer.
-    pub buf_ptr: &'a str,
+/// This is only used for types that can appear in non-opaque structs and
+/// `Result`s.
+pub struct UnderlyingIntoJs<'base> {
+    /// The type of the created value.
+    pub typ: &'base ast::TypeName,
 
-    /// The offset within the buffer to read from.
-    pub offset: usize,
+    /// The underlying buffer to read the value from.
+    pub underlying: Underlying<'base>,
 
-    /// The type being read from the buffer.
-    pub typ: &'a ast::TypeName,
+    /// An offset into the buffer.
+    pub offset: Offset,
 
-    /// A boolean determining if the value borrows from the object that created it.
-    pub borrows_self: bool,
-
-    /// A sequence of fields that the value borrows from.
-    pub borrowed_params: &'a [&'a ast::Param],
-
-    pub in_path: &'a ast::Path,
-    pub env: &'a Env,
+    /// Base data.
+    pub base: Base<'base>,
 }
 
-impl<'a> BufferedIntoJs<'a> {
-    fn as_value(&'a self, value_expr: &'a str) -> ValueIntoJs<'a> {
-        ValueIntoJs {
-            value_expr,
-            typ: self.typ,
-            borrows_self: self.borrows_self,
-            borrowed_params: self.borrowed_params,
-            in_path: self.in_path,
-            env: self.env,
-        }
+impl UnderlyingIntoJs<'_> {
+    /// Display the underlying pointer, including any additional offset.
+    fn display_offset<'display>(&'display self) -> impl fmt::Display + 'display {
+        display::expr(move |f| {
+            if let Some(offset) = self.offset {
+                write!(f, "{} + {offset}", self.underlying)
+            } else {
+                write!(f, "{}", self.underlying)
+            }
+        })
+    }
+
+    /// Display the result of reading a pointer from the underlying pointer with
+    /// any additional offset.
+    fn display_ptr_read<'display>(&'display self) -> impl fmt::Display + 'display {
+        display::expr(move |f| {
+            write!(
+                f,
+                "diplomatRuntime.ptrRead(wasm, {})",
+                self.display_offset()
+            )
+        })
+    }
+
+    /// Display the result of reading an enum discriminant from the underlying
+    /// pointer with any additional offset.
+    fn display_enum_discriminant<'display>(&'display self) -> impl fmt::Display + 'display {
+        display::expr(move |f| {
+            write!(
+                f,
+                "diplomatRuntime.enumDiscriminant(wasm, {})",
+                self.display_offset()
+            )
+        })
     }
 }
 
-impl<'a> fmt::Display for BufferedIntoJs<'a> {
+impl fmt::Display for UnderlyingIntoJs<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.typ {
             ast::TypeName::Primitive(prim) => {
                 macro_rules! read_prim {
                     ($array:expr) => {
-                        self.as_value(&format!(
-                            concat!("(new ", $array, "(wasm.memory.buffer, {} + {}, 1))[0]"),
-                            self.buf_ptr, self.offset
-                        ))
-                        .fmt(f)
+                        write!(
+                            f,
+                            concat!("(new ", $array, "(wasm.memory.buffer, {}, 1))[0]"),
+                            self.display_offset()
+                        )
                     };
                 }
                 match prim {
@@ -318,65 +520,71 @@ impl<'a> fmt::Display for BufferedIntoJs<'a> {
                     ast::PrimitiveType::usize => read_prim!("Uint32Array"),
                     ast::PrimitiveType::f32 => read_prim!("Float32Array"),
                     ast::PrimitiveType::f64 => read_prim!("Float64Array"),
-                    ast::PrimitiveType::bool => self
-                        .as_value(&format!(
-                            "(new Uint8Array(wasm.memory.buffer, {} + {}, 1))[0] == 1",
-                            self.buf_ptr, self.offset
-                        ))
-                        .fmt(f),
-                    ast::PrimitiveType::char => self
-                        .as_value(&format!(
-                            "String.fromCharCode((new Uint32Array(wasm.memory.buffer, {} + {}, 1))[0])",
-                            self.buf_ptr, self.offset
-                        ))
-                        .fmt(f),
+                    ast::PrimitiveType::bool => write!(
+                        f,
+                        "(new Uint8Array(wasm.memory.buffer, {}, 1))[0] == 1",
+                        self.display_offset()
+                    ),
+                    ast::PrimitiveType::char => write!(
+                        f,
+                        "String.fromCharCode((new Uint32Array(wasm.memory.buffer, {}, 1))[0])",
+                        self.display_offset()
+                    ),
                 }
             }
-            ast::TypeName::Named(path_type) => match path_type.resolve(self.in_path, self.env) {
+            ast::TypeName::Named(path_type) => match self.base.resolve_type(path_type) {
                 ast::CustomType::Struct(strct) => {
-                    write!(f, "new {}({})", strct.name, self.buf_ptr)
+                    // TODO: optimize because we already know it's a non-opaque struct
+                    match self.base.return_type_form(self.typ) {
+                        ReturnTypeForm::Scalar => {
+                            todo!("#173: constructing a scalar struct from a buffer")
+                        }
+                        ReturnTypeForm::Complex => {
+                            write!(f, "new {}({})", strct.name, self.display_offset())
+                        }
+                        ReturnTypeForm::Empty => unreachable!(),
+                    }
                 }
-                ast::CustomType::Opaque(opaque) => {
-                    write!(
-                        f,
-                        "new {}(diplomatRuntime.ptrRead(wasm, {} + {}))",
-                        opaque.name, self.buf_ptr, self.offset
-                    )
+                ast::CustomType::Opaque(_opaque) => {
+                    unreachable!("Opaque not behind a pointer")
                 }
-                ast::CustomType::Enum(enm) => {
-                    write!(
-                        f,
-                        "{}_rust_to_js[diplomatRuntime.enumDiscriminant(wasm, {} + {})]",
-                        enm.name, self.buf_ptr, self.offset
-                    )
-                }
-            },
-            ast::TypeName::Box(..) | ast::TypeName::Reference(..) => self
-                .as_value(&format!(
-                    "diplomatRuntime.ptrRead(wasm, {} + {})",
-                    self.buf_ptr, self.offset
-                ))
-                .fmt(f),
-            ast::TypeName::Option(typ) => match typ.as_ref() {
-                ast::TypeName::Box(..) | ast::TypeName::Reference(..) => self
-                    .as_value(&format!(
-                        "diplomatRuntime.ptrRead(wasm, {} + {})",
-                        self.buf_ptr, self.offset
-                    ))
-                    .fmt(f),
-                slice @ (ast::TypeName::StrReference(..) | ast::TypeName::PrimitiveSlice(..)) => {
-                    panic!(
-                        "`{}` is a fat pointer (ptr, len), and cannot be held in an option",
-                        slice
-                    )
-                }
-                other => panic!(
-                    "`{}` isn't a pointer type, and cannot be held in an option",
-                    other
+                ast::CustomType::Enum(enm) => write!(
+                    f,
+                    "{}_rust_to_js[{}]",
+                    enm.name,
+                    self.display_enum_discriminant()
                 ),
             },
-            ast::TypeName::Unit => write!(f, "{{}}"),
-            other => todo!("Read `{other}` from a buffer"),
+            ast::TypeName::Reference(.., typ) | ast::TypeName::Box(typ) => Pointer {
+                inner: typ,
+                underlying: Underlying::PtrRead(&self.underlying, self.offset),
+                base: self.base,
+            }
+            .fmt(f),
+            ast::TypeName::Option(inner) => match inner.as_ref() {
+                ast::TypeName::Box(inner) | ast::TypeName::Reference(.., inner) => {
+                    display::iife(|mut f| {
+                        let option_ptr: ast::Ident = "option_ptr".into();
+                        writeln!(f, "const {option_ptr} = {};", self.display_ptr_read())?;
+                        writeln!(
+                            f,
+                            "return ({option_ptr} == 0) ? null : {};",
+                            Pointer {
+                                inner,
+                                underlying: Underlying::Binding(&option_ptr),
+                                base: self.base,
+                            }
+                        )
+                    })
+                    .fmt(f)
+                }
+                _ => unreachable!(),
+            },
+            ast::TypeName::Result(..) => todo!("Result in a buffer"),
+            ast::TypeName::Writeable => todo!("Writeable in a buffer"),
+            ast::TypeName::StrReference(..) => todo!("StrReference in a buffer"),
+            ast::TypeName::PrimitiveSlice(..) => todo!("PrimitiveSlice in a buffer"),
+            ast::TypeName::Unit => "{}".fmt(f),
         }
     }
 }

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -106,7 +106,7 @@ pub fn gen_value_js_to_rust(
 /// Type alias for readability.
 type Offset = Option<NonZeroUsize>;
 
-/// An [`fmt::Display`] type that represents an invocation of a WASM function.
+/// An [`fmt::Display`] type representing an invocation of a WASM function.
 pub struct Invocation {
     /// Name of the method in the WASM namespace.
     full_path_name: ast::Ident,
@@ -207,19 +207,24 @@ impl<'base> Base<'base> {
         }
     }
 
+    /// Returns the [`ast::CustomType`] associated with a given [`ast::PathType`].
     fn resolve_type<'custom>(&'custom self, path_type: &ast::PathType) -> &'custom ast::CustomType {
         path_type.resolve(self.in_path, self.env)
     }
 
+    /// Returns the [`ReturnTypeForm`] of a given [`ast::TypeName`].
     fn return_type_form(&self, typ: &ast::TypeName) -> ReturnTypeForm {
         return_type_form(typ, self.in_path, self.env)
     }
 
+    /// Returns the size and align of a given [`ast::TypeName`].
     fn size_align(&self, typ: &ast::TypeName) -> (usize, usize) {
         let layout = layout::type_size_alignment(typ, self.in_path, self.env);
         (layout.size(), layout.align())
     }
 
+    /// Returns the size, align, and ok-offset of a `DiplomatResult` containing
+    /// the two provided types.
     fn result_size_align(
         &self,
         ok: &ast::TypeName,
@@ -230,13 +235,14 @@ impl<'base> Base<'base> {
         (ok_offset, (layout.size(), layout.align()))
     }
 
+    /// Returns `true` if there are any borrows, otherwise `false`.
     fn borrows(&self) -> bool {
         self.borrows_self || !self.borrowed_params.is_empty()
     }
 }
 
-/// An [`fmt::Display`] type that represents a JS expression whose overall type
-/// is a pointer.
+/// An [`fmt::Display`] type representing a JS expression that evaluates to a
+/// pointer.
 #[derive(Copy, Clone)]
 pub enum Underlying<'base> {
     /// A WASM invocation that evaluates to a pointer.
@@ -267,7 +273,7 @@ impl fmt::Display for Underlying<'_> {
     }
 }
 
-/// An [`fmt::Display`] type for creating a JS value from a WASM invocation.
+/// An [`fmt::Display`] type representing a JS value created from a WASM invocation.
 pub struct InvocationIntoJs<'base> {
     /// The type of the created value.
     pub typ: &'base ast::TypeName,
@@ -387,7 +393,7 @@ impl fmt::Display for InvocationIntoJs<'_> {
     }
 }
 
-/// An [`fmt::Display`] type for creating a JS value that's behind a pointer.
+/// An [`fmt::Display`] type representing a JS value behind a pointer.
 struct Pointer<'base> {
     /// The type behind the pointer.
     inner: &'base ast::TypeName,
@@ -432,10 +438,12 @@ impl fmt::Display for Pointer<'_> {
     }
 }
 
-/// An [`fmt::Display`] type for creating a JS value from an underlying buffer.
+/// An [`fmt::Display`] type representing a JS expression that builds a value
+/// from an underlying buffer.
 ///
-/// This is only used for types that can appear in non-opaque structs and
-/// `Result`s.
+/// WASM writes the contents of returned non-opaque structs and `Result`s into
+/// a buffer, and [`UnderlyingIntoJs`] allows for reading the contents of that
+/// buffer.
 pub struct UnderlyingIntoJs<'base> {
     /// The type inside the underlying buffer.
     pub inner: &'base ast::TypeName,

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -125,7 +125,7 @@ impl Invocation {
     }
 
     /// Invoke the function without passing in a return buffer.
-    pub fn scalar<'invoke>(&'invoke self) -> impl fmt::Display + 'invoke {
+    pub fn scalar(&self) -> impl fmt::Display + '_ {
         display::expr(move |f| {
             write!(
                 f,

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_returning_struct@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_returning_struct@api.mjs.snap
@@ -19,20 +19,19 @@ export class MyStruct {
   }
 
   get_non_opaque() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(8, 4);
       wasm.MyStruct_get_non_opaque(diplomat_receive_buffer, this.underlying);
       const out = new NonOpaqueStruct(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 8, 4);
       return out;
     })();
-    return diplomat_out;
   }
 }
 
 export class NonOpaqueStruct {
   constructor(underlying) {
-    this.a = (new Uint16Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.a = (new Uint16Array(wasm.memory.buffer, underlying, 1))[0];
     this.b = (new Uint8Array(wasm.memory.buffer, underlying + 2, 1))[0];
     this.c = (new Uint32Array(wasm.memory.buffer, underlying + 4, 1))[0];
   }

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@api.mjs.snap
@@ -33,7 +33,7 @@ export class MyStruct {
     let new_str_diplomat_ptr = wasm.diplomat_alloc(new_str_diplomat_bytes.length, 1);
     let new_str_diplomat_buf = new Uint8Array(wasm.memory.buffer, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
     new_str_diplomat_buf.set(new_str_diplomat_bytes, 0);
-    const diplomat_out = wasm.MyStruct_set_str(this.underlying, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
+    wasm.MyStruct_set_str(this.underlying, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
     wasm.diplomat_free(new_str_diplomat_ptr, new_str_diplomat_bytes.length, 1);
   }
 }

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_writeable_out@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_writeable_out@api.mjs.snap
@@ -19,37 +19,34 @@ export class MyStruct {
   }
 
   write() {
-    const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
+    return diplomatRuntime.withWriteable(wasm, (writeable) => {
       return wasm.MyStruct_write(this.underlying, writeable);
     });
-    return diplomat_out;
   }
 
   write_unit() {
-    const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
+    return diplomatRuntime.withWriteable(wasm, (writeable) => {
       return wasm.MyStruct_write_unit(this.underlying, writeable);
     });
-    return diplomat_out;
   }
 
   write_result() {
-    const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
+    return diplomatRuntime.withWriteable(wasm, (writeable) => {
       return (() => {
         const diplomat_receive_buffer = wasm.diplomat_alloc(2, 1);
         wasm.MyStruct_write_result(diplomat_receive_buffer, this.underlying, writeable);
         const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 1);
         if (is_ok) {
           const ok_value = {};
-          wasm.diplomat_free(diplomat_receive_buffer, 2, 1)
+          wasm.diplomat_free(diplomat_receive_buffer, 2, 1);
           return ok_value;
         } else {
-          const throw_value = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 0, 1))[0];
-          wasm.diplomat_free(diplomat_receive_buffer, 2, 1)
+          const throw_value = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
+          wasm.diplomat_free(diplomat_receive_buffer, 2, 1);
           throw new diplomatRuntime.FFIError(throw_value);
         }
       })();
     });
-    return diplomat_out;
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_non_opaque_struct@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_non_opaque_struct@api.mjs.snap
@@ -10,28 +10,26 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
 
 export class MyStruct {
   constructor(underlying) {
-    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying, 1))[0];
     this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   static new(a, b) {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(2, 1);
       wasm.MyStruct_new(diplomat_receive_buffer, a, b);
       const out = new MyStruct(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 2, 1);
       return out;
     })();
-    return diplomat_out;
   }
 
   get_a() {
-    const diplomat_out = wasm.MyStruct_get_a(this.underlying);
-    return diplomat_out;
+    return wasm.MyStruct_get_a(this.underlying);
   }
 
   set_b(b) {
-    const diplomat_out = wasm.MyStruct_set_b(this.underlying, b);
+    wasm.MyStruct_set_b(this.underlying, b);
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_opaque_struct@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_opaque_struct@api.mjs.snap
@@ -19,17 +19,15 @@ export class MyStruct {
   }
 
   static new(a, b) {
-    const diplomat_out = new MyStruct(wasm.MyStruct_new(a, b));
-    return diplomat_out;
+    return new MyStruct(wasm.MyStruct_new(a, b));
   }
 
   get_a() {
-    const diplomat_out = wasm.MyStruct_get_a(this.underlying);
-    return diplomat_out;
+    return wasm.MyStruct_get_a(this.underlying);
   }
 
   set_b(b) {
-    const diplomat_out = wasm.MyStruct_set_b(this.underlying, b);
+    wasm.MyStruct_set_b(this.underlying, b);
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__option_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__option_types@api.mjs.snap
@@ -22,7 +22,7 @@ export class MyOpaqueStruct {
 export class MyStruct {
   constructor(underlying) {
     this.a = (() => {
-      const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 0);
+      const option_ptr = diplomatRuntime.ptrRead(wasm, underlying);
       return (option_ptr == 0) ? null : new MyOpaqueStruct(option_ptr);
     })();
   }

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@api.mjs.snap
@@ -22,7 +22,7 @@ export class MyOpaqueStruct {
 export class MyStruct {
   constructor(underlying) {
     this.a = (() => {
-      const out = new MyOpaqueStruct(diplomatRuntime.ptrRead(wasm, underlying + 0));
+      const out = new MyOpaqueStruct(diplomatRuntime.ptrRead(wasm, underlying));
       out.__this_lifetime_guard = this;
       return out;
     })();
@@ -30,14 +30,13 @@ export class MyStruct {
   }
 
   static new(foo, bar) {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.MyStruct_new(diplomat_receive_buffer, foo.underlying, bar.underlying);
       const out = new MyStruct(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
       return out;
     })();
-    return diplomat_out;
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__result_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__result_types@api.mjs.snap
@@ -21,26 +21,25 @@ export class MyOpaqueStruct {
 
 export class MyStruct {
   constructor(underlying) {
-    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying, 1))[0];
     this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   static new() {
-    const diplomat_out = (() => {
+    return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(3, 1);
       wasm.MyStruct_new(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 2);
       if (is_ok) {
         const ok_value = new MyStruct(diplomat_receive_buffer);
-        wasm.diplomat_free(diplomat_receive_buffer, 3, 1)
+        wasm.diplomat_free(diplomat_receive_buffer, 3, 1);
         return ok_value;
       } else {
-        const throw_value = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer + 0, 1))[0];
-        wasm.diplomat_free(diplomat_receive_buffer, 3, 1)
+        const throw_value = (new Uint8Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
+        wasm.diplomat_free(diplomat_receive_buffer, 3, 1);
         throw new diplomatRuntime.FFIError(throw_value);
       }
     })();
-    return diplomat_out;
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__string_reference@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__string_reference@api.mjs.snap
@@ -10,7 +10,7 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
 
 export class MyStruct {
   constructor(underlying) {
-    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying, 1))[0];
     this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@api.mjs.snap
@@ -10,15 +10,14 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
 
 export class MyStruct {
   constructor(underlying) {
-    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying, 1))[0];
     this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   something() {
     const diplomat_MyStruct_extracted_a = this["a"];
     const diplomat_MyStruct_extracted_b = this["b"];
-    const diplomat_out = wasm.MyStruct_something(diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b);
-    return diplomat_out;
+    return wasm.MyStruct_something(diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b);
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@api.mjs.snap
@@ -10,17 +10,16 @@ const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
 
 export class MyStruct {
   constructor(underlying) {
-    this.a = (new Uint8Array(wasm.memory.buffer, underlying + 0, 1))[0];
+    this.a = (new Uint8Array(wasm.memory.buffer, underlying, 1))[0];
     this.b = (new Uint8Array(wasm.memory.buffer, underlying + 1, 1))[0];
   }
 
   write() {
     const diplomat_MyStruct_extracted_a = this["a"];
     const diplomat_MyStruct_extracted_b = this["b"];
-    const diplomat_out = diplomatRuntime.withWriteable(wasm, (writeable) => {
+    return diplomatRuntime.withWriteable(wasm, (writeable) => {
       return wasm.MyStruct_write(diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b, writeable);
     });
-    return diplomat_out;
   }
 }
 

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -1,11 +1,11 @@
-use diplomat_core::Env;
+use diplomat_core::{ast, Env};
 use std::fmt::{self, Display as _, Write as _};
+use std::num::NonZeroUsize;
 
-use diplomat_core::ast;
-
-use super::conversions::{gen_value_js_to_rust, BufferedIntoJs, ValueIntoJs};
+use super::conversions::{
+    gen_value_js_to_rust, Base, Invocation, InvocationIntoJs, Underlying, UnderlyingIntoJs,
+};
 use super::display;
-use super::types::{return_type_form, ReturnTypeForm};
 use crate::layout;
 
 /// Generates a JS class declaration
@@ -61,9 +61,10 @@ pub fn gen_struct<W: fmt::Write>(
                 "export class {} {}",
                 strct.name,
                 display::block(|mut f| {
+                    let underlying: ast::Ident = "underlying".into();
                     writeln!(
                         f,
-                        "constructor(underlying) {}",
+                        "constructor({underlying}) {}",
                         display::block(|mut f| {
                             let (offsets, _) = layout::struct_offsets_size_max_align(
                                 strct.fields.iter().map(|(_, typ, _)| typ),
@@ -88,15 +89,12 @@ pub fn gen_struct<W: fmt::Write>(
                                     f,
                                     "this.{} = {};",
                                     name,
-                                    BufferedIntoJs {
-                                        buf_ptr: "underlying",
-                                        offset,
+                                    UnderlyingIntoJs {
                                         typ,
-                                        in_path,
-                                        borrows_self,
-                                        borrowed_params: &[],
-                                        env,
-                                    }
+                                        underlying: Underlying::Binding(&underlying),
+                                        offset: NonZeroUsize::new(offset),
+                                        base: Base::new_field(in_path, env, borrows_self),
+                                    },
                                 )?;
                             }
 
@@ -212,15 +210,15 @@ fn gen_method<W: fmt::Write>(
         all_params.pop();
     }
 
-    let all_params_invocation = {
-        if let Some(ref return_type) = method.return_type {
-            if let ReturnTypeForm::Complex = return_type_form(return_type, in_path, env) {
-                all_param_exprs.insert(0, "diplomat_receive_buffer".to_string());
-            }
-        }
+    // let all_params_invocation = {
+    //     if let Some(ref return_type) = method.return_type {
+    //         if let ReturnTypeForm::Complex = return_type_form(return_type, in_path, env) {
+    //             all_param_exprs.insert(0, "diplomat_receive_buffer".to_string());
+    //         }
+    //     }
 
-        all_param_exprs.join(", ")
-    };
+    //     all_param_exprs.join(", ")
+    // };
 
     if method.self_param.is_none() {
         out.write_str("static ")?;
@@ -236,49 +234,56 @@ fn gen_method<W: fmt::Write>(
                 writeln!(f, "{}", s)?;
             }
 
-            let invocation_expr =
-                format!("wasm.{}({})", method.full_path_name, all_params_invocation);
+            let diplomat_out = display::expr(|f| {
+                let display_return_type = display::expr(|f| {
+                    let invocation =
+                        Invocation::new(method.full_path_name.clone(), all_param_exprs.clone());
 
-            writeln!(
-                f,
-                "const diplomat_out = {};",
-                display::expr(|f| {
-                    let display_return_type = display::expr(|f| match &method.return_type {
-                        None | Some(ast::TypeName::Unit) => invocation_expr.fmt(f),
-                        Some(typ) => {
-                            let borrowed_params = method.borrowed_params();
-                            ValueIntoJs {
-                                value_expr: &invocation_expr,
-                                typ,
-                                borrows_self: borrowed_params.borrows_self(),
-                                borrowed_params: &borrowed_params.1[..],
-                                in_path,
-                                env,
-                            }
-                            .fmt(f)
+                    if let Some(ref typ) = method.return_type {
+                        let borrowed_params = method.borrowed_params();
+                        InvocationIntoJs {
+                            invocation,
+                            typ,
+                            base: Base::new_method(in_path, env, &borrowed_params),
                         }
-                    });
-
-                    if is_writeable {
-                        write!(
-                            f,
-                            "diplomatRuntime.withWriteable(wasm, (writeable) => {})",
-                            display::block(|mut f| writeln!(f, "return {};", display_return_type))
-                        )
+                        .fmt(f)
                     } else {
-                        write!(f, "{}", display_return_type)
+                        invocation.scalar().fmt(f)
                     }
-                })
-            )?;
+                });
 
-            for s in post_stmts.iter() {
-                writeln!(f, "{}", s)?;
-            }
+                if is_writeable {
+                    write!(
+                        f,
+                        "diplomatRuntime.withWriteable(wasm, (writeable) => {})",
+                        display::block(|mut f| writeln!(f, "return {};", display_return_type))
+                    )
+                } else {
+                    write!(f, "{}", display_return_type)
+                }
+            });
 
-            if method.return_type.is_some() || is_writeable {
-                writeln!(f, "return diplomat_out;")?;
+            let do_return = method.return_type.is_some() || is_writeable;
+
+            if post_stmts.is_empty() && do_return {
+                writeln!(f, "return {diplomat_out};")
+            } else {
+                if do_return {
+                    writeln!(f, "const diplomat_out = {diplomat_out};")?;
+                } else {
+                    writeln!(f, "{diplomat_out};")?;
+                }
+
+                for s in post_stmts.iter() {
+                    writeln!(f, "{}", s)?;
+                }
+
+                if do_return {
+                    writeln!(f, "return diplomat_out;")?;
+                }
+
+                Ok(())
             }
-            Ok(())
         })
     )
 }

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -72,7 +72,8 @@ pub fn gen_struct<W: fmt::Write>(
                                 env,
                             );
 
-                            for ((name, typ, _), &offset) in strct.fields.iter().zip(offsets.iter())
+                            for ((name, inner, _), &offset) in
+                                strct.fields.iter().zip(offsets.iter())
                             {
                                 // If the type of a field has any named lifetimes
                                 // (elision is impossible in fields), then it
@@ -81,7 +82,7 @@ pub fn gen_struct<W: fmt::Write>(
                                 // want to be more intelligent about this and
                                 // only attach lifetime guards to the exact object
                                 // that holds it, instead of the outermost struct.
-                                let borrows_self = typ.any_lifetime(|lifetime, _| {
+                                let borrows_self = inner.any_lifetime(|lifetime, _| {
                                     matches!(lifetime, ast::Lifetime::Named(_))
                                 });
 
@@ -90,9 +91,11 @@ pub fn gen_struct<W: fmt::Write>(
                                     "this.{} = {};",
                                     name,
                                     UnderlyingIntoJs {
-                                        typ,
-                                        underlying: Underlying::Binding(&underlying),
-                                        offset: NonZeroUsize::new(offset),
+                                        inner,
+                                        underlying: Underlying::Binding(
+                                            &underlying,
+                                            NonZeroUsize::new(offset),
+                                        ),
                                         base: Base::new_field(in_path, env, borrows_self),
                                     },
                                 )?;


### PR DESCRIPTION
Fixes #178.

This PR introduces a complete overhaul of the JS conversion codegen so that everything is strongly typed, making it much easier to reason about the code that's being generated. 

Each commit is intended to be reviewed individually.