### PR TITLE
Fix double free in JS

### DIFF
--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -9,13 +9,15 @@ const ICU4XDataProvider_box_destroy_registry = new FinalizationRegistry(underlyi
 });
 
 export class ICU4XDataProvider {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    ICU4XDataProvider_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      ICU4XDataProvider_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new_static() {
-    return new ICU4XDataProvider(wasm.ICU4XDataProvider_new_static());
+    return new ICU4XDataProvider(wasm.ICU4XDataProvider_new_static(), true);
   }
 
   static returns_result() {
@@ -33,13 +35,15 @@ const ICU4XFixedDecimal_box_destroy_registry = new FinalizationRegistry(underlyi
 });
 
 export class ICU4XFixedDecimal {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    ICU4XFixedDecimal_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      ICU4XFixedDecimal_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new(v) {
-    return new ICU4XFixedDecimal(wasm.ICU4XFixedDecimal_new(v));
+    return new ICU4XFixedDecimal(wasm.ICU4XFixedDecimal_new(v), true);
   }
 
   multiply_pow10(power) {
@@ -67,9 +71,11 @@ const ICU4XFixedDecimalFormat_box_destroy_registry = new FinalizationRegistry(un
 });
 
 export class ICU4XFixedDecimalFormat {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    ICU4XFixedDecimalFormat_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      ICU4XFixedDecimalFormat_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static try_new(locale, provider, options) {
@@ -112,7 +118,7 @@ export class ICU4XFixedDecimalFormatResult {
   constructor(underlying) {
     this.fdf = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying);
-      return (option_ptr == 0) ? null : new ICU4XFixedDecimalFormat(option_ptr);
+      return (option_ptr == 0) ? null : new ICU4XFixedDecimalFormat(option_ptr, true);
     })();
     this.success = (new Uint8Array(wasm.memory.buffer, underlying + 4, 1))[0] == 1;
   }
@@ -151,21 +157,23 @@ const ICU4XLocale_box_destroy_registry = new FinalizationRegistry(underlying => 
 });
 
 export class ICU4XLocale {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    ICU4XLocale_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      ICU4XLocale_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new(name) {
     name = diplomatRuntime.DiplomatBuf.str(wasm, name);
-    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new(name.ptr, name.size));
+    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new(name.ptr, name.size), true);
     name.free();
     return diplomat_out;
   }
 
   static new_from_bytes(bytes) {
     bytes = diplomatRuntime.DiplomatBuf.slice(wasm, bytes, 1);
-    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new_from_bytes(bytes.ptr, bytes.size));
+    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new_from_bytes(bytes.ptr, bytes.size), true);
     bytes.free();
     return diplomat_out;
   }

