### PR TITLE
Detect implicit lifetime bounds

### DIFF
--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -73,6 +73,14 @@ impl Method {
             syn::ReturnType::Default => None,
         };
 
+        let lifetime_env = LifetimeEnv::from_method_item(
+            m,
+            impl_generics,
+            self_param.as_ref(),
+            &all_params[..],
+            return_ty.as_ref(),
+        );
+
         Method {
             name: Ident::from(method_ident),
             docs: Docs::from_attrs(&m.attrs),
@@ -80,7 +88,7 @@ impl Method {
             self_param,
             params: all_params,
             return_type: return_ty,
-            lifetime_env: LifetimeEnv::from_method_item(m, impl_generics),
+            lifetime_env,
         }
     }
 
@@ -424,7 +432,7 @@ mod tests {
 
         assert_borrowed_params! { [a, b, c, d] =>
             #[diplomat::rust_link(Foo, FnInStruct)]
-            fn many_dependents<'a, 'b: 'a, 'c: 'a, 'd: 'b, 'x, 'y>(a: &'x One<'a>, b: &'b One<'x>, c: &Two<'x, 'c>, d: &'x Two<'d, 'y>, nohold: &'x Two<'x, 'y>) -> Box<Foo<'a>> {
+            fn many_dependents<'a, 'b: 'a, 'c: 'a, 'd: 'b, 'x, 'y>(a: &'x One<'a>, b: &'b One<'a>, c: &Two<'x, 'c>, d: &'x Two<'d, 'y>, nohold: &'x Two<'x, 'y>) -> Box<Foo<'a>> {
                 unimplemented!()
             }
         }

--- a/feature_tests/c/include/One.h
+++ b/feature_tests/c/include/One.h
@@ -30,6 +30,10 @@ One* One_diamond_right(const One* top, const One* left, const One* right, const 
 One* One_diamond_bottom(const One* top, const One* left, const One* right, const One* bottom);
 
 One* One_diamond_and_nested_types(const One* a, const One* b, const One* c, const One* d, const One* nohold);
+
+One* One_implicit_bounds(const One* explicit_hold, const One* implicit_hold, const One* nohold);
+
+One* One_implicit_bounds_deep(const One* explicit, const One* implicit_1, const One* implicit_2, const One* nohold);
 void One_destroy(One* self);
 
 #ifdef __cplusplus

--- a/feature_tests/cpp/docs/lifetimes_ffi.rst
+++ b/feature_tests/cpp/docs/lifetimes_ffi.rst
@@ -51,4 +51,12 @@
 
         Lifetimes: ``a``, ``b``, ``c``, ``d`` must live at least as long as the output.
 
+    .. cpp:function:: static One implicit_bounds(const One& explicit_hold, const One& implicit_hold, const One& nohold)
+
+        Lifetimes: ``explicit_hold``, ``implicit_hold`` must live at least as long as the output.
+
+    .. cpp:function:: static One implicit_bounds_deep(const One& explicit, const One& implicit_1, const One& implicit_2, const One& nohold)
+
+        Lifetimes: ``explicit``, ``implicit_1``, ``implicit_2`` must live at least as long as the output.
+
 .. cpp:class:: Two

--- a/feature_tests/cpp/include/One.h
+++ b/feature_tests/cpp/include/One.h
@@ -30,6 +30,10 @@ One* One_diamond_right(const One* top, const One* left, const One* right, const 
 One* One_diamond_bottom(const One* top, const One* left, const One* right, const One* bottom);
 
 One* One_diamond_and_nested_types(const One* a, const One* b, const One* c, const One* d, const One* nohold);
+
+One* One_implicit_bounds(const One* explicit_hold, const One* implicit_hold, const One* nohold);
+
+One* One_implicit_bounds_deep(const One* explicit, const One* implicit_1, const One* implicit_2, const One* nohold);
 void One_destroy(One* self);
 
 #ifdef __cplusplus

--- a/feature_tests/cpp/include/One.hpp
+++ b/feature_tests/cpp/include/One.hpp
@@ -35,6 +35,8 @@ class One {
   static One diamond_right(const One& top, const One& left, const One& right, const One& bottom);
   static One diamond_bottom(const One& top, const One& left, const One& right, const One& bottom);
   static One diamond_and_nested_types(const One& a, const One& b, const One& c, const One& d, const One& nohold);
+  static One implicit_bounds(const One& explicit_hold, const One& implicit_hold, const One& nohold);
+  static One implicit_bounds_deep(const One& explicit, const One& implicit_1, const One& implicit_2, const One& nohold);
   inline const capi::One* AsFFI() const { return this->inner.get(); }
   inline capi::One* AsFFIMut() { return this->inner.get(); }
   inline One(capi::One* i) : inner(i) {}
@@ -73,5 +75,11 @@ inline One One::diamond_bottom(const One& top, const One& left, const One& right
 }
 inline One One::diamond_and_nested_types(const One& a, const One& b, const One& c, const One& d, const One& nohold) {
   return One(capi::One_diamond_and_nested_types(a.AsFFI(), b.AsFFI(), c.AsFFI(), d.AsFFI(), nohold.AsFFI()));
+}
+inline One One::implicit_bounds(const One& explicit_hold, const One& implicit_hold, const One& nohold) {
+  return One(capi::One_implicit_bounds(explicit_hold.AsFFI(), implicit_hold.AsFFI(), nohold.AsFFI()));
+}
+inline One One::implicit_bounds_deep(const One& explicit, const One& implicit_1, const One& implicit_2, const One& nohold) {
+  return One(capi::One_implicit_bounds_deep(explicit.AsFFI(), implicit_1.AsFFI(), implicit_2.AsFFI(), nohold.AsFFI()));
 }
 #endif

--- a/feature_tests/dotnet/Lib/Generated/One.cs
+++ b/feature_tests/dotnet/Lib/Generated/One.cs
@@ -330,6 +330,72 @@ public partial class One: IDisposable
         }
     }
 
+    /// <returns>
+    /// A <c>One</c> allocated on Rust side.
+    /// </returns>
+    public static One ImplicitBounds(One explicitHold, One implicitHold, One nohold)
+    {
+        unsafe
+        {
+            Raw.One* explicitHoldRaw;
+            explicitHoldRaw = explicitHold.AsFFI();
+            if (explicitHoldRaw == null)
+            {
+                throw new ObjectDisposedException("One");
+            }
+            Raw.One* implicitHoldRaw;
+            implicitHoldRaw = implicitHold.AsFFI();
+            if (implicitHoldRaw == null)
+            {
+                throw new ObjectDisposedException("One");
+            }
+            Raw.One* noholdRaw;
+            noholdRaw = nohold.AsFFI();
+            if (noholdRaw == null)
+            {
+                throw new ObjectDisposedException("One");
+            }
+            Raw.One* retVal = Raw.One.ImplicitBounds(explicitHoldRaw, implicitHoldRaw, noholdRaw);
+            return new One(retVal);
+        }
+    }
+
+    /// <returns>
+    /// A <c>One</c> allocated on Rust side.
+    /// </returns>
+    public static One ImplicitBoundsDeep(One explicit, One implicit1, One implicit2, One nohold)
+    {
+        unsafe
+        {
+            Raw.One* explicitRaw;
+            explicitRaw = explicit.AsFFI();
+            if (explicitRaw == null)
+            {
+                throw new ObjectDisposedException("One");
+            }
+            Raw.One* implicit1Raw;
+            implicit1Raw = implicit1.AsFFI();
+            if (implicit1Raw == null)
+            {
+                throw new ObjectDisposedException("One");
+            }
+            Raw.One* implicit2Raw;
+            implicit2Raw = implicit2.AsFFI();
+            if (implicit2Raw == null)
+            {
+                throw new ObjectDisposedException("One");
+            }
+            Raw.One* noholdRaw;
+            noholdRaw = nohold.AsFFI();
+            if (noholdRaw == null)
+            {
+                throw new ObjectDisposedException("One");
+            }
+            Raw.One* retVal = Raw.One.ImplicitBoundsDeep(explicitRaw, implicit1Raw, implicit2Raw, noholdRaw);
+            return new One(retVal);
+        }
+    }
+
     /// <summary>
     /// Returns the underlying raw handle.
     /// </summary>

--- a/feature_tests/dotnet/Lib/Generated/RawOne.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawOne.cs
@@ -43,6 +43,12 @@ public partial struct One
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "One_diamond_and_nested_types", ExactSpelling = true)]
     public static unsafe extern One* DiamondAndNestedTypes(One* a, One* b, One* c, One* d, One* nohold);
 
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "One_implicit_bounds", ExactSpelling = true)]
+    public static unsafe extern One* ImplicitBounds(One* explicitHold, One* implicitHold, One* nohold);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "One_implicit_bounds_deep", ExactSpelling = true)]
+    public static unsafe extern One* ImplicitBoundsDeep(One* explicit, One* implicit1, One* implicit2, One* nohold);
+
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "One_destroy", ExactSpelling = true)]
     public static unsafe extern void Destroy(One* self);
 }

