### PR TITLE
Support corner case from #232

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -556,6 +556,12 @@ impl TypeName {
         }
     }
 
+    /// Returns `true` if `self` is the `TypeName::SelfType` variant, otherwise
+    /// `false`.
+    pub fn is_self(&self) -> bool {
+        matches!(self, TypeName::SelfType(_))
+    }
+
     /// Recurse down the type tree, visiting all lifetimes.
     ///
     /// Using this function, you can collect all the lifetimes into a collection,

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -1,0 +1,409 @@
+//! This module provides the functionality for lowering lifetimes from the AST
+//! to the HIR, while simultaneously inferencing elided lifetimes.
+//!
+//! Full elision rules can be found in the [Nomicon].
+//!
+//! The key factor about lifetime elision is that all elision in the output of
+//! the method (if there is any) corresponds to exactly one lifetime in the method
+//! arguments, which may or may not be elided. Therefore, our task is to find this
+//! potential lifetime first, so that if we encounter an elided lifetime while
+//! lowering the output, we know which lifetime it corresponds to.
+//!
+//! # Unspoken Rules of Elision.
+//!
+//! Broadly speaking, the Nomicon defines the elision rules are such:
+//! 1. If there's a `&self` or `&mut self`, the lifetime of that borrow
+//! corresponds to elision in the output.
+//! 2. Otherwise, if there's exactly one lifetime in the input, then that lifetime
+//! corresponds to elision in the output.
+//! 3. If neither of these cases hold, then the output cannot contain elision.
+//!
+//! What the Nomicon doesn't tell you is that there are weird corner cases around
+//! using the `Self` type. Specifically, lifetimes in the `Self` type and in the
+//! type of the `self` argument (optional) aren't considered when figuring out
+//! which lifetime should correspond to elision in the output.
+//!
+//! Check out the following code:
+//! ```compile_fail
+//! struct Foo<'a>(&'a str);
+//!
+//! impl<'a> Foo<'a> {
+//!     fn get(self) -> &str { self.0 }
+//! }
+//! ```
+//! This code will fail to compile because it doesn't look at the `'a` in the
+//! `Foo<'a>`, which is what the type of `self` expands to. Therefore, it will
+//! conclude that there's nothing for the output to borrow from.
+//! This can be fixed by returning `&'a str` though. Many of the design
+//! decisions in this module were made to be able to replicate this behavior.
+//!
+//! You may be asking "why would we care about rejecting code that rustc rejects
+//! before it reaches us?" And the answer is this:
+//! ```rust
+//! # struct Foo<'a>(&'a str);
+//! impl<'a> Foo<'a> {
+//!     fn get(self, s: &str) -> &str { s }
+//! }
+//! ```
+//! This code is accepted by rustc, since it only considers the lifetime of `s`
+//! when searching for a lifetime that corresponds to output elision. If we were
+//! to naively look at all the lifetimes, we would see the lifetime in the `self`
+//! argument and the lifetime of `s`, making us reject this method. Therefore, we
+//! have to be extremely careful when traversing lifetimes, and make sure that
+//! lifetimes of `Self` are lowered but _not_ considered for elision, while other
+//! lifetimes are lowered while also being considered for elision.
+//!
+//! # Lowering and Inference
+//!
+//! Lowering and elision inference is broken into three distinct stages:
+//! 1. Lowering the borrow in `&self` or `&mut self`, if there is one.
+//! 2. Lowering lifetimes of other params.
+//! 3. Lowering lifetimes of the output.
+//!
+//! Although each stage fundementally lowers lifetimes, they behave differently
+//! when lowering elided lifetimes. Naturally, this module represents each stage
+//! as a state in a state machine.
+//!
+//! The first state is represented by the [`SelfParamLifetimeLowerer`] type.
+//! Since there is either zero or one occurrences of `&self` or `&mut self`, it
+//! exposes the `.no_self_ref()` and `.lower_self_ref(lt)` methods respectively,
+//! which consume the `SelfParamLifetimeLowerer` and return the next state,
+//! [`ParamLifetimeLowerer`], as well as the lowered lifetime. The reason these
+//! are two distinct types is that the lifetime in `&self` and `&mut self` takes
+//! precedence over any other lifetimes in the input, so `.lower_self_ref(lt)`
+//! tells the next state that the candidate lifetime is already found, and to
+//! generate fresh anonymous lifetimes for any elided lifetimes.
+//!
+//! The second state is represented by the [`ParamLifetimeLowerer`] type.
+//! It implements a helper trait, [`LifetimeLowerer`], which abstracts the lowering
+//! of references and generic lifetimes. Internally, it wraps an [`ElisionSource`],
+//! which acts as a state machine for tracking candidate lifetimes to correspond
+//! to elision in the output. When a lifetime that's not in the type of the `self`
+//! argument or in the expanded generics of the `Self` type is visited, this
+//! state machine is potentially updated to another state. If the lifetime is
+//! anonymous, it's added to the internal list of nodes that go into the final
+//! [`LifetimeEnv`] after lowering. Once all the lifetimes in the input are
+//! lowered, the `into_return_ltl()` method is called to transition into the
+//! final state.
+//!
+//! The third and final state is represented by the [`ReturnLifetimeLowerer`] type.
+//! Similar to `ParamLifetimeLowerer`, it also implements the [`LifetimeLowerer`]
+//! helper trait. However, it differs from `ParamLifetimeLowerer` since instead
+//! of potentially updating the internal `ElisionSource` when visiting a lifetime,
+//! it instead reads from it when an elided lifetime occurs. Once all the output
+//! lifetimes are lowered, `.finish()` is called to return the finalized
+//! [`LifetimeEnv`].
+//!
+//! [Nomicon]: https://doc.rust-lang.org/nomicon/lifetime-elision.html
+
+use super::{
+    lower_ident, ExplicitLifetime, ImplicitLifetime, LifetimeEnv, LifetimeNode, LoweringError,
+    TypeLifetime, TypeLifetimes,
+};
+use crate::ast;
+use smallvec::SmallVec;
+
+/// Generator for unique [`ImplicitLifetime`]s.
+pub struct ImplicitLifetimeGenerator {
+    next: u32,
+}
+
+impl ImplicitLifetimeGenerator {
+    /// Returns a new [`ImplicitLifetimeGenerator`].
+    pub fn new() -> Self {
+        Self { next: 1 }
+    }
+
+    /// Returns the next [`ImplicitLifetime`].
+    pub fn gen(&mut self) -> ImplicitLifetime {
+        let label = self.next;
+        self.next += 1;
+        ImplicitLifetime::new(label)
+    }
+}
+
+/// Lower [`ast::Lifetime`]s to [`TypeLifetime`]s.
+///
+/// This helper traits allows the [`lower_type`] and [`lower_out_type`] methods
+/// to abstractly lower lifetimes without concern for what sort of tracking
+/// goes on. In particular, elision inference requires updating internal state
+/// when visiting lifetimes in the input.
+pub trait LifetimeLowerer {
+    /// Lowers an [`ast::Lifetime`].
+    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> TypeLifetime;
+
+    /// Lowers a slice of [`ast::Lifetime`]s by calling
+    /// [`LifetimeLowerer::lower_lifetime`] repeatedly.
+    fn lower_lifetimes(&mut self, lifetimes: &[ast::Lifetime]) -> TypeLifetimes {
+        TypeLifetimes::from_fn(lifetimes, |lifetime| self.lower_lifetime(lifetime))
+    }
+
+    /// Lowers a slice of [`ast::Lifetime`], where the strategy may vary depending
+    /// on whether or not the lifetimes are expanded from the `Self` type.
+    ///
+    /// The distinction between this and [`LifetimeLowerer::lower_lifetimes`] is
+    /// that if `Self` expands to a type with anonymous lifetimes like `Foo<'_>`,
+    /// then multiple instances of `Self` should expand to have the same anonymous
+    /// lifetime, and this lifetime can be cached inside of the `self` argument.
+    /// Additionally, elision inferences knows to not search inside the generics
+    /// of `Self` types for candidate lifetimes to correspond to elided lifetimes
+    /// in the output.
+    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> TypeLifetimes;
+}
+
+/// A state machine for tracking which lifetime in a function's parameters
+/// may correspond to elided lifetimes in the output.
+#[derive(Copy, Clone)]
+enum ElisionSource {
+    /// No borrows in the input, no elision.
+    NoBorrows,
+    /// `&self` or `&mut self`, elision allowed.
+    SelfParam(TypeLifetime),
+    /// One param contains a borrow, elision allowed.
+    OneParam(TypeLifetime),
+    /// Multiple borrows and no self borrow, no elision.
+    MultipleBorrows,
+}
+
+impl ElisionSource {
+    /// Potentially transition to a new state.
+    fn visit_lifetime(&mut self, lifetime: TypeLifetime) {
+        match self {
+            ElisionSource::NoBorrows => *self = ElisionSource::OneParam(lifetime),
+            ElisionSource::SelfParam(_) => {
+                // References to self have the highest precedence, do nothing.
+            }
+            ElisionSource::OneParam(_) => *self = ElisionSource::MultipleBorrows,
+            ElisionSource::MultipleBorrows => {
+                // There's ambiguity. This is valid when there's no elision in
+                // the output.
+            }
+        };
+    }
+}
+
+/// A type for storing shared information between the different states of elision
+/// inference.
+///
+/// This contains data for generating fresh elided lifetimes, looking up named
+/// lifetimes, and caching lifetimes of `Self`.
+struct BaseLifetimeLowerer<'ast> {
+    elided_node_gen: ImplicitLifetimeGenerator,
+    lifetime_env: &'ast ast::LifetimeEnv,
+    self_lifetimes: Option<TypeLifetimes>,
+    nodes: SmallVec<[LifetimeNode; 2]>,
+}
+
+/// The first phase of output elision inference.
+///
+/// In the first phase, the type signature of the `&self` or `&mut self` type
+/// is lowered into its HIR representation, if present. According to elision
+/// rules, this reference has the highest precedence as the lifetime that
+/// goes into elision in the output, and so it's checked first.
+pub struct SelfParamLifetimeLowerer<'ast> {
+    base: BaseLifetimeLowerer<'ast>,
+}
+
+/// The second phase of output elision inference.
+///
+/// In the second phase, all lifetimes in the parameter type signatures
+/// (besides the lifetime of self, if present) are lowered. If a self param
+/// didn't claim the potential output elided lifetime, then if there's a
+/// single lifetime (elided or not) in the inputs, it will claim the
+/// potential output elided lifetime.
+pub struct ParamLifetimeLowerer<'ast> {
+    elision_source: ElisionSource,
+    base: BaseLifetimeLowerer<'ast>,
+}
+
+/// The third and final phase of output elision inference.
+///
+/// In the third phase, the type signature of the output type is lowered into
+/// its HIR representation. If one of the input lifetimes were marked as
+/// responsible for any elision in the output, then anonymous lifetimes get
+/// that lifetime. If none did and there is elision in the output, then
+/// rustc should have errored and said the elision was ambiguous, meaning
+/// that state should be impossible so it panics.
+pub struct ReturnLifetimeLowerer<'ast> {
+    elision_source: ElisionSource,
+    base: BaseLifetimeLowerer<'ast>,
+}
+
+impl<'ast> BaseLifetimeLowerer<'ast> {
+    /// Returns a [`TypeLifetime`] representing a new anonymous lifetime, and
+    /// pushes it to the nodes vector.
+    fn new_elided(&mut self) -> TypeLifetime {
+        TypeLifetime::new_elided(&mut self.elided_node_gen, &mut self.nodes)
+    }
+
+    /// Lowers a single [`ast::Lifetime`]. If the lifetime is elided, then a fresh
+    /// [`ImplicitLifetime`] is generated.
+    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> TypeLifetime {
+        match lifetime {
+            ast::Lifetime::Static => TypeLifetime::new_static(),
+            ast::Lifetime::Named(named) => TypeLifetime::from_ast(named, self.lifetime_env),
+            ast::Lifetime::Anonymous => self.new_elided(),
+        }
+    }
+
+    /// Retrieves the cached  `Self` lifetimes, or caches newly generated
+    /// lifetimes and returns those.
+    fn self_lifetimes_or_new(&mut self, ast_lifetimes: &[ast::Lifetime]) -> TypeLifetimes {
+        if let Some(lifetimes) = &self.self_lifetimes {
+            lifetimes.clone()
+        } else {
+            let lifetimes = TypeLifetimes::from_fn(ast_lifetimes, |lt| self.lower_lifetime(lt));
+            self.self_lifetimes = Some(lifetimes.clone());
+            lifetimes
+        }
+    }
+}
+
+impl<'ast> SelfParamLifetimeLowerer<'ast> {
+    /// Returns a new [`SelfParamLifetimeLowerer`].
+    pub fn new(
+        lifetime_env: &'ast ast::LifetimeEnv,
+        errors: &mut Vec<LoweringError>,
+    ) -> Option<Self> {
+        let mut hir_nodes = Some(SmallVec::new());
+
+        for ast_node in lifetime_env.nodes.iter() {
+            let lifetime = lower_ident(ast_node.lifetime.name(), "named lifetime", errors);
+            match (lifetime, &mut hir_nodes) {
+                (Some(lifetime), Some(hir_nodes)) => {
+                    hir_nodes.push(LifetimeNode::Explicit(ExplicitLifetime::new(
+                        lifetime,
+                        ast_node.longer.iter().copied().collect(),
+                        ast_node.shorter.iter().copied().collect(),
+                    )));
+                }
+                _ => hir_nodes = None,
+            }
+        }
+
+        Some(Self {
+            base: BaseLifetimeLowerer {
+                elided_node_gen: ImplicitLifetimeGenerator::new(),
+                lifetime_env,
+                self_lifetimes: None,
+                nodes: hir_nodes?,
+            },
+        })
+    }
+
+    /// Lowers the lifetime of `&self` or `&mut self`.
+    ///
+    /// The lifetimes of `&self` and `&mut self` are special, because they
+    /// automatically take priority over any other lifetime in the input for
+    /// being tied to any elided lifetimes in the output.
+    ///
+    /// Along with returning the lowered lifetime, this method also returns the
+    /// next state in elision inference, the [`ParamLifetimeLowerer`].
+    pub fn lower_self_ref(
+        mut self,
+        lifetime: &ast::Lifetime,
+    ) -> (TypeLifetime, ParamLifetimeLowerer<'ast>) {
+        let self_lifetime = self.base.lower_lifetime(lifetime);
+
+        (
+            self_lifetime,
+            self.into_param_ltl(ElisionSource::SelfParam(self_lifetime)),
+        )
+    }
+
+    /// Acknowledges that there's no `&self` or `&mut self`, and transitions
+    /// to the next state, [`ParamLifetimeLowerer`].
+    pub fn no_self_ref(self) -> ParamLifetimeLowerer<'ast> {
+        self.into_param_ltl(ElisionSource::NoBorrows)
+    }
+
+    /// Transition into the next state, [`ParamLifetimeLowerer`].
+    fn into_param_ltl(self, elision_source: ElisionSource) -> ParamLifetimeLowerer<'ast> {
+        ParamLifetimeLowerer {
+            elision_source,
+            base: self.base,
+        }
+    }
+}
+
+impl<'ast> ParamLifetimeLowerer<'ast> {
+    /// Once all lifetimes in the parameters are lowered, this function is
+    /// called to transition to the next state, [`ReturnLifetimeLowerer`].
+    pub fn into_return_ltl(self) -> ReturnLifetimeLowerer<'ast> {
+        ReturnLifetimeLowerer {
+            elision_source: self.elision_source,
+            base: self.base,
+        }
+    }
+}
+
+impl<'ast> LifetimeLowerer for ParamLifetimeLowerer<'ast> {
+    fn lower_lifetime(&mut self, borrow: &ast::Lifetime) -> TypeLifetime {
+        let lifetime = self.base.lower_lifetime(borrow);
+        self.elision_source.visit_lifetime(lifetime);
+        lifetime
+    }
+
+    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> TypeLifetimes {
+        if is_self {
+            self.base.self_lifetimes_or_new(lifetimes)
+        } else {
+            self.lower_lifetimes(lifetimes)
+        }
+    }
+}
+
+impl<'ast> ReturnLifetimeLowerer<'ast> {
+    /// Finalize the lifetimes in the method, returning the resulting [`LifetimeEnv`].
+    pub fn finish(self) -> LifetimeEnv {
+        LifetimeEnv::new(self.base.nodes)
+    }
+}
+
+impl<'ast> LifetimeLowerer for ReturnLifetimeLowerer<'ast> {
+    fn lower_lifetime(&mut self, borrow: &ast::Lifetime) -> TypeLifetime {
+        match borrow {
+            ast::Lifetime::Static => TypeLifetime::new_static(),
+            ast::Lifetime::Named(named) => TypeLifetime::from_ast(named, self.base.lifetime_env),
+            ast::Lifetime::Anonymous => match self.elision_source {
+                ElisionSource::SelfParam(lifetime) | ElisionSource::OneParam(lifetime) => lifetime,
+                ElisionSource::NoBorrows => {
+                    panic!("nothing to borrow from, this shouldn't pass rustc's checks")
+                }
+                ElisionSource::MultipleBorrows => {
+                    panic!("source of elision is ambiguous, this shouldn't pass rustc's checks")
+                }
+            },
+        }
+    }
+
+    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> TypeLifetimes {
+        if is_self {
+            self.base.self_lifetimes_or_new(lifetimes)
+        } else {
+            self.lower_lifetimes(lifetimes)
+        }
+    }
+}
+
+impl LifetimeLowerer for &ast::LifetimeEnv {
+    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> TypeLifetime {
+        match lifetime {
+            ast::Lifetime::Static => TypeLifetime::new_static(),
+            ast::Lifetime::Named(named) => TypeLifetime::from_ast(named, self),
+            ast::Lifetime::Anonymous => {
+                panic!("anonymous lifetime inside struct, this shouldn't pass rustc's checks")
+            }
+        }
+    }
+
+    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], _: bool) -> TypeLifetimes {
+        self.lower_lifetimes(lifetimes)
+    }
+}
+
+// Things to test:
+// 1. ensure that if there are multiple inputs that are `Self`, where `Self` has
+//    an elided lifetime, all expansions of `Self` have the same anonymous lifetimes.
+// 2. ensure that `fn foo(self, s: &str) -> &str` passes, where it infers that
+//    the output takes on the lifetime of `s`.

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -1,6 +1,6 @@
 //! Lifetime information for types.
 
