### PR TITLE
Fix `&str` borrowing in JS

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -307,6 +307,15 @@ impl BorrowedParams<'_> {
             .chain(self.1.iter().map(|param| param.name.as_str()))
     }
 
+    /// Returns `true` if a provided param name is included in the borrowed params,
+    /// otherwise `false`.
+    ///
+    /// This method doesn't check the `self` parameter. Use
+    /// [`BorrowedParams::borrows_self`] instead.
+    pub fn contains(&self, param_name: &Ident) -> bool {
+        self.1.iter().any(|param| &param.name == param_name)
+    }
+
     /// Returns `true` if there are no borrowed parameters, otherwise `false`.
     pub fn is_empty(&self) -> bool {
         !self.borrows_self() && !self.borrows_params()

--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -157,22 +157,16 @@ export class ICU4XLocale {
   }
 
   static new(name) {
-    let name_diplomat_bytes = (new TextEncoder()).encode(name);
-    let name_diplomat_ptr = wasm.diplomat_alloc(name_diplomat_bytes.length, 1);
-    let name_diplomat_buf = new Uint8Array(wasm.memory.buffer, name_diplomat_ptr, name_diplomat_bytes.length);
-    name_diplomat_buf.set(name_diplomat_bytes, 0);
-    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new(name_diplomat_ptr, name_diplomat_bytes.length));
-    wasm.diplomat_free(name_diplomat_ptr, name_diplomat_bytes.length, 1);
+    name = diplomatRuntime.DiplomatBuf.str(wasm, name);
+    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new(name.ptr, name.size));
+    name.free();
     return diplomat_out;
   }
 
   static new_from_bytes(bytes) {
-    let bytes_diplomat_bytes = new Uint8Array(bytes);
-    let bytes_diplomat_ptr = wasm.diplomat_alloc(bytes_diplomat_bytes.length, 1);
-    let bytes_diplomat_buf = new Uint8Array(wasm.memory.buffer, bytes_diplomat_ptr, bytes_diplomat_bytes.length);
-    bytes_diplomat_buf.set(bytes_diplomat_bytes, 0);
-    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new_from_bytes(bytes_diplomat_ptr, bytes_diplomat_bytes.length));
-    wasm.diplomat_free(bytes_diplomat_ptr, bytes_diplomat_bytes.length, 1);
+    bytes = diplomatRuntime.DiplomatBuf.slice(wasm, bytes, 1);
+    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new_from_bytes(bytes.ptr, bytes.size));
+    bytes.free();
     return diplomat_out;
   }
 }

--- a/example/js/diplomat-runtime.mjs
+++ b/example/js/diplomat-runtime.mjs
@@ -79,18 +79,12 @@ export class DiplomatBuf {
 
     this.ptr = ptr;
     this.size = size;
-    this.align = align;
-    this.freed = false;
-
-    DiplomatBuf_finalizer.register(this, { ptr, size, align });
-  }
-
-  free() {
-    if (!freed) {
-      this.freed = true;
-      wasm.diplomat_free(this.ptr, this.size, this.align);
+    this.free = () => {
+      wasm.diplomat_free(this.ptr, this.size, align);
       DiplomatBuf_finalizer.unregister(this);
     }
+
+    DiplomatBuf_finalizer.register(this, { ptr, size, align });
   }
 }
 

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -42,31 +42,22 @@ export class Float64Vec {
   }
 
   static new(v) {
-    let v_diplomat_bytes = new Uint8Array(v);
-    let v_diplomat_ptr = wasm.diplomat_alloc(v_diplomat_bytes.length, 8);
-    let v_diplomat_buf = new Uint8Array(wasm.memory.buffer, v_diplomat_ptr, v_diplomat_bytes.length);
-    v_diplomat_buf.set(v_diplomat_bytes, 0);
-    const diplomat_out = new Float64Vec(wasm.Float64Vec_new(v_diplomat_ptr, v_diplomat_bytes.length));
-    wasm.diplomat_free(v_diplomat_ptr, v_diplomat_bytes.length, 8);
+    v = diplomatRuntime.DiplomatBuf.slice(wasm, v, 8);
+    const diplomat_out = new Float64Vec(wasm.Float64Vec_new(v.ptr, v.size));
+    v.free();
     return diplomat_out;
   }
 
   fill_slice(v) {
-    let v_diplomat_bytes = new Uint8Array(v);
-    let v_diplomat_ptr = wasm.diplomat_alloc(v_diplomat_bytes.length, 8);
-    let v_diplomat_buf = new Uint8Array(wasm.memory.buffer, v_diplomat_ptr, v_diplomat_bytes.length);
-    v_diplomat_buf.set(v_diplomat_bytes, 0);
-    wasm.Float64Vec_fill_slice(this.underlying, v_diplomat_ptr, v_diplomat_bytes.length);
-    wasm.diplomat_free(v_diplomat_ptr, v_diplomat_bytes.length, 8);
+    v = diplomatRuntime.DiplomatBuf.slice(wasm, v, 8);
+    wasm.Float64Vec_fill_slice(this.underlying, v.ptr, v.size);
+    v.free();
   }
 
   set_value(new_slice) {
-    let new_slice_diplomat_bytes = new Uint8Array(new_slice);
-    let new_slice_diplomat_ptr = wasm.diplomat_alloc(new_slice_diplomat_bytes.length, 8);
-    let new_slice_diplomat_buf = new Uint8Array(wasm.memory.buffer, new_slice_diplomat_ptr, new_slice_diplomat_bytes.length);
-    new_slice_diplomat_buf.set(new_slice_diplomat_bytes, 0);
-    wasm.Float64Vec_set_value(this.underlying, new_slice_diplomat_ptr, new_slice_diplomat_bytes.length);
-    wasm.diplomat_free(new_slice_diplomat_ptr, new_slice_diplomat_bytes.length, 8);
+    new_slice = diplomatRuntime.DiplomatBuf.slice(wasm, new_slice, 8);
+    wasm.Float64Vec_set_value(this.underlying, new_slice.ptr, new_slice.size);
+    new_slice.free();
   }
 }
 
