### PR TITLE
HIR `MethodLifetime` transitivity, some testing

### DIFF
--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -5,6 +5,8 @@ use super::IdentBuf;
 use crate::ast;
 use smallvec::{smallvec, SmallVec};
 
+/// Convenience const representing the number of lifetimes a [`LifetimeEnv`]
+/// can hold inline before needing to dynamically allocate.
 const INLINE_NUM_LIFETIMES: usize = 4;
 
 // TODO(Quinn): This type is going to mainly be recycled from `ast::LifetimeEnv`.

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -138,7 +138,7 @@ pub struct TypeLifetimes {
 
 /// A lifetime that exists as part of a method signature, e.g. `'a` or an
 /// anonymous lifetime.
-/// 
+///
 /// This type is intended to be used as a key into a map to keep track of which
 /// borrowed fields depend on which method lifetimes.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -50,9 +50,14 @@ pub struct Param {
 
 /// An id for indexing into a [`BorrowingFieldsVisitor`].
 #[derive(Copy, Clone, Debug)]
-pub struct ParentId(usize);
+struct ParentId(usize);
 
+/// Convenience const representing the number of nested structs a [`BorrowingFieldVisitor`]
+/// can hold inline before needing to dynamically allocate.
 const INLINE_NUM_PARENTS: usize = 4;
+
+/// Convenience const representing the number of borrowed fields a [`BorrowingFieldVisitor`]
+/// can hold inline before needing to dynamically allocate.
 const INLINE_NUM_LEAVES: usize = 8;
 
 /// A tree of lifetimes mapping onto a specific instantiation of a type tree.
@@ -64,7 +69,7 @@ pub struct BorrowingFieldVisitor<'m> {
 }
 
 /// Non-recursive input-output types that contain lifetimes
