### PR TITLE
Improve lifetime tracking for backends

### DIFF
--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -53,22 +53,54 @@ impl ImplicitLifetime {
     }
 }
 
+/// Wrapper type for `TypeLifetime` and `MethodLifetime`, indicating that it may
+/// be the `'static` lifetime.
+#[derive(Copy, Clone, Debug)]
+pub enum MaybeStatic<T> {
+    Static,
+    NonStatic(T),
+}
+
+impl<T> MaybeStatic<T> {
+    /// Maps the lifetime, if it's not the `'static` lifetime, to another
+    /// non-static lifetime.
+    pub(super) fn map_nonstatic<F, R>(self, f: F) -> MaybeStatic<R>
+    where
+        F: FnOnce(T) -> R,
+    {
+        match self {
+            MaybeStatic::Static => MaybeStatic::Static,
+            MaybeStatic::NonStatic(lifetime) => MaybeStatic::NonStatic(f(lifetime)),
+        }
+    }
+
+    /// Maps the lifetime, if it's not the `'static` lifetime, to a potentially
+    /// static lifetime.
+    pub(super) fn flat_map_nonstatic<R, F>(self, f: F) -> MaybeStatic<R>
+    where
+        F: FnOnce(T) -> MaybeStatic<R>,
+    {
+        match self {
+            MaybeStatic::Static => MaybeStatic::Static,
+            MaybeStatic::NonStatic(lifetime) => f(lifetime),
+        }
+    }
+}
+
 /// A lifetime that exists as part of a type signature.
 ///
 /// This type can be mapped to a [`MethodLifetime`] by using the
-/// [`TypeLifetime::in_method`] method.
+/// [`TypeLifetime::as_method_lifetime`] method.
 #[derive(Copy, Clone, Debug)]
 pub struct TypeLifetime {
-    /// The index of the lifetime in a type's generic arguments,
-    /// or `None` if `'static`.
-    index: Option<usize>,
+    index: usize,
 }
 
 /// A set of lifetimes that exist as generic arguments on [`StructPath`]s,
 /// [`OutStructPath`]s, and [`OpaquePath`]s.
 ///
 /// By itself, `TypeLifetimes` isn't very useful. However, it can be combined with
-/// a [`MethodLifetimes`] using [`TypeLifetimes::in_method`] to get the lifetimes
+/// a [`MethodLifetimes`] using [`TypeLifetimes::as_method_lifetimes`] to get the lifetimes
 /// in the scope of a method it appears in.
 ///
 /// [`StructPath`]: super::StructPath