-use super::{elision, IdentBuf};
+use super::{IdentBuf, ImplicitLifetimeGenerator};
 use crate::ast;
 use smallvec::SmallVec;
 
@@ -69,6 +69,7 @@ pub struct TypeLifetime {
 /// [`StructPath`]: super::StructPath
 /// [`OutStructPath`]: super::OutStructPath
 /// [`OpaquePath`]: super::OpaquePath
+#[derive(Clone)]
 pub struct TypeLifetimes {
     indices: SmallVec<[TypeLifetime; 2]>,
 }
@@ -113,7 +114,7 @@ impl TypeLifetime {
 
     /// Returns a [`TypeLifetime`] representing a new anonymous lifetime.
     pub(super) fn new_elided(
-        elided_node_gen: &mut elision::ImplicitLifetimeGenerator,
+        elided_node_gen: &mut ImplicitLifetimeGenerator,
         nodes: &mut SmallVec<[LifetimeNode; 2]>,
     ) -> Self {
         let index = nodes.len();
@@ -152,13 +153,11 @@ impl TypeLifetime {
 }
 
 impl TypeLifetimes {
-    /// Returns a new [`TypeLifetimes`] from its AST counterparts.
-    pub(super) fn from_ast<L: elision::LifetimeLowerer>(ltl: &mut L, path: &ast::PathType) -> Self {
-        let indices = path
-            .lifetimes
-            .iter()
-            .map(|lifetime| ltl.lower_lifetime(lifetime))
-            .collect();
+    pub(super) fn from_fn<F>(lifetimes: &[ast::Lifetime], lower_fn: F) -> Self
+    where
+        F: FnMut(&ast::Lifetime) -> TypeLifetime,
+    {
+        let indices = lifetimes.iter().map(lower_fn).collect();
 
         Self { indices }
     }

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -1,4 +1,5 @@
 //! Lifetime information for types.
+#![allow(dead_code)]
 
 use super::{IdentBuf, ImplicitLifetimeGenerator};
 use crate::ast;

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1,11 +1,11 @@
 use super::{
-    Borrow, EnumDef, EnumPath, EnumVariant, IdentBuf, LifetimeEnv, LookupId, MaybeOwn, Method,
-    NonOptional, OpaqueDef, OpaquePath, Optional, OutStructDef, OutStructField, OutStructPath,
-    OutType, Param, ParamSelf, PrimitiveType, ReturnFallability, ReturnType, ReturnableStructPath,
-    SelfType, Slice, StructDef, StructField, StructPath, Type, TypeLifetimes,
+    Borrow, EnumDef, EnumPath, EnumVariant, IdentBuf, LifetimeEnv, LifetimeLowerer, LookupId,
+    MaybeOwn, Method, NonOptional, OpaqueDef, OpaquePath, Optional, OutStructDef, OutStructField,
+    OutStructPath, OutType, Param, ParamLifetimeLowerer, ParamSelf, PrimitiveType,
+    ReturnFallability, ReturnLifetimeLowerer, ReturnType, ReturnableStructPath,
+    SelfParamLifetimeLowerer, SelfType, Slice, StructDef, StructField, StructPath, Type,
 };
 use crate::{ast, Env};
-use smallvec::SmallVec;
 use strck_ident::IntoCk;
 
 /// An error from lowering the AST to the HIR.
@@ -24,38 +24,38 @@ pub enum LoweringError {
 
 /// Lowers an [`ast::Ident`]s into an [`hir::IdentBuf`].
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
-fn lower_ident(
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
+pub fn lower_ident(
     ident: &ast::Ident,
     context: &'static str,
     errors: &mut Vec<LoweringError>,
-) -> Result<IdentBuf, ()> {
+) -> Option<IdentBuf> {
     match ident.as_str().ck() {
-        Ok(name) => Ok(name.to_owned()),
+        Ok(name) => Some(name.to_owned()),
         Err(e) => {
             errors.push(LoweringError::Other(format!(
                 "Ident `{ident}` from {context} could not be turned into a Rust ident: {e}"
             )));
-            Err(())
+            None
         }
     }
 }
 
 /// Lowers an AST definition.
-pub(super) trait FromAstDef: Sized {
+pub(super) trait TypeLowerer: Sized {
     /// Type of the AST definition that gets lowered.
     type AstDef;
 
     /// Lowers the AST definition into `Self`.
     ///
-    /// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
     fn lower(
         ast_def: &Self::AstDef,
         lookup_id: &LookupId,
         in_path: &ast::Path,
         env: &Env,
         errors: &mut Vec<LoweringError>,
-    ) -> Result<Self, ()>;
+    ) -> Option<Self>;
 
     /// Lowers multiple items at once
     fn lower_all(
@@ -63,15 +63,15 @@ pub(super) trait FromAstDef: Sized {
         lookup_id: &LookupId,
         env: &Env,
         errors: &mut Vec<LoweringError>,
-    ) -> Result<Vec<Self>, ()> {
-        let mut hir_types = Ok(Vec::with_capacity(ast_defs.len()));
+    ) -> Option<Vec<Self>> {
+        let mut hir_types = Some(Vec::with_capacity(ast_defs.len()));
 
-        for (in_path, ast_type) in ast_defs {
-            let hir_type = FromAstDef::lower(*ast_type, lookup_id, in_path, env, errors);
+        for (in_path, ast_def) in ast_defs {
+            let hir_type = Self::lower(*ast_def, lookup_id, in_path, env, errors);
 
             match (hir_type, &mut hir_types) {
-                (Ok(hir_type), Ok(hir_types)) => hir_types.push(hir_type),
-                _ => hir_types = Err(()),
+                (Some(hir_type), Some(hir_types)) => hir_types.push(hir_type),
+                _ => hir_types = None,
             }
         }
 
@@ -79,7 +79,7 @@ pub(super) trait FromAstDef: Sized {
     }
 }
 
-impl FromAstDef for EnumDef {
+impl TypeLowerer for EnumDef {
     type AstDef = ast::Enum;
 
     fn lower(
@@ -88,29 +88,29 @@ impl FromAstDef for EnumDef {
         in_path: &ast::Path,
         env: &Env,
         errors: &mut Vec<LoweringError>,
-    ) -> Result<Self, ()> {
+    ) -> Option<Self> {
         let name = lower_ident(&ast_enum.name, "enum name", errors);
 
-        let mut variants = Ok(Vec::with_capacity(ast_enum.variants.len()));
+        let mut variants = Some(Vec::with_capacity(ast_enum.variants.len()));
 
         for (ident, discriminant, docs) in ast_enum.variants.iter() {
             let name = lower_ident(ident, "enum variant", errors);
 
             match (name, &mut variants) {
-                (Ok(name), Ok(variants)) => {
+                (Some(name), Some(variants)) => {
                     variants.push(EnumVariant {
                         docs: docs.clone(),
                         name,
                         discriminant: *discriminant,
                     });
                 }
-                _ => variants = Err(()),
+                _ => variants = None,
             }
         }
 
         let methods = lower_all_methods(&ast_enum.methods[..], lookup_id, in_path, env, errors);
 
-        Ok(EnumDef::new(
+        Some(EnumDef::new(
             ast_enum.docs.clone(),
             name?,
             variants?,
@@ -119,7 +119,7 @@ impl FromAstDef for EnumDef {
     }
 }
 
-impl FromAstDef for OpaqueDef {
+impl TypeLowerer for OpaqueDef {
     type AstDef = ast::OpaqueStruct;
 
     fn lower(
@@ -128,16 +128,16 @@ impl FromAstDef for OpaqueDef {
         in_path: &ast::Path,
         env: &Env,
         errors: &mut Vec<LoweringError>,
-    ) -> Result<Self, ()> {
+    ) -> Option<Self> {
         let name = lower_ident(&ast_opaque.name, "opaque name", errors);
 
         let methods = lower_all_methods(&ast_opaque.methods[..], lookup_id, in_path, env, errors);
 
-        Ok(OpaqueDef::new(ast_opaque.docs.clone(), name?, methods?))
+        Some(OpaqueDef::new(ast_opaque.docs.clone(), name?, methods?))
     }
 }
 
-impl FromAstDef for StructDef {
+impl TypeLowerer for StructDef {
     type AstDef = ast::Struct;
 
     fn lower(
@@ -146,7 +146,7 @@ impl FromAstDef for StructDef {
         in_path: &ast::Path,
         env: &Env,
         errors: &mut Vec<LoweringError>,
-    ) -> Result<Self, ()> {
+    ) -> Option<Self> {
         let name = lower_ident(&ast_struct.name, "struct name", errors);
 
         let fields = if ast_struct.fields.is_empty() {
@@ -154,15 +154,15 @@ impl FromAstDef for StructDef {
                 "struct `{}` is a ZST because it has no fields",
                 ast_struct.name
             )));
-            Err(())
+            None
         } else {
-            let mut fields = Ok(Vec::with_capacity(ast_struct.fields.len()));
+            let mut fields = Some(Vec::with_capacity(ast_struct.fields.len()));
 
             for (name, ty, docs) in ast_struct.fields.iter() {
                 let name = lower_ident(name, "struct field name", errors);
                 let ty = lower_type(
                     ty,
-                    Ok(&mut &ast_struct.lifetimes),
+                    Some(&mut &ast_struct.lifetimes),
                     lookup_id,
                     in_path,
                     env,
@@ -170,12 +170,12 @@ impl FromAstDef for StructDef {
                 );
 
                 match (name, ty, &mut fields) {
-                    (Ok(name), Ok(ty), Ok(fields)) => fields.push(StructField {
+                    (Some(name), Some(ty), Some(fields)) => fields.push(StructField {
                         docs: docs.clone(),
                         name,
                         ty,
                     }),
-                    _ => fields = Err(()),
+                    _ => fields = None,
                 }
             }
 
@@ -184,7 +184,7 @@ impl FromAstDef for StructDef {
 
         let methods = lower_all_methods(&ast_struct.methods[..], lookup_id, in_path, env, errors);
 
-        Ok(StructDef::new(
+        Some(StructDef::new(
             ast_struct.docs.clone(),
             name?,
             fields?,
@@ -193,7 +193,7 @@ impl FromAstDef for StructDef {
     }
 }
 
-impl FromAstDef for OutStructDef {
+impl TypeLowerer for OutStructDef {
     type AstDef = ast::Struct;
 
     fn lower(
@@ -202,7 +202,7 @@ impl FromAstDef for OutStructDef {
         in_path: &ast::Path,
         env: &Env,
         errors: &mut Vec<LoweringError>,
-    ) -> Result<Self, ()> {
+    ) -> Option<Self> {
         let name = lower_ident(&ast_out_struct.name, "out-struct name", errors);
 
         let fields = if ast_out_struct.fields.is_empty() {
@@ -210,15 +210,15 @@ impl FromAstDef for OutStructDef {
                 "struct `{}` is a ZST because it has no fields",
                 ast_out_struct.name
             )));
-            Err(())
+            None
         } else {
-            let mut fields = Ok(Vec::with_capacity(ast_out_struct.fields.len()));
+            let mut fields = Some(Vec::with_capacity(ast_out_struct.fields.len()));
 
             for (name, ty, docs) in ast_out_struct.fields.iter() {
                 let name = lower_ident(name, "out-struct field name", errors);
                 let ty = lower_out_type(
                     ty,
-                    Ok(&mut &ast_out_struct.lifetimes),
+                    Some(&mut &ast_out_struct.lifetimes),
                     lookup_id,
                     in_path,
                     env,
@@ -226,12 +226,12 @@ impl FromAstDef for OutStructDef {
                 );
 
                 match (name, ty, &mut fields) {
-                    (Ok(name), Ok(ty), Ok(fields)) => fields.push(OutStructField {
+                    (Some(name), Some(ty), Some(fields)) => fields.push(OutStructField {
                         docs: docs.clone(),
                         name,
                         ty,
                     }),
-                    _ => fields = Err(()),
+                    _ => fields = None,
                 }
             }
 
@@ -241,7 +241,7 @@ impl FromAstDef for OutStructDef {
         let methods =
             lower_all_methods(&ast_out_struct.methods[..], lookup_id, in_path, env, errors);
 
-        Ok(OutStructDef::new(
+        Some(OutStructDef::new(
             ast_out_struct.docs.clone(),
             name?,
             fields?,
@@ -252,23 +252,22 @@ impl FromAstDef for OutStructDef {
 
 /// Lowers an [`ast::Method`]s an [`hir::Method`].
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
 fn lower_method(
     method: &ast::Method,
     lookup_id: &LookupId,
     in_path: &ast::Path,
     env: &Env,
     errors: &mut Vec<LoweringError>,
-) -> Result<Method, ()> {
+) -> Option<Method> {
     let name = lower_ident(&method.name, "method name", errors);
-    let full_path_name = lower_ident(&method.full_path_name, "method full_path_name", errors);
 
     let (ast_params, takes_writeable) = match method.params.split_last() {
         Some((last, remaining)) if last.is_writeable() => (remaining, true),
         _ => (&method.params[..], false),
     };
 
-    let self_param_ltl = elision::SelfParamLifetimeLowerer::new(&method.lifetime_env, errors)?;
+    let self_param_ltl = SelfParamLifetimeLowerer::new(&method.lifetime_env, errors);
 
     let (param_self, param_ltl) = if let Some(self_param) = method.self_param.as_ref() {
         lower_self_param(
@@ -280,16 +279,19 @@ fn lower_method(
             env,
             errors,
         )
-        .map(|(param_self, param_ltl)| (Ok(Some(param_self)), Ok(param_ltl)))
-        .unwrap_or((Err(()), Err(())))
+        .map(|(param_self, param_ltl)| (Some(Some(param_self)), Some(param_ltl)))
+        .unwrap_or((None, None))
     } else {
-        (Ok(None), Ok(self_param_ltl.no_self_lifetime()))
+        (
+            Some(None),
+            self_param_ltl.map(SelfParamLifetimeLowerer::no_self_ref),
+        )
     };
 
     let (params, return_ltl) =
         lower_many_params(ast_params, param_ltl, lookup_id, in_path, env, errors)
-            .map(|(params, return_ltl)| (Ok(params), Ok(return_ltl)))
-            .unwrap_or((Err(()), Err(())));
+            .map(|(params, return_ltl)| (Some(params), Some(return_ltl)))
+            .unwrap_or((None, None));
 
     let (output, lifetime_env) = lower_return_type(
         method.return_type.as_ref(),
@@ -301,7 +303,7 @@ fn lower_method(
         errors,
     )?;
 
-    Ok(Method {
+    Some(Method {
         docs: method.docs.clone(),
         name: name?,
         lifetime_env,
@@ -313,23 +315,23 @@ fn lower_method(
 
 /// Lowers many [`ast::Method`]s into a vector of [`hir::Method`]s.
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
 fn lower_all_methods(
     ast_methods: &[ast::Method],
     lookup_id: &LookupId,
     in_path: &ast::Path,
     env: &Env,
     errors: &mut Vec<LoweringError>,
-) -> Result<Vec<Method>, ()> {
-    let mut methods = Ok(Vec::with_capacity(ast_methods.len()));
+) -> Option<Vec<Method>> {
+    let mut methods = Some(Vec::with_capacity(ast_methods.len()));
 
     for method in ast_methods {
         let method = lower_method(method, lookup_id, in_path, env, errors);
         match (method, &mut methods) {
-            (Ok(method), Ok(methods)) => {
+            (Some(method), Some(methods)) => {
                 methods.push(method);
             }
-            _ => methods = Err(()),
+            _ => methods = None,
         }
     }
 
@@ -338,49 +340,52 @@ fn lower_all_methods(
 
 /// Lowers an [`ast::TypeName`]s into a [`hir::Type`].
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
-fn lower_type<L: elision::LifetimeLowerer>(
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
+fn lower_type<L: LifetimeLowerer>(
     ty: &ast::TypeName,
-    ltl: Result<&mut L, ()>,
+    ltl: Option<&mut L>,
     lookup_id: &LookupId,
     in_path: &ast::Path,
     env: &Env,
     errors: &mut Vec<LoweringError>,
-) -> Result<Type, ()> {
+) -> Option<Type> {
     match ty {
-        ast::TypeName::Primitive(prim) => Ok(Type::Primitive(PrimitiveType::from_ast(*prim))),
-        ast::TypeName::Named(path) => match path.resolve(in_path, env) {
-            ast::CustomType::Struct(strct) => {
-                if let Some(tcx_id) = lookup_id.resolve_struct(strct) {
-                    let lifetimes = TypeLifetimes::from_ast(ltl?, path);
-                    Ok(Type::Struct(StructPath::new(lifetimes, tcx_id)))
-                } else if lookup_id.resolve_out_struct(strct).is_some() {
-                    errors.push(LoweringError::Other(format!("found struct in input that is marked with #[diplomat::out]: {ty} in {path}")));
-                    Err(())
-                } else {
-                    unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
+        ast::TypeName::Primitive(prim) => Some(Type::Primitive(PrimitiveType::from_ast(*prim))),
+        ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+            match path.resolve(in_path, env) {
+                ast::CustomType::Struct(strct) => {
+                    if let Some(tcx_id) = lookup_id.resolve_struct(strct) {
+                        let lifetimes = ltl?.lower_generics(&path.lifetimes[..], ty.is_self());
+
+                        Some(Type::Struct(StructPath::new(lifetimes, tcx_id)))
+                    } else if lookup_id.resolve_out_struct(strct).is_some() {
+                        errors.push(LoweringError::Other(format!("found struct in input that is marked with #[diplomat::out]: {ty} in {path}")));
+                        None
+                    } else {
+                        unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
+                    }
+                }
+                ast::CustomType::Opaque(_) => {
+                    errors.push(LoweringError::Other(format!(
+                        "Opaque passed by value in input: {path}"
+                    )));
+                    None
+                }
+                ast::CustomType::Enum(enm) => {
+                    let tcx_id = lookup_id
+                        .resolve_enum(enm)
+                        .expect("can't find enum in lookup map, which contains all enums from env");
+
+                    Some(Type::Enum(EnumPath::new(tcx_id)))
                 }
             }
-            ast::CustomType::Opaque(_) => {
-                errors.push(LoweringError::Other(format!(
-                    "Opaque passed by value in input: {path}"
-                )));
-                Err(())
-            }
-            ast::CustomType::Enum(enm) => {
-                let tcx_id = lookup_id
-                    .resolve_enum(enm)
-                    .expect("can't find enum in lookup map, which contains all enums from env");
-
-                Ok(Type::Enum(EnumPath::new(tcx_id)))
-            }
-        },
-        ast::TypeName::Reference(lifetime, mutability, ref_ty) => {
-            match ref_ty.as_ref() {
-                ast::TypeName::Named(path) => match path.resolve(in_path, env) {
+        }
+        ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
+            ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+                match path.resolve(in_path, env) {
                     ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                         let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
-                        let lifetimes = TypeLifetimes::from_ast(ltl, path);
+                        let lifetimes = ltl.lower_generics(&path.lifetimes[..], ref_ty.is_self());
                         let tcx_id = lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
@@ -389,18 +394,18 @@ fn lower_type<L: elision::LifetimeLowerer>(
                     }),
                     _ => {
                         errors.push(LoweringError::Other(format!("found &T in input where T is a custom type, but not opaque. T = {ref_ty}")));
-                        Err(())
+                        None
                     }
-                },
-                _ => {
-                    errors.push(LoweringError::Other(format!("found &T in input where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
-                    Err(())
                 }
             }
-        }
+            _ => {
+                errors.push(LoweringError::Other(format!("found &T in input where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                None
+            }
+        },
         ast::TypeName::Box(box_ty) => {
             errors.push(match box_ty.as_ref() {
-                ast::TypeName::Named(path) => {
+                ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
                     match path.resolve(in_path, env) {
                         ast::CustomType::Opaque(_) => LoweringError::Other(format!("found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = {path}")),
                         _ => LoweringError::Other(format!("found Box<T> in input where T is a custom type but not opaque. non-opaques can't be behind pointers, and opaques in inputs can't be owned. T = {path}")),
@@ -408,46 +413,44 @@ fn lower_type<L: elision::LifetimeLowerer>(
                 }
                 _ => LoweringError::Other(format!("found Box<T> in input where T isn't a custom type. T = {box_ty}")),
             });
-            Err(())
+            None
         }
         ast::TypeName::Option(opt_ty) => {
             match opt_ty.as_ref() {
-                ast::TypeName::Reference(lifetime, mutability, ref_ty) => {
-                    match ref_ty.as_ref() {
-                        ast::TypeName::Named(path) => match path.resolve(in_path, env) {
-                            ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
-                                let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
-                                let lifetimes = TypeLifetimes::from_ast(ltl, path);
-                                let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
+                    ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => match path.resolve(in_path, env) {
+                        ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
+                            let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
+                            let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
+                            let tcx_id = lookup_id.resolve_opaque(opaque).expect(
                                     "can't find opaque in lookup map, which contains all opaques from env",
                                 );
 
-                                Type::Opaque(OpaquePath::new(
-                                    lifetimes,
-                                    Optional(false),
-                                    borrow,
-                                    tcx_id,
-                                ))
-                            }),
-                            _ => {
-                                errors.push(LoweringError::Other(format!("found Option<&T> in input where T is a custom type, but it's not opaque. T = {ref_ty}")));
-                                Err(())
-                            }
-                        },
+                            Type::Opaque(OpaquePath::new(
+                                lifetimes,
+                                Optional(false),
+                                borrow,
+                                tcx_id,
+                            ))
+                        }),
                         _ => {
-                            errors.push(LoweringError::Other(format!("found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
-                            Err(())
+                            errors.push(LoweringError::Other(format!("found Option<&T> in input where T is a custom type, but it's not opaque. T = {ref_ty}")));
+                            None
                         }
+                    },
+                    _ => {
+                        errors.push(LoweringError::Other(format!("found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                        None
                     }
-                }
+                },
                 ast::TypeName::Box(box_ty) => {
                     // we could see whats in the box here too
                     errors.push(LoweringError::Other(format!("found Option<Box<T>> in input, but box isn't allowed in inputs. T = {box_ty}")));
-                    Err(())
+                    None
                 }
                 _ => {
                     errors.push(LoweringError::Other(format!("found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
-                    Err(())
+                    None
                 }
             }
         }
@@ -455,84 +458,81 @@ fn lower_type<L: elision::LifetimeLowerer>(
             errors.push(LoweringError::Other(
                 "Results can only appear as the top-level return type of methods".into(),
             ));
-            Err(())
+            None
         }
         ast::TypeName::Writeable => {
             errors.push(LoweringError::Other(
                 "Writeables can only appear as the last parameter of a method".into(),
             ));
-            Err(())
+            None
         }
         ast::TypeName::StrReference(lifetime) => {
-            let type_lifetime = ltl.map(|ltl| ltl.lower_lifetime(lifetime))?;
-
-            Ok(Type::Slice(Slice::Str(type_lifetime)))
+            Some(Type::Slice(Slice::Str(ltl?.lower_lifetime(lifetime))))
         }
-        ast::TypeName::PrimitiveSlice(lifetime, mutability, prim) => ltl.map(|ltl| {
-            let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
+        ast::TypeName::PrimitiveSlice(lifetime, mutability, prim) => {
+            let borrow = Borrow::new(ltl?.lower_lifetime(lifetime), *mutability);
             let prim = PrimitiveType::from_ast(*prim);
 
-            Type::Slice(Slice::Primitive(borrow, prim))
-        }),
+            Some(Type::Slice(Slice::Primitive(borrow, prim)))
+        }
         ast::TypeName::Unit => {
             errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
-            Err(())
-        }
-        ast::TypeName::SelfType(path) => {
-            todo!("Finalize lifetime elision")
+            None
         }
     }
 }
 
 /// Lowers an [`ast::TypeName`]s into an [`hir::OutType`].
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
-fn lower_out_type<L: elision::LifetimeLowerer>(
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
+fn lower_out_type<L: LifetimeLowerer>(
     ty: &ast::TypeName,
-    ltl: Result<&mut L, ()>,
+    ltl: Option<&mut L>,
     lookup_id: &LookupId,
     in_path: &ast::Path,
     env: &Env,
     errors: &mut Vec<LoweringError>,
-) -> Result<OutType, ()> {
+) -> Option<OutType> {
     match ty {
-        ast::TypeName::Primitive(prim) => Ok(OutType::Primitive(PrimitiveType::from_ast(*prim))),
-        ast::TypeName::Named(path) => match path.resolve(in_path, env) {
-            ast::CustomType::Struct(strct) => {
-                let lifetimes = TypeLifetimes::from_ast(ltl?, path);
+        ast::TypeName::Primitive(prim) => Some(OutType::Primitive(PrimitiveType::from_ast(*prim))),
+        ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+            match path.resolve(in_path, env) {
+                ast::CustomType::Struct(strct) => {
+                    let lifetimes = ltl?.lower_generics(&path.lifetimes, ty.is_self());
 
-                if let Some(tcx_id) = lookup_id.resolve_struct(strct) {
-                    Ok(OutType::Struct(ReturnableStructPath::Struct(
-                        StructPath::new(lifetimes, tcx_id),
-                    )))
-                } else if let Some(tcx_id) = lookup_id.resolve_out_struct(strct) {
-                    Ok(OutType::Struct(ReturnableStructPath::OutStruct(
-                        OutStructPath::new(lifetimes, tcx_id),
-                    )))
-                } else {
-                    unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
+                    if let Some(tcx_id) = lookup_id.resolve_struct(strct) {
+                        Some(OutType::Struct(ReturnableStructPath::Struct(
+                            StructPath::new(lifetimes, tcx_id),
+                        )))
+                    } else if let Some(tcx_id) = lookup_id.resolve_out_struct(strct) {
+                        Some(OutType::Struct(ReturnableStructPath::OutStruct(
+                            OutStructPath::new(lifetimes, tcx_id),
+                        )))
+                    } else {
+                        unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
+                    }
+                }
+                ast::CustomType::Opaque(_) => {
+                    errors.push(LoweringError::Other(format!(
+                        "Opaque passed by value in input: {path}"
+                    )));
+                    None
+                }
+                ast::CustomType::Enum(enm) => {
+                    let tcx_id = lookup_id
+                        .resolve_enum(enm)
+                        .expect("can't find enum in lookup map, which contains all enums from env");
+
+                    Some(OutType::Enum(EnumPath::new(tcx_id)))
                 }
             }
-            ast::CustomType::Opaque(_) => {
-                errors.push(LoweringError::Other(format!(
-                    "Opaque passed by value in input: {path}"
-                )));
-                Err(())
-            }
-            ast::CustomType::Enum(enm) => {
-                let tcx_id = lookup_id
-                    .resolve_enum(enm)
-                    .expect("can't find enum in lookup map, which contains all enums from env");
-
-                Ok(OutType::Enum(EnumPath::new(tcx_id)))
-            }
-        },
-        ast::TypeName::Reference(lifetime, mutability, ref_ty) => {
-            match ref_ty.as_ref() {
-                ast::TypeName::Named(path) => match path.resolve(in_path, env) {
+        }
+        ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
+            ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+                match path.resolve(in_path, env) {
                     ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                         let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
-                        let lifetimes = TypeLifetimes::from_ast(ltl, path);
+                        let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
                         let tcx_id = lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
@@ -546,18 +546,18 @@ fn lower_out_type<L: elision::LifetimeLowerer>(
                     }),
                     _ => {
                         errors.push(LoweringError::Other(format!("found &T in output where T is a custom type, but not opaque. T = {ref_ty}")));
-                        Err(())
+                        None
                     }
-                },
-                _ => {
-                    errors.push(LoweringError::Other(format!("found &T in output where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
-                    Err(())
                 }
             }
-        }
+            _ => {
+                errors.push(LoweringError::Other(format!("found &T in output where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                None
+            }
+        },
         ast::TypeName::Box(box_ty) => {
             errors.push(match box_ty.as_ref() {
-                ast::TypeName::Named(path) => {
+                ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
                     match path.resolve(in_path, env) {
                         ast::CustomType::Opaque(_) => LoweringError::Other(format!("found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = {path}")),
                         _ => LoweringError::Other(format!("found Box<T> in input where T is a custom type but not opaque. non-opaques can't be behind pointers, and opaques in inputs can't be owned. T = {path}")),
@@ -565,132 +565,136 @@ fn lower_out_type<L: elision::LifetimeLowerer>(
                 }
                 _ => LoweringError::Other(format!("found Box<T> in input where T isn't a custom type. T = {box_ty}")),
             });
-            Err(())
+            None
         }
         ast::TypeName::Option(opt_ty) => match opt_ty.as_ref() {
             ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
-                ast::TypeName::Named(path) => match path.resolve(in_path, env) {
-                    ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
-                        let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
-                        let lifetimes = TypeLifetimes::from_ast(ltl, path);
-                        let tcx_id = lookup_id.resolve_opaque(opaque).expect(
-                            "can't find opaque in lookup map, which contains all opaques from env",
-                        );
+                ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+                    match path.resolve(in_path, env) {
+                        ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
+                            let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
+                            let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
+                            let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                                "can't find opaque in lookup map, which contains all opaques from env",
+                            );
 
-                        OutType::Opaque(OpaquePath::new(
-                            lifetimes,
-                            Optional(true),
-                            MaybeOwn::Borrow(borrow),
-                            tcx_id,
-                        ))
-                    }),
-                    _ => {
-                        errors.push(LoweringError::Other(format!("found Option<&T> where T is a custom type, but it's not opaque. T = {ref_ty}")));
-                        Err(())
+                            OutType::Opaque(OpaquePath::new(
+                                lifetimes,
+                                Optional(true),
+                                MaybeOwn::Borrow(borrow),
+                                tcx_id,
+                            ))
+                        }),
+                        _ => {
+                            errors.push(LoweringError::Other(format!("found Option<&T> where T is a custom type, but it's not opaque. T = {ref_ty}")));
+                            None
+                        }
                     }
-                },
+                }
                 _ => {
                     errors.push(LoweringError::Other(format!("found Option<&T>, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
-                    Err(())
+                    None
                 }
             },
             ast::TypeName::Box(box_ty) => match box_ty.as_ref() {
-                ast::TypeName::Named(path) => match path.resolve(in_path, env) {
-                    ast::CustomType::Opaque(opaque) => {
-                        let lifetimes = TypeLifetimes::from_ast(ltl?, path);
-                        let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+                    match path.resolve(in_path, env) {
+                        ast::CustomType::Opaque(opaque) => {
+                            let lifetimes = ltl?.lower_generics(&path.lifetimes, box_ty.is_self());
+                            let tcx_id = lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
-                        Ok(OutType::Opaque(OpaquePath::new(
-                            lifetimes,
-                            Optional(true),
-                            MaybeOwn::Own,
-                            tcx_id,
-                        )))
+                            Some(OutType::Opaque(OpaquePath::new(
+                                lifetimes,
+                                Optional(true),
+                                MaybeOwn::Own,
+                                tcx_id,
+                            )))
+                        }
+                        _ => {
+                            errors.push(LoweringError::Other(format!("found Option<Box<T>> where T is a custom type, but it's not opaque. T = {box_ty}")));
+                            None
+                        }
                     }
-                    _ => {
-                        errors.push(LoweringError::Other(format!("found Option<Box<T>> where T is a custom type, but it's not opaque. T = {box_ty}")));
-                        Err(())
-                    }
-                },
+                }
                 _ => {
                     errors.push(LoweringError::Other(format!("found Option<Box<T>>, but T isn't a custom type and therefore not opaque. T = {box_ty}")));
-                    Err(())
+                    None
                 }
             },
             _ => {
                 errors.push(LoweringError::Other(format!("found Option<T>, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
-                Err(())
+                None
             }
         },
         ast::TypeName::Result(_, _) => {
             errors.push(LoweringError::Other(
                 "Results can only appear as the top-level return type of methods".into(),
             ));
-            Err(())
+            None
         }
         ast::TypeName::Writeable => {
             errors.push(LoweringError::Other(
                 "Writeables can only appear as the last parameter of a method".into(),
             ));
-            Err(())
+            None
         }
         ast::TypeName::StrReference(lifetime) => {
-            let type_lifetime = ltl?.lower_lifetime(lifetime);
-
-            Ok(OutType::Slice(Slice::Str(type_lifetime)))
+            Some(OutType::Slice(Slice::Str(ltl?.lower_lifetime(lifetime))))
         }
         ast::TypeName::PrimitiveSlice(lifetime, mutability, prim) => {
             let borrow = Borrow::new(ltl?.lower_lifetime(lifetime), *mutability);
             let prim = PrimitiveType::from_ast(*prim);
 
-            Ok(OutType::Slice(Slice::Primitive(borrow, prim)))
+            Some(OutType::Slice(Slice::Primitive(borrow, prim)))
         }
         ast::TypeName::Unit => {
             errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
-            Err(())
-        }
-        ast::TypeName::SelfType(path) => {
-            todo!("Finalize lifetime elision")
+            None
         }
     }
 }
 
 /// Lowers an [`ast::SelfParam`] into an [`hir::ParamSelf`].
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
 fn lower_self_param<'ast>(
     self_param: &ast::SelfParam,
-    self_param_ltl: elision::SelfParamLifetimeLowerer<'ast>,
+    self_param_ltl: Option<SelfParamLifetimeLowerer<'ast>>,
     lookup_id: &LookupId,
     method_full_path: &ast::Ident, // for better error msg
     in_path: &ast::Path,
     env: &Env,
     errors: &mut Vec<LoweringError>,
-) -> Result<(ParamSelf, elision::ParamLifetimeLowerer<'ast>), ()> {
+) -> Option<(ParamSelf, ParamLifetimeLowerer<'ast>)> {
     match self_param.path_type.resolve(in_path, env) {
         ast::CustomType::Struct(strct) => {
             if let Some(tcx_id) = lookup_id.resolve_struct(strct) {
                 if self_param.reference.is_some() {
                     errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes a reference to a struct as a self parameter, which isn't allowed")));
-                    Err(())
+                    None
                 } else {
-                    let (type_lifetimes, param_ltl) =
-                        self_param_ltl.lower_owned_self(&self_param.path_type);
+                    let mut param_ltl = self_param_ltl?.no_self_ref();
 
-                    Ok((
+                    // Even if we explicitly write out the type of `self` like
+                    // `self: Foo<'a>`, the `'a` is still not considered for
+                    // elision according to rustc, so is_self=true.
+                    let type_lifetimes =
+                        param_ltl.lower_generics(&self_param.path_type.lifetimes[..], true);
+
+                    Some((
                         ParamSelf::new(SelfType::Struct(StructPath::new(type_lifetimes, tcx_id))),
                         param_ltl,
                     ))
                 }
             } else if lookup_id.resolve_out_struct(strct).is_some() {
                 if let Some((lifetime, _)) = &self_param.reference {
-                    errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed. Also, it's behind a reference, but only opaques can be behind references")));
-                    Err(())
+                    errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed. Also, it's behind a reference, `{lifetime}`, but only opaques can be behind references")));
+                    None
                 } else {
                     errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed")));
-                    Err(())
+                    None
                 }
             } else {
                 unreachable!(
@@ -703,11 +707,11 @@ fn lower_self_param<'ast>(
             let tcx_id = lookup_id.resolve_opaque(opaque).expect("opaque is in env");
 
             if let Some((lifetime, mutability)) = &self_param.reference {
-                let (borrow_lifetime, lifetimes, param_ltl) =
-                    self_param_ltl.lower_borrowed_self(lifetime, &self_param.path_type);
+                let (borrow_lifetime, mut param_ltl) = self_param_ltl?.lower_self_ref(lifetime);
                 let borrow = Borrow::new(borrow_lifetime, *mutability);
+                let lifetimes = param_ltl.lower_generics(&self_param.path_type.lifetimes, true);
 
-                Ok((
+                Some((
                     ParamSelf::new(SelfType::Opaque(OpaquePath::new(
                         lifetimes,
                         NonOptional,
@@ -718,15 +722,15 @@ fn lower_self_param<'ast>(
                 ))
             } else {
                 errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs")));
-                Err(())
+                None
             }
         }
         ast::CustomType::Enum(enm) => {
             let tcx_id = lookup_id.resolve_enum(enm).expect("enum is in env");
 
-            Ok((
+            Some((
                 ParamSelf::new(SelfType::Enum(EnumPath::new(tcx_id))),
-                self_param_ltl.no_self_lifetime(),
+                self_param_ltl?.no_self_ref(),
             ))
         }
     }
@@ -734,454 +738,88 @@ fn lower_self_param<'ast>(
 
 /// Lowers an [`ast::Param`] into an [`hir::Param`].
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
 ///
 /// Note that this expects that if there was a writeable param at the end in
 /// the method, it's not passed into here.
-fn lower_param(
+fn lower_param<L: LifetimeLowerer>(
     param: &ast::Param,
-    param_ltl: Result<&mut elision::ParamLifetimeLowerer, ()>,
+    ltl: Option<&mut L>,
     lookup_id: &LookupId,
     in_path: &ast::Path,
     env: &Env,
     errors: &mut Vec<LoweringError>,
-) -> Result<Param, ()> {
+) -> Option<Param> {
     let name = lower_ident(&param.name, "param name", errors);
-    let ty = lower_type(&param.ty, param_ltl, lookup_id, in_path, env, errors);
+    let ty = lower_type(&param.ty, ltl, lookup_id, in_path, env, errors);
 
-    Ok(Param::new(name?, ty?))
+    Some(Param::new(name?, ty?))
 }
 
 /// Lowers many [`ast::Param`]s into a vector of [`hir::Param`]s.
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
 ///
 /// Note that this expects that if there was a writeable param at the end in
 /// the method, `ast_params` was sliced to not include it. This happens in
 /// `lower_method`, the caller of this function.
 fn lower_many_params<'ast>(
     ast_params: &[ast::Param],
-    mut param_ltl: Result<elision::ParamLifetimeLowerer<'ast>, ()>,
+    mut param_ltl: Option<ParamLifetimeLowerer<'ast>>,
     lookup_id: &LookupId,
     in_path: &ast::Path,
     env: &Env,
     errors: &mut Vec<LoweringError>,
-) -> Result<(Vec<Param>, elision::ReturnLifetimeLowerer<'ast>), ()> {
-    let mut params = Ok(Vec::with_capacity(ast_params.len()));
+) -> Option<(Vec<Param>, ReturnLifetimeLowerer<'ast>)> {
+    let mut params = Some(Vec::with_capacity(ast_params.len()));
 
     for param in ast_params {
-        let param = lower_param(
-            param,
-            param_ltl.as_mut().map_err(|_| ()),
-            lookup_id,
-            in_path,
-            env,
-            errors,
-        );
+        let param = lower_param(param, param_ltl.as_mut(), lookup_id, in_path, env, errors);
 
         match (param, &mut params) {
-            (Ok(param), Ok(params)) => {
+            (Some(param), Some(params)) => {
                 params.push(param);
             }
-            _ => params = Err(()),
+            _ => params = None,
         }
     }
 
-    Ok((params?, param_ltl?.finish()))
+    Some((params?, param_ltl?.into_return_ltl()))
 }
 
 /// Lowers the return type of an [`ast::Method`] into a [`hir::ReturnFallability`].
 ///
-/// If there are any errors, they're pushed to `errors` and `Err(())` is returned.
+/// If there are any errors, they're pushed to `errors` and `None` is returned.
 fn lower_return_type(
     return_type: Option<&ast::TypeName>,
     takes_writeable: bool,
-    return_ltl: Result<elision::ReturnLifetimeLowerer<'_>, ()>,
+    mut return_ltl: Option<ReturnLifetimeLowerer<'_>>,
     lookup_id: &LookupId,
     in_path: &ast::Path,
     env: &Env,
     errors: &mut Vec<LoweringError>,
-) -> Result<(ReturnFallability, LifetimeEnv), ()> {
-    let return_type = return_type.unwrap_or(&ast::TypeName::Unit);
-
-    match return_type {
-        ast::TypeName::Result(ok_ty, err_ty) => return_ltl.and_then(|mut return_ltl| {
+) -> Option<(ReturnFallability, LifetimeEnv)> {
+    match return_type.unwrap_or(&ast::TypeName::Unit) {
+        ast::TypeName::Result(ok_ty, err_ty) => {
             let ok_ty = match ok_ty.as_ref() {
-                ast::TypeName::Unit => {
-                    if takes_writeable {
-                        Ok(Some(ReturnType::Writeable))
-                    } else {
-                        Ok(None)
-                    }
-                }
-                ty => lower_out_type(ty, Ok(&mut return_ltl), lookup_id, in_path, env, errors)
+                ast::TypeName::Unit => Some(takes_writeable.then_some(ReturnType::Writeable)),
+                ty => lower_out_type(ty, return_ltl.as_mut(), lookup_id, in_path, env, errors)
                     .map(|ty| Some(ReturnType::OutType(ty))),
             };
 
             let err_ty =
-                lower_out_type(err_ty, Ok(&mut return_ltl), lookup_id, in_path, env, errors);
+                lower_out_type(err_ty, return_ltl.as_mut(), lookup_id, in_path, env, errors);
 
             match (ok_ty, err_ty) {
-                (Ok(ok_ty), Ok(err_ty)) => Ok((
-                    ReturnFallability::Fallible(ok_ty, err_ty),
-                    return_ltl.finish(),
-                )),
-                _ => Err(()),
-            }
-        }),
-        ast::TypeName::Unit => return_ltl.map(|return_ltl| {
-            if takes_writeable {
-                (
-                    ReturnFallability::Infallible(Some(ReturnType::Writeable)),
-                    return_ltl.finish(),
-                )
-            } else {
-                (ReturnFallability::Infallible(None), return_ltl.finish())
-            }
-        }),
-        _ => return_ltl.and_then(|mut return_ltl| {
-            lower_out_type(
-                return_type,
-                Ok(&mut return_ltl),
-                lookup_id,
-                in_path,
-                env,
-                errors,
-            )
-            .map(|ty| {
-                (
-                    ReturnFallability::Infallible(Some(ReturnType::OutType(ty))),
-                    return_ltl.finish(),
-                )
-            })
-        }),
-    }
-}
-
-pub mod elision {
-    use super::*;
-    use crate::hir::{ExplicitLifetime, ImplicitLifetime, LifetimeNode, TypeLifetime};
-
-    /// Generator for unique [`ImplicitLifetime`]s.
-    pub(in crate::hir) struct ImplicitLifetimeGenerator {
-        next: u32,
-    }
-
-    impl ImplicitLifetimeGenerator {
-        /// Returns a new [`ImplicitLifetimeGenerator`].
-        pub fn new() -> Self {
-            Self { next: 1 }
-        }
-
-        /// Returns the next [`ImplicitLifetime`].
-        pub fn gen(&mut self) -> ImplicitLifetime {
-            let label = self.next;
-            self.next += 1;
-            ImplicitLifetime::new(label)
-        }
-    }
-
-    pub(super) struct BaseLifetimeLowerer<'ast> {
-        elided_node_gen: ImplicitLifetimeGenerator,
-        method_lifetime_env: &'ast ast::LifetimeEnv,
-        nodes: SmallVec<[LifetimeNode; 2]>,
-    }
-
-    #[derive(Copy, Clone)]
-    enum ElisionSource {
-        /// No borrows in the input, no elision.
-        NoBorrows,
-        /// `&self` or `&mut self`, elision allowed.
-        SelfParam(TypeLifetime),
-        /// One param contains a borrow, elision allowed.
-        OneParam(TypeLifetime),
-        /// Multiple borrows and no self borrow, no elision.
-        MultipleBorrows,
-    }
-
-    /// The first phase of output elision inference.
-    ///
-    /// In the first phase, the type signature of the `&self` or `&mut self` type
-    /// is lowered into its HIR representation, if present. According to elision
-    /// rules, this reference has the highest precedence as the lifetime that
-    /// goes into elision in the output, and so it's checked first.
-    pub(super) struct SelfParamLifetimeLowerer<'ast> {
-        base: BaseLifetimeLowerer<'ast>,
-    }
-
-    /// The second phase of output elision inference.
-    ///
-    /// In the second phase, all lifetimes in the parameter type signatures
-    /// (besides the lifetime of self, if present) are lowered. If a self param
-    /// didn't claim the potential output elided lifetime, then if there's a
-    /// single lifetime (named or anonymous) in the inputs, it will calim the
-    /// potential output elided lifetime.
-    pub(super) struct ParamLifetimeLowerer<'ast> {
-        elision_source: ElisionSource,
-        base: BaseLifetimeLowerer<'ast>,
-    }
-
-    /// The third and final phase of output elision inference.
-    ///
-    /// In the third phase, the type signature of the output type is lowered into
-    /// its HIR representation. If one of the input lifetimes were marked as
-    /// responsible for any elision in the output, then anonymous lifetimes get
-    /// that lifetime. If none did and there is elision in the output, then
-    /// rustc should have errored and said the elision was ambiguous, meaning
-    /// that state should be impossible so it panics.
-    pub(super) struct ReturnLifetimeLowerer<'ast> {
-        elision_source: ElisionSource,
-        base: BaseLifetimeLowerer<'ast>,
-    }
-
-    impl<'ast> BaseLifetimeLowerer<'ast> {
-        /// Returns a [`TypeLifetime`] representing a new anonymous lifetime.
-        fn new_elided(&mut self) -> TypeLifetime {
-            TypeLifetime::new_elided(&mut self.elided_node_gen, &mut self.nodes)
-        }
-    }
-
-    impl<'ast> SelfParamLifetimeLowerer<'ast> {
-        /// Returns a new [`SelfParamLifetimeLowerer`].
-        pub(super) fn new(
-            method_lt_env: &'ast ast::LifetimeEnv,
-            errors: &mut Vec<LoweringError>,
-        ) -> Result<Self, ()> {
-            let mut hir_nodes = Ok(SmallVec::new());
-
-            for ast_node in method_lt_env.nodes.iter() {
-                let lifetime = lower_ident(ast_node.lifetime.name(), "named lifetime", errors);
-                match (lifetime, &mut hir_nodes) {
-                    (Ok(lifetime), Ok(hir_nodes)) => {
-                        hir_nodes.push(LifetimeNode::Explicit(ExplicitLifetime::new(
-                            lifetime,
-                            ast_node.longer.iter().copied().collect(),
-                            ast_node.shorter.iter().copied().collect(),
-                        )));
-                    }
-                    _ => hir_nodes = Err(()),
-                }
-            }
-
-            Ok(Self {
-                base: BaseLifetimeLowerer {
-                    elided_node_gen: ImplicitLifetimeGenerator::new(),
-                    method_lifetime_env: method_lt_env,
-                    nodes: hir_nodes?,
-                },
-            })
-        }
-
-        /// Lowers the lifetimes in the `&self` or `&mut self` parameter, as well
-        /// as any lifetime generics in the type of the expanded self parameter.
-        ///
-        /// This method lowers all the lifetime of the self argument at once
-        /// to have symmetry with [`SelfParamLifetimeLowerer::lower_owned_self`],
-        /// which has to because elision inference in Rust... interesting.
-        pub(super) fn lower_borrowed_self(
-            mut self,
-            lifetime: &ast::Lifetime,
-            self_path_type: &ast::PathType,
-        ) -> (TypeLifetime, TypeLifetimes, ParamLifetimeLowerer<'ast>) {
-            let self_lifetime = match lifetime {
-                ast::Lifetime::Static => TypeLifetime::new_static(),
-                ast::Lifetime::Named(named) => {
-                    TypeLifetime::from_ast(named, self.base.method_lifetime_env)
-                }
-                ast::Lifetime::Anonymous => self.base.new_elided(),
-            };
-
-            (
-                self_lifetime,
-                TypeLifetimes::from_ast(&mut self.base, self_path_type),
-                self.finish(ElisionSource::SelfParam(self_lifetime)),
-            )
-        }
-
-        /// Lowers the lifetime generics of the expanded type in the `self` or
-        /// `mut self` parameter.
-        ///
-        /// Unlike other parameters, lifetimes in the generics of the type that
-        /// `self` expands to are not considered for lifetime elision. This can
-        /// lead to examples that should intuitively work, but don't.
-        ///
-        /// Consider the following code:
-        /// ```ignore
-        /// struct Foo<'a>(&'a str);
-        ///
-        /// impl<'a> Foo<'a> {
-        ///     // error[E0106]: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-        ///     fn bar(self) -> &str {
-        ///         self.0
-        ///     }
-        /// }
-        /// ```
-        /// For some reason, the compiler errors by saying "hey, there's nothing
-        /// to borrow from." But that's obviously not true. You can even
-        /// explicitly annotate the type of `self` and it still complains:
-        /// ```ignore
-        /// impl<'a> Foo<'a> {
-        ///     // error[E0106]: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-        ///     fn bar(self: Foo<'a>) -> &str {
-        ///         self.0
-        ///     }
-        /// }
-        /// ```
-        /// And it's not just for methods. Elision inferencing will never search
-        /// for a source in the generics of the type of `self` or in an argument
-        /// with the `Self` type:
-        /// ```ignore
-        /// impl<'a> Foo<'a> {
-        ///     // error[E0106]: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-        ///     fn bar(this: Self) -> &str {
-        ///         this.0
-        ///     }
-        /// }
-        /// ```
-        /// But once you get rid of self altogether, it works.
-        /// ```rust
-        /// # struct Foo<'a>(&'a str);
-        /// impl<'a> Foo<'a> {
-        ///     // works
-        ///     fn bar(this: Foo<'a>) -> &str {
-        ///         this.0
-        ///     }
-        /// }
-        /// ```
-        /// Thus, the purpose of this function is to lower the generics from the
-        /// expanded type of `self` or `mut self`, while ensuring that they
-        /// can't be marked as the source of lifetime elision. This is so that
-        /// programs like the following, which are accepted by rustc, work:
-        /// ```rust
-        /// # struct Foo<'a>(&'a str);
-        /// impl<'a> Foo<'a> {
-        ///     // rustc only sees the lifetime of `s`, so we need to make sure
-        ///     // to not look at the `'a` when considering an elision source.
-        ///     fn bar(self: Foo<'a>, s: &str) -> &str {
-        ///         s
-        ///     }
-        /// }
-        /// ```
-        /// There's currently a bug in our implementation though:
-        /// ```rust
-        /// # struct Foo<'a>(&'a str);
-        /// impl<'a> Foo<'a> {
-        ///     // rustc only sees the lifetime of `s`, but we will see the
-        ///     // lifetime `'a` in the `Foo<'a>` that `that` expands to, as well
-        ///     // as the lifetime of `s`, making us think that elision cannot
-        ///     // be inferred.
-        ///     fn bar(self: Foo<'a>, that: Self, s: &str) -> &str {
-        ///         s
-        ///     }
-        /// }
-        /// ```
-        /// The solution is to track `Self` types in the ast,
-        /// which is being worked on now.
-        pub(super) fn lower_owned_self(
-            mut self,
-            self_path_type: &ast::PathType,
-        ) -> (TypeLifetimes, ParamLifetimeLowerer<'ast>) {
-            (
-                TypeLifetimes::from_ast(&mut self.base, self_path_type),
-                self.finish(ElisionSource::NoBorrows),
-            )
-        }
-
-        /// Indicates that there is no `&self` or `&mut self`.
-        pub(super) fn no_self_lifetime(self) -> ParamLifetimeLowerer<'ast> {
-            self.finish(ElisionSource::NoBorrows)
-        }
-
-        fn finish(self, elision_source: ElisionSource) -> ParamLifetimeLowerer<'ast> {
-            ParamLifetimeLowerer {
-                elision_source,
-                base: self.base,
+                (Some(ok_ty), Some(err_ty)) => Some(ReturnFallability::Fallible(ok_ty, err_ty)),
+                _ => None,
             }
         }
+        ast::TypeName::Unit => Some(ReturnFallability::Infallible(
+            takes_writeable.then_some(ReturnType::Writeable),
+        )),
+        ty => lower_out_type(ty, return_ltl.as_mut(), lookup_id, in_path, env, errors)
+            .map(|ty| ReturnFallability::Infallible(Some(ReturnType::OutType(ty)))),
     }
-
-    impl<'ast> ParamLifetimeLowerer<'ast> {
-        pub fn finish(self) -> ReturnLifetimeLowerer<'ast> {
-            ReturnLifetimeLowerer {
-                elision_source: self.elision_source,
-                base: self.base,
-            }
-        }
-    }
-
-    impl<'ast> ReturnLifetimeLowerer<'ast> {
-        pub fn finish(self) -> LifetimeEnv {
-            LifetimeEnv::new(self.base.nodes)
-        }
-    }
-
-    /// Types that can lower a lifetime into the HIR representation.
-    pub trait LifetimeLowerer {
-        /// Lower the lifetime.
-        ///
-        /// This method takes `&mut self` so that self can update internal state.
-        /// This is used during lifetime inference, where the inferencer can
-        /// update its state depending on what lifetimes are encountered.
-        fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> TypeLifetime;
-    }
-
-    impl LifetimeLowerer for &ast::LifetimeEnv {
-        fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> TypeLifetime {
-            match lifetime {
-                ast::Lifetime::Static => TypeLifetime::new_static(),
-                ast::Lifetime::Named(named) => TypeLifetime::from_ast(named, self),
-                ast::Lifetime::Anonymous => {
-                    panic!("anonymous lifetime inside struct, this shouldn't pass rustc's checks")
-                }
-            }
-        }
-    }
-
-    impl<'ast> LifetimeLowerer for BaseLifetimeLowerer<'ast> {
-        fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> TypeLifetime {
-            match lifetime {
-                ast::Lifetime::Static => TypeLifetime::new_static(),
-                ast::Lifetime::Named(named) => {
-                    TypeLifetime::from_ast(named, self.method_lifetime_env)
-                }
-                ast::Lifetime::Anonymous => self.new_elided(),
-            }
-        }
-    }
-
-    impl<'ast> LifetimeLowerer for ParamLifetimeLowerer<'ast> {
-        fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> TypeLifetime {
-            let type_lifetime = self.base.lower_lifetime(lifetime);
-
-            self.elision_source = match self.elision_source {
-                ElisionSource::NoBorrows => ElisionSource::OneParam(type_lifetime),
-                ElisionSource::OneParam(_) => ElisionSource::MultipleBorrows,
-                no_change => no_change,
-            };
-
-            type_lifetime
-        }
-    }
-
-    impl<'ast> LifetimeLowerer for ReturnLifetimeLowerer<'ast> {
-        fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> TypeLifetime {
-            match lifetime {
-                ast::Lifetime::Static => TypeLifetime::new_static(),
-                ast::Lifetime::Named(named) => {
-                    TypeLifetime::from_ast(named, self.base.method_lifetime_env)
-                }
-                ast::Lifetime::Anonymous => match self.elision_source {
-                    ElisionSource::SelfParam(lifetime) | ElisionSource::OneParam(lifetime) => {
-                        lifetime
-                    }
-                    ElisionSource::NoBorrows => {
-                        panic!("nothing to borrow from, this shouldn't pass rustc's checks")
-                    }
-                    ElisionSource::MultipleBorrows => {
-                        panic!("source of elision is ambiguous, this shouldn't pass rustc's checks")
-                    }
-                },
-            }
-        }
-    }
+    .and_then(|return_fallability| Some((return_fallability, return_ltl?.finish())))
 }

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -1,7 +1,7 @@
-//! Experiment high-level representation (HIR) for Diplomat.
+//! Experimental high-level representation (HIR) for Diplomat.
 
-#![allow(unused_mut, unused_variables, dead_code)]
 mod defs;
+mod elision;
 mod lifetimes;
 mod lowering;
 mod methods;
@@ -10,8 +10,9 @@ mod primitives;
 mod type_context;
 mod types;
 pub use defs::*;
+pub(super) use elision::*;
 pub use lifetimes::*;
-pub use lowering::*;
+pub(super) use lowering::*;
 pub use methods::*;
 pub use paths::*;
 pub use primitives::*;

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1,6 +1,6 @@
 //! Store all the types contained in the HIR.
 
-use super::{EnumDef, FromAstDef, LoweringError, OpaqueDef, OutStructDef, StructDef};
+use super::{EnumDef, LoweringError, OpaqueDef, OutStructDef, StructDef, TypeLowerer};
 #[allow(unused_imports)] // use in docs links
 use crate::hir;
 use crate::{ast, Env};
@@ -48,9 +48,7 @@ impl TypeContext {
     pub(crate) fn resolve_enum(&self, id: EnumId) -> &EnumDef {
         self.enums.index(id.0)
     }
-}
 
-impl TypeContext {
     /// Lower the AST to the HIR while simultaneously performing validation.
     pub fn from_ast(env: &Env) -> Result<Self, Vec<LoweringError>> {
         let mut ast_out_structs = SmallVec::<[_; 16]>::new();
@@ -90,7 +88,7 @@ impl TypeContext {
         let enums = EnumDef::lower_all(&ast_enums[..], &lookup_id, env, &mut errors);
 
         match (out_structs, structs, opaques, enums) {
-            (Ok(out_structs), Ok(structs), Ok(opaques), Ok(enums)) => {
+            (Some(out_structs), Some(structs), Some(opaques), Some(enums)) => {
                 assert!(
                     errors.is_empty(),
                     "All lowering succeeded but still found error messages: {errors:?}"


### PR DESCRIPTION
# This PR:
* Support the corner case from #232.
* Moved the `elision` module to be under `hir` instead of `hir::lowering`, and wrote a thicc wall of module docs.
* Refactored a lot of the elision code.
# Remaining work:
_Oh my god_ we need snapshot testing. I've written so much code and done so little testing and I am ashamed of myself. I promise this is next on the list.
# Questions:
This is slightly pedantic, but I was wondering: if there's an impl block like `impl Foo<'_>` which contains a method with two `Self` arguments, should they get expanded to have the same anonymous lifetime?