### PR TITLE
JS struct borrowing

### DIFF
--- a/core/src/ast/idents.rs
+++ b/core/src/ast/idents.rs
@@ -31,6 +31,9 @@ impl Ident {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// An [`Ident`] containing "this".
+    pub const THIS: Self = Ident(Cow::Borrowed("this"));
 }
 
 impl From<&'static str> for Ident {

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -14,6 +14,12 @@ use super::Ident;
 #[serde(transparent)]
 pub struct NamedLifetime(Ident);
 
+impl NamedLifetime {
+    pub fn name(&self) -> &Ident {
+        &self.0
+    }
+}
+
 impl<'de> Deserialize<'de> for NamedLifetime {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -88,6 +94,11 @@ impl LifetimeEnv {
     /// to dedup at the end.
     pub fn outlives(&self) -> Outlives {
         Outlives::new(self)
+    }
+
+    /// Iterate through the names of the lifetimes in scope.
+    pub fn names(&self) -> impl Iterator<Item = &NamedLifetime> {
+        self.nodes.iter().map(|node| &node.lifetime)
     }
 
     /// Constructs a new [`LifetimeEnv`] from a [`syn::ImplItemMethod`] and optional

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -383,8 +383,11 @@ mod tests {
             );
 
             let borrowed_params = method.borrowed_params();
-            let actual: Vec<&Ident> = borrowed_params.names(&Ident::THIS).collect();
-            let expected: &[&Ident] = &[$(&stringify!($param).into()),*];
+            let mut actual: Vec<&str> = borrowed_params.names(&Ident::THIS).map(|ident| ident.as_str()).collect();
+            if let Some(first @ &mut "this") = actual.first_mut() {
+                *first = "self";
+            }
+            let expected: &[&str] = &[$(stringify!($param)),*];
             assert_eq!(actual, expected);
         }};
     }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -277,12 +277,12 @@ pub struct BorrowedParams<'a>(pub Option<&'a SelfParam>, pub Vec<&'a Param>);
 
 impl BorrowedParams<'_> {
     /// Returns an [`Iterator`] through the names of the borrowed parameters,
-    /// accepting a `&str` that the `self` param will be called if present.
-    pub fn names<'a>(&'a self, self_name: &'a str) -> impl Iterator<Item = &'a str> {
+    /// accepting an `Ident` that the `self` param will be called if present.
+    pub fn names<'a>(&'a self, self_name: &'a Ident) -> impl Iterator<Item = &'a Ident> {
         self.0
             .iter()
             .map(move |_| self_name)
-            .chain(self.1.iter().map(|param| param.name.as_str()))
+            .chain(self.1.iter().map(|param| &param.name))
     }
 
     /// Returns `true` if a provided param name is included in the borrowed params,
@@ -383,8 +383,8 @@ mod tests {
             );
 
             let borrowed_params = method.borrowed_params();
-            let actual: Vec<&str> = borrowed_params.names("self").collect();
-            let expected: &[&str] = &[$(stringify!($param)),*];
+            let actual: Vec<&Ident> = borrowed_params.names(&Ident::THIS).collect();
+            let expected: &[&Ident] = &[$(&stringify!($param).into()),*];
             assert_eq!(actual, expected);
         }};
     }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -383,9 +383,11 @@ mod tests {
             );
 
             let borrowed_params = method.borrowed_params();
+            // The ident parser in syn doesn't allow `self`, so we use "this" as a placeholder
+            // and then change it.
             let mut actual: Vec<&str> = borrowed_params.names(&Ident::THIS).map(|ident| ident.as_str()).collect();
