### PR TITLE
Add `TypeName::longer_lifetimes`

### DIFF
--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -80,7 +80,7 @@ impl LifetimeEnv {
     }
 
     /// Collect all lifetimes that live _at least_ as long as _any_ provided lifetimes.
-    /// 
+    ///
     /// This method returns a visitor type, [`Outlives`], which can be used to
     /// incrementally visit lifetimes and build up an internal list of which
     /// lifetimes are reachable after each new visited lifetime. This is useful
@@ -396,7 +396,7 @@ impl Lifetime {
 }
 
 /// Incrementally collect lifetimes that outlive a set of visited lifetimes.
-/// 
+///
 /// See [`LifetimeEnv::outlives`] for more information.
 pub struct Outlives<'env> {
     env: &'env LifetimeEnv,

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -427,16 +427,17 @@ impl<'env> Outlives<'env> {
         }
     }
 
-    /// Performs DFS to visit all longer lifetimes.
-    fn dfs(&mut self, id: usize) {
+    /// Recursively mark all lifetimes that live at least as long as the
+    /// lifetime at the provided index in the [`LifetimeEnv`] as reachable.
+    fn dfs(&mut self, index: usize) {
         // Note: all of these indexings SHOULD be valid because
         // `visited.len() == nodes.len()`, and the ids come from
         // calling `Iterator::position` on `nodes`, which never shrinks.
         // So we should be able to change these to `get_unchecked`...
-        if !self.visited[id] {
-            self.visited[id] = true;
+        if !self.visited[index] {
+            self.visited[index] = true;
 
-            let node = &self.env.nodes[id];
+            let node = &self.env.nodes[index];
             self.out.push(&node.lifetime);
             for &longer_id in node.longer.iter() {
                 self.dfs(longer_id);
@@ -444,7 +445,7 @@ impl<'env> Outlives<'env> {
         }
     }
 
-    /// Returns all lifetimes that must outlive any of the visited lifetimes.
+    /// Returns all lifetimes that outlive any of the visited lifetimes.
     pub fn finish(self) -> Vec<&'env NamedLifetime> {
         self.out
     }


### PR DESCRIPTION
This PR does two very small things:
1. Resolves #186.
2. Add `TypeName::longer_lifetimes`, which the new `LifetimeEnv::outlives` helps optimize.

Prior to this PR, we already had the `TypeName::longer_lifetimes` logic used for return types. However, I'm working on the JS codegen currently and it's also needed for inputs as well when determining which fields of a returned non-opaque struct borrow from which inputs. Therefore, this PR abstracts the behavior and will help reduce the PR bloat when I submit my JS changes later.