--- a/feature_tests/js/api/One.mjs
+++ b/feature_tests/js/api/One.mjs
@@ -51,4 +51,12 @@ export default class One {
   static diamond_and_nested_types(arg_a, arg_b, arg_c, arg_d, arg_nohold) {
     return new One(wasm.One_diamond_and_nested_types(arg_a.underlying, arg_b.underlying, arg_c.underlying, arg_d.underlying, arg_nohold.underlying), true, [arg_a, arg_b, arg_c, arg_d]);
   }
+
+  static implicit_bounds(arg_explicit_hold, arg_implicit_hold, arg_nohold) {
+    return new One(wasm.One_implicit_bounds(arg_explicit_hold.underlying, arg_implicit_hold.underlying, arg_nohold.underlying), true, [arg_explicit_hold, arg_implicit_hold]);
+  }
+
+  static implicit_bounds_deep(arg_explicit, arg_implicit_1, arg_implicit_2, arg_nohold) {
+    return new One(wasm.One_implicit_bounds_deep(arg_explicit.underlying, arg_implicit_1.underlying, arg_implicit_2.underlying, arg_nohold.underlying), true, [arg_explicit, arg_implicit_1, arg_implicit_2]);
+  }
 }

--- a/feature_tests/js/docs/lifetimes_ffi.rst
+++ b/feature_tests/js/docs/lifetimes_ffi.rst
@@ -29,4 +29,8 @@
 
     .. js:staticfunction:: diamond_and_nested_types(a, b, c, d, nohold)
 