-            if let Some(first @ &mut "this") = actual.first_mut() {
-                *first = "self";
+            if borrowed_params.0.is_some() {
+                actual[0] = "self";
             }
             let expected: &[&str] = &[$(stringify!($param)),*];
             assert_eq!(actual, expected);

--- a/tool/src/cpp/docs.rs
+++ b/tool/src/cpp/docs.rs
@@ -230,7 +230,7 @@ pub fn gen_method_docs<W: fmt::Write>(
         writeln!(method_indented)?;
     }
     let borrowed_params = method.borrowed_params();
-    let mut names = borrowed_params.names("this");
+    let mut names = borrowed_params.names(&ast::Ident::THIS);
 
     if let Some(first) = names.next() {
         write!(method_indented, "\nLifetimes: ``{}``", first).unwrap();

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -172,6 +172,7 @@ impl Invocation {
 }
 
 /// Base information shared across the different conversion types.
+#[derive(Copy, Clone)]
 pub struct Base<'base> {
     /// Scope of the Diplomat type environment.
     pub in_path: &'base ast::Path,
@@ -313,14 +314,14 @@ impl fmt::Display for InvocationIntoJs<'_> {
                 inner,
                 underlying: Underlying::Invocation(&self.invocation),
                 owned: false,
-                base: &self.base,
+                base: self.base,
             }
             .fmt(f),
             ast::TypeName::Box(inner) => Pointer {
                 inner,
                 underlying: Underlying::Invocation(&self.invocation),
                 owned: true,
-                base: &self.base,
+                base: self.base,
             }
             .fmt(f),
             ast::TypeName::Option(inner) => {
@@ -340,7 +341,7 @@ impl fmt::Display for InvocationIntoJs<'_> {
                             inner,
                             underlying: Underlying::Binding(&option_ptr, None),
                             owned,
-                            base: &self.base,
+                            base: self.base,
                         }
                     )
                 })
@@ -369,7 +370,7 @@ impl fmt::Display for InvocationIntoJs<'_> {
                                     writeln!(f, "const ok_value = {};", UnderlyingIntoJs {
                                         inner: ok.as_ref(),
                                         underlying: Underlying::Binding(&diplomat_receive_buffer, None),
-                                        base: &self.base,
+                                        base: self.base,
                                     })?;
                                     writeln!(f, "wasm.diplomat_free({diplomat_receive_buffer}, {size}, {align});")?;
                                     writeln!(f, "return ok_value;")
@@ -378,7 +379,7 @@ impl fmt::Display for InvocationIntoJs<'_> {
                                     writeln!(f, "const throw_value = {};", UnderlyingIntoJs {
                                         inner: err.as_ref(),
                                         underlying: Underlying::Binding(&diplomat_receive_buffer, None),
-                                        base: &self.base,
+                                        base: self.base,
                                     })?;
                                     writeln!(f, "wasm.diplomat_free({diplomat_receive_buffer}, {size}, {align});")?;
                                     writeln!(f, "throw new diplomatRuntime.FFIError(throw_value);")
@@ -410,7 +411,7 @@ struct Pointer<'base> {
     owned: bool,
 
     /// Base data.
-    base: &'base Base<'base>,
+    base: Base<'base>,
 }
 
 impl fmt::Display for Pointer<'_> {
@@ -467,7 +468,7 @@ pub struct UnderlyingIntoJs<'base> {
     pub underlying: Underlying<'base>,
 
     /// Base data.
