### PR TITLE
JS unambiguous field unpacking

### DIFF
--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -80,11 +80,11 @@ export class ICU4XFixedDecimalFormat {
   }
 
   static try_new(locale, provider, options) {
-    const diplomat_ICU4XFixedDecimalFormatOptions_extracted_grouping_strategy = options["grouping_strategy"];
-    const diplomat_ICU4XFixedDecimalFormatOptions_extracted_sign_display = options["sign_display"];
+    const _options_grouping_strategy = options["grouping_strategy"];
+    const _options_sign_display = options["sign_display"];
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XFixedDecimalFormat_try_new(diplomat_receive_buffer, locale.underlying, provider.underlying, ICU4XFixedDecimalGroupingStrategy_js_to_rust[diplomat_ICU4XFixedDecimalFormatOptions_extracted_grouping_strategy], ICU4XFixedDecimalSignDisplay_js_to_rust[diplomat_ICU4XFixedDecimalFormatOptions_extracted_sign_display]);
+      wasm.ICU4XFixedDecimalFormat_try_new(diplomat_receive_buffer, locale.underlying, provider.underlying, ICU4XFixedDecimalGroupingStrategy_js_to_rust[_options_grouping_strategy], ICU4XFixedDecimalSignDisplay_js_to_rust[_options_sign_display]);
       const out = new ICU4XFixedDecimalFormatResult(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
       return out;

--- a/example/js/api.mjs
+++ b/example/js/api.mjs
@@ -80,11 +80,11 @@ export class ICU4XFixedDecimalFormat {
   }
 
   static try_new(locale, provider, options) {
-    const _options_grouping_strategy = options["grouping_strategy"];
-    const _options_sign_display = options["sign_display"];
+    const f_options_grouping_strategy = options["grouping_strategy"];
+    const f_options_sign_display = options["sign_display"];
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
-      wasm.ICU4XFixedDecimalFormat_try_new(diplomat_receive_buffer, locale.underlying, provider.underlying, ICU4XFixedDecimalGroupingStrategy_js_to_rust[_options_grouping_strategy], ICU4XFixedDecimalSignDisplay_js_to_rust[_options_sign_display]);
+      wasm.ICU4XFixedDecimalFormat_try_new(diplomat_receive_buffer, locale.underlying, provider.underlying, ICU4XFixedDecimalGroupingStrategy_js_to_rust[f_options_grouping_strategy], ICU4XFixedDecimalSignDisplay_js_to_rust[f_options_sign_display]);
       const out = new ICU4XFixedDecimalFormatResult(diplomat_receive_buffer);
       wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
       return out;

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -288,13 +288,13 @@ export class Opaque {
   }
 
   assert_struct(s) {
-    const _s_a = s["a"];
-    const _s_b = s["b"];
-    const _s_c = s["c"];
-    const _s_d = s["d"];
-    const _s_e = s["e"];
-    const _s_f = s["f"];
-    wasm.Opaque_assert_struct(this.underlying, _s_a, _s_b, _s_c, _s_d, _s_e, diplomatRuntime.extractCodePoint(_s_f, '_s_f'));
+    const f_s_a = s["a"];
+    const f_s_b = s["b"];
+    const f_s_c = s["c"];
+    const f_s_d = s["d"];
+    const f_s_e = s["e"];
+    const f_s_f = s["f"];
+    wasm.Opaque_assert_struct(this.underlying, f_s_a, f_s_b, f_s_c, f_s_d, f_s_e, diplomatRuntime.extractCodePoint(f_s_f, 'f_s_f'));
   }
 }
 

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -288,13 +288,13 @@ export class Opaque {
   }
 
   assert_struct(s) {
-    const diplomat_MyStruct_extracted_a = s["a"];
-    const diplomat_MyStruct_extracted_b = s["b"];
-    const diplomat_MyStruct_extracted_c = s["c"];
-    const diplomat_MyStruct_extracted_d = s["d"];
-    const diplomat_MyStruct_extracted_e = s["e"];
-    const diplomat_MyStruct_extracted_f = s["f"];
-    wasm.Opaque_assert_struct(this.underlying, diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b, diplomat_MyStruct_extracted_c, diplomat_MyStruct_extracted_d, diplomat_MyStruct_extracted_e, diplomatRuntime.extractCodePoint(diplomat_MyStruct_extracted_f, 'diplomat_MyStruct_extracted_f'));
+    const _s_a = s["a"];
+    const _s_b = s["b"];
+    const _s_c = s["c"];
+    const _s_d = s["d"];
+    const _s_e = s["e"];
+    const _s_f = s["f"];
+    wasm.Opaque_assert_struct(this.underlying, _s_a, _s_b, _s_c, _s_d, _s_e, diplomatRuntime.extractCodePoint(_s_f, '_s_f'));
   }
 }
 

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -76,7 +76,7 @@ pub fn gen_value_js_to_rust(
         ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
             ast::CustomType::Struct(struct_type) => {
                 for (field_name, field_type, _) in struct_type.fields.iter() {
-                    let field_extracted_name = format!("_{param_name}_{field_name}").into();
+                    let field_extracted_name = format!("f_{param_name}_{field_name}").into();
                     pre_logic.push(format!(
                         "const {} = {}[\"{}\"];",
                         field_extracted_name, param_name, field_name

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -76,8 +76,7 @@ pub fn gen_value_js_to_rust(
         ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
             ast::CustomType::Struct(struct_type) => {
                 for (field_name, field_type, _) in struct_type.fields.iter() {
-                    let field_extracted_name =
-                        format!("diplomat_{}_extracted_{}", struct_type.name, field_name).into();
+                    let field_extracted_name = format!("_{param_name}_{field_name}").into();
                     pre_logic.push(format!(
                         "const {} = {}[\"{}\"];",
                         field_extracted_name, param_name, field_name
@@ -593,6 +592,32 @@ impl fmt::Display for UnderlyingIntoJs<'_> {
             ast::TypeName::StrReference(..) => todo!("StrReference in a buffer"),
             ast::TypeName::PrimitiveSlice(..) => todo!("PrimitiveSlice in a buffer"),
             ast::TypeName::Unit => "{}".fmt(f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_unambiguous_names() {
+        test_file! {
+            #[diplomat::bridge]
+            mod ffi {
+                pub struct Point {
+                    x: i32,
+                    y: i32,
+                }
+
+                pub struct Line {
+                    start: Point,
+                    end: Point,
+                }
+
+                impl Line {
+                    pub fn do_stuff(self) {}
+                }
+            }
         }
     }
 }

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@api.mjs.snap
@@ -15,13 +15,13 @@ export class Line {
   }
 
   do_stuff() {
-    const _this_start = this["start"];
-    const __this_start_x = _this_start["x"];
-    const __this_start_y = _this_start["y"];
-    const _this_end = this["end"];
-    const __this_end_x = _this_end["x"];
-    const __this_end_y = _this_end["y"];
-    wasm.Line_do_stuff(__this_start_x, __this_start_y, __this_end_x, __this_end_y);
+    const f_this_start = this["start"];
+    const f_f_this_start_x = f_this_start["x"];
+    const f_f_this_start_y = f_this_start["y"];
+    const f_this_end = this["end"];
+    const f_f_this_end_x = f_this_end["x"];
+    const f_f_this_end_y = f_this_end["y"];
+    wasm.Line_do_stuff(f_f_this_start_x, f_f_this_start_y, f_f_this_end_x, f_f_this_end_y);
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@api.mjs.snap
@@ -1,0 +1,34 @@
+---
+source: tool/src/js/conversions.rs
+expression: out_texts.get(out).unwrap()
+---
+import wasm from "./wasm.mjs"
+import * as diplomatRuntime from "./diplomat-runtime.mjs"
+const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
+  wasm.diplomat_free(obj["ptr"], obj["size"], obj["align"]);
+});
+
+export class Line {
+  constructor(underlying) {
+    this.start = new Point(underlying);
+    this.end = new Point(underlying + 8);
+  }
+
+  do_stuff() {
+    const _this_start = this["start"];
+    const __this_start_x = _this_start["x"];
+    const __this_start_y = _this_start["y"];
+    const _this_end = this["end"];
+    const __this_end_x = _this_end["x"];
+    const __this_end_y = _this_end["y"];
+    wasm.Line_do_stuff(__this_start_x, __this_start_y, __this_end_x, __this_end_y);
+  }
+}
+
+export class Point {
+  constructor(underlying) {
+    this.x = (new Int32Array(wasm.memory.buffer, underlying, 1))[0];
+    this.y = (new Int32Array(wasm.memory.buffer, underlying + 4, 1))[0];
+  }
+}
+

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@ffi.rst.snap
@@ -1,0 +1,21 @@
+---
+source: tool/src/js/conversions.rs
+expression: out_docs.get(out).unwrap()
+---
+``ffi``
+=======
+
+.. js:class:: Line
+
+    .. js:attribute:: start
+
+    .. js:attribute:: end
+
+    .. js:function:: do_stuff()
+
+.. js:class:: Point
+
+    .. js:attribute:: x
+
+    .. js:attribute:: y
+

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@index.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@index.rst.snap
@@ -1,0 +1,19 @@
+---
+source: tool/src/js/conversions.rs
+expression: out_docs.get(out).unwrap()
+---
+Documentation
+=============
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Modules:
+
+   ffi
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`
+

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@api.mjs.snap
@@ -15,9 +15,9 @@ export class MyStruct {
   }
 
   something() {
-    const diplomat_MyStruct_extracted_a = this["a"];
-    const diplomat_MyStruct_extracted_b = this["b"];
-    return wasm.MyStruct_something(diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b);
+    const _this_a = this["a"];
+    const _this_b = this["b"];
+    return wasm.MyStruct_something(_this_a, _this_b);
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@api.mjs.snap
@@ -15,9 +15,9 @@ export class MyStruct {
   }
 
   something() {
-    const _this_a = this["a"];
-    const _this_b = this["b"];
-    return wasm.MyStruct_something(_this_a, _this_b);
+    const f_this_a = this["a"];
+    const f_this_b = this["b"];
+    return wasm.MyStruct_something(f_this_a, f_this_b);
   }
 }
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@api.mjs.snap
@@ -15,10 +15,10 @@ export class MyStruct {
   }
 
   write() {
-    const diplomat_MyStruct_extracted_a = this["a"];
-    const diplomat_MyStruct_extracted_b = this["b"];
+    const _this_a = this["a"];
+    const _this_b = this["b"];
     return diplomatRuntime.withWriteable(wasm, (writeable) => {
-      return wasm.MyStruct_write(diplomat_MyStruct_extracted_a, diplomat_MyStruct_extracted_b, writeable);
+      return wasm.MyStruct_write(_this_a, _this_b, writeable);
     });
   }
 }

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@api.mjs.snap
@@ -15,10 +15,10 @@ export class MyStruct {
   }
 
   write() {
-    const _this_a = this["a"];
-    const _this_b = this["b"];
+    const f_this_a = this["a"];
+    const f_this_b = this["b"];
     return diplomatRuntime.withWriteable(wasm, (writeable) => {
-      return wasm.MyStruct_write(_this_a, _this_b, writeable);
+      return wasm.MyStruct_write(f_this_a, f_this_b, writeable);
     });
   }
 }


### PR DESCRIPTION
Say we had the following:
```rust
pub struct Int {
    x: i32,
}

pub struct Range {
    start: Int,
    stop: Int,
}

impl Range {
    pub fn consume(self) { ... }
}
```
This would cause an issue in the JS backend for the generated `Range.consume` static method, where it would unpack the `start` and `stop` inner values both as `diplomat_Int_extracted_x`, causing a naming conflict.

This PR fixes that by changing them to be named according to the name of the field, which is always unique, as opposed to the type. Now, they get unpacked as `_this_start_x` and `_this_end_x`.