@@ -76,7 +108,7 @@ pub struct TypeLifetime {
 /// [`OpaquePath`]: super::OpaquePath
 #[derive(Clone, Debug)]
 pub struct TypeLifetimes {
-    indices: SmallVec<[TypeLifetime; 2]>,
+    indices: SmallVec<[MaybeStatic<TypeLifetime>; 2]>,
 }
 
 /// A lifetime that exists as part of a method signature.
@@ -90,7 +122,7 @@ pub struct MethodLifetime<'m> {
 /// in the method that it refers to.
 pub struct MethodLifetimes<'m> {
     lifetime_env: &'m LifetimeEnv,
-    indices: SmallVec<[Option<usize>; 2]>,
+    indices: SmallVec<[MaybeStatic<usize>; 2]>,
 }
 
 impl LifetimeEnv {
@@ -103,7 +135,7 @@ impl LifetimeEnv {
     pub fn method_lifetimes(&self) -> MethodLifetimes {
         MethodLifetimes {
             lifetime_env: self,
-            indices: (0..self.nodes.len()).map(Some).collect(),
+            indices: (0..self.nodes.len()).map(MaybeStatic::NonStatic).collect(),
         }
     }
 }
@@ -127,44 +159,43 @@ impl TypeLifetime {
         Self::new(index)
     }
 
-    /// Returns a [`TypeLifetime`] representing the `'static` lifetime.
-    pub(super) fn new_static() -> Self {
-        Self { index: None }
-    }
-
     /// Returns a [`TypeLifetime`] from an index.
-    ///
-    /// This method is used internally by [`TypeLifetime::from_ast`] and
-    /// [`TypeLifetime::new_elided`].
     fn new(index: usize) -> Self {
-        Self { index: Some(index) }
+        Self { index }
     }
 
-    /// Returns the index that `self` appears in a [`MethodLifetimes`],
-    /// or `None` if it is, or is substituted as, the `'static` lifetime.
-    fn as_method_index(self, method_lifetimes: &MethodLifetimes<'_>) -> Option<usize> {
-        self.index.and_then(|index| method_lifetimes.indices[index])
+    /// Returns the index that `self` appears in a [`MethodLifetimes`] wrapped
+    /// in `MaybeStatic::NonStatic`, or `MaybeStatic::Static` if it's substituted
+    /// as `'static`.
+    fn as_method_index(self, method_lifetimes: &MethodLifetimes<'_>) -> MaybeStatic<usize> {
+        method_lifetimes.indices[self.index]
     }
 
-    /// Returns a new [`MethodLifetime`] representing `self` in the scope of the
-    /// method that it appears in.
-    pub fn in_method<'m>(
+    /// Returns a new [`MaybeStatic<MethodLifetime>`] representing `self` in the
+    /// scope of the method that it appears in.
+    ///
+    /// For example, if we have some `Foo<'a>` type with a field `&'a Bar`, then
+    /// we can call this on the `'a` on the field. If `Foo` was `Foo<'static>`
+    /// in the method, then this will return `MaybeStatic::Static`. But if it
+    /// was `Foo<'b>`, then this will return `MaybeStatic::NonStatic` containing
+    /// the `MethodLifetime` corresponding to `'b`.
+    pub fn as_method_lifetime<'m>(
         self,
         method_lifetimes: &MethodLifetimes<'m>,
-    ) -> Option<MethodLifetime<'m>> {
+    ) -> MaybeStatic<MethodLifetime<'m>> {
         self.as_method_index(method_lifetimes)
-            .map(|index| MethodLifetime::new(index, method_lifetimes.lifetime_env))
+            .map_nonstatic(|index| MethodLifetime::new(index, method_lifetimes.lifetime_env))
     }
 }
 
 impl TypeLifetimes {
     pub(super) fn from_fn<F>(lifetimes: &[ast::Lifetime], lower_fn: F) -> Self
     where
-        F: FnMut(&ast::Lifetime) -> TypeLifetime,
+        F: FnMut(&ast::Lifetime) -> MaybeStatic<TypeLifetime>,
     {
-        let indices = lifetimes.iter().map(lower_fn).collect();
-
-        Self { indices }
+        Self {
+            indices: lifetimes.iter().map(lower_fn).collect(),
+        }
     }
 
     /// Returns a new [`MethodLifetimes`] representing the lifetimes in the scope
@@ -190,14 +221,19 @@ impl TypeLifetimes {
     ///
     /// This tells us that `arg.alice` has lifetime `'x` in the method, and
     /// that `arg.bob` has lifetime `'y`.
-    pub fn in_method<'m>(&self, method_lifetimes: &MethodLifetimes<'m>) -> MethodLifetimes<'m> {
+    pub fn as_method_lifetimes<'m>(
+        &self,
+        method_lifetimes: &MethodLifetimes<'m>,
+    ) -> MethodLifetimes<'m> {
         MethodLifetimes {
             indices: self
                 .indices
                 .iter()
-                .map(|lifetime| lifetime.as_method_index(method_lifetimes))
+                .map(|maybe_static_lt| {
+                    maybe_static_lt.flat_map_nonstatic(|lt| lt.as_method_index(method_lifetimes))
+                })
                 .collect(),
-            ..*method_lifetimes
+            lifetime_env: method_lifetimes.lifetime_env,
         }
     }
 }
