### PR TITLE
Add `TypeName::SelfType`

### DIFF
--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -478,6 +478,9 @@ fn lower_type<L: elision::LifetimeLowerer>(
             errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
             Err(())
         }
+        ast::TypeName::SelfType(path) => {
+            todo!("Finalize lifetime elision")
+        }
     }
 }
 
@@ -647,6 +650,9 @@ fn lower_out_type<L: elision::LifetimeLowerer>(
         ast::TypeName::Unit => {
             errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
             Err(())
+        }
+        ast::TypeName::SelfType(path) => {
+            todo!("Finalize lifetime elision")
         }
     }
 }

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -252,7 +252,7 @@ pub fn gen_includes<W: fmt::Write>(
     out: &mut W,
 ) -> fmt::Result {
     match typ {
-        ast::TypeName::Named(path_type) => {
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
             let custom_typ = path_type.resolve(in_path, env);
             match (custom_typ, behind_ref) {
                 (ast::CustomType::Opaque(_) | ast::CustomType::Struct(_), true) => {

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -16,7 +16,7 @@ pub fn gen_rust_to_cpp<W: Write>(
 ) -> String {
     match typ {
         ast::TypeName::Box(underlying) => match underlying.as_ref() {
-            ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
+            ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => match path_type.resolve(in_path, env) {
                 ast::CustomType::Opaque(opaque) => {
                     format!("{}({})", opaque.name, cpp)
                 }
@@ -255,7 +255,7 @@ pub fn gen_cpp_to_rust<W: Write>(
             is_self,
             out,
         ),
-        ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => match path_type.resolve(in_path, env) {
             ast::CustomType::Opaque(_opaque) => {
                 if let Some(reference) = behind_ref {
                     if is_self {

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -16,21 +16,23 @@ pub fn gen_rust_to_cpp<W: Write>(
 ) -> String {
     match typ {
         ast::TypeName::Box(underlying) => match underlying.as_ref() {
-            ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => match path_type.resolve(in_path, env) {
-                ast::CustomType::Opaque(opaque) => {
-                    format!("{}({})", opaque.name, cpp)
-                }
+            ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+                match path_type.resolve(in_path, env) {
+                    ast::CustomType::Opaque(opaque) => {
+                        format!("{}({})", opaque.name, cpp)
+                    }
 
-                ast::CustomType::Struct(_strct) => {
-                    // TODO(#59): should emit a unique_ptr
-                    todo!("Receiving boxes of structs is not yet supported")
-                }
+                    ast::CustomType::Struct(_strct) => {
+                        // TODO(#59): should emit a unique_ptr
+                        todo!("Receiving boxes of structs is not yet supported")
+                    }
 
-                ast::CustomType::Enum(_) => {
-                    // TODO(#59): should emit a unique_ptr
-                    todo!("Receiving boxes of enums is not yet supported")
+                    ast::CustomType::Enum(_) => {
+                        // TODO(#59): should emit a unique_ptr
+                        todo!("Receiving boxes of enums is not yet supported")
+                    }
                 }
-            },
+            }
             _o => todo!(),
         },
         ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
@@ -255,59 +257,61 @@ pub fn gen_cpp_to_rust<W: Write>(
             is_self,
             out,
         ),
-        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => match path_type.resolve(in_path, env) {
-            ast::CustomType::Opaque(_opaque) => {
-                if let Some(reference) = behind_ref {
-                    if is_self {
-                        format!("{}->inner.get()", cpp)
-                    } else if reference.mutable {
-                        format!("{}.AsFFIMut()", cpp)
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+            match path_type.resolve(in_path, env) {
+                ast::CustomType::Opaque(_opaque) => {
+                    if let Some(reference) = behind_ref {
+                        if is_self {
+                            format!("{}->inner.get()", cpp)
+                        } else if reference.mutable {
+                            format!("{}.AsFFIMut()", cpp)
+                        } else {
+                            format!("{}.AsFFI()", cpp)
+                        }
                     } else {
-                        format!("{}.AsFFI()", cpp)
+                        panic!("Cannot handle opaque types by value");
                     }
-                } else {
-                    panic!("Cannot handle opaque types by value");
                 }
-            }
 
-            ast::CustomType::Struct(strct) => {
-                if let Some(reference) = behind_ref {
-                    if reference.owned {
-                        format!("(capi::{}*) {}", strct.name, cpp)
+                ast::CustomType::Struct(strct) => {
+                    if let Some(reference) = behind_ref {
+                        if reference.owned {
+                            format!("(capi::{}*) {}", strct.name, cpp)
+                        } else {
+                            format!("(capi::{}*) &{}", strct.name, cpp)
+                        }
                     } else {
-                        format!("(capi::{}*) &{}", strct.name, cpp)
-                    }
-                } else {
-                    let wrapped_struct_id = format!("diplomat_wrapped_struct_{}", path);
-                    writeln!(out, "{} {} = {};", strct.name, wrapped_struct_id, cpp).unwrap();
-                    let mut all_fields_wrapped = vec![];
-                    for (name, typ, _) in &strct.fields {
-                        all_fields_wrapped.push(format!(
-                            ".{} = {}",
-                            name,
-                            gen_cpp_to_rust(
-                                &format!("{}.{}", wrapped_struct_id, name),
-                                &format!("{}_{}", path, name),
-                                None,
-                                typ,
-                                in_path,
-                                env,
-                                false,
-                                out
-                            )
-                        ));
-                    }
+                        let wrapped_struct_id = format!("diplomat_wrapped_struct_{}", path);
+                        writeln!(out, "{} {} = {};", strct.name, wrapped_struct_id, cpp).unwrap();
+                        let mut all_fields_wrapped = vec![];
+                        for (name, typ, _) in &strct.fields {
+                            all_fields_wrapped.push(format!(
+                                ".{} = {}",
+                                name,
+                                gen_cpp_to_rust(
+                                    &format!("{}.{}", wrapped_struct_id, name),
+                                    &format!("{}_{}", path, name),
+                                    None,
+                                    typ,
+                                    in_path,
+                                    env,
+                                    false,
+                                    out
+                                )
+                            ));
+                        }
 
-                    format!(
-                        "capi::{}{{ {} }}",
-                        strct.name,
-                        all_fields_wrapped.join(", ")
-                    )
+                        format!(
+                            "capi::{}{{ {} }}",
+                            strct.name,
+                            all_fields_wrapped.join(", ")
+                        )
+                    }
                 }
-            }
 
-            ast::CustomType::Enum(enm) => format!("static_cast<capi::{}>({})", enm.name, cpp),
-        },
+                ast::CustomType::Enum(enm) => format!("static_cast<capi::{}>({})", enm.name, cpp),
+            }
+        }
         ast::TypeName::Writeable => {
             if behind_ref
                 == Some(ReferenceMeta {

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -232,7 +232,7 @@ fn gen_includes<W: fmt::Write>(
     out: &mut W,
 ) -> fmt::Result {
     match typ {
-        ast::TypeName::Named(path_type) => {
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
             let custom_typ = path_type.resolve(in_path, env);
             match custom_typ {
                 ast::CustomType::Opaque(_) => {

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -40,29 +40,31 @@ fn gen_type_inner<W: fmt::Write>(
 ) -> fmt::Result {
     let mut handled_ref = false;
     match typ {
-        ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
-            ast::CustomType::Opaque(opaque) => {
-                if let Some(owned) = behind_ref {
-                    if owned {
-                        write!(out, "{}", opaque.name)?;
-                    } else {
-                        write!(out, "{}&", opaque.name)?;
-                    }
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+            match path_type.resolve(in_path, env) {
+                ast::CustomType::Opaque(opaque) => {
+                    if let Some(owned) = behind_ref {
+                        if owned {
+                            write!(out, "{}", opaque.name)?;
+                        } else {
+                            write!(out, "{}&", opaque.name)?;
+                        }
 
-                    handled_ref = true;
-                } else {
-                    panic!("Cannot pass opaque structs as values");
+                        handled_ref = true;
+                    } else {
+                        panic!("Cannot pass opaque structs as values");
+                    }
+                }
+
+                ast::CustomType::Struct(strct) => {
+                    write!(out, "{}", strct.name)?;
+                }
+
+                ast::CustomType::Enum(enm) => {
+                    write!(out, "{}", enm.name)?;
                 }
             }
-
-            ast::CustomType::Struct(strct) => {
-                write!(out, "{}", strct.name)?;
-            }
-
-            ast::CustomType::Enum(enm) => {
-                write!(out, "{}", enm.name)?;
-            }
-        },
+        }
 
         ast::TypeName::Box(underlying) => {
             gen_type_inner(

--- a/tool/src/dotnet/conversions.rs
+++ b/tool/src/dotnet/conversions.rs
@@ -69,14 +69,16 @@ pub fn to_idiomatic_object<W: fmt::Write>(
         _ => {
             let name = gen_type_name_to_string(typ, in_path, env)?;
             match typ {
-                ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type)=> match path_type.resolve(in_path, env) {
-                    ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
-                        write!(out, "new {name}({input_var_name})")
+                ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+                    match path_type.resolve(in_path, env) {
+                        ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
+                            write!(out, "new {name}({input_var_name})")
+                        }
+                        ast::CustomType::Enum(_) => {
+                            write!(out, "({name}){input_var_name}")
+                        }
                     }
-                    ast::CustomType::Enum(_) => {
-                        write!(out, "({name}){input_var_name}")
-                    }
-                },
+                }
                 other => panic!("expected named type name, found `{}`", other),
             }
         }
@@ -109,14 +111,16 @@ pub fn to_raw_object<W: fmt::Write>(
         _ => {
             let name = gen_type_name_to_string(typ, in_path, env)?;
             match typ {
-                ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type)=> match path_type.resolve(in_path, env) {
-                    ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
-                        write!(out, "{input_var_name}.AsFFI()")
+                ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+                    match path_type.resolve(in_path, env) {
+                        ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
+                            write!(out, "{input_var_name}.AsFFI()")
+                        }
+                        ast::CustomType::Enum(_) => {
+                            write!(out, "(Raw.{name}){input_var_name}")
+                        }
                     }
-                    ast::CustomType::Enum(_) => {
-                        write!(out, "(Raw.{name}){input_var_name}")
-                    }
-                },
+                }
                 other => panic!("expected named type name, found `{}`", other),
             }
         }

--- a/tool/src/dotnet/conversions.rs
+++ b/tool/src/dotnet/conversions.rs
@@ -69,7 +69,7 @@ pub fn to_idiomatic_object<W: fmt::Write>(
         _ => {
             let name = gen_type_name_to_string(typ, in_path, env)?;
             match typ {
-                ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
+                ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type)=> match path_type.resolve(in_path, env) {
                     ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
                         write!(out, "new {name}({input_var_name})")
                     }
@@ -109,7 +109,7 @@ pub fn to_raw_object<W: fmt::Write>(
         _ => {
             let name = gen_type_name_to_string(typ, in_path, env)?;
             match typ {
-                ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
+                ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type)=> match path_type.resolve(in_path, env) {
                     ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
                         write!(out, "{input_var_name}.AsFFI()")
                     }

--- a/tool/src/dotnet/idiomatic.rs
+++ b/tool/src/dotnet/idiomatic.rs
@@ -201,17 +201,19 @@ fn gen_property_for_field(
 ) -> fmt::Result {
     match typ {
         ast::TypeName::Primitive(_) => {}
-        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => match path_type.resolve(in_path, env) {
-            ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
-                println!(
-                    "{} ({name})",
-                    "[WARNING] C# properties for non primitive types are not supported yet"
-                        .yellow(),
-                );
-                return Ok(());
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+            match path_type.resolve(in_path, env) {
+                ast::CustomType::Struct(_) | ast::CustomType::Opaque(_) => {
+                    println!(
+                        "{} ({name})",
+                        "[WARNING] C# properties for non primitive types are not supported yet"
+                            .yellow(),
+                    );
+                    return Ok(());
+                }
+                ast::CustomType::Enum(_) => {}
             }
-            ast::CustomType::Enum(_) => {}
-        },
+        }
         _ => {
             println!(
                 "{} ({name})",
@@ -711,16 +713,18 @@ fn gen_raw_conversion_type_name_decl_position(
     out: &mut dyn fmt::Write,
 ) -> fmt::Result {
     match typ {
-        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => match path_type.resolve(in_path, env) {
-            ast::CustomType::Opaque(_) => {
-                write!(out, "Raw.")?;
-                gen_type_name(typ, in_path, env, out)?;
-                write!(out, "*")
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+            match path_type.resolve(in_path, env) {
+                ast::CustomType::Opaque(_) => {
+                    write!(out, "Raw.")?;
+                    gen_type_name(typ, in_path, env, out)?;
+                    write!(out, "*")
+                }
+                ast::CustomType::Enum(_) | ast::CustomType::Struct(_) => {
+                    gen_raw_type_name_decl_position(typ, in_path, env, out)
+                }
             }
-            ast::CustomType::Enum(_) | ast::CustomType::Struct(_) => {
-                gen_raw_type_name_decl_position(typ, in_path, env, out)
-            }
-        },
+        }
         _ => gen_raw_type_name_decl_position(typ, in_path, env, out),
     }
 }
@@ -782,10 +786,12 @@ fn requires_null_check(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> b
         }
         ast::TypeName::Option(opt) => requires_null_check(opt.as_ref(), in_path, env),
         _ => match typ {
-            ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => match path_type.resolve(in_path, env) {
-                ast::CustomType::Opaque(_) => true,
-                ast::CustomType::Struct(_) | ast::CustomType::Enum(_) => false,
-            },
+            ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+                match path_type.resolve(in_path, env) {
+                    ast::CustomType::Opaque(_) => true,
+                    ast::CustomType::Struct(_) | ast::CustomType::Enum(_) => false,
+                }
+            }
             other => panic!("expected named type name, found `{}`", other),
         },
     }

--- a/tool/src/dotnet/types.rs
+++ b/tool/src/dotnet/types.rs
@@ -20,7 +20,7 @@ pub fn gen_type_name(
     out: &mut dyn fmt::Write,
 ) -> fmt::Result {
     match typ {
-        ast::TypeName::Named(path_type) => {
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
             write!(out, "{}", path_type.resolve(in_path, env).name())
         }
 
@@ -87,7 +87,9 @@ pub fn type_name_for_prim(prim: &ast::PrimitiveType) -> &str {
 /// Generates a struct name that uniquely identifies the given type.
 pub fn name_for_type(typ: &ast::TypeName) -> ast::Ident {
     match typ {
-        ast::TypeName::Named(name) => name.path.elements.last().unwrap().clone(),
+        ast::TypeName::Named(name) | ast::TypeName::SelfType(name) => {
+            name.path.elements.last().unwrap().clone()
+        }
         ast::TypeName::Box(underlying) => {
             ast::Ident::from(format!("Box{}", name_for_type(underlying)))
         }

--- a/tool/src/dotnet/util.rs
+++ b/tool/src/dotnet/util.rs
@@ -61,6 +61,7 @@ pub fn collect_results<'ast>(
         | ast::TypeName::StrReference(..)
         | ast::TypeName::PrimitiveSlice(..)
         | ast::TypeName::Named(_)
+        | ast::TypeName::SelfType(_)
         | ast::TypeName::Primitive(_) => {}
     }
 }
@@ -102,7 +103,7 @@ fn collect_errors_impl<'ast>(
         ast::TypeName::Option(underlying) => {
             collect_errors_impl(underlying, in_path, env, errors, is_err_variant);
         }
-        ast::TypeName::Named(path_type) => {
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
             if is_err_variant {
                 let (custom_ty_path, _) = path_type.resolve_with_path(in_path, env);
                 let key = (custom_ty_path, typ);

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -212,7 +212,7 @@ impl<'env> Imports<'env> {
         state: TypePosition,
     ) {
         match typ {
-            ast::TypeName::Named(path_type) => {
+            ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
                 let custom = path_type.resolve(in_path, env);
                 // JS wants: return type, fields, _all_ enums.
                 // TS wants: return type, fields, params.

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -255,7 +255,9 @@ fn gen_method<W: fmt::Write>(
     // lifetimes as declared in the returned struct, if the return type is a struct.
     // Otherwise return `None`.
     let arguments_that_use_lifetimes: Option<BTreeMap<&ast::NamedLifetime, Vec<Argument>>> =
-        if let Some(ast::TypeName::Named(path_type)) = &method.return_type {
+        if let Some(ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type)) =
+            &method.return_type
+        {
             path_type
                 .resolve(in_path, env)
                 .lifetimes()
@@ -479,7 +481,7 @@ pub fn gen_ts_type<W: fmt::Write>(
                 write!(out, "{}", prim)?;
             }
         },
-        ast::TypeName::Named(path_type) => {
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
             let name = path_type.resolve(in_path, env).name();
             out.write_str(name.as_str())?;
         }

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -77,25 +77,27 @@ pub fn type_size_alignment(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) 
             let (_, size_align) = result_ok_offset_size_align(ok, err, in_path, env);
             size_align
         }
-        ast::TypeName::Named(path_type) => match path_type.resolve(in_path, env) {
-            ast::CustomType::Struct(strct) => {
-                let (_, size_max_align) = struct_offsets_size_max_align(
-                    strct.fields.iter().map(|(_, typ, _)| typ),
-                    in_path,
-                    env,
-                );
-                size_max_align
-            }
+        ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+            match path_type.resolve(in_path, env) {
+                ast::CustomType::Struct(strct) => {
+                    let (_, size_max_align) = struct_offsets_size_max_align(
+                        strct.fields.iter().map(|(_, typ, _)| typ),
+                        in_path,
+                        env,
+                    );
+                    size_max_align
+                }
 
-            ast::CustomType::Enum(_) => {
-                // repr(C) fieldless enums use the default platform representation: isize
-                Layout::new::<usize_target>()
-            }
+                ast::CustomType::Enum(_) => {
+                    // repr(C) fieldless enums use the default platform representation: isize
+                    Layout::new::<usize_target>()
+                }
 
-            ast::CustomType::Opaque(_) => {
-                panic!("Size of opaque types is unknown")
+                ast::CustomType::Opaque(_) => {
+                    panic!("Size of opaque types is unknown")
+                }
             }
-        },
+        }
         ast::TypeName::Primitive(p) => primitive_size_alignment(*p),
         // TODO(#58): support non-32-bit platforms
         // Actual:


### PR DESCRIPTION
Make a distinction in the AST about which types are `Self`, instead of eagerly expanding it to the type in the impl block.

This is the first step towards fixing the corner case in https://github.com/rust-diplomat/diplomat/pull/232, which requires knowledge of whether or not a type is specified as `Self` in order to determine elision inference.