--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -9,15 +9,17 @@ const ICU4XDataProvider_box_destroy_registry = new FinalizationRegistry(underlyi
 });
 
 export class ICU4XDataProvider {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      ICU4XDataProvider_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new_static() {
-    return new ICU4XDataProvider(wasm.ICU4XDataProvider_new_static(), true);
+    return (() => {
+      const underlying = wasm.ICU4XDataProvider_new_static();
+      const out = new ICU4XDataProvider(underlying);
+      ICU4XDataProvider_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
   }
 
   static returns_result() {
@@ -35,15 +37,17 @@ const ICU4XFixedDecimal_box_destroy_registry = new FinalizationRegistry(underlyi
 });
 
 export class ICU4XFixedDecimal {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      ICU4XFixedDecimal_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new(v) {
-    return new ICU4XFixedDecimal(wasm.ICU4XFixedDecimal_new(v), true);
+    return (() => {
+      const underlying = wasm.ICU4XFixedDecimal_new(v);
+      const out = new ICU4XFixedDecimal(underlying);
+      ICU4XFixedDecimal_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
   }
 
   multiply_pow10(power) {
@@ -71,11 +75,8 @@ const ICU4XFixedDecimalFormat_box_destroy_registry = new FinalizationRegistry(un
 });
 
 export class ICU4XFixedDecimalFormat {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      ICU4XFixedDecimalFormat_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static try_new(locale, provider, options) {
@@ -118,7 +119,12 @@ export class ICU4XFixedDecimalFormatResult {
   constructor(underlying) {
     this.fdf = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying);
-      return (option_ptr == 0) ? null : new ICU4XFixedDecimalFormat(option_ptr, true);
+      return (option_ptr == 0) ? null : (() => {
+        const underlying = option_ptr;
+        const out = new ICU4XFixedDecimalFormat(underlying);
+        ICU4XFixedDecimalFormat_box_destroy_registry.register(out, underlying);
+        return out;
+      })();
     })();
     this.success = (new Uint8Array(wasm.memory.buffer, underlying + 4, 1))[0] == 1;
   }
@@ -157,23 +163,30 @@ const ICU4XLocale_box_destroy_registry = new FinalizationRegistry(underlying => 
 });
 
 export class ICU4XLocale {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      ICU4XLocale_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new(name) {
     name = diplomatRuntime.DiplomatBuf.str(wasm, name);
-    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new(name.ptr, name.size), true);
+    const diplomat_out = (() => {
+      const underlying = wasm.ICU4XLocale_new(name.ptr, name.size);
+      const out = new ICU4XLocale(underlying);
+      ICU4XLocale_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
     name.free();
     return diplomat_out;
   }
 
   static new_from_bytes(bytes) {
     bytes = diplomatRuntime.DiplomatBuf.slice(wasm, bytes, 1);
-    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new_from_bytes(bytes.ptr, bytes.size), true);
+    const diplomat_out = (() => {
+      const underlying = wasm.ICU4XLocale_new_from_bytes(bytes.ptr, bytes.size);
+      const out = new ICU4XLocale(underlying);
+      ICU4XLocale_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
     bytes.free();
     return diplomat_out;
   }

--- a/feature_tests/c/include/Bar.h
+++ b/feature_tests/c/include/Bar.h
@@ -11,7 +11,9 @@ extern "C" {
 #endif
 
 typedef struct Bar Bar;
+#include "Foo.h"
 
+const Foo* Bar_foo(const Bar* self);
 void Bar_destroy(Bar* self);
 
 #ifdef __cplusplus

--- a/feature_tests/dotnet/Lib/Generated/Bar.cs
+++ b/feature_tests/dotnet/Lib/Generated/Bar.cs
@@ -30,6 +30,22 @@ public partial class Bar: IDisposable
         _inner = handle;
     }
 
+    /// <returns>
+    /// A <c>Foo</c> allocated on Rust side.
+    /// </returns>
+    public Foo Foo()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Bar");
+            }
+            Raw.Foo* retVal = Raw.Bar.Foo(_inner);
+            return new Foo(retVal);
+        }
+    }
+
     /// <summary>
     /// Returns the underlying raw handle.
     /// </summary>

--- a/feature_tests/dotnet/Lib/Generated/RawBar.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawBar.cs
@@ -16,6 +16,9 @@ public partial struct Bar
 {
     private const string NativeLib = "diplomat_feature_tests";
 
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Bar_foo", ExactSpelling = true)]
+    public static unsafe extern Foo* Foo(Bar* self);
+
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Bar_destroy", ExactSpelling = true)]
     public static unsafe extern void Destroy(Bar* self);
 }

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -9,9 +9,19 @@ const Bar_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Bar {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    Bar_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      Bar_box_destroy_registry.register(this, underlying);
+    }
+  }
+
+  foo() {
+    return (() => {
+      const out = new Foo(wasm.Bar_foo(this.underlying), false);
+      out.__this_lifetime_guard = this;
+      return out;
+    })();
   }
 }
 
@@ -36,14 +46,16 @@ const Float64Vec_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Float64Vec {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    Float64Vec_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      Float64Vec_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new(v) {
     v = diplomatRuntime.DiplomatBuf.slice(wasm, v, 8);
-    const diplomat_out = new Float64Vec(wasm.Float64Vec_new(v.ptr, v.size));
+    const diplomat_out = new Float64Vec(wasm.Float64Vec_new(v.ptr, v.size), true);
     v.free();
     return diplomat_out;
   }
@@ -66,15 +78,17 @@ const Foo_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Foo {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    Foo_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      Foo_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new(x) {
     x = diplomatRuntime.DiplomatBuf.str(wasm, x);
     return (() => {
-      const out = new Foo(wasm.Foo_new(x.ptr, x.size));
+      const out = new Foo(wasm.Foo_new(x.ptr, x.size), true);
       out.__x_lifetime_guard = x;
       return out;
     })();
@@ -82,7 +96,7 @@ export class Foo {
 
   get_bar() {
     return (() => {
-      const out = new Bar(wasm.Foo_get_bar(this.underlying));
+      const out = new Bar(wasm.Foo_get_bar(this.underlying), true);
       out.__this_lifetime_guard = this;
       return out;
     })();
@@ -94,14 +108,16 @@ const MyString_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class MyString {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    MyString_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      MyString_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new(v) {
     v = diplomatRuntime.DiplomatBuf.str(wasm, v);
-    const diplomat_out = new MyString(wasm.MyString_new(v.ptr, v.size));
+    const diplomat_out = new MyString(wasm.MyString_new(v.ptr, v.size), true);
     v.free();
     return diplomat_out;
   }
@@ -145,14 +161,16 @@ const One_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class One {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    One_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      One_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static transitivity(hold, nohold) {
     return (() => {
-      const out = new One(wasm.One_transitivity(hold.underlying, nohold.underlying));
+      const out = new One(wasm.One_transitivity(hold.underlying, nohold.underlying), true);
       out.__hold_lifetime_guard = hold;
       return out;
     })();
@@ -160,7 +178,7 @@ export class One {
 
   static cycle(hold, nohold) {
     return (() => {
-      const out = new One(wasm.One_cycle(hold.underlying, nohold.underlying));
+      const out = new One(wasm.One_cycle(hold.underlying, nohold.underlying), true);
       out.__hold_lifetime_guard = hold;
       return out;
     })();
@@ -168,7 +186,7 @@ export class One {
 
   static many_dependents(a, b, c, d, nohold) {
     return (() => {
-      const out = new One(wasm.One_many_dependents(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying));
+      const out = new One(wasm.One_many_dependents(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying), true);
       out.__a_lifetime_guard = a;
       out.__b_lifetime_guard = b;
       out.__c_lifetime_guard = c;
@@ -179,7 +197,7 @@ export class One {
 
   static return_outlives_param(hold, nohold) {
     return (() => {
-      const out = new One(wasm.One_return_outlives_param(hold.underlying, nohold.underlying));
+      const out = new One(wasm.One_return_outlives_param(hold.underlying, nohold.underlying), true);
       out.__hold_lifetime_guard = hold;
       return out;
     })();
@@ -187,7 +205,7 @@ export class One {
 
   static diamond_top(top, left, right, bottom) {
     return (() => {
-      const out = new One(wasm.One_diamond_top(top.underlying, left.underlying, right.underlying, bottom.underlying));
+      const out = new One(wasm.One_diamond_top(top.underlying, left.underlying, right.underlying, bottom.underlying), true);
       out.__top_lifetime_guard = top;
       out.__left_lifetime_guard = left;
       out.__right_lifetime_guard = right;
@@ -198,7 +216,7 @@ export class One {
 
   static diamond_left(top, left, right, bottom) {
     return (() => {
-      const out = new One(wasm.One_diamond_left(top.underlying, left.underlying, right.underlying, bottom.underlying));
+      const out = new One(wasm.One_diamond_left(top.underlying, left.underlying, right.underlying, bottom.underlying), true);
       out.__left_lifetime_guard = left;
       out.__bottom_lifetime_guard = bottom;
       return out;
@@ -207,7 +225,7 @@ export class One {
 
   static diamond_right(top, left, right, bottom) {
     return (() => {
-      const out = new One(wasm.One_diamond_right(top.underlying, left.underlying, right.underlying, bottom.underlying));
+      const out = new One(wasm.One_diamond_right(top.underlying, left.underlying, right.underlying, bottom.underlying), true);
       out.__right_lifetime_guard = right;
       out.__bottom_lifetime_guard = bottom;
       return out;
@@ -216,7 +234,7 @@ export class One {
 
   static diamond_bottom(top, left, right, bottom) {
     return (() => {
-      const out = new One(wasm.One_diamond_bottom(top.underlying, left.underlying, right.underlying, bottom.underlying));
+      const out = new One(wasm.One_diamond_bottom(top.underlying, left.underlying, right.underlying, bottom.underlying), true);
       out.__bottom_lifetime_guard = bottom;
       return out;
     })();
@@ -224,7 +242,7 @@ export class One {
 
   static diamond_and_nested_types(a, b, c, d, nohold) {
     return (() => {
-      const out = new One(wasm.One_diamond_and_nested_types(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying));
+      const out = new One(wasm.One_diamond_and_nested_types(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying), true);
       out.__a_lifetime_guard = a;
       out.__b_lifetime_guard = b;
       out.__c_lifetime_guard = c;
@@ -239,13 +257,15 @@ const Opaque_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Opaque {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    Opaque_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      Opaque_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new() {
-    return new Opaque(wasm.Opaque_new());
+    return new Opaque(wasm.Opaque_new(), true);
   }
 
   assert_struct(s) {
@@ -264,22 +284,24 @@ const OptionOpaque_box_destroy_registry = new FinalizationRegistry(underlying =>
 });
 
 export class OptionOpaque {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    OptionOpaque_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      OptionOpaque_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new(i) {
     return (() => {
       const option_ptr = wasm.OptionOpaque_new(i);
-      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr);
+      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr, true);
     })();
   }
 
   static new_none() {
     return (() => {
       const option_ptr = wasm.OptionOpaque_new_none();
-      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr);
+      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr, true);
     })();
   }
 
@@ -313,9 +335,11 @@ const OptionOpaqueChar_box_destroy_registry = new FinalizationRegistry(underlyin
 });
 
 export class OptionOpaqueChar {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    OptionOpaqueChar_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      OptionOpaqueChar_box_destroy_registry.register(this, underlying);
+    }
   }
 
   assert_char(ch) {
@@ -327,16 +351,16 @@ export class OptionStruct {
   constructor(underlying) {
     this.a = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying);
-      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr);
+      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr, true);
     })();
     this.b = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 4);
-      return (option_ptr == 0) ? null : new OptionOpaqueChar(option_ptr);
+      return (option_ptr == 0) ? null : new OptionOpaqueChar(option_ptr, true);
     })();
     this.c = (new Uint32Array(wasm.memory.buffer, underlying + 8, 1))[0];
     this.d = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 12);
-      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr);
+      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr, true);
     })();
   }
 }
@@ -346,14 +370,16 @@ const RefList_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class RefList {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    RefList_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      RefList_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static node(data) {
     return (() => {
-      const out = new RefList(wasm.RefList_node(data.underlying));
+      const out = new RefList(wasm.RefList_node(data.underlying), true);
       out.__data_lifetime_guard = data;
       return out;
     })();
@@ -365,9 +391,11 @@ const ResultOpaque_box_destroy_registry = new FinalizationRegistry(underlying =>
 });
 
 export class ResultOpaque {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    ResultOpaque_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      ResultOpaque_box_destroy_registry.register(this, underlying);
+    }
   }
 
   static new(i) {
@@ -376,7 +404,7 @@ export class ResultOpaque {
       wasm.ResultOpaque_new(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
@@ -393,7 +421,7 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_foo(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
@@ -410,7 +438,7 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_bar(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
@@ -427,7 +455,7 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_unit(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
@@ -444,7 +472,7 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_struct(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 8);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
         wasm.diplomat_free(diplomat_receive_buffer, 9, 4);
         return ok_value;
       } else {
@@ -465,7 +493,7 @@ export class ResultOpaque {
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
-        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
@@ -482,7 +510,7 @@ export class ResultOpaque {
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
-        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer));
+        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
@@ -499,8 +527,10 @@ const Two_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Two {
-  constructor(underlying) {
+  constructor(underlying, owned) {
     this.underlying = underlying;
-    Two_box_destroy_registry.register(this, underlying);
+    if (owned) {
+      Two_box_destroy_registry.register(this, underlying);
+    }
   }
 }

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -9,16 +9,13 @@ const Bar_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Bar {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      Bar_box_destroy_registry.register(this, underlying);
-    }
   }
 
   foo() {
     return (() => {
-      const out = new Foo(wasm.Bar_foo(this.underlying), false);
+      const out = new Foo(wasm.Bar_foo(this.underlying));
       out.__this_lifetime_guard = this;
       return out;
     })();
@@ -46,16 +43,18 @@ const Float64Vec_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Float64Vec {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      Float64Vec_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new(v) {
     v = diplomatRuntime.DiplomatBuf.slice(wasm, v, 8);
-    const diplomat_out = new Float64Vec(wasm.Float64Vec_new(v.ptr, v.size), true);
+    const diplomat_out = (() => {
+      const underlying = wasm.Float64Vec_new(v.ptr, v.size);
+      const out = new Float64Vec(underlying);
+      Float64Vec_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
     v.free();
     return diplomat_out;
   }
@@ -78,17 +77,16 @@ const Foo_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Foo {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      Foo_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new(x) {
     x = diplomatRuntime.DiplomatBuf.str(wasm, x);
     return (() => {
-      const out = new Foo(wasm.Foo_new(x.ptr, x.size), true);
+      const underlying = wasm.Foo_new(x.ptr, x.size);
+      const out = new Foo(underlying);
+      Foo_box_destroy_registry.register(out, underlying);
       out.__x_lifetime_guard = x;
       return out;
     })();
@@ -96,7 +94,9 @@ export class Foo {
 
   get_bar() {
     return (() => {
-      const out = new Bar(wasm.Foo_get_bar(this.underlying), true);
+      const underlying = wasm.Foo_get_bar(this.underlying);
+      const out = new Bar(underlying);
+      Bar_box_destroy_registry.register(out, underlying);
       out.__this_lifetime_guard = this;
       return out;
     })();
@@ -108,16 +108,18 @@ const MyString_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class MyString {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      MyString_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new(v) {
     v = diplomatRuntime.DiplomatBuf.str(wasm, v);
-    const diplomat_out = new MyString(wasm.MyString_new(v.ptr, v.size), true);
+    const diplomat_out = (() => {
+      const underlying = wasm.MyString_new(v.ptr, v.size);
+      const out = new MyString(underlying);
+      MyString_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
     v.free();
     return diplomat_out;
   }
@@ -161,16 +163,15 @@ const One_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class One {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      One_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static transitivity(hold, nohold) {
     return (() => {
-      const out = new One(wasm.One_transitivity(hold.underlying, nohold.underlying), true);
+      const underlying = wasm.One_transitivity(hold.underlying, nohold.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__hold_lifetime_guard = hold;
       return out;
     })();
@@ -178,7 +179,9 @@ export class One {
 
   static cycle(hold, nohold) {
     return (() => {
-      const out = new One(wasm.One_cycle(hold.underlying, nohold.underlying), true);
+      const underlying = wasm.One_cycle(hold.underlying, nohold.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__hold_lifetime_guard = hold;
       return out;
     })();
@@ -186,7 +189,9 @@ export class One {
 
   static many_dependents(a, b, c, d, nohold) {
     return (() => {
-      const out = new One(wasm.One_many_dependents(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying), true);
+      const underlying = wasm.One_many_dependents(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__a_lifetime_guard = a;
       out.__b_lifetime_guard = b;
       out.__c_lifetime_guard = c;
@@ -197,7 +202,9 @@ export class One {
 
   static return_outlives_param(hold, nohold) {
     return (() => {
-      const out = new One(wasm.One_return_outlives_param(hold.underlying, nohold.underlying), true);
+      const underlying = wasm.One_return_outlives_param(hold.underlying, nohold.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__hold_lifetime_guard = hold;
       return out;
     })();
@@ -205,7 +212,9 @@ export class One {
 
   static diamond_top(top, left, right, bottom) {
     return (() => {
-      const out = new One(wasm.One_diamond_top(top.underlying, left.underlying, right.underlying, bottom.underlying), true);
+      const underlying = wasm.One_diamond_top(top.underlying, left.underlying, right.underlying, bottom.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__top_lifetime_guard = top;
       out.__left_lifetime_guard = left;
       out.__right_lifetime_guard = right;
@@ -216,7 +225,9 @@ export class One {
 
   static diamond_left(top, left, right, bottom) {
     return (() => {
-      const out = new One(wasm.One_diamond_left(top.underlying, left.underlying, right.underlying, bottom.underlying), true);
+      const underlying = wasm.One_diamond_left(top.underlying, left.underlying, right.underlying, bottom.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__left_lifetime_guard = left;
       out.__bottom_lifetime_guard = bottom;
       return out;
@@ -225,7 +236,9 @@ export class One {
 
   static diamond_right(top, left, right, bottom) {
     return (() => {
-      const out = new One(wasm.One_diamond_right(top.underlying, left.underlying, right.underlying, bottom.underlying), true);
+      const underlying = wasm.One_diamond_right(top.underlying, left.underlying, right.underlying, bottom.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__right_lifetime_guard = right;
       out.__bottom_lifetime_guard = bottom;
       return out;
@@ -234,7 +247,9 @@ export class One {
 
   static diamond_bottom(top, left, right, bottom) {
     return (() => {
-      const out = new One(wasm.One_diamond_bottom(top.underlying, left.underlying, right.underlying, bottom.underlying), true);
+      const underlying = wasm.One_diamond_bottom(top.underlying, left.underlying, right.underlying, bottom.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__bottom_lifetime_guard = bottom;
       return out;
     })();
@@ -242,7 +257,9 @@ export class One {
 
   static diamond_and_nested_types(a, b, c, d, nohold) {
     return (() => {
-      const out = new One(wasm.One_diamond_and_nested_types(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying), true);
+      const underlying = wasm.One_diamond_and_nested_types(a.underlying, b.underlying, c.underlying, d.underlying, nohold.underlying);
+      const out = new One(underlying);
+      One_box_destroy_registry.register(out, underlying);
       out.__a_lifetime_guard = a;
       out.__b_lifetime_guard = b;
       out.__c_lifetime_guard = c;
@@ -257,15 +274,17 @@ const Opaque_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Opaque {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      Opaque_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new() {
-    return new Opaque(wasm.Opaque_new(), true);
+    return (() => {
+      const underlying = wasm.Opaque_new();
+      const out = new Opaque(underlying);
+      Opaque_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
   }
 
   assert_struct(s) {
@@ -284,24 +303,31 @@ const OptionOpaque_box_destroy_registry = new FinalizationRegistry(underlying =>
 });
 
 export class OptionOpaque {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      OptionOpaque_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new(i) {
     return (() => {
       const option_ptr = wasm.OptionOpaque_new(i);
-      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr, true);
+      return (option_ptr == 0) ? null : (() => {
+        const underlying = option_ptr;
+        const out = new OptionOpaque(underlying);
+        OptionOpaque_box_destroy_registry.register(out, underlying);
+        return out;
+      })();
     })();
   }
 
   static new_none() {
     return (() => {
       const option_ptr = wasm.OptionOpaque_new_none();
-      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr, true);
+      return (option_ptr == 0) ? null : (() => {
+        const underlying = option_ptr;
+        const out = new OptionOpaque(underlying);
+        OptionOpaque_box_destroy_registry.register(out, underlying);
+        return out;
+      })();
     })();
   }
 
@@ -335,11 +361,8 @@ const OptionOpaqueChar_box_destroy_registry = new FinalizationRegistry(underlyin
 });
 
 export class OptionOpaqueChar {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      OptionOpaqueChar_box_destroy_registry.register(this, underlying);
-    }
   }
 
   assert_char(ch) {
@@ -351,16 +374,31 @@ export class OptionStruct {
   constructor(underlying) {
     this.a = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying);
-      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr, true);
+      return (option_ptr == 0) ? null : (() => {
+        const underlying = option_ptr;
+        const out = new OptionOpaque(underlying);
+        OptionOpaque_box_destroy_registry.register(out, underlying);
+        return out;
+      })();
     })();
     this.b = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 4);
-      return (option_ptr == 0) ? null : new OptionOpaqueChar(option_ptr, true);
+      return (option_ptr == 0) ? null : (() => {
+        const underlying = option_ptr;
+        const out = new OptionOpaqueChar(underlying);
+        OptionOpaqueChar_box_destroy_registry.register(out, underlying);
+        return out;
+      })();
     })();
     this.c = (new Uint32Array(wasm.memory.buffer, underlying + 8, 1))[0];
     this.d = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying + 12);
-      return (option_ptr == 0) ? null : new OptionOpaque(option_ptr, true);
+      return (option_ptr == 0) ? null : (() => {
+        const underlying = option_ptr;
+        const out = new OptionOpaque(underlying);
+        OptionOpaque_box_destroy_registry.register(out, underlying);
+        return out;
+      })();
     })();
   }
 }
@@ -370,16 +408,15 @@ const RefList_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class RefList {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      RefList_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static node(data) {
     return (() => {
-      const out = new RefList(wasm.RefList_node(data.underlying), true);
+      const underlying = wasm.RefList_node(data.underlying);
+      const out = new RefList(underlying);
+      RefList_box_destroy_registry.register(out, underlying);
       out.__data_lifetime_guard = data;
       return out;
     })();
@@ -391,11 +428,8 @@ const ResultOpaque_box_destroy_registry = new FinalizationRegistry(underlying =>
 });
 
 export class ResultOpaque {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      ResultOpaque_box_destroy_registry.register(this, underlying);
-    }
   }
 
   static new(i) {
@@ -404,7 +438,12 @@ export class ResultOpaque {
       wasm.ResultOpaque_new(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
+        const ok_value = (() => {
+          const underlying = diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer);
+          const out = new ResultOpaque(underlying);
+          ResultOpaque_box_destroy_registry.register(out, underlying);
+          return out;
+        })();
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
@@ -421,7 +460,12 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_foo(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
+        const ok_value = (() => {
+          const underlying = diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer);
+          const out = new ResultOpaque(underlying);
+          ResultOpaque_box_destroy_registry.register(out, underlying);
+          return out;
+        })();
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
@@ -438,7 +482,12 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_bar(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
+        const ok_value = (() => {
+          const underlying = diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer);
+          const out = new ResultOpaque(underlying);
+          ResultOpaque_box_destroy_registry.register(out, underlying);
+          return out;
+        })();
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
@@ -455,7 +504,12 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_unit(diplomat_receive_buffer);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
+        const ok_value = (() => {
+          const underlying = diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer);
+          const out = new ResultOpaque(underlying);
+          ResultOpaque_box_destroy_registry.register(out, underlying);
+          return out;
+        })();
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
@@ -472,7 +526,12 @@ export class ResultOpaque {
       wasm.ResultOpaque_new_failing_struct(diplomat_receive_buffer, i);
       const is_ok = diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 8);
       if (is_ok) {
-        const ok_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
+        const ok_value = (() => {
+          const underlying = diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer);
+          const out = new ResultOpaque(underlying);
+          ResultOpaque_box_destroy_registry.register(out, underlying);
+          return out;
+        })();
         wasm.diplomat_free(diplomat_receive_buffer, 9, 4);
         return ok_value;
       } else {
@@ -493,7 +552,12 @@ export class ResultOpaque {
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
-        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
+        const throw_value = (() => {
+          const underlying = diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer);
+          const out = new ResultOpaque(underlying);
+          ResultOpaque_box_destroy_registry.register(out, underlying);
+          return out;
+        })();
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
@@ -510,7 +574,12 @@ export class ResultOpaque {
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         return ok_value;
       } else {
-        const throw_value = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), true);
+        const throw_value = (() => {
+          const underlying = diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer);
+          const out = new ResultOpaque(underlying);
+          ResultOpaque_box_destroy_registry.register(out, underlying);
+          return out;
+        })();
         wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
         throw new diplomatRuntime.FFIError(throw_value);
       }
@@ -527,10 +596,7 @@ const Two_box_destroy_registry = new FinalizationRegistry(underlying => {
 });
 
 export class Two {
-  constructor(underlying, owned) {
+  constructor(underlying) {
     this.underlying = underlying;
-    if (owned) {
-      Two_box_destroy_registry.register(this, underlying);
-    }
   }
 }

--- a/feature_tests/js/docs/lifetimes_ffi.rst
+++ b/feature_tests/js/docs/lifetimes_ffi.rst
@@ -3,6 +3,8 @@
 
 .. js:class:: Bar
 
+    .. js:function:: foo()
+
 .. js:class:: Foo
 
     .. js:staticfunction:: new(x)

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -16,6 +16,12 @@ pub mod ffi {
         }
     }
 
+    impl<'b, 'a: 'b> Bar<'b, 'a> {
+        pub fn foo(&'b self) -> &'b Foo<'a> {
+            self.0
+        }
+    }
+
     #[diplomat::opaque]
     pub struct One<'a>(super::One<'a>);
 

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -321,31 +321,43 @@ impl fmt::Display for InvocationIntoJs<'_> {
                     write!(f, "{}_rust_to_js[{}]", enm.name, self.invocation.scalar())
                 }
             },
-            ast::TypeName::Reference(.., inner) | ast::TypeName::Box(inner) => Pointer {
+            ast::TypeName::Reference(.., inner) => Pointer {
                 inner,
                 underlying: Underlying::Invocation(&self.invocation),
+                owned: false,
                 base: self.base,
             }
             .fmt(f),
-            ast::TypeName::Option(inner) => match inner.as_ref() {
-                ast::TypeName::Box(inner) | ast::TypeName::Reference(.., inner) => {
-                    display::iife(|mut f| {
-                        let option_ptr: ast::Ident = "option_ptr".into();
-                        writeln!(f, "const {option_ptr} = {};", self.invocation.scalar())?;
-                        writeln!(
-                            f,
-                            "return ({option_ptr} == 0) ? null : {};",
-                            Pointer {
-                                inner,
-                                underlying: Underlying::Binding(&option_ptr, None),
-                                base: self.base,
-                            }
-                        )
-                    })
-                    .fmt(f)
-                }
-                _ => unreachable!(),
-            },
+            ast::TypeName::Box(inner) => Pointer {
+                inner,
+                underlying: Underlying::Invocation(&self.invocation),
+                owned: true,
+                base: self.base,
+            }
+            .fmt(f),
+            ast::TypeName::Option(inner) => {
+                let (inner, owned) = match inner.as_ref() {
+                    ast::TypeName::Reference(.., inner) => (inner, false),
+                    ast::TypeName::Box(inner) => (inner, true),
+                    _ => unreachable!("non-pointer type in an Option"),
+                };
+
+                display::iife(|mut f| {
+                    let option_ptr: ast::Ident = "option_ptr".into();
+                    writeln!(f, "const {option_ptr} = {};", self.invocation.scalar())?;
+                    writeln!(
+                        f,
+                        "return ({option_ptr} == 0) ? null : {};",
+                        Pointer {
+                            inner,
+                            underlying: Underlying::Binding(&option_ptr, None),
+                            owned,
+                            base: self.base,
+                        }
+                    )
+                })
+                .fmt(f)
+            }
             ast::TypeName::Result(ok, err) => {
                 match self.base.return_type_form(self.typ) {
                     ReturnTypeForm::Scalar => display::iife(|mut f| {
@@ -406,6 +418,9 @@ struct Pointer<'base> {
     /// An expression that evaluates into the pointer.
     underlying: Underlying<'base>,
 
+    /// Whether or not the pointer is owned.
+    owned: bool,
+
     /// Base data.
     base: Base<'base>,
 }
@@ -415,10 +430,18 @@ impl fmt::Display for Pointer<'_> {
         if let ast::TypeName::Named(path_type) = self.inner {
             if let ast::CustomType::Opaque(opaque) = self.base.resolve_type(path_type) {
                 if !self.base.borrows() {
-                    write!(f, "new {}({})", opaque.name, self.underlying)?;
+                    write!(
+                        f,
+                        "new {}({}, {})",
+                        opaque.name, self.underlying, self.owned
+                    )?;
                 } else {
                     display::iife(|mut f| {
-                        writeln!(f, "const out = new {}({});", opaque.name, self.underlying)?;
+                        writeln!(
+                            f,
+                            "const out = new {}({}, {});",
+                            opaque.name, self.underlying, self.owned
+                        )?;
                         if self.base.borrows_self {
                             writeln!(f, "out.__this_lifetime_guard = this;")?;
                         }
@@ -522,35 +545,47 @@ impl fmt::Display for UnderlyingIntoJs<'_> {
                     enm.name, self.underlying,
                 ),
             },
-            ast::TypeName::Reference(.., typ) | ast::TypeName::Box(typ) => Pointer {
+            ast::TypeName::Reference(.., typ) => Pointer {
                 inner: typ,
                 underlying: Underlying::PtrRead(&self.underlying),
+                owned: false,
                 base: self.base,
             }
             .fmt(f),
-            ast::TypeName::Option(inner) => match inner.as_ref() {
-                ast::TypeName::Box(inner) | ast::TypeName::Reference(.., inner) => {
-                    display::iife(|mut f| {
-                        let option_ptr: ast::Ident = "option_ptr".into();
-                        writeln!(
-                            f,
-                            "const {option_ptr} = {};",
-                            Underlying::PtrRead(&self.underlying)
-                        )?;
-                        writeln!(
-                            f,
-                            "return ({option_ptr} == 0) ? null : {};",
-                            Pointer {
-                                inner,
-                                underlying: Underlying::Binding(&option_ptr, None),
-                                base: self.base,
-                            }
-                        )
-                    })
-                    .fmt(f)
-                }
-                _ => unreachable!(),
-            },
+            ast::TypeName::Box(typ) => Pointer {
+                inner: typ,
+                underlying: Underlying::PtrRead(&self.underlying),
+                owned: true,
+                base: self.base,
+            }
+            .fmt(f),
+            ast::TypeName::Option(inner) => {
+                let (inner, owned) = match inner.as_ref() {
+                    ast::TypeName::Reference(.., inner) => (inner, false),
+                    ast::TypeName::Box(inner) => (inner, true),
+                    _ => unreachable!("non-pointer in an Option"),
+                };
+
+                display::iife(|mut f| {
+                    let option_ptr: ast::Ident = "option_ptr".into();
+                    writeln!(
+                        f,
+                        "const {option_ptr} = {};",
+                        Underlying::PtrRead(&self.underlying)
+                    )?;
+                    writeln!(
+                        f,
+                        "return ({option_ptr} == 0) ? null : {};",
+                        Pointer {
+                            inner,
+                            underlying: Underlying::Binding(&option_ptr, None),
+                            owned,
+                            base: self.base,
+                        }
+                    )
+                })
+                .fmt(f)
+            }
             ast::TypeName::Result(..) => todo!("Result in a buffer"),
             ast::TypeName::Writeable => todo!("Writeable in a buffer"),
             ast::TypeName::StrReference(..) => todo!("StrReference in a buffer"),

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_returning_struct@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_returning_struct@api.mjs.snap
@@ -15,7 +15,6 @@ const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
 export class MyStruct {
   constructor(underlying) {
     this.underlying = underlying;
-    MyStruct_box_destroy_registry.register(this, underlying);
   }
 
   get_non_opaque() {

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@api.mjs.snap
@@ -15,12 +15,16 @@ const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
 export class MyStruct {
   constructor(underlying) {
     this.underlying = underlying;
-    MyStruct_box_destroy_registry.register(this, underlying);
   }
 
   static new_str(v) {
     v = diplomatRuntime.DiplomatBuf.str(wasm, v);
-    const diplomat_out = new MyStruct(wasm.MyStruct_new_str(v.ptr, v.size));
+    const diplomat_out = (() => {
+      const underlying = wasm.MyStruct_new_str(v.ptr, v.size);
+      const out = new MyStruct(underlying);
+      MyStruct_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
     v.free();
     return diplomat_out;
   }

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_writeable_out@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_writeable_out@api.mjs.snap
@@ -15,7 +15,6 @@ const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
 export class MyStruct {
   constructor(underlying) {
     this.underlying = underlying;
-    MyStruct_box_destroy_registry.register(this, underlying);
   }
 
   write() {

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_opaque_struct@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_opaque_struct@api.mjs.snap
@@ -15,11 +15,15 @@ const MyStruct_box_destroy_registry = new FinalizationRegistry(underlying => {
 export class MyStruct {
   constructor(underlying) {
     this.underlying = underlying;
-    MyStruct_box_destroy_registry.register(this, underlying);
   }
 
   static new(a, b) {
-    return new MyStruct(wasm.MyStruct_new(a, b));
+    return (() => {
+      const underlying = wasm.MyStruct_new(a, b);
+      const out = new MyStruct(underlying);
+      MyStruct_box_destroy_registry.register(out, underlying);
+      return out;
+    })();
   }
 
   get_a() {

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__option_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__option_types@api.mjs.snap
@@ -15,7 +15,6 @@ const MyOpaqueStruct_box_destroy_registry = new FinalizationRegistry(underlying 
 export class MyOpaqueStruct {
   constructor(underlying) {
     this.underlying = underlying;
-    MyOpaqueStruct_box_destroy_registry.register(this, underlying);
   }
 }
 
@@ -23,7 +22,12 @@ export class MyStruct {
   constructor(underlying) {
     this.a = (() => {
       const option_ptr = diplomatRuntime.ptrRead(wasm, underlying);
-      return (option_ptr == 0) ? null : new MyOpaqueStruct(option_ptr);
+      return (option_ptr == 0) ? null : (() => {
+        const underlying = option_ptr;
+        const out = new MyOpaqueStruct(underlying);
+        MyOpaqueStruct_box_destroy_registry.register(out, underlying);
+        return out;
+      })();
     })();
   }
 }

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@api.mjs.snap
@@ -15,7 +15,6 @@ const MyOpaqueStruct_box_destroy_registry = new FinalizationRegistry(underlying 
 export class MyOpaqueStruct {
   constructor(underlying) {
     this.underlying = underlying;
-    MyOpaqueStruct_box_destroy_registry.register(this, underlying);
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__result_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__result_types@api.mjs.snap
@@ -15,7 +15,6 @@ const MyOpaqueStruct_box_destroy_registry = new FinalizationRegistry(underlying 
 export class MyOpaqueStruct {
   constructor(underlying) {
     this.underlying = underlying;
-    MyOpaqueStruct_box_destroy_registry.register(this, underlying);
   }
 }
 

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -130,13 +130,19 @@ pub fn gen_struct<W: fmt::Write>(
                 display::block(|mut f| {
                     writeln!(
                         f,
-                        "constructor(underlying) {}",
+                        "constructor(underlying, owned) {}",
                         display::block(|mut f| {
                             writeln!(f, "this.underlying = underlying;")?;
                             writeln!(
                                 f,
-                                "{}_box_destroy_registry.register(this, underlying);",
-                                opaque.name
+                                "if (owned) {}",
+                                display::block(|mut f| {
+                                    writeln!(
+                                        f,
+                                        "{}_box_destroy_registry.register(this, underlying);",
+                                        opaque.name
+                                    )
+                                })
                             )
                         })
                     )?;

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -130,21 +130,8 @@ pub fn gen_struct<W: fmt::Write>(
                 display::block(|mut f| {
                     writeln!(
                         f,
-                        "constructor(underlying, owned) {}",
-                        display::block(|mut f| {
-                            writeln!(f, "this.underlying = underlying;")?;
-                            writeln!(
-                                f,
-                                "if (owned) {}",
-                                display::block(|mut f| {
-                                    writeln!(
-                                        f,
-                                        "{}_box_destroy_registry.register(this, underlying);",
-                                        opaque.name
-                                    )
-                                })
-                            )
-                        })
+                        "constructor(underlying) {}",
+                        display::block(|mut f| writeln!(f, "this.underlying = underlying;"))
                     )?;
 
                     for method in opaque.methods.iter() {


### PR DESCRIPTION
Fixes #183.

I decided to just move the `FinalizationRegistry` registration out of the constructor so we could manually invoke it for owned types, and I think this will be cleaner in the long run.

I also added a test method, `Bar::foo` which returns a reference to an opaque to demonstrate that borrowed opaques don't register.