+    .. js:staticfunction:: implicit_bounds(explicit_hold, implicit_hold, nohold)
+
+    .. js:staticfunction:: implicit_bounds_deep(explicit, implicit_1, implicit_2, nohold)
+
 .. js:class:: Two

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -55,7 +55,7 @@ pub mod ffi {
         // Holds: [a, b, c, d]
         pub fn many_dependents<'a, 'b: 'a, 'c: 'a, 'd: 'b, 'x, 'y>(
             a: &'x One<'a>,
-            b: &'b One<'x>,
+            b: &'b One<'a>,
             c: &Two<'x, 'c>,
             d: &'x Two<'d, 'y>,
             nohold: &'x Two<'x, 'y>,
@@ -129,10 +129,10 @@ pub mod ffi {
 
         // Holds: [a, b, c, d]
         pub fn diamond_and_nested_types<'a, 'b: 'a, 'c: 'b, 'd: 'b + 'c, 'x, 'y>(
-            a: &'x One<'a>,
+            a: &One<'a>,
             b: &'y One<'b>,
             c: &One<'c>,
-            d: &'d One<'x>,
+            d: &One<'d>,
             nohold: &One<'x>,
         ) -> Box<One<'a>> {
             let _ = nohold;
@@ -140,9 +140,36 @@ pub mod ffi {
                 0 => *a,
                 1 => *b,
                 2 => *c,
-                3 => *d,
-                // FIXME(#198): this should be disallowed by our type universe
-                _ => *nohold,
+                _ => *d,
+            })
+        }
+
+        // Holds: [implicit_hold, explicit_hold]
+        #[allow(clippy::extra_unused_lifetimes)]
+        pub fn implicit_bounds<'a, 'b: 'a, 'c: 'b, 'd: 'c, 'x, 'y>(
+            explicit_hold: &'d One<'x>, // implies that 'x: 'd
+            implicit_hold: &One<'x>,
+            nohold: &One<'y>,
+        ) -> Box<One<'a>> {
+            let _ = nohold;
+            Box::new(match 0 {
+                0 => *explicit_hold,
+                _ => *implicit_hold,
+            })
+        }
+
+        // Holds: [a, b, c]
+        pub fn implicit_bounds_deep<'a, 'b, 'c, 'd, 'x>(
+            explicit: &'a One<'b>,
+            implicit_1: &'b One<'c>,
+            implicit_2: &'c One<'d>,
+            nohold: &'x One<'x>,
+        ) -> Box<One<'a>> {
+            let _ = nohold;
+            Box::new(match 0 {
+                0 => *explicit,
+                1 => *implicit_1,
+                _ => *implicit_2,
             })
         }
     }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -446,6 +446,10 @@ mod tests {
                     #[diplomat::opaque]
                     struct Bar<'b, 'a: 'b>(&'b Foo<'a>);
 
+                    struct Baz<'x, 'y> {
+                        foo: &'y Foo<'x>,
+                    }
+
                     impl<'a> Foo<'a> {
                         pub fn new(x: &'a str) -> Box<Foo<'a>> {
                             unimplemented!()
@@ -453,6 +457,10 @@ mod tests {
 
                         pub fn get_bar<'b>(&'b self) -> Box<Bar<'b, 'a>> {
                             unimplemented!()
+                        }
+
+                        pub fn get_baz<'b>(&'b self) -> Baz<'b, 'a> {
+                            Bax { foo: self }
                         }
                     }
                 }

--- a/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
+++ b/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
@@ -1,12 +1,16 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                #[diplomat :: opaque] struct Foo < 'a > (& 'a str) ;\n                                #[diplomat :: opaque] struct Bar < 'b, 'a : 'b >\n                                (& 'b Foo < 'a >) ; impl < 'a > Foo < 'a >\n                                {\n                                    pub fn new(x : & 'a str) -> Box < Foo < 'a >>\n                                    { unimplemented! () } pub fn get_bar < 'b > (& 'b self) ->\n                                    Box < Bar < 'b, 'a >> { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                #[diplomat :: opaque] struct Foo < 'a > (& 'a str) ;\n                                #[diplomat :: opaque] struct Bar < 'b, 'a : 'b >\n                                (& 'b Foo < 'a >) ; struct Baz < 'x, 'y >\n                                { foo : & 'y Foo < 'x >, } impl < 'a > Foo < 'a >\n                                {\n                                    pub fn new(x : & 'a str) -> Box < Foo < 'a >>\n                                    { unimplemented! () } pub fn get_bar < 'b > (& 'b self) ->\n                                    Box < Bar < 'b, 'a >> { unimplemented! () } pub fn get_baz <\n                                    'b > (& 'b self) -> Baz < 'b, 'a > { Bax { foo : self } }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(transparent)]
     struct Foo<'a>(&'a str);
     #[repr(transparent)]
     struct Bar<'b, 'a: 'b>(&'b Foo<'a>);
