### PR TITLE
Support lifetime elision in HIR

### DIFF
--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1088,7 +1088,7 @@ pub mod elision {
 
         fn finish(self, elision_source: ElisionSource) -> ParamLifetimeLowerer<'ast> {
             ParamLifetimeLowerer {
-                elision_source: ElisionSource::NoBorrows,
+                elision_source,
                 base: self.base,
             }
         }

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -55,8 +55,8 @@ pub struct LifetimeTree<'m> {
 
 /// Non-recursive input-output types that contain lifetimes
 pub enum LifetimeTreeLeaf<'m> {
-    Opaque(ParentId, MethodLifetime<'m>, MethodLifetimes<'m>),
-    Slice(ParentId, MethodLifetime<'m>),
+    Opaque(ParentId, Option<MethodLifetime<'m>>, MethodLifetimes<'m>),
+    Slice(ParentId, Option<MethodLifetime<'m>>),
 }
 
 /// A leaf of a lifetime tree capable of tracking its parents.
@@ -324,12 +324,15 @@ impl<'m> UnpackedField<'m> {
     /// Iterate over the [`MethodLifetime`]s of an unpacked field.
     pub fn lifetimes(&self) -> impl Iterator<Item = MethodLifetime> + '_ {
         let (lifetime, lifetimes) = match self.leaf {
-            LifetimeTreeLeaf::Opaque(_, lifetime, lifetimes) => (lifetime, Some(lifetimes.iter())),
-            LifetimeTreeLeaf::Slice(_, lifetime) => (lifetime, None),
+            LifetimeTreeLeaf::Opaque(_, lifetime, lifetimes) => {
+                (lifetime.as_ref(), Some(lifetimes.iter()))
+            }
+            LifetimeTreeLeaf::Slice(_, lifetime) => (lifetime.as_ref(), None),
         };
 
-        Some(*lifetime)
+        lifetime
             .into_iter()
+            .copied()
             .chain(lifetimes.into_iter().flatten())
     }
 

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -5,6 +5,7 @@ use super::{
     StructPath, TypeContext, TypeLifetime,
 };
 use crate::ast;
+pub use ast::Mutability;
 
 /// Type that can only be used as an output.
 pub enum OutType {
@@ -39,8 +40,6 @@ pub enum Slice {
     /// A primitive slice, e.g. `&mut [u8]`.
     Primitive(Borrow, PrimitiveType),
 }
-
-pub use ast::Mutability;
 
 // For now, the lifetime in not optional. This is because when you have references
 // as fields of structs, the lifetime must always be present, and we want to uphold
@@ -85,13 +84,9 @@ impl Slice {
 }
 
 impl Borrow {
-    pub(super) fn from_ast(
-        parent_lifetimes: &ast::LifetimeEnv,
-        lifetime: &ast::Lifetime,
-        mutability: Mutability,
-    ) -> Self {
-        Borrow {
-            lifetime: TypeLifetime::from_ast(parent_lifetimes, lifetime),
+    pub(super) fn new(lifetime: TypeLifetime, mutability: Mutability) -> Self {
+        Self {
+            lifetime,
             mutability,
         }
     }


### PR DESCRIPTION
This is the third PR towards having a type universe (https://github.com/rust-diplomat/diplomat/issues/204).

# This PR:
* Adds lifetime elision inference in the HIR using the elision rules according to the [Rustonomicon](https://doc.rust-lang.org/nomicon/lifetime-elision.html), which says:
  > Elision rules are as follows:
  > * Each elided lifetime in input position becomes a distinct lifetime parameter.
  > * If there is exactly one input lifetime position (elided or not), that lifetime is assigned to all elided output lifetimes.
  > * If there are multiple input lifetime positions, but one of them is &self or &mut self, the lifetime of self is assigned to all elided output lifetimes.
  > * Otherwise, it is an error to elide an output lifetime.
* Makes progress towards https://github.com/rust-diplomat/diplomat/issues/160

# Remaining work
There are some weird examples where rustc can figure out elision, but we can't. This is caused by the fact that when searching for a lifetime in the input that can be tied to elided lifetimes in the output, rustc doesn't look at the lifetimes in the generics of the `self` type, _and_ it also doesn't look at any parameter that has the type `Self`. We can't figure this out because the AST eagerly substitutes that actual type in for `Self`, so we don't know what was and wasn't `Self` by the time we lower and do elision inferece. This means changes to `ast` are required. Here's an example of where this breaks the elision inference implementation in this PR:
```rust
struct Foo<'x>(&'x str);

impl<'x> Foo<'x> {
    // rustc doesn't see the `'x` in the type of `self` or in `a: Self`,
    // so it thinks the only lifetime is on `b: Foo<'x>`

    // Like rustc, we also skip the `'x` in `self`, but we don't skip the `'x` in `a: Self`,
    // so we think there are multiple lifetimes and that the elision is ambiguous.
    fn bar(self: Foo<'x>, a: Self, b: Foo<'x>) -> &str {
        b.0
    }
}
```

# Questions
I made this comment awhile ago about not needing to detect implicit bounds...

> For JS, I realized this isn't actually that much of an issue because even though `LifetimeEnv` doesn't get that information, it's impossible for `Foo<'b>` to drop before `'a` expires _if we return something with `x`_. This is because opaques also hold onto their owner if borrowed.
> We would still need to add a validity check because the C++ backend is still affected by this.
> _Originally posted by @QnnOkabayashi in https://github.com/rust-diplomat/diplomat/issues/198#issuecomment-1179190150_

... and I think I was right about the JS, but I was wrong about C++ not working since you can just follow the same reasoning as JS. That is, if B borrows A, and C borrows B, the docs will tells C that it can't outlive B, and somewhere else it will say that B can't outlive A. So if the programmer is following those invariants, then it's impossible for that implicit lifetime bound to be broken.