### PR TITLE
Attr parsing for `#[diplomat::opaque_mut]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "diplomat_core",
  "insta",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-example"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-feature-tests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -271,11 +271,11 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "diplomat-tool"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "colored",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat_core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "displaydoc",
  "impls",

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -30,9 +30,9 @@ enum DiplomatStructAttribute {
 }
 
 impl DiplomatStructAttribute {
-    /// Parses a [`DiplomatAttr`] from an array of [`syn::Attribute`]s.
+    /// Parses a [`DiplomatStructAttribute`] from an array of [`syn::Attribute`]s.
     /// If more than one kind is found, an error is returned containing all the
-    /// ones encountered.
+    /// ones encountered, since all the current attributes are disjoint.
     fn parse(attrs: &[syn::Attribute]) -> Result<Option<Self>, Vec<Self>> {
         let mut buf = String::with_capacity(32);
         let mut res = Ok(None);

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -1,15 +1,63 @@
-use std::collections::BTreeMap;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
+use std::fmt::Write as _;
 
 use quote::ToTokens;
 use serde::{Deserialize, Serialize};
 use syn::{ImplItem, Item, ItemMod, UseTree, Visibility};
 
 use super::{
-    CustomType, Enum, Ident, Method, ModSymbol, OpaqueStruct, Path, PathType, RustLink, Struct,
-    ValidityError,
+    CustomType, Enum, Ident, Method, ModSymbol, Mutability, OpaqueStruct, Path, PathType, RustLink,
+    Struct, ValidityError,
 };
 use crate::environment::*;
+
+/// Custom Diplomat attribute that can be placed on a struct definition.
+#[derive(Debug)]
+enum DiplomatStructAttribute {
+    /// The `#[diplomat::out]` attribute, used for non-opaque structs that
+    /// contain an owned opaque in the form of a `Box`.
+    Out,
+    /// The `#[diplomat::opaque]` attribute, used for marking a struct as opaque.
+    /// Note that opaque structs can be borrowed in return types, but cannot
+    /// be passed into a function behind a mutable reference.
+    Opaque,
+    /// The `#[diplomat::opaque_mut]` attribute, used for marking a struct as
+    /// opaque and mutable.
+    /// Note that mutable opaque structs can never be borrowed in return types
+    /// (even immutably!), but can be passed into a function behind a mutable
+    /// reference.
+    OpaqueMut,
+}
+
+impl DiplomatStructAttribute {
+    /// Parses a [`DiplomatAttr`] from an array of [`syn::Attribute`]s.
+    /// If more than one kind is found, an error is returned containing all the
+    /// ones encountered.
+    fn parse(attrs: &[syn::Attribute]) -> Result<Option<Self>, Vec<Self>> {
+        let mut buf = String::with_capacity(32);
+        let mut res = Ok(None);
+        for attr in attrs {
+            buf.clear();
+            write!(&mut buf, "{}", attr.path.to_token_stream()).unwrap();
+            let parsed = match buf.as_str() {
+                "diplomat :: out" => Some(Self::Out),
+                "diplomat :: opaque" => Some(Self::Opaque),
+                "diplomat :: opaque_mut" => Some(Self::OpaqueMut),
+                _ => None,
+            };
+
+            if let Some(parsed) = parsed {
+                match res {
+                    Ok(None) => res = Ok(Some(parsed)),
+                    Ok(Some(first)) => res = Err(vec![first, parsed]),
+                    Err(ref mut errors) => errors.push(parsed),
+                }
+            }
+        }
+
+        res
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Module {
@@ -93,21 +141,23 @@ impl Module {
                 }
                 Item::Struct(strct) => {
                     if analyze_types {
-                        if strct
-                            .attrs
-                            .iter()
-                            .any(|a| a.path.to_token_stream().to_string() == "diplomat :: opaque")
-                        {
-                            custom_types_by_name.insert(
-                                (&strct.ident).into(),
-                                CustomType::Opaque(OpaqueStruct::from(strct)),
-                            );
-                        } else {
-                            custom_types_by_name.insert(
-                                (&strct.ident).into(),
-                                CustomType::Struct(Struct::from(strct)),
-                            );
-                        }
+                        let custom_type = match DiplomatStructAttribute::parse(&strct.attrs[..]) {
+                            Ok(None) => CustomType::Struct(Struct::new(strct, false)),
+                            Ok(Some(DiplomatStructAttribute::Out)) => {
+                                CustomType::Struct(Struct::new(strct, true))
+                            }
+                            Ok(Some(DiplomatStructAttribute::Opaque)) => {
+                                CustomType::Opaque(OpaqueStruct::new(strct, Mutability::Immutable))
+                            }
+                            Ok(Some(DiplomatStructAttribute::OpaqueMut)) => {
+                                CustomType::Opaque(OpaqueStruct::new(strct, Mutability::Mutable))
+                            }
+                            Err(errors) => {
+                                panic!("Multiple conflicting Diplomat struct attributes, there can be at most one: {:?}", errors);
+                            }
+                        };
+
+                        custom_types_by_name.insert(Ident::from(&strct.ident), custom_type);
                     }
                 }
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -110,5 +110,6 @@ declared_types:
                   - String
               lifetimes: []
           lifetime_env: {}
+      mutability: Immutable
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/structs.rs
-expression: "Struct::from(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Struct)] struct\n                MyLocalStruct { a : i32, b : Box < MyLocalStruct > }\n            })"
+expression: "Struct::new(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Struct)] struct\n                MyLocalStruct { a : i32, b : Box < MyLocalStruct > }\n            }, true)"
 ---
 name: MyLocalStruct
 docs:
@@ -27,5 +27,5 @@ fields:
     - - ""
       - []
 methods: []
-output_only: false
+output_only: true
 


### PR DESCRIPTION
This is the first PR towards https://github.com/rust-diplomat/diplomat/issues/225.

The first step towards adding opaque_mut is supporting parsing it from the AST. The way we parsed our custom attributes from the AST was a bit of a mess, so this PR improves that mechanism, and then uses the improved version to also support parsing `#[diplomat::opaque_mut]`. It then uses this information to set a new flag field in `ast::OpaqueStruct` when constructed, which dictates whether or not it's an opaque_mut.