### PR TITLE
Fix redundant JS edges + struct borrow bug

### DIFF
--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -20,7 +20,7 @@ pub use types::{
 };
 
 mod lifetimes;
-pub use lifetimes::{Lifetime, LifetimeEnv, NamedLifetime};
+pub use lifetimes::{Lifetime, LifetimeEnv, LifetimeTransitivity, NamedLifetime};
 
 mod paths;
 pub use paths::Path;

--- a/feature_tests/js/api.mjs
+++ b/feature_tests/js/api.mjs
@@ -86,7 +86,7 @@ export class Foo {
   }
 
   get_bar() {
-    return new Bar(wasm.Foo_get_bar(this.underlying), [this, this], true);
+    return new Bar(wasm.Foo_get_bar(this.underlying), [this], true);
   }
 }
 
@@ -162,35 +162,35 @@ export class One {
   }
 
   static cycle(arg_hold, arg_nohold) {
-    return new One(wasm.One_cycle(arg_hold.underlying, arg_nohold.underlying), [arg_hold, arg_hold, arg_hold], true);
+    return new One(wasm.One_cycle(arg_hold.underlying, arg_nohold.underlying), [arg_hold], true);
   }
 
   static many_dependents(arg_a, arg_b, arg_c, arg_d, arg_nohold) {
-    return new One(wasm.One_many_dependents(arg_a.underlying, arg_b.underlying, arg_c.underlying, arg_d.underlying, arg_nohold.underlying), [arg_a, arg_a, arg_b, arg_a, arg_c, arg_a, arg_b, arg_d], true);
+    return new One(wasm.One_many_dependents(arg_a.underlying, arg_b.underlying, arg_c.underlying, arg_d.underlying, arg_nohold.underlying), [arg_a, arg_b, arg_c, arg_d], true);
   }
 
   static return_outlives_param(arg_hold, arg_nohold) {
-    return new One(wasm.One_return_outlives_param(arg_hold.underlying, arg_nohold.underlying), [arg_hold, arg_nohold], true);
+    return new One(wasm.One_return_outlives_param(arg_hold.underlying, arg_nohold.underlying), [arg_hold], true);
   }
 
   static diamond_top(arg_top, arg_left, arg_right, arg_bottom) {
-    return new One(wasm.One_diamond_top(arg_top.underlying, arg_left.underlying, arg_right.underlying, arg_bottom.underlying), [arg_top, arg_left, arg_right, arg_bottom, arg_top, arg_left, arg_top, arg_right, arg_top], true);
+    return new One(wasm.One_diamond_top(arg_top.underlying, arg_left.underlying, arg_right.underlying, arg_bottom.underlying), [arg_bottom, arg_left, arg_right, arg_top], true);
   }
 
   static diamond_left(arg_top, arg_left, arg_right, arg_bottom) {
-    return new One(wasm.One_diamond_left(arg_top.underlying, arg_left.underlying, arg_right.underlying, arg_bottom.underlying), [arg_top, arg_left, arg_right, arg_bottom, arg_top, arg_left], true);
+    return new One(wasm.One_diamond_left(arg_top.underlying, arg_left.underlying, arg_right.underlying, arg_bottom.underlying), [arg_bottom, arg_left], true);
   }
 
   static diamond_right(arg_top, arg_left, arg_right, arg_bottom) {
-    return new One(wasm.One_diamond_right(arg_top.underlying, arg_left.underlying, arg_right.underlying, arg_bottom.underlying), [arg_top, arg_left, arg_right, arg_bottom, arg_top, arg_right], true);
+    return new One(wasm.One_diamond_right(arg_top.underlying, arg_left.underlying, arg_right.underlying, arg_bottom.underlying), [arg_bottom, arg_right], true);
   }
 
   static diamond_bottom(arg_top, arg_left, arg_right, arg_bottom) {
-    return new One(wasm.One_diamond_bottom(arg_top.underlying, arg_left.underlying, arg_right.underlying, arg_bottom.underlying), [arg_top, arg_left, arg_right, arg_bottom], true);
+    return new One(wasm.One_diamond_bottom(arg_top.underlying, arg_left.underlying, arg_right.underlying, arg_bottom.underlying), [arg_bottom], true);
   }
 
   static diamond_and_nested_types(arg_a, arg_b, arg_c, arg_d, arg_nohold) {
-    return new One(wasm.One_diamond_and_nested_types(arg_a.underlying, arg_b.underlying, arg_c.underlying, arg_d.underlying, arg_nohold.underlying), [arg_a, arg_a, arg_b, arg_a, arg_b, arg_c, arg_a, arg_b, arg_c, arg_d], true);
+    return new One(wasm.One_diamond_and_nested_types(arg_a.underlying, arg_b.underlying, arg_c.underlying, arg_d.underlying, arg_nohold.underlying), [arg_a, arg_b, arg_c, arg_d], true);
   }
 }
 

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -23,9 +23,11 @@ pub mod ffi {
     //     }
     // }
 
+    #[derive(Copy, Clone)]
     #[diplomat::opaque]
     pub struct One<'a>(super::One<'a>);
 
+    #[derive(Copy, Clone)]
     #[diplomat::opaque]
     pub struct Two<'a, 'b>(super::Two<'a, 'b>);
 
@@ -78,8 +80,12 @@ pub mod ffi {
             right: &One<'right>,
             bottom: &One<'bottom>,
         ) -> Box<One<'top>> {
