### PR TITLE
Replace `structopt` with `clap@3`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,17 +144,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -262,16 +277,16 @@ version = "0.3.0"
 name = "diplomat-tool"
 version = "0.3.0"
 dependencies = [
+ "clap",
  "colored",
  "diplomat_core",
  "displaydoc",
- "heck 0.4.0",
+ "heck",
  "indenter",
  "insta",
  "pulldown-cmark",
  "quote",
  "serde",
- "structopt",
  "syn",
  "syn-inline-mod",
  "tera",
@@ -430,6 +445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heapless"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,15 +460,6 @@ dependencies = [
  "hash32",
  "serde",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -671,6 +683,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "insta"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,15 +798,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "pest"
@@ -1142,33 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1234,6 +1238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,12 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -1394,12 +1404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,12 +1426,6 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -16,7 +16,7 @@ syn-inline-mod = "0.4.0"
 quote = "1.0"
 indenter = "0.3.3"
 pulldown-cmark = "0.8.0"
-structopt = "0.3"
+clap = { features = ["color", "derive", "std", "suggestions"], version = "3.2.2" }
 colored = "2.0"
 serde = { features = ["derive"], version = "1.0.130" }
 toml = "0.5.8"

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -6,40 +6,40 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use clap::Parser;
 use colored::*;
 use diplomat_core::ast;
 use diplomat_tool::{c, cpp, dotnet, js};
-use structopt::StructOpt;
 
-/// diplomat-tool CLI options, as parsed by [structopt].
-#[derive(Debug, StructOpt)]
-#[structopt(
+/// diplomat-tool CLI options, as parsed by [clap-derive].
+#[derive(Debug, Parser)]
+#[clap(
     name = "diplomat-tool",
     about = "Generate bindings to a target language"
 )]
 struct Opt {
     /// The target language, "js", "c", "cpp" or "dotnet" (C#).
-    #[structopt()]
+    #[clap()]
     target_language: String,
 
     /// The folder that stores the bindings.
-    #[structopt(parse(from_os_str))]
+    #[clap(value_parser)]
     out_folder: PathBuf,
 
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     docs: Option<PathBuf>,
 
-    #[structopt(short = "-u", long)]
+    #[clap(short = 'u', long)]
     docs_base_urls: Vec<String>,
 
     /// The path to the lib.rs file. Defaults to src/lib.rs
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     entry: Option<PathBuf>,
 
     /// The path to an optional config file to override code generation defaults.
     /// This is currently used by the cpp generator to allow for code to be
     /// different libraries.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     library_config: Option<PathBuf>,
 }
 


### PR DESCRIPTION
Running [`cargo audit`](https://crates.io/crates/cargo-audit) on a project depending on this repository gives a warning that the transitive dependency `ansi_term` [is unmaintained ](https://rustsec.org/advisories/RUSTSEC-2021-0139).  This comes from the `structopt` dependency by way of `clap@2`.  However, `structopt` [is in maintenance mode](https://github.com/TeXitoi/structopt/tree/v0.3.26#maintenance) since its main feature is included in `clap@3`, so that dependency on `clap@2` will not be updated.  As it is suggested by `structopt` to move to `clap@3`, and `clap@3` replaced the `ansi_term` dependency, I am filing this PR to do so.

Please let me know if I have missed anything, or if this change is unwanted.