### PR TITLE
Add `diplomat.config.js`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,13 @@ jobs:
       with:
         node-version: 14.17.0
     - name: Build feature tests
-      run: cd feature_tests && cargo build --target wasm32-unknown-unknown && cp ../target/wasm32-unknown-unknown/debug/diplomat_feature_tests.wasm ./js/api/diplomat-lib.wasm
+      run: cd feature_tests && cargo build --target wasm32-unknown-unknown && cp ../target/wasm32-unknown-unknown/debug/diplomat_feature_tests.wasm ./js/api
     - name: install node deps for feature_tests
       run: cd feature_tests/js && npm install
     - name: test feature_tests
       run: cd feature_tests/js && npm run test
     - name: Build examples
-      run: cd example && cargo build --target wasm32-unknown-unknown && cp ../target/wasm32-unknown-unknown/debug/diplomat_example.wasm ./js/lib/api/diplomat-lib.wasm
+      run: cd example && cargo build --target wasm32-unknown-unknown && cp ../target/wasm32-unknown-unknown/debug/diplomat_example.wasm ./js/lib/api
     - name: install node deps for example lib
       run: cd example/js/lib && npm install
     - name: test example lib

--- a/docs/npm_packaging.md
+++ b/docs/npm_packaging.md
@@ -87,7 +87,7 @@ Then, add your `tsconfig.json` with the following configuration to transpile you
 ```
 
 Lastly, create a `diplomat.config.js` file. There are currently two settings:
-1. `wasm_path`: URL path to the compiled `.wasm` binary relative to the generated bindings in `api/`. The reason a URL is required is so that if consumers choose to use Webpack, it can detect that the `wasm` file needs to be stored. It's recommended to put the binary in `my-bindings/lib/api/` for releases.
+1. `wasm_path`: URL path to the compiled `.wasm` binary. The reason a URL is required is so that if consumers choose to use Webpack, it can detect that the `wasm` file needs to be cached. It's recommended to put the binary in `my-bindings/lib/api/` for releases.
 2. `init` (optional): A function that takes a `wasm` object and gets run during initialization. This is particularly useful when initializing a global, such as a logger. When omitted, no additional initialization is run.
 
 An example config file for `my-bindings` could look like this:

--- a/docs/npm_packaging.md
+++ b/docs/npm_packaging.md
@@ -86,6 +86,19 @@ Then, add your `tsconfig.json` with the following configuration to transpile you
 }
 ```
 
+Lastly, create a `diplomat.config.js` file. There are currently two settings:
+1. `wasm_path`: URL path to the compiled `.wasm` binary relative to the generated bindings in `api/`. The reason a URL is required is so that if consumers choose to use Webpack, it can detect that the `wasm` file needs to be stored. It's recommended to put the binary in `my-bindings/lib/api/` for releases.
+2. `init` (optional): A function that takes a `wasm` object and gets run during initialization. This is particularly useful when initializing a global, such as a logger. When omitted, no additional initialization is run.
+
+An example config file for `my-bindings` could look like this:
+```js
+// my-bindings/lib/diplomat.config.js
+export default {
+    wasm_path: new URL('./api/my_bindings.wasm', import.meta.url),
+};
+```
+
+
 ## Step 3. Generate bindings and compile WebAssembly
 
 Since Diplomat provides JavaScript bindings to make the developer-facing API idiomatic in JS/TS, it requires a binding generation step in addition to the WASM compilation step.
@@ -104,14 +117,15 @@ diplomat-tool js lib/api --docs lib/docs
 To compile your bindings into a `.wasm` file, run:
 ```sh
 # my-bindings/
-cargo build --target wasm32-unknown-unknown --target-dir target
+cargo build --target wasm32-unknown-unknown
 ```
 
-Finally, copy the generated `wasm` binary into `my-bindings/lib/api/`:
-> ⚠️ Note that it must be renamed to `diplomat-lib.wasm` ⚠️
+Make sure that the generated `wasm` binary is in the location and has the name that `diplomat.config.js` expects it to be.
+
+For example, the above configuration expects it to be in `my-bindings/lib/api`, so we have to copy it over:
 ```sh
 # my-bindings/
-cp target/wasm32-unknown-unknown/debug/my_lib.wasm lib/api/diplomat-lib.wasm
+cp target/wasm32-unknown-unknown/debug/my_bindings.wasm lib/api
 ```
 
 ## Step 4. Publish to NPM

--- a/example/js/lib/api/diplomat-wasm.mjs
+++ b/example/js/lib/api/diplomat-wasm.mjs
@@ -1,3 +1,5 @@
+import cfg from '../diplomat.config.js';
+
 let wasm;
 
 function readString(ptr) {
@@ -21,17 +23,19 @@ const imports = {
   }
 }
 