-    pub base: &'base Base<'base>,
+    pub base: Base<'base>,
 }
 
 impl fmt::Display for UnderlyingIntoJs<'_> {

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -616,4 +616,34 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_struct_borrowing() {
+        test_file! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Scalar;
+
+                pub struct Point<'x, 'y> {
+                    x: &'x Scalar,
+                    y: &'y Scalar,
+                }
+
+                pub struct PointReflection<'u, 'v> {
+                    point: Point<'u, 'v>,
+                    reflection: Point<'v, 'u>,
+                }
+
+                impl<'u, 'v> PointReflection<'u, 'v> {
+                    pub fn new(u: &'u Opaque, v: &'v Opaque) -> Self {
+                        SuperStruct {
+                            point: Point { u, v },
+                            reflection: Point { v, u },
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@api.mjs.snap
@@ -1,0 +1,52 @@
+---
+source: tool/src/js/conversions.rs
+expression: out_texts.get(out).unwrap()
+---
+import wasm from "./wasm.mjs"
+import * as diplomatRuntime from "./diplomat-runtime.mjs"
+const diplomat_alloc_destroy_registry = new FinalizationRegistry(obj => {
+  wasm.diplomat_free(obj["ptr"], obj["size"], obj["align"]);
+});
+
+export class Point {
+  constructor(underlying, x_edges, y_edges) {
+    this.x = (() => {
+      const out = new Scalar(diplomatRuntime.ptrRead(wasm, underlying));
+      out.__x_edges_lifetime_guard = x_edges;
+      return out;
+    })();
+    this.y = (() => {
+      const out = new Scalar(diplomatRuntime.ptrRead(wasm, underlying + 4));
+      out.__y_edges_lifetime_guard = y_edges;
+      return out;
+    })();
+  }
+}
+
+export class PointReflection {
+  constructor(underlying, u_edges, v_edges) {
+    this.point = new Point(underlying, u_edges, v_edges);
+    this.reflection = new Point(underlying + 8, v_edges, u_edges);
+  }
+
+  static new(u, v) {
+    return (() => {
+      const diplomat_receive_buffer = wasm.diplomat_alloc(16, 4);
+      wasm.PointReflection_new(diplomat_receive_buffer, u.underlying, v.underlying);
+      const out = new PointReflection(diplomat_receive_buffer, [u], [v]);
+      wasm.diplomat_free(diplomat_receive_buffer, 16, 4);
+      return out;
+    })();
+  }
+}
+
+const Scalar_box_destroy_registry = new FinalizationRegistry(underlying => {
+  wasm.Scalar_destroy(underlying);
+});
+
+export class Scalar {
+  constructor(underlying) {
+    this.underlying = underlying;
+  }
+}
+

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@ffi.rst.snap
@@ -1,0 +1,23 @@
+---
+source: tool/src/js/conversions.rs
+expression: out_docs.get(out).unwrap()
+---
+``ffi``
+=======
+
+.. js:class:: Point
+
+    .. js:attribute:: x
+
+    .. js:attribute:: y
+
+.. js:class:: PointReflection
+
+    .. js:attribute:: point
+
+    .. js:attribute:: reflection
+
+    .. js:staticfunction:: new(u, v)
+
+.. js:class:: Scalar
+

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@index.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@index.rst.snap
@@ -1,0 +1,19 @@
+---
+source: tool/src/js/conversions.rs
+expression: out_docs.get(out).unwrap()
+---
+Documentation
+=============
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Modules:
+
+   ffi
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`
+

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@api.mjs.snap
@@ -19,10 +19,10 @@ export class MyOpaqueStruct {
 }
 
 export class MyStruct {
-  constructor(underlying) {
+  constructor(underlying, a_edges) {
     this.a = (() => {
       const out = new MyOpaqueStruct(diplomatRuntime.ptrRead(wasm, underlying));
-      out.__this_lifetime_guard = this;
+      out.__a_edges_lifetime_guard = a_edges;
       return out;
     })();
     this.b = (new Uint8Array(wasm.memory.buffer, underlying + 4, 1))[0];
@@ -32,7 +32,7 @@ export class MyStruct {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(5, 4);
       wasm.MyStruct_new(diplomat_receive_buffer, foo.underlying, bar.underlying);
-      const out = new MyStruct(diplomat_receive_buffer);
+      const out = new MyStruct(diplomat_receive_buffer, [foo, bar]);
       wasm.diplomat_free(diplomat_receive_buffer, 5, 4);
       return out;
     })();

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -101,7 +101,7 @@ pub fn gen_struct<W: fmt::Write>(
                                             &underlying,
                                             NonZeroUsize::new(offset),
                                         ),
-                                        base: &Base {
+                                        base: Base {
                                             in_path,
                                             env,
                                             borrows: &borrows[..],


### PR DESCRIPTION
Fixes #185 .

This PR adds support for non-opaque structs to contain lifetimes, and thus implements a big chunk of what #172 set out to achieve. It does this by treating non-opaque structs transparently by attaching lifetime edges directly to the fields themselves during construction.

Next steps are to support string references and primitive slices in structs, but this should be relatively straight-forward.