@@ -81,17 +72,12 @@ export class Foo {
   }
 
   static new(x) {
-    let x_diplomat_bytes = (new TextEncoder()).encode(x);
-    let x_diplomat_ptr = wasm.diplomat_alloc(x_diplomat_bytes.length, 1);
-    let x_diplomat_buf = new Uint8Array(wasm.memory.buffer, x_diplomat_ptr, x_diplomat_bytes.length);
-    x_diplomat_buf.set(x_diplomat_bytes, 0);
-    const diplomat_out = (() => {
-      const out = new Foo(wasm.Foo_new(x_diplomat_ptr, x_diplomat_bytes.length));
+    x = diplomatRuntime.DiplomatBuf.str(wasm, x);
+    return (() => {
+      const out = new Foo(wasm.Foo_new(x.ptr, x.size));
       out.__x_lifetime_guard = x;
       return out;
     })();
-    wasm.diplomat_free(x_diplomat_ptr, x_diplomat_bytes.length, 1);
-    return diplomat_out;
   }
 
   get_bar() {
@@ -114,22 +100,16 @@ export class MyString {
   }
 
   static new(v) {
-    let v_diplomat_bytes = (new TextEncoder()).encode(v);
-    let v_diplomat_ptr = wasm.diplomat_alloc(v_diplomat_bytes.length, 1);
-    let v_diplomat_buf = new Uint8Array(wasm.memory.buffer, v_diplomat_ptr, v_diplomat_bytes.length);
-    v_diplomat_buf.set(v_diplomat_bytes, 0);
-    const diplomat_out = new MyString(wasm.MyString_new(v_diplomat_ptr, v_diplomat_bytes.length));
-    wasm.diplomat_free(v_diplomat_ptr, v_diplomat_bytes.length, 1);
+    v = diplomatRuntime.DiplomatBuf.str(wasm, v);
+    const diplomat_out = new MyString(wasm.MyString_new(v.ptr, v.size));
+    v.free();
     return diplomat_out;
   }
 
   set_str(new_str) {
-    let new_str_diplomat_bytes = (new TextEncoder()).encode(new_str);
-    let new_str_diplomat_ptr = wasm.diplomat_alloc(new_str_diplomat_bytes.length, 1);
-    let new_str_diplomat_buf = new Uint8Array(wasm.memory.buffer, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
-    new_str_diplomat_buf.set(new_str_diplomat_bytes, 0);
-    wasm.MyString_set_str(this.underlying, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
-    wasm.diplomat_free(new_str_diplomat_ptr, new_str_diplomat_bytes.length, 1);
+    new_str = diplomatRuntime.DiplomatBuf.str(wasm, new_str);
+    wasm.MyString_set_str(this.underlying, new_str.ptr, new_str.size);
+    new_str.free();
   }
 
   get_str() {

--- a/feature_tests/js/diplomat-runtime.mjs
+++ b/feature_tests/js/diplomat-runtime.mjs
@@ -79,18 +79,12 @@ export class DiplomatBuf {
 
     this.ptr = ptr;
     this.size = size;
-    this.align = align;
-    this.freed = false;
-
-    DiplomatBuf_finalizer.register(this, { ptr, size, align });
-  }
-
-  free() {
-    if (!freed) {
-      this.freed = true;
-      wasm.diplomat_free(this.ptr, this.size, this.align);
+    this.free = () => {
+      wasm.diplomat_free(this.ptr, this.size, align);
       DiplomatBuf_finalizer.unregister(this);
     }
+
+    DiplomatBuf_finalizer.register(this, { ptr, size, align });
   }
 }
 

--- a/tool/src/js/runtime.mjs
+++ b/tool/src/js/runtime.mjs
@@ -79,18 +79,12 @@ export class DiplomatBuf {
 
     this.ptr = ptr;
     this.size = size;
-    this.align = align;
-    this.freed = false;
-
-    DiplomatBuf_finalizer.register(this, { ptr, size, align });
-  }
-
-  free() {
-    if (!freed) {
-      this.freed = true;
-      wasm.diplomat_free(this.ptr, this.size, this.align);
+    this.free = () => {
+      wasm.diplomat_free(this.ptr, this.size, align);
       DiplomatBuf_finalizer.unregister(this);
     }
+
+    DiplomatBuf_finalizer.register(this, { ptr, size, align });
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@api.mjs.snap
@@ -19,22 +19,16 @@ export class MyStruct {
   }
 
   static new_str(v) {
-    let v_diplomat_bytes = (new TextEncoder()).encode(v);
-    let v_diplomat_ptr = wasm.diplomat_alloc(v_diplomat_bytes.length, 1);
-    let v_diplomat_buf = new Uint8Array(wasm.memory.buffer, v_diplomat_ptr, v_diplomat_bytes.length);
-    v_diplomat_buf.set(v_diplomat_bytes, 0);
-    const diplomat_out = new MyStruct(wasm.MyStruct_new_str(v_diplomat_ptr, v_diplomat_bytes.length));
-    wasm.diplomat_free(v_diplomat_ptr, v_diplomat_bytes.length, 1);
+    v = diplomatRuntime.DiplomatBuf.str(wasm, v);
+    const diplomat_out = new MyStruct(wasm.MyStruct_new_str(v.ptr, v.size));
+    v.free();
     return diplomat_out;
   }
 
   set_str(new_str) {
-    let new_str_diplomat_bytes = (new TextEncoder()).encode(new_str);
-    let new_str_diplomat_ptr = wasm.diplomat_alloc(new_str_diplomat_bytes.length, 1);
-    let new_str_diplomat_buf = new Uint8Array(wasm.memory.buffer, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
-    new_str_diplomat_buf.set(new_str_diplomat_bytes, 0);
-    wasm.MyStruct_set_str(this.underlying, new_str_diplomat_ptr, new_str_diplomat_bytes.length);
-    wasm.diplomat_free(new_str_diplomat_ptr, new_str_diplomat_bytes.length, 1);
+    new_str = diplomatRuntime.DiplomatBuf.str(wasm, new_str);
+    wasm.MyStruct_set_str(this.underlying, new_str.ptr, new_str.size);
+    new_str.free();
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__string_reference@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__string_reference@api.mjs.snap
@@ -15,18 +15,15 @@ export class MyStruct {
   }
 
   static new(v) {
-    let v_diplomat_bytes = (new TextEncoder()).encode(v);
-    let v_diplomat_ptr = wasm.diplomat_alloc(v_diplomat_bytes.length, 1);
-    let v_diplomat_buf = new Uint8Array(wasm.memory.buffer, v_diplomat_ptr, v_diplomat_bytes.length);
-    v_diplomat_buf.set(v_diplomat_bytes, 0);
+    v = diplomatRuntime.DiplomatBuf.str(wasm, v);
     const diplomat_out = (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(2, 1);
-      wasm.MyStruct_new(diplomat_receive_buffer, v_diplomat_ptr, v_diplomat_bytes.length);
+      wasm.MyStruct_new(diplomat_receive_buffer, v.ptr, v.size);
       const out = new MyStruct(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 2, 1);
       return out;
     })();
-    wasm.diplomat_free(v_diplomat_ptr, v_diplomat_bytes.length, 1);
+    v.free();
     return diplomat_out;
   }
 }

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -177,10 +177,13 @@ fn gen_method<W: fmt::Write>(
     let mut all_param_exprs = vec![];
     let mut post_stmts = vec![];
 
+    let borrowed_params = method.borrowed_params();
+
     if let Some(ref self_param) = method.self_param {
         gen_value_js_to_rust(
             &ast::Ident::from("this"),
             &self_param.to_typename(),
+            &borrowed_params,
             in_path,
             env,
             &mut pre_stmts,
@@ -193,6 +196,7 @@ fn gen_method<W: fmt::Write>(
         gen_value_js_to_rust(
             &p.name,
             &p.ty,
+            &borrowed_params,
             in_path,
             env,
             &mut pre_stmts,


### PR DESCRIPTION
Fixes #61, #180.

This PR introduces the `DiplomatBuf` class in the JS runtime, which is described in this comment:

> One of the issues with this is that if the `&str` should be held, it still needs to eventually be cleaned up. That's why we initially tried to introduce the `DiplomatBuf` class, which would free the memory when finalized, in #172 (which didn't land for other reasons). Therefore, I think the solution to this is to recreate it, fixing this issue as well as #61.
>
> _Originally posted by @QnnOkabayashi in https://github.com/rust-diplomat/diplomat/issues/180#issuecomment-1164729432_

Additionally, it uses this to fix #180, so we now only free the `DiplomatBuf` object if it's not borrowed (and thus has an edge on it).

One thing I'm unsure about: for the implementation, I just reassigned the variable holding the string/slice value to the instantiated `DiplomatBuf` object representing it. This makes things easier because the logic for holding edges is nested deeper and it was easier to just make the `DiplomatBuf` object appear in place of the original param for when we grab an edge to it. Is this a bad idea?