+    #[repr(C)]
+    struct Baz<'x, 'y> {
+        foo: &'y Foo<'x>,
+    }
     impl<'a> Foo<'a> {
         pub fn new(x: &'a str) -> Box<Foo<'a>> {
             unimplemented!()
@@ -14,9 +18,14 @@ mod ffi {
         pub fn get_bar<'b>(&'b self) -> Box<Bar<'b, 'a>> {
             unimplemented!()
         }
+        pub fn get_baz<'b>(&'b self) -> Baz<'b, 'a> {
+            Bax { foo: self }
+        }
     }
     #[no_mangle]
     extern "C" fn Bar_destroy<'b, 'a: 'b>(this: Box<Bar<'b, 'a>>) {}
+    #[no_mangle]
+    extern "C" fn Baz_destroy<'x: 'y, 'y>(this: Box<Baz<'x, 'y>>) {}
     #[no_mangle]
     extern "C" fn Foo_new<'a>(x_diplomat_data: *const u8, x_diplomat_len: usize) -> Box<Foo<'a>> {
         Foo::new(unsafe {
@@ -27,6 +36,10 @@ mod ffi {
     #[no_mangle]
     extern "C" fn Foo_get_bar<'a: 'b, 'b>(this: &'b Foo<'a>) -> Box<Bar<'b, 'a>> {
         this.get_bar()
+    }
+    #[no_mangle]
+    extern "C" fn Foo_get_baz<'a: 'b, 'b>(this: &'b Foo<'a>) -> Baz<'b, 'a> {
+        this.get_baz()
     }
     #[no_mangle]
     extern "C" fn Foo_destroy<'a>(this: Box<Foo<'a>>) {}

--- a/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
+++ b/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
@@ -25,7 +25,7 @@ mod ffi {
         })
     }
     #[no_mangle]