-const url = new URL('./diplomat-lib.wasm', import.meta.url);
 if (typeof fetch === 'undefined') { // Node
   const fs = await import("fs");
-  const wasmFile = new Uint8Array(fs.readFileSync(url));
+  const wasmFile = new Uint8Array(fs.readFileSync(cfg['wasm_path']));
   const loadedWasm = await WebAssembly.instantiate(wasmFile, imports);
   wasm = loadedWasm.instance.exports;
 } else { // Browser
-  const loadedWasm = await WebAssembly.instantiateStreaming(fetch(url), imports);
+  const loadedWasm = await WebAssembly.instantiateStreaming(fetch(cfg['wasm_path']), imports);
   wasm = loadedWasm.instance.exports;
 }
 
 wasm.diplomat_init();
+if (cfg['init'] !== undefined) {
+  cfg['init'](wasm);
+}
 
 export default wasm;

--- a/example/js/lib/diplomat.config.js
+++ b/example/js/lib/diplomat.config.js
@@ -1,0 +1,3 @@
+export default {
+    wasm_path: new URL('./api/diplomat_example.wasm', import.meta.url),
+};

--- a/example/js/lib/make_sphinx_happy.js
+++ b/example/js/lib/make_sphinx_happy.js
@@ -1,1 +1,0 @@
-// need a non-mjs file for Sphinx jsdoc integration to work

--- a/feature_tests/js/api/diplomat-wasm.mjs
+++ b/feature_tests/js/api/diplomat-wasm.mjs
@@ -1,3 +1,5 @@
+import cfg from '../diplomat.config.js';
+
 let wasm;
 
 function readString(ptr) {
@@ -21,17 +23,19 @@ const imports = {
   }
 }
 
-const url = new URL('./diplomat-lib.wasm', import.meta.url);
 if (typeof fetch === 'undefined') { // Node
   const fs = await import("fs");
-  const wasmFile = new Uint8Array(fs.readFileSync(url));
+  const wasmFile = new Uint8Array(fs.readFileSync(cfg['wasm_path']));
   const loadedWasm = await WebAssembly.instantiate(wasmFile, imports);
   wasm = loadedWasm.instance.exports;
 } else { // Browser
-  const loadedWasm = await WebAssembly.instantiateStreaming(fetch(url), imports);
+  const loadedWasm = await WebAssembly.instantiateStreaming(fetch(cfg['wasm_path']), imports);
   wasm = loadedWasm.instance.exports;
 }
 
 wasm.diplomat_init();
+if (cfg['init'] !== undefined) {
+  cfg['init'](wasm);
+}
 
 export default wasm;

--- a/feature_tests/js/diplomat.config.js
+++ b/feature_tests/js/diplomat.config.js
@@ -1,3 +1,3 @@
 export default {
-    wasm_path: new URL('./diplomat_feature_tests.wasm', import.meta.url),
+    wasm_path: new URL('./api/diplomat_feature_tests.wasm', import.meta.url),
 };

--- a/feature_tests/js/diplomat.config.js
+++ b/feature_tests/js/diplomat.config.js
@@ -1,0 +1,3 @@
+export default {
+    wasm_path: new URL('./diplomat_feature_tests.wasm', import.meta.url),
+};

--- a/feature_tests/js/make_sphinx_happy.js
+++ b/feature_tests/js/make_sphinx_happy.js
@@ -1,1 +1,0 @@
-// need a non-mjs file for Sphinx jsdoc integration to work

--- a/tool/src/js/wasm.mjs
+++ b/tool/src/js/wasm.mjs
@@ -1,3 +1,5 @@
+import cfg from '../diplomat.config.js';
+
 let wasm;
 
 function readString(ptr) {
@@ -21,17 +23,19 @@ const imports = {
   }
 }
 
-const url = new URL('./diplomat-lib.wasm', import.meta.url);
 if (typeof fetch === 'undefined') { // Node
   const fs = await import("fs");
-  const wasmFile = new Uint8Array(fs.readFileSync(url));
+  const wasmFile = new Uint8Array(fs.readFileSync(cfg['wasm_path']));
   const loadedWasm = await WebAssembly.instantiate(wasmFile, imports);
   wasm = loadedWasm.instance.exports;
 } else { // Browser
-  const loadedWasm = await WebAssembly.instantiateStreaming(fetch(url), imports);
+  const loadedWasm = await WebAssembly.instantiateStreaming(fetch(cfg['wasm_path']), imports);
   wasm = loadedWasm.instance.exports;
 }
 
 wasm.diplomat_init();
+if (cfg['init'] !== undefined) {
+  cfg['init'](wasm);
+}
 
 export default wasm;


### PR DESCRIPTION
Add support for a `diplomat.config.js`, which allows for library authors to specify the path to their `.wasm` file and an initialization function that will get run right after the `wasm` object is instantiated. I've also updated the documentation in `docs/npm_packaging.md`.

Here's an example:
```js
function init(wasm) {
    wasm.some_logger_init();
}

export default {
    wasm_path: new URL('./api/diplomat_example.wasm', import.meta.url),
    init,
};
```