### PR TITLE
Helper macro for enum conversion

### DIFF
--- a/example/src/decimal.rs
+++ b/example/src/decimal.rs
@@ -25,6 +25,7 @@ pub mod ffi {
     }
 
     // Doc comments for testing TSDoc
+    #[diplomat::enum_convert(GroupingStrategy, needs_wildcard)]
     pub enum ICU4XFixedDecimalGroupingStrategy {
         /// Auto grouping
         Auto,
@@ -36,6 +37,7 @@ pub mod ffi {
         Min2,
     }
 
+    #[diplomat::enum_convert(SignDisplay, needs_wildcard)]
     pub enum ICU4XFixedDecimalSignDisplay {
         Auto,
         Never,
@@ -73,19 +75,8 @@ pub mod ffi {
                 langid,
                 provider,
                 FixedDecimalFormatOptions {
-                    grouping_strategy: match options.grouping_strategy {
-                        ICU4XFixedDecimalGroupingStrategy::Auto => GroupingStrategy::Auto,
-                        ICU4XFixedDecimalGroupingStrategy::Never => GroupingStrategy::Never,
-                        ICU4XFixedDecimalGroupingStrategy::Always => GroupingStrategy::Always,
-                        ICU4XFixedDecimalGroupingStrategy::Min2 => GroupingStrategy::Min2,
-                    },
-                    sign_display: match options.sign_display {
-                        ICU4XFixedDecimalSignDisplay::Auto => SignDisplay::Auto,
-                        ICU4XFixedDecimalSignDisplay::Never => SignDisplay::Never,
-                        ICU4XFixedDecimalSignDisplay::Always => SignDisplay::Always,
-                        ICU4XFixedDecimalSignDisplay::ExceptZero => SignDisplay::ExceptZero,
-                        ICU4XFixedDecimalSignDisplay::Negative => SignDisplay::Negative,
-                    },
+                    grouping_strategy: options.grouping_strategy.into(),
+                    sign_display: options.sign_display.into(),
                 },
             ) {
                 ICU4XFixedDecimalFormatResult {

--- a/macro/src/enum_convert.rs
+++ b/macro/src/enum_convert.rs
@@ -57,7 +57,7 @@ pub fn gen_enum_convert(attr: EnumConvertAttribute, input: ItemEnum) -> proc_mac
 
         let variant_name = &variant.ident;
         from_arms.push(quote!(#other_name::#variant_name => Self::#variant_name));
-        into_arms.push(quote!(Self::#variant_name => #other_name::#variant_name));
+        into_arms.push(quote!(#this_name::#variant_name => Self::#variant_name));
     }
 
     if attr.needs_wildcard {
@@ -75,9 +75,9 @@ pub fn gen_enum_convert(attr: EnumConvertAttribute, input: ItemEnum) -> proc_mac
                 }
             }
         }
-        impl Into<#other_name> for #this_name {
-            fn into(self) -> #other_name {
-                match self {
+        impl From<#this_name> for #other_name {
+            fn from(this: #this_name) -> Self {
+                match this {
                     #(#into_arms,)*
                 }
             }

--- a/macro/src/enum_convert.rs
+++ b/macro/src/enum_convert.rs
@@ -1,0 +1,86 @@
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::*;
+
+// An attribute that is a list of idents
+pub struct EnumConvertAttribute {
+    path: Path,
+
+    needs_wildcard: bool,
+}
+
+impl Parse for EnumConvertAttribute {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let paths: Punctuated<Path, Token![,]> = input.parse_terminated(Path::parse)?;
+        if paths.is_empty() {
+            return Err(input.error("#[diplomat::enum_convert] needs a path argument"));
+        }
+        let needs_wildcard = if paths.len() == 2 {
+            if let Some(ident) = paths[1].get_ident() {
+                if ident == "needs_wildcard" {
+                    true
+                } else {
+                    return Err(input.error(
+                        "#[diplomat::enum_convert] only recognizes needs_wildcard keyword",
+                    ));
+                }
+            } else {
+                return Err(
+                    input.error("#[diplomat::enum_convert] only recognizes needs_wildcard keyword")
+                );
+            }
+        } else if paths.len() > 1 {
+            return Err(input.error("#[diplomat::enum_convert] only supports up to two arguments"));
+        } else {
+            // no needs_wildcard marker
+            false
+        };
+        Ok(EnumConvertAttribute {
+            path: paths[0].clone(),
+            needs_wildcard,
+        })
+    }
+}
+
+pub fn gen_enum_convert(attr: EnumConvertAttribute, input: ItemEnum) -> proc_macro2::TokenStream {
+    let mut from_arms = vec![];
+    let mut into_arms = vec![];
+
+    let this_name = &input.ident;
+    let other_name = &attr.path;
+    for variant in &input.variants {
+        if variant.fields != Fields::Unit {
+            return Error::new(variant.ident.span(), "variant may not have fields")
+                .to_compile_error();
+        }
+
+        let variant_name = &variant.ident;
+        from_arms.push(quote!(#other_name::#variant_name => Self::#variant_name));
+        into_arms.push(quote!(Self::#variant_name => #other_name::#variant_name));
+    }
+
+    if attr.needs_wildcard {
+        let error = format!(
+            "Encountered unknown field for {}",
+            other_name.to_token_stream()
+        );
+        from_arms.push(quote!(_ => unreachable!(#error)))
+    }
+    quote! {
+        impl From<#other_name> for #this_name {
+            fn from(other: #other_name) -> Self {
+                match other {
+                    #(#from_arms,)*
+                }
+            }
+        }
+        impl Into<#other_name> for #this_name {
+            fn into(self) -> #other_name {
+                match self {
+                    #(#into_arms,)*
+                }
+            }
+        }
+    }
+}

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -313,7 +313,7 @@ pub fn bridge(
 /// This is invoked as `#[diplomat::enum_convert(OtherEnumName)]`
 /// on a Diplomat enum. It will assume the other enum has exactly the same variants
 /// and generate From and Into implementations using those. In case that enum is `#[non_exhaustive]`,
-/// you may use `#[diplomat::enum_convert(OtherEnumName, needs_wildcart)]` to generate a panicky wildcard
+/// you may use `#[diplomat::enum_convert(OtherEnumName, needs_wildcard)]` to generate a panicky wildcard
 /// branch. It is up to the library author to ensure the enums are kept in sync. You may use the `#[non_exhaustive_omitted_patterns]`
 /// lint to enforce this.
 #[proc_macro_attribute]


### PR DESCRIPTION
In most cases Diplomat enums are defined as a direct copy of their Rust counterparts. This reduces boilerplate for a very common task.