### PR TITLE
Update `strck_ident` to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,13 +1126,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strck"
-version = "0.1.0"
-source = "git+https://github.com/QnnOkabayashi/strck?rev=a57d391d8f028cca28fb51d1dd8cf49578fb6cd5#a57d391d8f028cca28fb51d1dd8cf49578fb6cd5"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b99bb054f5dcde86a98558e47aeeaa334cedc523728dff80a4c2824a5a54ad"
 
 [[package]]
 name = "strck_ident"
-version = "0.1.0"
-source = "git+https://github.com/QnnOkabayashi/strck?rev=a57d391d8f028cca28fb51d1dd8cf49578fb6cd5#a57d391d8f028cca28fb51d1dd8cf49578fb6cd5"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af2d128f1161e1356e1f9a5cc32e58c62ccbdb79287a2269fc2aaaacf8ff27b"
 dependencies = [
  "strck",
  "unicode-ident",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 displaydoc = { version = "0.2", optional = true }
 rustdoc-types = "0.11"
 smallvec = "1.9.0"
-strck_ident = { git = "https://github.com/QnnOkabayashi/strck", rev = "a57d391d8f028cca28fb51d1dd8cf49578fb6cd5", features = ["rust"] }
+strck_ident = { version = "0.1", features = ["rust"] }
 
 [dev-dependencies]
 insta = "1.7.1"


### PR DESCRIPTION
I released the latest version of `strck_ident` on crates.io and updated the dependencies to now pull from there instead of a specific git commit.