@@ -214,10 +250,9 @@ impl<'m> MethodLifetime<'m> {
 
 impl<'m> MethodLifetimes<'m> {
     /// Returns an iterator over the contained [`MethodLifetime`]s.
-    pub(super) fn iter(&self) -> impl Iterator<Item = MethodLifetime<'m>> + '_ {
-        self.indices
-            .iter()
-            .flatten()
-            .map(|&index| MethodLifetime::new(index, self.lifetime_env))
+    pub(super) fn lifetimes(&self) -> impl Iterator<Item = MaybeStatic<MethodLifetime<'m>>> + '_ {
+        self.indices.iter().map(|maybe_static| {
+            maybe_static.map_nonstatic(|index| MethodLifetime::new(index, self.lifetime_env))
+        })
     }
 }

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -186,7 +186,7 @@ impl ParentId {
 
 impl<'m> BorrowingFieldVisitor<'m> {
     /// Visits every borrowing field and method lifetime that it uses.
-    /// 
+    ///
     /// The idea is that you could use this to construct a mapping from
     /// `MethodLifetime`s to `BorrowingField`s. We choose to use a visitor
     /// pattern to avoid having to

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -341,8 +341,8 @@ impl<'m> BorrowingFieldVisitor<'m> {
         method_lifetimes: &MethodLifetimes<'m>,
         leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf<'m>; 8]>,
     ) {
-        let method_borrow_lifetime = borrow.in_method(&method_lifetimes);
-        let method_type_lifetimes = lifetimes.in_method(&method_lifetimes);
+        let method_borrow_lifetime = borrow.in_method(method_lifetimes);
+        let method_type_lifetimes = lifetimes.in_method(method_lifetimes);
         leaves.push(BorrowingFieldVisitorLeaf::Opaque(
             parent,
             method_borrow_lifetime,
@@ -357,7 +357,7 @@ impl<'m> BorrowingFieldVisitor<'m> {
         method_lifetimes: &MethodLifetimes<'m>,
         leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf<'m>; 8]>,
     ) {
-        let method_lifetime = slice.lifetime().in_method(&method_lifetimes);
+        let method_lifetime = slice.lifetime().in_method(method_lifetimes);
         leaves.push(BorrowingFieldVisitorLeaf::Slice(parent, method_lifetime));
     }
 
@@ -371,7 +371,7 @@ impl<'m> BorrowingFieldVisitor<'m> {
         parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
         leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf<'m>; 8]>,
     ) {
-        let method_type_lifetimes = ty.lifetimes.in_method(&method_lifetimes);
+        let method_type_lifetimes = ty.lifetimes.in_method(method_lifetimes);
         for field in ty.resolve(tcx).fields.iter() {
             Self::from_type(
                 &field.ty,

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -27,11 +27,11 @@ TypeContext {
                         OpaquePath {
                             lifetimes: TypeLifetimes {
                                 indices: [
-                                    TypeLifetime {
-                                        index: Some(
-                                            0,
-                                        ),
-                                    },
+                                    NonStatic(
+                                        TypeLifetime {
+                                            index: 0,
+                                        },
+                                    ),
                                 ],
                             },
                             optional: Optional(
@@ -78,11 +78,11 @@ TypeContext {
                             },
                             ty: Slice(
                                 Str(
-                                    TypeLifetime {
-                                        index: Some(
-                                            0,
-                                        ),
-                                    },
+                                    NonStatic(
+                                        TypeLifetime {
+                                            index: 0,
+                                        },
+                                    ),
                                 ),
                             ),
                         },
@@ -95,11 +95,11 @@ TypeContext {
                                         OutStructPath {
                                             lifetimes: TypeLifetimes {
                                                 indices: [
-                                                    TypeLifetime {
-                                                        index: Some(
-                                                            0,
-                                                        ),
-                                                    },
+                                                    NonStatic(
+                                                        TypeLifetime {
+                                                            index: 0,
+                                                        },
+                                                    ),
                                                 ],
                                             },
                                             tcx_id: OutStructId(
@@ -137,11 +137,11 @@ TypeContext {
                     },
                     ty: Slice(
                         Str(
-                            TypeLifetime {
-                                index: Some(
-                                    0,
-                                ),
-                            },
+                            NonStatic(
+                                TypeLifetime {
+                                    index: 0,
+                                },
+                            ),
                         ),
                     ),
                 },
@@ -181,11 +181,11 @@ TypeContext {
                                 StructPath {
                                     lifetimes: TypeLifetimes {
                                         indices: [
-                                            TypeLifetime {
-                                                index: Some(
-                                                    0,
-                                                ),
-                                            },
+                                            NonStatic(
+                                                TypeLifetime {
+                                                    index: 0,
+                                                },
+                                            ),
                                         ],
                                     },
                                     tcx_id: StructId(
@@ -203,11 +203,11 @@ TypeContext {
                             },
                             ty: Slice(
                                 Str(
-                                    TypeLifetime {
-                                        index: Some(
-                                            1,
-                                        ),
-                                    },
+                                    NonStatic(
+                                        TypeLifetime {
+                                            index: 1,
+                                        },
+                                    ),
                                 ),
                             ),
                         },
@@ -217,11 +217,11 @@ TypeContext {
                             OutType(
                                 Slice(
                                     Str(
-                                        TypeLifetime {
-                                            index: Some(
-                                                1,
-                                            ),
-                                        },
+                                        NonStatic(
+                                            TypeLifetime {
+                                                index: 1,
+                                            },
+                                        ),
                                     ),
                                 ),
                             ),

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -1,8 +1,8 @@
 //! Types that can be exposed in Diplomat APIs.
 
 use super::{
-    EnumPath, MaybeOwn, NonOptional, OpaquePath, Optional, PrimitiveType, ReturnableStructPath,
-    StructPath, TypeContext, TypeLifetime,
+    EnumPath, MaybeOwn, MaybeStatic, NonOptional, OpaquePath, Optional, PrimitiveType,
+    ReturnableStructPath, StructPath, TypeContext, TypeLifetime,
 };
 use crate::ast;
 pub use ast::Mutability;
@@ -38,7 +38,7 @@ pub enum SelfType {
 #[derive(Copy, Clone, Debug)]
 pub enum Slice {
     /// A string slice, e.g. `&str`.
-    Str(TypeLifetime),
+    Str(MaybeStatic<TypeLifetime>),
 
     /// A primitive slice, e.g. `&mut [u8]`.
     Primitive(Borrow, PrimitiveType),
@@ -54,7 +54,7 @@ pub enum Slice {
 // should be doable.
 #[derive(Copy, Clone, Debug)]
 pub struct Borrow {
-    pub lifetime: TypeLifetime,
+    pub lifetime: MaybeStatic<TypeLifetime>,
     pub mutability: Mutability,
 }
 
@@ -78,7 +78,7 @@ impl Type {
 impl Slice {
     /// Returns the [`TypeLifetime`] contained in either the `Str` or `Primitive`
     /// variant.
-    pub fn lifetime(&self) -> &TypeLifetime {
+    pub fn lifetime(&self) -> &MaybeStatic<TypeLifetime> {
         match self {
             Slice::Str(lifetime) => lifetime,
             Slice::Primitive(reference, _) => &reference.lifetime,
@@ -87,7 +87,7 @@ impl Slice {
 }
 
 impl Borrow {
-    pub(super) fn new(lifetime: TypeLifetime, mutability: Mutability) -> Self {
+    pub(super) fn new(lifetime: MaybeStatic<TypeLifetime>, mutability: Mutability) -> Self {
         Self {
             lifetime,
             mutability,


### PR DESCRIPTION
When I designed the HIR, I made it easy to track lifetimes down through nested structs. What I didn't consider was how backends would actually use this information, or how I could make that process less painful.

The goal of this PR was to provide an interface for backends to be able to ask an HIR method "what are all the (potentially nested in structs) opaques and slices that borrow in the arguments, and from which lifetimes do they borrow from at the method level?" It should be noted that this PR **doesn't intend to change the model of the HIR,** it only extends upon its existing functionality to provide better QOL tools.
It does this with minimal allocations by using a visitor, but I anticipate that backends will just use it to create a `BTreeMap` from lifetimes to a vec of unpacked fields. **(Q: should I just make it return a `BTreeMap` if I think that's what it's mostly gonna be used for?)**

As of the time of writing this, it works by calling `Method::borrowing_field_visitor` on a method, which creates a `BorrowingFieldsVisitor` that allocates memory to efficiently represent unpacked fields and their paths (like first.second.third) of the arguments, but only the ones that borrow.

Then, `BorrowingFieldsVisitor::visit_borrowing_fields` is called, which takes a visitor function that accepts a `MethodLifetime` and a `BorrowingField`. The `BorrowingField` (prev `UnpackedField`) can then call a `trace` function, which lets you see the path like `first.second.third`.

# Questions
I'm not happy with a lot of the naming and want ideas for improving it.

Also I still need to think more thoroughly about how backends are going to use this information when tying input fields to fields in the output, since all of this only works on inputs. I think it should be straightforward though but I want to have a concrete plan/impl before this gets merged.