-pub enum BorrowingFieldVisitorLeaf {
+enum BorrowingFieldVisitorLeaf {
     Opaque(ParentId, MaybeStatic<MethodLifetime>, MethodLifetimes),
     Slice(ParentId, MaybeStatic<MethodLifetime>),
 }

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -52,15 +52,15 @@ pub struct Param {
 #[derive(Copy, Clone, Debug)]
 pub struct ParentId(usize);
 
-const EXPECTED_NUM_PARENTS: usize = 4;
-const EXPECTED_NUM_LEAVES: usize = 8;
+const INLINE_NUM_PARENTS: usize = 4;
+const INLINE_NUM_LEAVES: usize = 8;
 
 /// A tree of lifetimes mapping onto a specific instantiation of a type tree.
 ///
 /// Each `BorrowingFieldsVisitor` corresponds to the type of an input of a method.
 pub struct BorrowingFieldVisitor<'m> {
-    parents: SmallVec<[(Option<ParentId>, &'m Ident); EXPECTED_NUM_PARENTS]>,
-    leaves: SmallVec<[BorrowingFieldVisitorLeaf; EXPECTED_NUM_LEAVES]>,
+    parents: SmallVec<[(Option<ParentId>, &'m Ident); INLINE_NUM_PARENTS]>,
+    leaves: SmallVec<[BorrowingFieldVisitorLeaf; INLINE_NUM_LEAVES]>,
 }
 
 /// Non-recursive input-output types that contain lifetimes
@@ -289,11 +289,11 @@ impl<'m> BorrowingFieldVisitor<'m> {
                 // sanity check that the preallocations were correct
                 debug_assert_eq!(
                     parents.capacity(),
-                    std::cmp::max(EXPECTED_NUM_PARENTS, num_fields + num_params)
+                    std::cmp::max(INLINE_NUM_PARENTS, num_fields + num_params)
                 );
                 debug_assert_eq!(
                     leaves.capacity(),
-                    std::cmp::max(EXPECTED_NUM_LEAVES, num_leaves)
+                    std::cmp::max(INLINE_NUM_LEAVES, num_leaves)
                 );
                 (parents, leaves)
             })

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -1,5 +1,7 @@
 //! Methods for types and navigating lifetimes within methods.
 
+use std::fmt::{self, Write};
+
 use smallvec::SmallVec;
 
 use super::{
@@ -47,25 +49,24 @@ pub struct Param {
 }
 
 /// An id for indexing into a [`BorrowingFieldsVisitor`].
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct ParentId(usize);
+
+const EXPECTED_NUM_PARENTS: usize = 4;
+const EXPECTED_NUM_LEAVES: usize = 8;
 
 /// A tree of lifetimes mapping onto a specific instantiation of a type tree.
 ///
 /// Each `BorrowingFieldsVisitor` corresponds to the type of an input of a method.
 pub struct BorrowingFieldVisitor<'m> {
-    parents: SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
-    leaves: SmallVec<[BorrowingFieldVisitorLeaf<'m>; 8]>,
+    parents: SmallVec<[(Option<ParentId>, &'m Ident); EXPECTED_NUM_PARENTS]>,
+    leaves: SmallVec<[BorrowingFieldVisitorLeaf; EXPECTED_NUM_LEAVES]>,
 }
 
 /// Non-recursive input-output types that contain lifetimes
-pub enum BorrowingFieldVisitorLeaf<'m> {
-    Opaque(
-        ParentId,
-        MaybeStatic<MethodLifetime<'m>>,
-        MethodLifetimes<'m>,
-    ),
-    Slice(ParentId, MaybeStatic<MethodLifetime<'m>>),
+pub enum BorrowingFieldVisitorLeaf {
+    Opaque(ParentId, MaybeStatic<MethodLifetime>, MethodLifetimes),
+    Slice(ParentId, MaybeStatic<MethodLifetime>),
 }
 
 /// A leaf of a lifetime tree capable of tracking its parents.
@@ -76,7 +77,7 @@ pub struct BorrowingField<'m> {
     parents: &'m [(Option<ParentId>, &'m Ident)],
 
     /// The unpacked field that is a leaf on the tree.
-    leaf: &'m BorrowingFieldVisitorLeaf<'m>,
+    leaf: &'m BorrowingFieldVisitorLeaf,
 }
 
 impl ReturnType {
@@ -118,13 +119,12 @@ impl ParamSelf {
         Self { ty }
     }
 
-    /// Return the number of fields and leaves that will show up in the [`BorrowingFieldsVisitor`]
-    /// returned by [`ParamSelf::lifetime_tree`].
+    /// Return the number of fields and leaves that will show up in the [`BorrowingFieldVisitor`].
     ///
     /// This method is used to calculate how much space to allocate upfront.
     fn field_leaf_lifetime_counts(&self, tcx: &TypeContext) -> (usize, usize) {
         match self.ty {
-            SelfType::Opaque(_) => (0, 1),
+            SelfType::Opaque(_) => (1, 1),
             SelfType::Struct(ref ty) => ty.resolve(tcx).fields.iter().fold((1, 0), |acc, field| {
                 let inner = field.ty.field_leaf_lifetime_counts(tcx);
                 (acc.0 + inner.0, acc.1 + inner.1)
@@ -148,7 +148,7 @@ impl Method {
     }
 
     /// Returns a fresh [`MethodLifetimes`] corresponding to `self`.
-    pub fn method_lifetimes(&self) -> MethodLifetimes<'_> {
+    pub fn method_lifetimes(&self) -> MethodLifetimes {
         self.lifetime_env.method_lifetimes()
     }
 
@@ -157,20 +157,17 @@ impl Method {
     /// have a lifetime.
     /// ```ignore
     /// # use std::collections::BTreeMap;
-    /// let visitor = method.borrowing_field_visitor(tcx, "this".ck().unwrap());
+    /// let visitor = method.borrowing_field_visitor(&tcx, "this".ck().unwrap());
     /// let mut map = BTreeMap::new();
     /// visitor.visit_borrowing_fields(|lifetime, field| {
     ///     map.entry(lifetime).or_default().push(field);
     /// })
     /// ```
-    pub fn borrowing_field_visitor<'m, F>(
+    pub fn borrowing_field_visitor<'m>(
         &'m self,
         tcx: &'m TypeContext,
         self_name: &'m Ident,
-    ) -> BorrowingFieldVisitor<'m>
-    where
-        F: FnMut(MethodLifetime<'m>, BorrowingField<'m>),
-    {
+    ) -> BorrowingFieldVisitor<'m> {
         BorrowingFieldVisitor::new(self, tcx, self_name)
     }
 }
@@ -205,9 +202,9 @@ impl<'m> BorrowingFieldVisitor<'m> {
     /// into so far, and when you hit some lifetime 'a, generate docs saying
     /// "path.to.current.field must be outlived by {borrowing fields of input that
     /// contain 'a}".
-    pub fn visit_borrowing_fields<F>(&'m self, mut visit: F)
+    pub fn visit_borrowing_fields<'a, F>(&'a self, mut visit: F)
     where
-        F: FnMut(MaybeStatic<MethodLifetime<'m>>, BorrowingField<'m>),
+        F: FnMut(MaybeStatic<MethodLifetime>, BorrowingField<'a>),
     {
         for leaf in self.leaves.iter() {
             let borrowing_field = BorrowingField {
@@ -216,7 +213,6 @@ impl<'m> BorrowingFieldVisitor<'m> {
             };
 
             match leaf {
-                // todo: fix this
                 BorrowingFieldVisitorLeaf::Opaque(_, lt, method_lifetimes) => {
                     visit(*lt, borrowing_field);
                     for lt in method_lifetimes.lifetimes() {
@@ -290,9 +286,15 @@ impl<'m> BorrowingFieldVisitor<'m> {
                     );
                 }
 
-                // just confirm that we did things right
-                debug_assert_eq!(parents.capacity(), num_fields + num_params);
-                debug_assert_eq!(leaves.capacity(), num_leaves);
+                // sanity check that the preallocations were correct
+                debug_assert_eq!(
+                    parents.capacity(),
+                    std::cmp::max(EXPECTED_NUM_PARENTS, num_fields + num_params)
+                );
+                debug_assert_eq!(
+                    leaves.capacity(),
+                    std::cmp::max(EXPECTED_NUM_LEAVES, num_leaves)
+                );
                 (parents, leaves)
             })
             .unwrap_or_default();
@@ -305,9 +307,9 @@ impl<'m> BorrowingFieldVisitor<'m> {
         ty: &'m Type,
         tcx: &'m TypeContext,
         parent: ParentId,
-        method_lifetimes: &MethodLifetimes<'m>,
+        method_lifetimes: &MethodLifetimes,
         parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
-        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf<'m>; 8]>,
+        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
     ) {
         match ty {
             Type::Opaque(path) => {
@@ -334,8 +336,8 @@ impl<'m> BorrowingFieldVisitor<'m> {
         lifetimes: &'m TypeLifetimes,
         borrow: &'m MaybeStatic<TypeLifetime>,
         parent: ParentId,
-        method_lifetimes: &MethodLifetimes<'m>,
-        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf<'m>; 8]>,
+        method_lifetimes: &MethodLifetimes,
+        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
     ) {
         let method_borrow_lifetime =
             borrow.flat_map_nonstatic(|lt| lt.as_method_lifetime(method_lifetimes));
@@ -351,8 +353,8 @@ impl<'m> BorrowingFieldVisitor<'m> {
     fn visit_slice(
         slice: &Slice,
         parent: ParentId,
-        method_lifetimes: &MethodLifetimes<'m>,
-        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf<'m>; 8]>,
+        method_lifetimes: &MethodLifetimes,
+        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
     ) {
         let method_lifetime = slice
             .lifetime()
@@ -360,15 +362,15 @@ impl<'m> BorrowingFieldVisitor<'m> {
         leaves.push(BorrowingFieldVisitorLeaf::Slice(parent, method_lifetime));
     }
 
-    /// Add a struct as a parent an recurse down leaves during construction of a
+    /// Add a struct as a parent and recurse down leaves during construction of a
     /// [`BorrowingFieldsVisitor`].
     fn visit_struct(
         ty: &paths::StructPath,
         tcx: &'m TypeContext,
         parent: ParentId,
-        method_lifetimes: &MethodLifetimes<'m>,
+        method_lifetimes: &MethodLifetimes,
         parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
-        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf<'m>; 8]>,
+        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
     ) {
         let method_type_lifetimes = ty.lifetimes.as_method_lifetimes(method_lifetimes);
         for field in ty.resolve(tcx).fields.iter() {
@@ -389,9 +391,9 @@ impl<'m> BorrowingField<'m> {
     ///
     /// If `self` represents the field `param.first.second`, then calling [`BorrowingField::trace`]
     /// will visit the following in order: `"param"`, `"first"`, `"second"`.
-    pub fn trace<F>(&self, visit: &mut F)
+    pub fn backtrace<F>(&self, mut visit: F)
     where
-        F: FnMut(&'m Ident),
+        F: FnMut(usize, &'m Ident),
     {
         let (parent, ident) = match self.leaf {
             BorrowingFieldVisitorLeaf::Opaque(id, ..) | BorrowingFieldVisitorLeaf::Slice(id, _) => {
@@ -399,20 +401,77 @@ impl<'m> BorrowingField<'m> {
             }
         };
 
-        self._trace(parent, ident, visit);
+        self.backtrace_rec(parent, ident, &mut visit);
     }
 
     /// Recursively visits fields in order from root to leaf by building up the
     /// stack, and then visiting fields as it unwinds.
-    fn _trace<F>(&self, parent: Option<ParentId>, ident: &'m Ident, visit: &mut F)
+    fn backtrace_rec<F>(&self, parent: Option<ParentId>, ident: &'m Ident, visit: &mut F) -> usize
     where
-        F: FnMut(&'m Ident),
+        F: FnMut(usize, &'m Ident),
     {
-        if let Some(id) = parent {
+        let from_end = if let Some(id) = parent {
             let (parent, ident) = self.parents[id.0];
-            self._trace(parent, ident, visit);
-        }
+            self.backtrace_rec(parent, ident, visit)
+        } else {
+            0
+        };
 
-        visit(ident);
+        visit(from_end, ident);
+
+        from_end + 1
+    }
+
+    /// Fallibly visits fields in order.
+    ///
+    /// This method is similar to [`BorrowinfField::backtrace`], but short-circuits
+    /// when an `Err` is returned.
+    pub fn try_backtrace<F, E>(&self, mut visit: F) -> Result<(), E>
+    where
+        F: FnMut(usize, &'m Ident) -> Result<(), E>,
+    {
+        let (parent, ident) = match self.leaf {
+            BorrowingFieldVisitorLeaf::Opaque(id, ..) | BorrowingFieldVisitorLeaf::Slice(id, _) => {
+                self.parents[id.0]
+            }
+        };
+
+        self.try_backtrace_rec(parent, ident, &mut visit)?;
+
+        Ok(())
+    }
+
+    /// Recursively visits fields in order from root to leaf by building up the
+    /// stack, and then visiting fields as it unwinds.
+    fn try_backtrace_rec<F, E>(
+        &self,
+        parent: Option<ParentId>,
+        ident: &'m Ident,
+        visit: &mut F,
+    ) -> Result<usize, E>
+    where
+        F: FnMut(usize, &'m Ident) -> Result<(), E>,
+    {
+        let from_end = if let Some(id) = parent {
+            let (parent, ident) = self.parents[id.0];
+            self.try_backtrace_rec(parent, ident, visit)?
+        } else {
+            0
+        };
+
+        visit(from_end, ident)?;
+
+        Ok(from_end + 1)
+    }
+}
+
+impl<'m> fmt::Display for BorrowingField<'m> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.try_backtrace(|i, ident| {
+            if i != 0 {
+                f.write_char('.')?;
+            }
+            f.write_str(ident.as_str())
+        })
     }
 }

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
@@ -1,0 +1,25 @@
+---
+source: core/src/hir/elision.rs
+expression: map
+---
+{
+    Static: [
+        "this.name",
+        "_s",
+    ],
+    NonStatic(
+        MethodLifetime(
+            0,
+        ),
+    ): [
+        "this.p_data",
+    ],
+    NonStatic(
+        MethodLifetime(
+            1,
+        ),
+    ): [
+        "this.q_data",
+        "this.inner.more_data",
+    ],
+}

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/hir/elision.rs
-expression: "{\n    use crate::ast;\n    let m =\n        ast::Module::from_syn(&syn::parse_quote! {\n                        mod ffi\n                        {\n                            #[diplomat :: opaque] struct Opaque < 'a > { s : & 'a str, }\n                            struct Struct < 'a > { s : & 'a str, } #[diplomat :: out]\n                            struct OutStruct < 'a > { inner : Box < Opaque < 'a >>, }\n                            impl < 'a > OutStruct < 'a >\n                            {\n                                pub fn new(s : & 'a str) -> Self\n                                { Self { inner : Box :: new(Opaque { s }) } }\n                            } impl < 'a > Struct < 'a >\n                            { pub fn rustc_elision(self, s : & str) -> & str { s } }\n                        }\n                    }, true);\n    let mut env = crate::Env::default();\n    let mut top_symbols = crate::ModuleEnv::default();\n    m.insert_all_types(ast::Path::empty(), &mut env);\n    top_symbols.insert(m.name.clone(),\n        ast::ModSymbol::SubModule(m.name.clone()));\n    env.insert(ast::Path::empty(), top_symbols);\n    let tcx = crate::hir::TypeContext::from_ast(&env).unwrap();\n    tcx\n}"
+expression: tcx
 ---
 TypeContext {
     out_structs: [
@@ -28,9 +28,9 @@ TypeContext {
                             lifetimes: TypeLifetimes {
                                 indices: [
                                     NonStatic(
-                                        TypeLifetime {
-                                            index: 0,
-                                        },
+                                        TypeLifetime(
+                                            0,
+                                        ),
                                     ),
                                 ],
                             },
@@ -57,17 +57,16 @@ TypeContext {
                     },
                     lifetime_env: LifetimeEnv {
                         nodes: [
-                            Explicit(
-                                ExplicitLifetime {
-                                    ident: Check {
-                                        _marker: PhantomData,
-                                        buf: "a",
-                                    },
-                                    longer: [],
-                                    shorter: [],
+                            Lifetime {
+                                ident: Check {
+                                    _marker: PhantomData,
+                                    buf: "a",
                                 },
-                            ),
+                                longer: [],
+                                shorter: [],
+                            },
                         ],
+                        num_lifetimes: 1,
                     },
                     param_self: None,
                     params: [
@@ -79,9 +78,9 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        TypeLifetime {
-                                            index: 0,
-                                        },
+                                        TypeLifetime(
+                                            0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -96,9 +95,9 @@ TypeContext {
                                             lifetimes: TypeLifetimes {
                                                 indices: [
                                                     NonStatic(
-                                                        TypeLifetime {
-                                                            index: 0,
-                                                        },
+                                                        TypeLifetime(
+                                                            0,
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -138,9 +137,9 @@ TypeContext {
                     ty: Slice(
                         Str(
                             NonStatic(
-                                TypeLifetime {
-                                    index: 0,
-                                },
+                                TypeLifetime(
+                                    0,
+                                ),
                             ),
                         ),
                     ),
@@ -158,22 +157,16 @@ TypeContext {
                     },
                     lifetime_env: LifetimeEnv {
                         nodes: [
-                            Explicit(
-                                ExplicitLifetime {
-                                    ident: Check {
-                                        _marker: PhantomData,
-                                        buf: "a",
-                                    },
-                                    longer: [],
-                                    shorter: [],
+                            Lifetime {
+                                ident: Check {
+                                    _marker: PhantomData,
+                                    buf: "a",
                                 },
-                            ),
-                            Implicit(
-                                ImplicitLifetime(
-                                    1,
-                                ),
-                            ),
+                                longer: [],
+                                shorter: [],
+                            },
                         ],
+                        num_lifetimes: 2,
                     },
                     param_self: Some(
                         ParamSelf {
@@ -182,9 +175,9 @@ TypeContext {
                                     lifetimes: TypeLifetimes {
                                         indices: [
                                             NonStatic(
-                                                TypeLifetime {
-                                                    index: 0,
-                                                },
+                                                TypeLifetime(
+                                                    0,
+                                                ),
                                             ),
                                         ],
                                     },
@@ -204,9 +197,9 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        TypeLifetime {
-                                            index: 1,
-                                        },
+                                        TypeLifetime(
+                                            1,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -218,9 +211,9 @@ TypeContext {
                                 Slice(
                                     Str(
                                         NonStatic(
-                                            TypeLifetime {
-                                                index: 1,
-                                            },
+                                            TypeLifetime(
+                                                1,
+                                            ),
                                         ),
                                     ),
                                 ),

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -34,6 +34,22 @@ pub struct OpaqueId(usize);
 pub struct EnumId(usize);
 
 impl TypeContext {
+    pub fn out_structs(&self) -> &[OutStructDef] {
+        &self.out_structs
+    }
+
+    pub fn structs(&self) -> &[StructDef] {
+        &self.structs
+    }
+
+    pub fn opaques(&self) -> &[OpaqueDef] {
+        &self.opaques
+    }
+
+    pub fn enums(&self) -> &[EnumDef] {
+        &self.enums
+    }
+
     pub(crate) fn resolve_out_struct(&self, id: OutStructId) -> &OutStructDef {
         self.out_structs.index(id.0)
     }

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -69,7 +69,7 @@ impl Type {
                 let inner = field.ty.field_leaf_lifetime_counts(tcx);
                 (acc.0 + inner.0, acc.1 + inner.1)
             }),
-            Type::Opaque(_) | Type::Slice(_) => (0, 1),
+            Type::Opaque(_) | Type::Slice(_) => (1, 1),
             Type::Primitive(_) | Type::Enum(_) => (0, 0),
         }
     }


### PR DESCRIPTION
Sorry for the wall of text
* Fixes #229 by making it so that `MethodLifetime` doesn't store the `hir::LifetimeEnv` it came from in order to calculate the subtype lifetimes. Instead, we introduce the new `SubtypeLifetimeVisitor` type which visits sublifetimes for a set of lifetimes passed in via the `SubtypeLifetimeVisitor::visit_subtypes` method. This is the direct HIR analog of `ast::LifetimeTransitivity`, but slightly more flexible since it doesn't always push the subtype lifetimes into a `Vec`, and instead allows you to just visit them however you like.

* `MethodLifetime` now derives all the main derivable traits, namely `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash`. This means that it can go in `HashMap`/`BTreeMap`s, which is nice because I anticipate that it will be used as a key to a vec of `BorrowingField`s which use the lifetime.

* Implicit lifetimes are no longer stored as values in the `nodes` field of `hir::LifetimeEnv`, instead it just stores explicit lifetimes and the **number** of implicit lifetimes (since implicit lifetimes cannot be bounded except for implicit bounds, [which I determined we don't need to track](https://github.com/rust-diplomat/diplomat/pull/232)). This is more memory efficient and more intuitive, since it means that named lifetimes, which store their bounds as adjacency lists of indices, cannot have one of their indices pointing towards an implicit lifetime.

* I wrote some basic tests at the bottom of `elision.rs` to get a feel for how backends might work. I realized that for the C++ backend, it would be really nice if we could have the `BorrowingField` stuff on the output type, since it only works on inputs right now and we want all the borrowing field relationships upfront for generating docs. But I didn't want to squeeze too much into this PR.

* `BorrowingField`, which is used to track fields that borrow (e.g. `first.second.data`) previously had the `BorrowingField::trace` method to visit the names of the fields in order (e.g. `first` -> `second` -> `data`). I renamed this to `backtrace` (is this name okay?), and also added a `try_backtrace` method because I realized the visitor will probably be formatting most of the time.

* Fixed some issues with `BorrowingFieldVisitor` miscalculating how much space to prealloc up front (not a bug, just an optimization).

      
      