-    extern "C" fn Foo_get_bar<'a, 'b>(this: &'b Foo<'a>) -> Box<Bar<'b, 'a>> {
+    extern "C" fn Foo_get_bar<'a: 'b, 'b>(this: &'b Foo<'a>) -> Box<Bar<'b, 'a>> {
         this.get_bar()
     }
     #[no_mangle]


### PR DESCRIPTION
Fixes #198.

I was going to add a validity check, but realized the check was basically the same code required to just add the bound, so we now support implicit bounds on functions and structs (mostly).

Something I realized that's not strictly related to implicit bounds is that if you have a struct with a field of type `Foo<'a, 'b>` (non-opaque), you know nothing about what `Foo` thinks the relationship between `'a` and `'b` is. For example, `Foo` could have `'b: 'a`. Normally, we'd just resolve the `Foo` path in our `Env` and ask it, but we're creating the `Env` so it doesn't exist yet. Here's what we're facing so far:
```rust
pub struct MyStruct<'a, 'b> {
    foo: Foo<'a, 'b>, // secretly implies `'b: 'a`
}

pub struct Foo<'a, 'b: 'a> {
    // some fields...
}
```
Right now, `Foo` obviously knows that `'b: 'a`, but `MyStruct` doesn't. I _think_ this is okay, because even if `MyStruct` doesn't have all the information, any time you have `Foo` or one of its fields that rely on `'b: 'a` as an input/output on a method of `MyStruct`, the bounds (either implicit or explicit) would be detected by the method signature, allowing us to attach edges in JS and generate a doc comment in c++.

If this isn't the case, I have three alternate ideas:
1. Disallow structs and opaques with more than 1 lifetime so bounds in nested structs become impossible. This would be really easy, but not allow for full flexibility with multiple lifetimes. This means we can only have references to opaques with lifetimes in method inputs and outputs, but not as fields of structs (unless the lifetime of the borrow was the same as that of the struct).
2. Do some fancy stuff where we create the env, and then go back and actually do lookups on types and fancy graph traversal stuff to collect all the nested bounds.
3. Revert all my changes and require explicit bounds everywhere, enforced by validity checks. This would suck for end users but allow you to do crazy lifetime hacks.