-            let _ = (top, left, right, bottom);
-            unimplemented!()
+            Box::new(match 0 {
+                0 => *bottom,
+                1 => *left,
+                2 => *right,
+                _ => *top,
+            })
         }
 
         // Holds: [left, bottom]
@@ -89,8 +95,11 @@ pub mod ffi {
             right: &One<'right>,
             bottom: &One<'bottom>,
         ) -> Box<One<'left>> {
-            let _ = (top, left, right, bottom);
-            unimplemented!()
+            let _ = (top, right);
+            Box::new(match 0 {
+                0 => *bottom,
+                _ => *left,
+            })
         }
 
         // Holds: [right, bottom]
@@ -100,8 +109,11 @@ pub mod ffi {
             right: &One<'right>,
             bottom: &One<'bottom>,
         ) -> Box<One<'right>> {
-            let _ = (top, left, right, bottom);
-            unimplemented!()
+            let _ = (top, left);
+            Box::new(match 0 {
+                0 => *bottom,
+                _ => *right,
+            })
         }
 
         // Holds: [bottom]
@@ -111,8 +123,8 @@ pub mod ffi {
             right: &One<'right>,
             bottom: &One<'bottom>,
         ) -> Box<One<'bottom>> {
-            let _ = (top, left, right, bottom);
-            unimplemented!()
+            let _ = (top, left, right);
+            Box::new(*bottom)
         }
 
         // Holds: [a, b, c, d]
@@ -123,12 +135,21 @@ pub mod ffi {
             d: &'d One<'x>,
             nohold: &One<'x>,
         ) -> Box<One<'a>> {
-            let _ = (a, b, c, d, nohold);
-            unimplemented!()
+            let _ = nohold;
+            Box::new(match 0 {
+                0 => *a,
+                1 => *b,
+                2 => *c,
+                3 => *d,
+                // FIXME(#198): this should be disallowed by our type universe
+                _ => *nohold,
+            })
         }
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct One<'a>(&'a ());
 
+#[derive(Copy, Clone)]
 pub struct Two<'a, 'b>(&'a (), &'b ());

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@api.mjs.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@api.mjs.snap
@@ -47,8 +47,24 @@ export class PointTranspose {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(16, 4);
       wasm.PointTranspose_transpose(diplomat_receive_buffer, field_x_field_point_this.underlying, field_y_field_point_this.underlying, field_x_field_transpose_this.underlying, field_y_field_transpose_this.underlying);
-      const out = new PointTranspose(diplomat_receive_buffer, [field_x_field_point_this, field_y_field_transpose_this], [field_y_field_point_this, field_x_field_transpose_this]);
+      const out = new PointTranspose(diplomat_receive_buffer, [field_y_field_point_this, field_x_field_transpose_this], [field_x_field_point_this, field_y_field_transpose_this]);
       wasm.diplomat_free(diplomat_receive_buffer, 16, 4);
+      return out;
+    })();
+  }
+
+  point() {
+    const field_point_this = this["point"];
+    const field_x_field_point_this = field_point_this["x"];
+    const field_y_field_point_this = field_point_this["y"];
+    const field_transpose_this = this["transpose"];
+    const field_x_field_transpose_this = field_transpose_this["x"];
+    const field_y_field_transpose_this = field_transpose_this["y"];
+    return (() => {
+      const diplomat_receive_buffer = wasm.diplomat_alloc(8, 4);
+      wasm.PointTranspose_point(diplomat_receive_buffer, field_x_field_point_this.underlying, field_y_field_point_this.underlying, field_x_field_transpose_this.underlying, field_y_field_transpose_this.underlying);
+      const out = new Point(diplomat_receive_buffer, [field_x_field_point_this, field_y_field_transpose_this], [field_y_field_point_this, field_x_field_transpose_this]);
+      wasm.diplomat_free(diplomat_receive_buffer, 8, 4);
       return out;
     })();
   }

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@ffi.rst.snap
@@ -23,5 +23,7 @@ expression: out_docs.get(out).unwrap()
 
     .. js:function:: transpose()
 
+    .. js:function:: point()
+
 .. js:class:: Scalar
 

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -241,7 +241,7 @@ fn gen_method<W: fmt::Write>(
     // Rebuild the mapping from lifetimes to `Arguments`, but using the names of
     // lifetimes as declared in the returned struct, if the return type is a struct.
     // Otherwise return `None`.
-    let arguments_that_use_lifetimes =
+    let arguments_that_use_lifetimes: Option<BTreeMap<&ast::NamedLifetime, Vec<Argument>>> =
         if let Some(ast::TypeName::Named(path_type)) = &method.return_type {
             path_type
                 .resolve(in_path, env)
@@ -251,7 +251,8 @@ fn gen_method<W: fmt::Write>(
                     assert_eq!(
                         path_type.lifetimes.len(),
                         lifetime_env.len(),
-                        "doesn't have the same number of lifetimes as declared with"
+                        "{} doesn't have the same number of lifetimes as declared with",
+                        path_type.path
                     );
 
                     path_type


### PR DESCRIPTION
This fixes a bug where we were accidentally overly conservative on which edges we would hold on to, as opposed to just adding edges to objects that we directly rely on.

This also fixes a bug when returning non-opaque structs where if it had lifetimes that didn't match the lifetime names exactly as described when used as a return type, it would panic.