### PR TITLE
HIR snapshots

### DIFF
--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -43,7 +43,7 @@ impl Module {
         rust_links
     }
 
-    fn insert_all_types(&self, in_path: Path, out: &mut Env) {
+    pub fn insert_all_types(&self, in_path: Path, out: &mut Env) {
         let mut mod_symbols = ModuleEnv::default();
 
         self.imports.iter().for_each(|(path, name)| {

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -9,6 +9,7 @@ pub enum ReturnableStructDef<'tcx> {
 }
 
 /// Structs that can only be returned from methods.
+#[derive(Debug)]
 pub struct OutStructDef {
     pub docs: Docs,
     pub name: IdentBuf,
@@ -17,6 +18,7 @@ pub struct OutStructDef {
 }
 
 /// Structs that can be either inputs or outputs in methods.
+#[derive(Debug)]
 pub struct StructDef {
     pub docs: Docs,
     pub name: IdentBuf,
@@ -32,6 +34,7 @@ pub struct StructDef {
 /// to give up ownership.
 ///
 /// A struct marked with `#[diplomat::opaque]`.
+#[derive(Debug)]
 pub struct OpaqueDef {
     pub docs: Docs,
     pub name: IdentBuf,
@@ -39,6 +42,7 @@ pub struct OpaqueDef {
 }
 
 /// The enum type.
+#[derive(Debug)]
 pub struct EnumDef {
     pub docs: Docs,
     pub name: IdentBuf,
@@ -47,6 +51,7 @@ pub struct EnumDef {
 }
 
 /// A field on a [`OutStruct`]s.
+#[derive(Debug)]
 pub struct OutStructField {
     pub docs: Docs,
     pub name: IdentBuf,
@@ -54,6 +59,7 @@ pub struct OutStructField {
 }
 
 /// A field on a [`Struct`]s.
+#[derive(Debug)]
 pub struct StructField {
     pub docs: Docs,
     pub name: IdentBuf,
@@ -61,6 +67,7 @@ pub struct StructField {
 }
 
 /// A variant of an [`Enum`].
+#[derive(Debug)]
 pub struct EnumVariant {
     pub docs: Docs,
     pub name: IdentBuf,

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -113,7 +113,7 @@ impl TypeLifetime {
     pub(super) fn from_ast(named: &ast::NamedLifetime, lifetime_env: &ast::LifetimeEnv) -> Self {
         let index = lifetime_env
             .id(named)
-            .expect("named lifetime in lifetime env");
+            .unwrap_or_else(|| panic!("lifetime `{}` not found in lifetime env", named));
         Self::new(index)
     }
 

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -8,16 +8,19 @@ use smallvec::SmallVec;
 // TODO(Quinn): This type is going to mainly be recycled from `ast::LifetimeEnv`.
 // Not fully sure how that will look like yet, but the ideas of what this will do
 // is basically the same.
+#[derive(Debug)]
 pub struct LifetimeEnv {
     nodes: SmallVec<[LifetimeNode; 2]>,
 }
 
+#[derive(Debug)]
 pub enum LifetimeNode {
     Explicit(ExplicitLifetime),
     Implicit(ImplicitLifetime),
 }
 
 /// A named, boundable lifetime.
+#[derive(Debug)]
 pub struct ExplicitLifetime {
     ident: IdentBuf,
     longer: SmallVec<[usize; 2]>,
@@ -40,6 +43,7 @@ impl ExplicitLifetime {
 }
 
 /// An anonymous lifetime.
+#[derive(Debug)]
 pub struct ImplicitLifetime(u32);
 
 impl ImplicitLifetime {
@@ -53,7 +57,7 @@ impl ImplicitLifetime {
 ///
 /// This type can be mapped to a [`MethodLifetime`] by using the
 /// [`TypeLifetime::in_method`] method.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TypeLifetime {
     /// The index of the lifetime in a type's generic arguments,
     /// or `None` if `'static`.
@@ -70,7 +74,7 @@ pub struct TypeLifetime {
 /// [`StructPath`]: super::StructPath
 /// [`OutStructPath`]: super::OutStructPath
 /// [`OpaquePath`]: super::OpaquePath
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TypeLifetimes {
     indices: SmallVec<[TypeLifetime; 2]>,
 }

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -8,6 +8,7 @@ use super::{
 };
 
 /// A method exposed to Diplomat.
+#[derive(Debug)]
 pub struct Method {
     pub docs: Docs,
     pub name: IdentBuf,
@@ -19,23 +20,27 @@ pub struct Method {
 }
 
 /// Type that the method returns.
+#[derive(Debug)]
 pub enum ReturnType {
     Writeable,
     OutType(OutType),
 }
 
 /// Whether or not the method returns a value or a result.
+#[derive(Debug)]
 pub enum ReturnFallability {
     Infallible(Option<ReturnType>),
     Fallible(Option<ReturnType>, OutType),
 }
 
 /// The `self` parameter of a method.
+#[derive(Debug)]
 pub struct ParamSelf {
     ty: SelfType,
 }
 
 /// A parameter in a method.
+#[derive(Debug)]
 pub struct Param {
     name: IdentBuf,
     ty: Type,

--- a/core/src/hir/paths.rs
+++ b/core/src/hir/paths.rs
@@ -4,18 +4,21 @@ use super::{
 };
 
 /// Path to a struct that may appear as an output.
+#[derive(Debug)]
 pub enum ReturnableStructPath {
     Struct(StructPath),
     OutStruct(OutStructPath),
 }
 
 /// Path to a struct that can only be used as an output.
+#[derive(Debug)]
 pub struct OutStructPath {
     pub lifetimes: TypeLifetimes,
     tcx_id: OutStructId,
 }
 
 /// Path to a struct that can be used in inputs and outputs.
+#[derive(Debug)]
 pub struct StructPath {
     pub lifetimes: TypeLifetimes,
     tcx_id: StructId,
@@ -35,6 +38,7 @@ pub struct StructPath {
 /// entirely give up ownership of a value.
 /// 3. `OpaquePath<NonOptional, Borrow>`: Opaques in the `&self` position, which
 /// cannot be optional and must be borrowed for the same reason as above.
+#[derive(Debug)]
 pub struct OpaquePath<Opt, Owner> {
     pub lifetimes: TypeLifetimes,
     optional: Opt,
@@ -42,8 +46,10 @@ pub struct OpaquePath<Opt, Owner> {
     tcx_id: OpaqueId,
 }
 
+#[derive(Debug)]
 pub struct Optional(pub(super) bool);
 
+#[derive(Debug)]
 pub struct NonOptional;
 
 impl<Owner> OpaquePath<Optional, Owner> {
@@ -65,6 +71,7 @@ impl<Opt> OpaquePath<Opt, Borrow> {
 }
 
 /// Path to an enum.
+#[derive(Debug)]
 pub struct EnumPath {
     tcx_id: EnumId,
 }
@@ -72,7 +79,7 @@ pub struct EnumPath {
 /// Determine whether a pointer to an opaque type is owned or borrowed.
 ///
 /// Since owned opaques cannot be used as inputs, this only appears in output types.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum MaybeOwn {
     Own,
     Borrow(Borrow),

--- a/core/src/hir/primitives.rs
+++ b/core/src/hir/primitives.rs
@@ -2,7 +2,7 @@
 use crate::ast;
 
 /// 8, 16, 32, and 64-bit signed and unsigned integers.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum IntType {
     I8,
     I16,
@@ -15,28 +15,28 @@ pub enum IntType {
 }
 
 /// Platform-dependent signed and unsigned size types.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum IntSizeType {
     Isize,
     Usize,
 }
 
 /// 128-bit signed and unsigned integers.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum Int128Type {
     I128,
     U128,
 }
 
 /// 32 and 64-bit floating point numbers.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum FloatType {
     F32,
     F64,
 }
 
 /// All primitive types.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum PrimitiveType {
     Bool,
     Char,

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -1,0 +1,248 @@
+---
+source: core/src/hir/elision.rs
+expression: "{\n    use crate::ast;\n    let m =\n        ast::Module::from_syn(&syn::parse_quote! {\n                        mod ffi\n                        {\n                            #[diplomat :: opaque] struct Opaque < 'a > { s : & 'a str, }\n                            struct Struct < 'a > { s : & 'a str, } #[diplomat :: out]\n                            struct OutStruct < 'a > { inner : Box < Opaque < 'a >>, }\n                            impl < 'a > OutStruct < 'a >\n                            {\n                                pub fn new(s : & 'a str) -> Self\n                                { Self { inner : Box :: new(Opaque { s }) } }\n                            } impl < 'a > Struct < 'a >\n                            { pub fn rustc_elision(self, s : & str) -> & str { s } }\n                        }\n                    }, true);\n    let mut env = crate::Env::default();\n    let mut top_symbols = crate::ModuleEnv::default();\n    m.insert_all_types(ast::Path::empty(), &mut env);\n    top_symbols.insert(m.name.clone(),\n        ast::ModSymbol::SubModule(m.name.clone()));\n    env.insert(ast::Path::empty(), top_symbols);\n    let tcx = crate::hir::TypeContext::from_ast(&env).unwrap();\n    tcx\n}"
+---
+TypeContext {
+    out_structs: [
+        OutStructDef {
+            docs: Docs(
+                "",
+                [],
+            ),
+            name: Check {
+                _marker: PhantomData,
+                buf: "OutStruct",
+            },
+            fields: [
+                OutStructField {
+                    docs: Docs(
+                        "",
+                        [],
+                    ),
+                    name: Check {
+                        _marker: PhantomData,
+                        buf: "inner",
+                    },
+                    ty: Opaque(
+                        OpaquePath {
+                            lifetimes: TypeLifetimes {
+                                indices: [
+                                    TypeLifetime {
+                                        index: Some(
+                                            0,
+                                        ),
+                                    },
+                                ],
+                            },
+                            optional: Optional(
+                                true,
+                            ),
+                            owner: Own,
+                            tcx_id: OpaqueId(
+                                0,
+                            ),
+                        },
+                    ),
+                },
+            ],
+            methods: [
+                Method {
+                    docs: Docs(
+                        "",
+                        [],
+                    ),
+                    name: Check {
+                        _marker: PhantomData,
+                        buf: "new",
+                    },
+                    lifetime_env: LifetimeEnv {
+                        nodes: [
+                            Explicit(
+                                ExplicitLifetime {
+                                    ident: Check {
+                                        _marker: PhantomData,
+                                        buf: "a",
+                                    },
+                                    longer: [],
+                                    shorter: [],
+                                },
+                            ),
+                        ],
+                    },
+                    param_self: None,
+                    params: [
+                        Param {
+                            name: Check {
+                                _marker: PhantomData,
+                                buf: "s",
+                            },
+                            ty: Slice(
+                                Str(
+                                    TypeLifetime {
+                                        index: Some(
+                                            0,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    output: Infallible(
+                        Some(
+                            OutType(
+                                Struct(
+                                    OutStruct(
+                                        OutStructPath {
+                                            lifetimes: TypeLifetimes {
+                                                indices: [
+                                                    TypeLifetime {
+                                                        index: Some(
+                                                            0,
+                                                        ),
+                                                    },
+                                                ],
+                                            },
+                                            tcx_id: OutStructId(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                },
+            ],
+        },
+    ],
+    structs: [
+        StructDef {
+            docs: Docs(
+                "",
+                [],
+            ),
+            name: Check {
+                _marker: PhantomData,
+                buf: "Struct",
+            },
+            fields: [
+                StructField {
+                    docs: Docs(
+                        "",
+                        [],
+                    ),
+                    name: Check {
+                        _marker: PhantomData,
+                        buf: "s",
+                    },
+                    ty: Slice(
+                        Str(
+                            TypeLifetime {
+                                index: Some(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ],
+            methods: [
+                Method {
+                    docs: Docs(
+                        "",
+                        [],
+                    ),
+                    name: Check {
+                        _marker: PhantomData,
+                        buf: "rustc_elision",
+                    },
+                    lifetime_env: LifetimeEnv {
+                        nodes: [
+                            Explicit(
+                                ExplicitLifetime {
+                                    ident: Check {
+                                        _marker: PhantomData,
+                                        buf: "a",
+                                    },
+                                    longer: [],
+                                    shorter: [],
+                                },
+                            ),
+                            Implicit(
+                                ImplicitLifetime(
+                                    1,
+                                ),
+                            ),
+                        ],
+                    },
+                    param_self: Some(
+                        ParamSelf {
+                            ty: Struct(
+                                StructPath {
+                                    lifetimes: TypeLifetimes {
+                                        indices: [
+                                            TypeLifetime {
+                                                index: Some(
+                                                    0,
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                    tcx_id: StructId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    params: [
+                        Param {
+                            name: Check {
+                                _marker: PhantomData,
+                                buf: "s",
+                            },
+                            ty: Slice(
+                                Str(
+                                    TypeLifetime {
+                                        index: Some(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    output: Infallible(
+                        Some(
+                            OutType(
+                                Slice(
+                                    Str(
+                                        TypeLifetime {
+                                            index: Some(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                },
+            ],
+        },
+    ],
+    opaques: [
+        OpaqueDef {
+            docs: Docs(
+                "",
+                [],
+            ),
+            name: Check {
+                _marker: PhantomData,
+                buf: "Opaque",
+            },
+            methods: [],
+        },
+    ],
+    enums: [],
+}

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -17,19 +17,19 @@ pub struct TypeContext {
 }
 
 /// Key used to index into a [`TypeContext`] representing a struct.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct StructId(usize);
 
 /// Key used to index into a [`TypeContext`] representing an out struct.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct OutStructId(usize);
 
 /// Key used to index into a [`TypeContext`] representing a opaque.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct OpaqueId(usize);
 
 /// Key used to index into a [`TypeContext`] representing an enum.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct EnumId(usize);
 
 impl TypeContext {

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::ops::Index;
 
 /// A context type owning all types exposed to Diplomat.
+#[derive(Debug)]
 pub struct TypeContext {
     out_structs: Vec<OutStructDef>,
     structs: Vec<StructDef>,
@@ -100,7 +101,10 @@ impl TypeContext {
                     enums,
                 })
             }
-            _ => Err(errors),
+            _ => {
+                assert!(!errors.is_empty(), "Lowering failed without error messages");
+                Err(errors)
+            }
         }
     }
 }

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -8,6 +8,7 @@ use crate::ast;
 pub use ast::Mutability;
 
 /// Type that can only be used as an output.
+#[derive(Debug)]
 pub enum OutType {
     Primitive(PrimitiveType),
     Opaque(OpaquePath<Optional, MaybeOwn>),
@@ -17,6 +18,7 @@ pub enum OutType {
 }
 
 /// Type that may be used as input or output.
+#[derive(Debug)]
 pub enum Type {
     Primitive(PrimitiveType),
     Opaque(OpaquePath<Optional, Borrow>),
@@ -26,13 +28,14 @@ pub enum Type {
 }
 
 /// Type that can appear in the `self` position.
+#[derive(Debug)]
 pub enum SelfType {
     Opaque(OpaquePath<NonOptional, Borrow>),
     Struct(StructPath),
     Enum(EnumPath),
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum Slice {
     /// A string slice, e.g. `&str`.
     Str(TypeLifetime),
@@ -49,7 +52,7 @@ pub enum Slice {
 // where implicit lifetimes are allowed. Getting this to all fit together will
 // involve getting the implicit lifetime thing to be understood by Diplomat, but
 // should be doable.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Borrow {
     pub lifetime: TypeLifetime,
     pub mutability: Mutability,


### PR DESCRIPTION
Small PR to add the first iteration of snapshots, which are just debug snapshots. Eventually we'll want to do this better with serde and converting the IDs into type names, but this is good for now for catching bugs in the implementation.

For example, I caught a copy-pasta error that didn't allow out structs to contain owned opaques. We should write a lot more tests, but it seems from my super naive testing that lifetime elision works :)