### PR TITLE
Ergonomic improvements

### DIFF
--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -174,7 +174,7 @@ impl LifetimeEnv {
                 self.extend_implicit_lifetime_bounds(typ, behind_ref);
             }
             TypeName::Option(typ) => self.extend_implicit_lifetime_bounds(typ, None),
-            TypeName::Result(ok, err) | TypeName::DiplomatResult(ok, err) => {
+            TypeName::Result(ok, err, _) => {
                 self.extend_implicit_lifetime_bounds(ok, None);
                 self.extend_implicit_lifetime_bounds(err, None);
             }

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -174,7 +174,7 @@ impl LifetimeEnv {
                 self.extend_implicit_lifetime_bounds(typ, behind_ref);
             }
             TypeName::Option(typ) => self.extend_implicit_lifetime_bounds(typ, None),
-            TypeName::Result(ok, err) => {
+            TypeName::Result(ok, err) | TypeName::DiplomatResult(ok, err) => {
                 self.extend_implicit_lifetime_bounds(ok, None);
                 self.extend_implicit_lifetime_bounds(err, None);
             }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -220,7 +220,7 @@ impl Method {
             .as_ref()
             .map(|return_type| match return_type {
                 TypeName::Unit => true,
-                TypeName::Result(ok, _) | TypeName::DiplomatResult(ok, _) => {
+                TypeName::Result(ok, _, _) => {
                     matches!(ok.as_ref(), TypeName::Unit)
                 }
                 _ => false,

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -220,7 +220,9 @@ impl Method {
             .as_ref()
             .map(|return_type| match return_type {
                 TypeName::Unit => true,
-                TypeName::Result(ok, _) => matches!(ok.as_ref(), TypeName::Unit),
+                TypeName::Result(ok, _) | TypeName::DiplomatResult(ok, _) => {
+                    matches!(ok.as_ref(), TypeName::Unit)
+                }
                 _ => false,
             })
             .unwrap_or(true);
@@ -510,7 +512,7 @@ mod tests {
 
         assert_borrowed_params! { [hold] =>
             #[diplomat::rust_link(Foo, FnInStruct)]
-            fn transitivity_deep_types<'a, 'b: 'a, 'c: 'b, 'd: 'c>(hold: Option<Box<Bar<'d>>>, nohold: &'a Box<Option<Baz<'a>>>) -> DiplomatResult<Box<Foo<'b>>, Error> {
+            fn transitivity_deep_types<'a, 'b: 'a, 'c: 'b, 'd: 'c>(hold: Option<Box<Bar<'d>>>, nohold: &'a Box<Option<Baz<'a>>>) -> Result<Box<Foo<'b>>, Error> {
                 unimplemented!()
             }
         }

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-7.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-7.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! {\n                DiplomatResult < OkRef < 'a, 'b >, ErrRef < 'c >>\n            })"
+expression: "TypeName::from_syn(&syn::parse_quote! {\n                Result < OkRef < 'a, 'b >, ErrRef < 'c >>\n            }, None)"
 ---
 Result:
   - Named:
@@ -16,4 +16,5 @@ Result:
           - ErrRef
       lifetimes:
         - Named: c
+  - true
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
@@ -2,11 +2,12 @@
 source: core/src/ast/types.rs
 expression: "TypeName::from_syn(&syn::parse_quote! {\n                DiplomatResult < (), MyLocalStruct >\n            }, None)"
 ---
-DiplomatResult:
+Result:
   - Unit
   - Named:
       path:
         elements:
           - MyLocalStruct
       lifetimes: []
+  - true
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
@@ -1,8 +1,8 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { DiplomatResult < (), MyLocalStruct > })"
+expression: "TypeName::from_syn(&syn::parse_quote! {\n                DiplomatResult < (), MyLocalStruct >\n            }, None)"
 ---
-Result:
+DiplomatResult:
   - Unit
   - Named:
       path:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-2.snap
@@ -9,5 +9,5 @@ Result:
         elements:
           - MyLocalStruct
       lifetimes: []
-  - true
+  - false
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-3.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-3.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from_syn(&syn::parse_quote! { Result < MyLocalStruct, i32 > }, None)"
+---
+Result:
+  - Named:
+      path:
+        elements:
+          - MyLocalStruct
+      lifetimes: []
+  - Primitive: i32
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-3.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-3.snap
@@ -9,4 +9,5 @@ Result:
           - MyLocalStruct
       lifetimes: []
   - Primitive: i32
+  - true
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-4.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-4.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from_syn(&syn::parse_quote! { Result < (), MyLocalStruct > }, None)"
+---
+Result:
+  - Unit
+  - Named:
+      path:
+        elements:
+          - MyLocalStruct
+      lifetimes: []
+

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-4.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result-4.snap
@@ -9,4 +9,5 @@ Result:
         elements:
           - MyLocalStruct
       lifetimes: []
+  - true
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
@@ -1,8 +1,8 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { DiplomatResult < MyLocalStruct, i32 > })"
+expression: "TypeName::from_syn(&syn::parse_quote! {\n                DiplomatResult < MyLocalStruct, i32 >\n            }, None)"
 ---
-Result:
+DiplomatResult:
   - Named:
       path:
         elements:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
@@ -2,11 +2,12 @@
 source: core/src/ast/types.rs
 expression: "TypeName::from_syn(&syn::parse_quote! {\n                DiplomatResult < MyLocalStruct, i32 >\n            }, None)"
 ---
-DiplomatResult:
+Result:
   - Named:
       path:
         elements:
           - MyLocalStruct
       lifetimes: []
   - Primitive: i32
+  - true
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_result.snap
@@ -9,5 +9,5 @@ Result:
           - MyLocalStruct
       lifetimes: []
   - Primitive: i32
-  - true
+  - false
 

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__option_invalid.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__option_invalid.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/validity.rs
 expression: output
-
 ---
 A non-reference type was found inside an Option<T>: Option<u8>
 A non-reference type was found inside an Option<T>: Option<Option<u16>>

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -365,7 +365,7 @@ pub enum TypeName {
     Box(Box<TypeName>),
     /// A `Option<T>` type.
     Option(Box<TypeName>),
-    /// A `Result<T, E>` or `diplomat_runtime::DiplomatWriteable` type. If the bool is true, it's `Result
+    /// A `Result<T, E>` or `diplomat_runtime::DiplomatWriteable` type. If the bool is true, it's `Result`
     Result(Box<TypeName>, Box<TypeName>, bool),
     Writeable,
     /// A `&str` type.
@@ -591,7 +591,7 @@ impl TypeName {
                             TypeName::Result(
                                 Box::new(ok),
                                 Box::new(err),
-                                p.path.segments.len() == 1,
+                                !is_runtime_type(p, "DiplomatResult"),
                             )
                         } else {
                             panic!("Expected both type arguments for Result to be a type")

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -463,7 +463,7 @@ fn lower_type<L: LifetimeLowerer>(
                 }
             }
         }
-        ast::TypeName::Result(_, _) => {
+        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
             errors.push(LoweringError::Other(
                 "Results can only appear as the top-level return type of methods".into(),
             ));
@@ -654,7 +654,7 @@ fn lower_out_type<L: LifetimeLowerer>(
                 None
             }
         },
-        ast::TypeName::Result(_, _) => {
+        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
             errors.push(LoweringError::Other(
                 "Results can only appear as the top-level return type of methods".into(),
             ));
@@ -831,7 +831,7 @@ fn lower_return_type(
         None
     };
     match return_type.unwrap_or(&ast::TypeName::Unit) {
-        ast::TypeName::Result(ok_ty, err_ty) => {
+        ast::TypeName::Result(ok_ty, err_ty) | ast::TypeName::DiplomatResult(ok_ty, err_ty) => {
             let ok_ty = match ok_ty.as_ref() {
                 ast::TypeName::Unit => Some(writeable_option),
                 ty => lower_out_type(ty, return_ltl.as_mut(), lookup_id, in_path, env, errors)

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -463,7 +463,7 @@ fn lower_type<L: LifetimeLowerer>(
                 }
             }
         }
-        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
+        ast::TypeName::Result(_, _, _) => {
             errors.push(LoweringError::Other(
                 "Results can only appear as the top-level return type of methods".into(),
             ));
@@ -654,7 +654,7 @@ fn lower_out_type<L: LifetimeLowerer>(
                 None
             }
         },
-        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
+        ast::TypeName::Result(_, _, _) => {
             errors.push(LoweringError::Other(
                 "Results can only appear as the top-level return type of methods".into(),
             ));
@@ -831,7 +831,7 @@ fn lower_return_type(
         None
     };
     match return_type.unwrap_or(&ast::TypeName::Unit) {
-        ast::TypeName::Result(ok_ty, err_ty) | ast::TypeName::DiplomatResult(ok_ty, err_ty) => {
+        ast::TypeName::Result(ok_ty, err_ty, _) => {
             let ok_ty = match ok_ty.as_ref() {
                 ast::TypeName::Unit => Some(writeable_option),
                 ty => lower_out_type(ty, return_ltl.as_mut(), lookup_id, in_path, env, errors)

--- a/example/src/data_provider.rs
+++ b/example/src/data_provider.rs
@@ -1,6 +1,5 @@
 #[diplomat::bridge]
 pub mod ffi {
-    use diplomat_runtime::DiplomatResult;
     use icu_provider::serde::SerdeDeDataProvider;
 
     #[diplomat::opaque]
@@ -15,9 +14,10 @@ pub mod ffi {
             Box::new(ICU4XDataProvider(Box::new(provider)))
         }
 
+        #[allow(clippy::result_unit_err)]
         /// This exists as a regression test for https://github.com/rust-diplomat/diplomat/issues/155
-        pub fn returns_result() -> DiplomatResult<(), ()> {
-            Ok(()).into()
+        pub fn returns_result() -> Result<(), ()> {
+            Ok(())
         }
     }
 }

--- a/example/src/fixed_decimal.rs
+++ b/example/src/fixed_decimal.rs
@@ -1,6 +1,6 @@
 #[diplomat::bridge]
 pub mod ffi {
-    use diplomat_runtime::{DiplomatResult, DiplomatWriteable};
+    use diplomat_runtime::DiplomatWriteable;
     use fixed_decimal::FixedDecimal;
     use writeable::Writeable;
 
@@ -28,8 +28,9 @@ pub mod ffi {
 
         /// Format the [`ICU4XFixedDecimal`] as a string.
         #[diplomat::rust_link(fixed_decimal::FixedDecimal::write_to, FnInStruct)]
-        pub fn to_string(&self, to: &mut DiplomatWriteable) -> DiplomatResult<(), ()> {
-            self.0.write_to(to).map_err(|_| ()).into()
+        #[allow(clippy::result_unit_err)]
+        pub fn to_string(&self, to: &mut DiplomatWriteable) -> Result<(), ()> {
+            self.0.write_to(to).map_err(|_| ())
         }
     }
 }

--- a/feature_tests/src/result.rs
+++ b/feature_tests/src/result.rs
@@ -1,8 +1,6 @@
 #[diplomat::bridge]
 pub mod ffi {
 
-    use diplomat_runtime::DiplomatResult;
-
     #[diplomat::opaque]
     pub struct ResultOpaque(i32);
 
@@ -18,32 +16,32 @@ pub mod ffi {
         j: i32,
     }
     impl ResultOpaque {
-        pub fn new(i: i32) -> DiplomatResult<Box<ResultOpaque>, ErrorEnum> {
-            Ok(Box::new(ResultOpaque(i))).into()
+        pub fn new(i: i32) -> Result<Box<ResultOpaque>, ErrorEnum> {
+            Ok(Box::new(ResultOpaque(i)))
         }
 
-        pub fn new_failing_foo() -> DiplomatResult<Box<ResultOpaque>, ErrorEnum> {
-            Err(ErrorEnum::Foo).into()
+        pub fn new_failing_foo() -> Result<Box<ResultOpaque>, ErrorEnum> {
+            Err(ErrorEnum::Foo)
         }
 
-        pub fn new_failing_bar() -> DiplomatResult<Box<ResultOpaque>, ErrorEnum> {
-            Err(ErrorEnum::Bar).into()
+        pub fn new_failing_bar() -> Result<Box<ResultOpaque>, ErrorEnum> {
+            Err(ErrorEnum::Bar)
         }
 
-        pub fn new_failing_unit() -> DiplomatResult<Box<ResultOpaque>, ()> {
-            Err(()).into()
+        pub fn new_failing_unit() -> Result<Box<ResultOpaque>, ()> {
+            Err(())
         }
 
-        pub fn new_failing_struct(i: i32) -> DiplomatResult<Box<ResultOpaque>, ErrorStruct> {
-            Err(ErrorStruct { i, j: 12 }).into()
+        pub fn new_failing_struct(i: i32) -> Result<Box<ResultOpaque>, ErrorStruct> {
+            Err(ErrorStruct { i, j: 12 })
         }
 
-        pub fn new_in_err(i: i32) -> DiplomatResult<(), Box<ResultOpaque>> {
-            Err(Box::new(ResultOpaque(i))).into()
+        pub fn new_in_err(i: i32) -> Result<(), Box<ResultOpaque>> {
+            Err(Box::new(ResultOpaque(i)))
         }
 
-        pub fn new_in_enum_err(i: i32) -> DiplomatResult<ErrorEnum, Box<ResultOpaque>> {
-            Err(Box::new(ResultOpaque(i))).into()
+        pub fn new_in_enum_err(i: i32) -> Result<ErrorEnum, Box<ResultOpaque>> {
+            Err(Box::new(ResultOpaque(i)))
         }
 
         pub fn assert_integer(&self, i: i32) {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -100,7 +100,7 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
             };
             expanded_params.push(parse2(tokens).unwrap());
         }
-        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
+        ast::TypeName::Result(_, _, _) => {
             let param = &param.name;
             expanded_params.push(parse2(quote!(#param.into())).unwrap());
         }
@@ -165,7 +165,7 @@ fn gen_custom_type_method(strct: &ast::CustomType, m: &ast::Method) -> Item {
     };
 
     let (return_tokens, maybe_into) = if let Some(return_type) = &m.return_type {
-        if let ast::TypeName::Result(ok, err) = return_type {
+        if let ast::TypeName::Result(ok, err, true) = return_type {
             let ok = ok.to_syn();
             let err = err.to_syn();
             (

--- a/macro/src/snapshots/diplomat__tests__mod_with_rust_result.snap
+++ b/macro/src/snapshots/diplomat__tests__mod_with_rust_result.snap
@@ -1,0 +1,20 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn bar(& self) -> Result < (), () >\n                                    { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+---
+mod ffi {
+    #[repr(C)]
+    struct Foo {}
+    impl Foo {
+        pub fn bar(&self) -> Result<(), ()> {
+            unimplemented!()
+        }
+    }
+    #[no_mangle]
+    extern "C" fn Foo_bar(this: &Foo) -> diplomat_runtime::DiplomatResult<(), ()> {
+        this.bar().into()
+    }
+    #[no_mangle]
+    extern "C" fn Foo_destroy(this: Box<Foo>) {}
+}
+

--- a/macro/src/snapshots/diplomat__tests__mod_with_writeable_result.snap
+++ b/macro/src/snapshots/diplomat__tests__mod_with_writeable_result.snap
@@ -1,7 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                             mod ffi\n                             {\n                                 struct Foo { } impl Foo\n                                 {\n                                     pub fn\n                                     to_string(& self, to : & mut\n                                               DiplomatWriteable) ->\n                                     DiplomatResult < (), () >\n                                     { unimplemented! () }\n                                 }\n                             }\n                         }).to_token_stream().to_string())"
-
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn to_string(& self, to : & mut DiplomatWriteable) ->\n                                    DiplomatResult < (), () > { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]

--- a/macro/src/snapshots/diplomat__tests__mod_with_writeable_result.snap
+++ b/macro/src/snapshots/diplomat__tests__mod_with_writeable_result.snap
@@ -1,12 +1,12 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn to_string(& self, to : & mut DiplomatWriteable) ->\n                                    DiplomatResult < (), () > { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn to_string(& self, to : & mut DiplomatWriteable) ->\n                                    Result < (), () > { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
     struct Foo {}
     impl Foo {
-        pub fn to_string(&self, to: &mut DiplomatWriteable) -> DiplomatResult<(), ()> {
+        pub fn to_string(&self, to: &mut DiplomatWriteable) -> Result<(), ()> {
             unimplemented!()
         }
     }
@@ -15,7 +15,9 @@ mod ffi {
         this: &Foo,
         to: &mut diplomat_runtime::DiplomatWriteable,
     ) -> diplomat_runtime::DiplomatResult<(), ()> {
-        this.to_string(to)
+        let ret = this.to_string(to);
+        to.flush();
+        ret.into()
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/runtime/src/writeable.rs
+++ b/runtime/src/writeable.rs
@@ -47,7 +47,7 @@ pub struct DiplomatWriteable {
     /// The current capacity of the buffer
     cap: usize,
     /// Called by Rust to indicate that there is no more data to write.
-    /// 
+    ///
     /// May be called multiple times.
     ///
     /// Arguments:

--- a/runtime/src/writeable.rs
+++ b/runtime/src/writeable.rs
@@ -31,7 +31,8 @@ use core::{fmt, ptr};
 ///  - `buf` must be `cap` bytes long
 ///  - `grow()` must either return false or update `buf` and `cap` for a valid buffer
 ///    of at least the requested buffer size
-///  - Rust code must call `DiplomatWriteable::flush()` before releasing to C
+///  - `DiplomatWriteable::flush()` will be automatically called by Diplomat. `flush()` might also be called
+///    (erroneously) on the Rust side (it's a public method), so it must be idempotent.
 #[repr(C)]
 pub struct DiplomatWriteable {
     /// Context pointer for additional data needed by `grow()` and `flush()`. May be `null`.
@@ -46,6 +47,8 @@ pub struct DiplomatWriteable {
     /// The current capacity of the buffer
     cap: usize,
     /// Called by Rust to indicate that there is no more data to write.
+    /// 
+    /// May be called multiple times.
     ///
     /// Arguments:
     /// - `self` (`*mut DiplomatWriteable`): This `DiplomatWriteable`

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -191,7 +191,7 @@ fn gen_result_header(
     outs: &mut HashMap<String, String>,
     env: &Env,
 ) -> fmt::Result {
-    if let ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) = typ {
+    if let ast::TypeName::Result(ok, err, _) = typ {
         let out = outs
             .entry(format!("{}.h", name_for_type(typ)))
             .or_insert_with(String::new);
@@ -322,7 +322,7 @@ pub fn gen_includes<W: fmt::Write>(
                 out,
             )?;
         }
-        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
+        ast::TypeName::Result(_, _, _) => {
             let include = format!("#include \"{}.h\"", name_for_type(typ));
             if !seen_includes.contains(&include) {
                 writeln!(out, "{}", include)?;

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -191,7 +191,7 @@ fn gen_result_header(
     outs: &mut HashMap<String, String>,
     env: &Env,
 ) -> fmt::Result {
-    if let ast::TypeName::Result(ok, err) = typ {
+    if let ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) = typ {
         let out = outs
             .entry(format!("{}.h", name_for_type(typ)))
             .or_insert_with(String::new);
@@ -322,7 +322,7 @@ pub fn gen_includes<W: fmt::Write>(
                 out,
             )?;
         }
-        ast::TypeName::Result(_, _) => {
+        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
             let include = format!("#include \"{}.h\"", name_for_type(typ));
             if !seen_includes.contains(&include) {
                 writeln!(out, "{}", include)?;

--- a/tool/src/c/results.rs
+++ b/tool/src/c/results.rs
@@ -24,7 +24,7 @@ pub fn collect_results<'a>(
         ast::TypeName::Option(underlying) => {
             collect_results(underlying, in_path, _env, seen, results);
         }
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             if !seen.contains(&typ) {
                 seen.insert(typ);
                 collect_results(ok, in_path, _env, seen, results);
@@ -42,7 +42,7 @@ pub fn gen_result<W: fmt::Write>(
     env: &Env,
     out: &mut W,
 ) -> fmt::Result {
-    if let ast::TypeName::Result(ok, err) = typ {
+    if let ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) = typ {
         let result_name = name_for_type(typ);
         writeln!(out, "typedef struct {} {{", result_name)?;
         let mut result_indent = indented(out).with_str("    ");

--- a/tool/src/c/results.rs
+++ b/tool/src/c/results.rs
@@ -24,7 +24,7 @@ pub fn collect_results<'a>(
         ast::TypeName::Option(underlying) => {
             collect_results(underlying, in_path, _env, seen, results);
         }
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             if !seen.contains(&typ) {
                 seen.insert(typ);
                 collect_results(ok, in_path, _env, seen, results);
@@ -42,7 +42,7 @@ pub fn gen_result<W: fmt::Write>(
     env: &Env,
     out: &mut W,
 ) -> fmt::Result {
-    if let ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) = typ {
+    if let ast::TypeName::Result(ok, err, _) = typ {
         let result_name = name_for_type(typ);
         writeln!(out, "typedef struct {} {{", result_name)?;
         let mut result_indent = indented(out).with_str("    ");

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -47,7 +47,7 @@ pub fn gen_type<W: fmt::Write>(
             _ => unreachable!("Cannot have non-pointer types inside Option"),
         },
 
-        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
+        ast::TypeName::Result(_, _, _) => {
             write!(out, "{}", name_for_type(typ))?;
         }
 
@@ -89,13 +89,11 @@ pub fn name_for_type(typ: &ast::TypeName) -> ast::Ident {
         ast::TypeName::Option(underlying) => {
             ast::Ident::from(format!("opt_{}", name_for_type(underlying)))
         }
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
-            ast::Ident::from(format!(
-                "diplomat_result_{}_{}",
-                name_for_type(ok),
-                name_for_type(err)
-            ))
-        }
+        ast::TypeName::Result(ok, err, _) => ast::Ident::from(format!(
+            "diplomat_result_{}_{}",
+            name_for_type(ok),
+            name_for_type(err)
+        )),
         ast::TypeName::Writeable => ast::Ident::from("writeable"),
         ast::TypeName::StrReference(_) => ast::Ident::from("str_ref"),
         ast::TypeName::PrimitiveSlice(_lt, ast::Mutability::Mutable, prim) => {

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -47,7 +47,7 @@ pub fn gen_type<W: fmt::Write>(
             _ => unreachable!("Cannot have non-pointer types inside Option"),
         },
 
-        ast::TypeName::Result(_, _) => {
+        ast::TypeName::Result(_, _) | ast::TypeName::DiplomatResult(_, _) => {
             write!(out, "{}", name_for_type(typ))?;
         }
 
@@ -89,11 +89,13 @@ pub fn name_for_type(typ: &ast::TypeName) -> ast::Ident {
         ast::TypeName::Option(underlying) => {
             ast::Ident::from(format!("opt_{}", name_for_type(underlying)))
         }
-        ast::TypeName::Result(ok, err) => ast::Ident::from(format!(
-            "diplomat_result_{}_{}",
-            name_for_type(ok),
-            name_for_type(err)
-        )),
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+            ast::Ident::from(format!(
+                "diplomat_result_{}_{}",
+                name_for_type(ok),
+                name_for_type(err)
+            ))
+        }
         ast::TypeName::Writeable => ast::Ident::from("writeable"),
         ast::TypeName::StrReference(_) => ast::Ident::from("str_ref"),
         ast::TypeName::PrimitiveSlice(_lt, ast::Mutability::Mutable, prim) => {
@@ -172,7 +174,7 @@ mod tests {
                 }
 
                 impl MyStruct {
-                    pub fn new() -> DiplomatResult<MyStruct, u8> {
+                    pub fn new() -> Result<MyStruct, u8> {
                         unimplemented!()
                     }
                 }

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -132,7 +132,7 @@ pub fn gen_rust_to_cpp<W: Write>(
             _ => todo!(),
         },
 
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             let raw_value_id = format!("diplomat_result_raw_{}", path);
             writeln!(out, "auto {} = {};", raw_value_id, cpp).unwrap();
             let wrapped_value_id = format!("diplomat_result_{}", path);

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -132,7 +132,7 @@ pub fn gen_rust_to_cpp<W: Write>(
             _ => todo!(),
         },
 
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             let raw_value_id = format!("diplomat_result_raw_{}", path);
             writeln!(out, "auto {} = {};", raw_value_id, cpp).unwrap();
             let wrapped_value_id = format!("diplomat_result_{}", path);

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -314,7 +314,7 @@ fn gen_includes<W: fmt::Write>(
                 out,
             )?;
         }
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             gen_includes(
                 ok.as_ref(),
                 in_path,

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -314,7 +314,7 @@ fn gen_includes<W: fmt::Write>(
                 out,
             )?;
         }
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             gen_includes(
                 ok.as_ref(),
                 in_path,

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -561,7 +561,7 @@ mod tests {
                         unimplemented!()
                     }
 
-                    pub fn write_result(&self, out: &mut DiplomatWriteable) -> DiplomatResult<(), u8> {
+                    pub fn write_result(&self, out: &mut DiplomatWriteable) -> Result<(), u8> {
                         unimplemented!()
                     }
 

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -353,7 +353,7 @@ pub fn gen_method_interface<W: fmt::Write>(
     }
 
     if rearranged_writeable {
-        if let Some(ast::TypeName::Result(_, err)) = &method.return_type {
+        if let Some(ast::TypeName::Result(_, err, _)) = &method.return_type {
             let err_ty = if err.is_zst() {
                 "std::monostate".into()
             } else {
@@ -414,7 +414,7 @@ fn gen_writeable_out_value<W: fmt::Write>(
     ret_typ: &ast::TypeName,
     method_body: &mut W,
 ) -> fmt::Result {
-    if let ast::TypeName::Result(_, _) = ret_typ {
+    if let ast::TypeName::Result(_, _, _) = ret_typ {
         writeln!(
             method_body,
             "return {}.replace_ok(std::move(diplomat_writeable_string));",

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -129,7 +129,7 @@ fn gen_type_inner<W: fmt::Write>(
             _ => todo!(),
         },
 
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             write!(out, "diplomat::result<")?;
             if ok.is_zst() {
                 write!(out, "std::monostate")?;

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -129,7 +129,7 @@ fn gen_type_inner<W: fmt::Write>(
             _ => todo!(),
         },
 
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             write!(out, "diplomat::result<")?;
             if ok.is_zst() {
                 write!(out, "std::monostate")?;
@@ -259,7 +259,7 @@ mod tests {
                 }
 
                 impl MyStruct {
-                    pub fn new() -> DiplomatResult<MyStruct, u8> {
+                    pub fn new() -> Result<MyStruct, u8> {
                         unimplemented!()
                     }
                 }

--- a/tool/src/dotnet/idiomatic.rs
+++ b/tool/src/dotnet/idiomatic.rs
@@ -508,7 +508,7 @@ fn gen_method(
 
             match &method.return_type {
                 None | Some(ast::TypeName::Unit) => {}
-                Some(typ @ ast::TypeName::Result(..)) => {
+                Some(typ @ (ast::TypeName::Result(..) | ast::TypeName::DiplomatResult(..))) => {
                     gen_raw_type_name_decl_position(typ, in_path, env, out)?;
                     write!(out, " result = ")?;
                 }

--- a/tool/src/dotnet/idiomatic.rs
+++ b/tool/src/dotnet/idiomatic.rs
@@ -338,7 +338,7 @@ fn gen_method(
     )?;
 
     let result_to_handle: Option<(&ast::TypeName, &ast::TypeName)> = match &method.return_type {
-        Some(ast::TypeName::Result(ok_variant, err_variant)) => {
+        Some(ast::TypeName::Result(ok_variant, err_variant, _)) => {
             let exception_name = if err_variant.is_zst() {
                 "DiplomatOpaqueException".to_owned()
             } else {
@@ -508,7 +508,7 @@ fn gen_method(
 
             match &method.return_type {
                 None | Some(ast::TypeName::Unit) => {}
-                Some(typ @ (ast::TypeName::Result(..) | ast::TypeName::DiplomatResult(..))) => {
+                Some(typ @ ast::TypeName::Result(..)) => {
                     gen_raw_type_name_decl_position(typ, in_path, env, out)?;
                     write!(out, " result = ")?;
                 }
@@ -736,7 +736,7 @@ fn gen_type_name_return_position<'ast>(
     out: &mut dyn fmt::Write,
 ) -> fmt::Result {
     match &typ.into() {
-        Some(ast::TypeName::Result(ok, _)) => gen_type_name(ok, in_path, env, out),
+        Some(ast::TypeName::Result(ok, _, _)) => gen_type_name(ok, in_path, env, out),
         Some(ast::TypeName::Option(underlying)) => {
             gen_type_name(underlying.as_ref(), in_path, env, out)?;
             write!(out, "?")
@@ -770,7 +770,7 @@ fn gen_return_type_remark_about_drop(
                 _ => gen_return_type_remark_about_drop(underlying, in_path, env, out),
             }
         }
-        ast::TypeName::Result(underlying, _) | ast::TypeName::Option(underlying) => {
+        ast::TypeName::Result(underlying, _, _) | ast::TypeName::Option(underlying) => {
             gen_return_type_remark_about_drop(underlying, in_path, env, out)
         }
         _ => Ok(()),

--- a/tool/src/dotnet/raw.rs
+++ b/tool/src/dotnet/raw.rs
@@ -232,11 +232,12 @@ pub fn gen_result(
     env: &Env,
     out: &mut CodeWriter,
 ) -> fmt::Result {
-    let (ok, err) = if let ast::TypeName::Result(ok, err) = typ {
-        (ok, err)
-    } else {
-        panic!("not a result: {:?}", typ);
-    };
+    let (ok, err) =
+        if let ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) = typ {
+            (ok, err)
+        } else {
+            panic!("not a result: {:?}", typ);
+        };
 
     writeln!(out)?;
     writeln!(out, "[StructLayout(LayoutKind.Sequential)]")?;

--- a/tool/src/dotnet/raw.rs
+++ b/tool/src/dotnet/raw.rs
@@ -232,12 +232,11 @@ pub fn gen_result(
     env: &Env,
     out: &mut CodeWriter,
 ) -> fmt::Result {
-    let (ok, err) =
-        if let ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) = typ {
-            (ok, err)
-        } else {
-            panic!("not a result: {:?}", typ);
-        };
+    let (ok, err) = if let ast::TypeName::Result(ok, err, _) = typ {
+        (ok, err)
+    } else {
+        panic!("not a result: {:?}", typ);
+    };
 
     writeln!(out)?;
     writeln!(out, "[StructLayout(LayoutKind.Sequential)]")?;

--- a/tool/src/dotnet/types.rs
+++ b/tool/src/dotnet/types.rs
@@ -32,7 +32,7 @@ pub fn gen_type_name(
 
         ast::TypeName::Option(underlying) => gen_type_name(underlying.as_ref(), in_path, env, out),
 
-        ast::TypeName::Result(..) | ast::TypeName::DiplomatResult(..) => {
+        ast::TypeName::Result(..) => {
             write!(
                 out,
                 "{}{}",
@@ -103,7 +103,7 @@ pub fn name_for_type(typ: &ast::TypeName) -> ast::Ident {
         ast::TypeName::Option(underlying) => {
             ast::Ident::from(format!("Opt{}", name_for_type(underlying)))
         }
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             ast::Ident::from(format!("Result{}{}", name_for_type(ok), name_for_type(err)))
         }
         ast::TypeName::Writeable => ast::Ident::from("Writeable"),

--- a/tool/src/dotnet/types.rs
+++ b/tool/src/dotnet/types.rs
@@ -32,7 +32,7 @@ pub fn gen_type_name(
 
         ast::TypeName::Option(underlying) => gen_type_name(underlying.as_ref(), in_path, env, out),
 
-        ast::TypeName::Result(..) => {
+        ast::TypeName::Result(..) | ast::TypeName::DiplomatResult(..) => {
             write!(
                 out,
                 "{}{}",
@@ -103,7 +103,7 @@ pub fn name_for_type(typ: &ast::TypeName) -> ast::Ident {
         ast::TypeName::Option(underlying) => {
             ast::Ident::from(format!("Opt{}", name_for_type(underlying)))
         }
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             ast::Ident::from(format!("Result{}{}", name_for_type(ok), name_for_type(err)))
         }
         ast::TypeName::Writeable => ast::Ident::from("Writeable"),

--- a/tool/src/dotnet/util.rs
+++ b/tool/src/dotnet/util.rs
@@ -48,7 +48,7 @@ pub fn collect_results<'ast>(
         ast::TypeName::Option(underlying) => {
             collect_results(underlying, in_path, _env, results);
         }
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             let key = (in_path.clone(), typ);
             if !results.contains(&key) {
                 results.insert(key);
@@ -83,7 +83,7 @@ fn collect_errors_impl<'ast>(
     is_err_variant: bool,
 ) {
     match typ {
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             if is_err_variant {
                 let key = (in_path.clone(), typ);
                 if !errors.contains(&key) {

--- a/tool/src/dotnet/util.rs
+++ b/tool/src/dotnet/util.rs
@@ -48,7 +48,7 @@ pub fn collect_results<'ast>(
         ast::TypeName::Option(underlying) => {
             collect_results(underlying, in_path, _env, results);
         }
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             let key = (in_path.clone(), typ);
             if !results.contains(&key) {
                 results.insert(key);
@@ -83,7 +83,7 @@ fn collect_errors_impl<'ast>(
     is_err_variant: bool,
 ) {
     match typ {
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             if is_err_variant {
                 let key = (in_path.clone(), typ);
                 if !errors.contains(&key) {

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -461,7 +461,7 @@ impl fmt::Display for InvocationIntoJs<'_> {
                 })
                 .fmt(f)
             }
-            ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+            ast::TypeName::Result(ok, err, _) => {
                 match self.base.return_type_form(self.typ) {
                     ReturnTypeForm::Scalar => display::iife(|mut f| {
                         writeln!(f, "const is_ok = {} == 1;", self.invocation.scalar())?;
@@ -772,7 +772,7 @@ impl fmt::Display for UnderlyingIntoJs<'_> {
                 })
                 .fmt(f)
             }
-            ast::TypeName::Result(..) | ast::TypeName::DiplomatResult(..) => {
+            ast::TypeName::Result(..) => {
                 todo!("Result in a buffer")
             }
             ast::TypeName::Writeable => todo!("Writeable in a buffer"),

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -379,10 +379,11 @@ impl fmt::Display for InvocationIntoJs<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.typ {
             ast::TypeName::Primitive(..) => self.invocation.scalar().fmt(f),
-            ast::TypeName::Named(path_type) |ast::TypeName::SelfType(path_type)=> match self.base.resolve_type(path_type) {
-                ast::CustomType::Struct(strct) => {
-                    // TODO: optimize `return_type_form` because we already know we're a non-opaque struct
-                    match self.base.return_type_form(self.typ) {
+            ast::TypeName::Named(path_type) | ast::TypeName::SelfType(path_type) => {
+                match self.base.resolve_type(path_type) {
+                    ast::CustomType::Struct(strct) => {
+                        // TODO: optimize `return_type_form` because we already know we're a non-opaque struct
+                        match self.base.return_type_form(self.typ) {
                         ReturnTypeForm::Scalar => {
                             todo!("#173: constructing a scalar struct")
                         }
@@ -413,15 +414,16 @@ impl fmt::Display for InvocationIntoJs<'_> {
                         .fmt(f),
                         ReturnTypeForm::Empty => unreachable!(),
                     }
+                    }
+                    ast::CustomType::Opaque(_opaque) => {
+                        // Codegen for opaque structs is in `Pointer`s `fmt::Display` impl
+                        unreachable!("Cannot construct an opaque struct that's not borrowed")
+                    }
+                    ast::CustomType::Enum(enm) => {
+                        write!(f, "{}_rust_to_js[{}]", enm.name, self.invocation.scalar())
+                    }
                 }
-                ast::CustomType::Opaque(_opaque) => {
-                    // Codegen for opaque structs is in `Pointer`s `fmt::Display` impl
-                    unreachable!("Cannot construct an opaque struct that's not borrowed")
-                }
-                ast::CustomType::Enum(enm) => {
-                    write!(f, "{}_rust_to_js[{}]", enm.name, self.invocation.scalar())
-                }
-            },
+            }
             ast::TypeName::Reference(.., inner) => Pointer {
                 inner,
                 underlying: Underlying::Invocation(&self.invocation),
@@ -459,7 +461,7 @@ impl fmt::Display for InvocationIntoJs<'_> {
                 })
                 .fmt(f)
             }
-            ast::TypeName::Result(ok, err) => {
+            ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
                 match self.base.return_type_form(self.typ) {
                     ReturnTypeForm::Scalar => display::iife(|mut f| {
                         writeln!(f, "const is_ok = {} == 1;", self.invocation.scalar())?;
@@ -504,7 +506,9 @@ impl fmt::Display for InvocationIntoJs<'_> {
                 }
             }
             ast::TypeName::StrReference(..) => self.display_slice(SliceKind::Str).fmt(f),
-            ast::TypeName::PrimitiveSlice(.., prim) => self.display_slice(SliceKind::Primitive(prim.into())).fmt(f),
+            ast::TypeName::PrimitiveSlice(.., prim) => {
+                self.display_slice(SliceKind::Primitive(prim.into())).fmt(f)
+            }
             ast::TypeName::Writeable => todo!(),
             ast::TypeName::Unit => self.invocation.scalar().fmt(f),
         }
@@ -768,7 +772,9 @@ impl fmt::Display for UnderlyingIntoJs<'_> {
                 })
                 .fmt(f)
             }
-            ast::TypeName::Result(..) => todo!("Result in a buffer"),
+            ast::TypeName::Result(..) | ast::TypeName::DiplomatResult(..) => {
+                todo!("Result in a buffer")
+            }
             ast::TypeName::Writeable => todo!("Writeable in a buffer"),
             ast::TypeName::StrReference(..) => self.display_slice(SliceKind::Str).fmt(f),
             ast::TypeName::PrimitiveSlice(.., prim) => {

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -244,7 +244,7 @@ impl<'env> Imports<'env> {
             | ast::TypeName::Option(typ) => {
                 self.collect_usages(typ, in_path, env, state);
             }
-            ast::TypeName::Result(ok, err) => {
+            ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
                 self.collect_usages(ok, in_path, env, state);
                 self.collect_usages(err, in_path, env, state);
                 self.ts_ffierror = true;

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -244,7 +244,7 @@ impl<'env> Imports<'env> {
             | ast::TypeName::Option(typ) => {
                 self.collect_usages(typ, in_path, env, state);
             }
-            ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+            ast::TypeName::Result(ok, err, _) => {
                 self.collect_usages(ok, in_path, env, state);
                 self.collect_usages(err, in_path, env, state);
                 self.ts_ffierror = true;

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -489,7 +489,7 @@ pub fn gen_ts_type<W: fmt::Write>(
             return gen_ts_type(out, typ, in_path, env)
         }
         ast::TypeName::Option(typ) => return gen_ts_type(out, typ, in_path, env).map(|_| true),
-        ast::TypeName::Result(ok, _err) | ast::TypeName::DiplomatResult(ok, _err) => {
+        ast::TypeName::Result(ok, _err, _) => {
             let opt = gen_ts_type(out, ok, in_path, env)?;
             write!(out, " | never")?;
             return Ok(opt);
@@ -541,7 +541,7 @@ fn gen_ts_method_declaration<W: fmt::Write>(
                     env,
                     &mut f,
                 )?;
-                if let Some(ast::TypeName::Result(_, ref err)) = method.return_type {
+                if let Some(ast::TypeName::Result(_, ref err, _)) = method.return_type {
                     writeln!(
                         f,
                         "@throws {{@link FFIError}}<{}>",
@@ -615,11 +615,7 @@ fn gen_ts_method_declaration<W: fmt::Write>(
                     assert!(
                         matches!(
                             method.return_type,
-                            Some(
-                                ast::TypeName::Result(..)
-                                    | ast::TypeName::DiplomatResult(..)
-                                    | ast::TypeName::Unit
-                            ),
+                            Some(ast::TypeName::Result(..) | ast::TypeName::Unit),
                         ),
                         "found {:?}",
                         method.return_type

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -489,7 +489,7 @@ pub fn gen_ts_type<W: fmt::Write>(
             return gen_ts_type(out, typ, in_path, env)
         }
         ast::TypeName::Option(typ) => return gen_ts_type(out, typ, in_path, env).map(|_| true),
-        ast::TypeName::Result(ok, _err) => {
+        ast::TypeName::Result(ok, _err) | ast::TypeName::DiplomatResult(ok, _err) => {
             let opt = gen_ts_type(out, ok, in_path, env)?;
             write!(out, " | never")?;
             return Ok(opt);
@@ -615,7 +615,11 @@ fn gen_ts_method_declaration<W: fmt::Write>(
                     assert!(
                         matches!(
                             method.return_type,
-                            Some(ast::TypeName::Result(..) | ast::TypeName::Unit),
+                            Some(
+                                ast::TypeName::Result(..)
+                                    | ast::TypeName::DiplomatResult(..)
+                                    | ast::TypeName::Unit
+                            ),
                         ),
                         "found {:?}",
                         method.return_type
@@ -753,7 +757,7 @@ mod tests {
                         unimplemented!()
                     }
 
-                    pub fn write_result(&self, out: &mut DiplomatWriteable) -> DiplomatResult<(), u8> {
+                    pub fn write_result(&self, out: &mut DiplomatWriteable) -> Result<(), u8> {
                         unimplemented!()
                     }
                 }

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -53,7 +53,7 @@ pub fn return_type_form(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> 
             }
         }
 
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             let ok_form = return_type_form(ok, in_path, env);
             let err_form = return_type_form(err, in_path, env);
 
@@ -135,7 +135,7 @@ mod tests {
                 }
 
                 impl MyStruct {
-                    pub fn new() -> DiplomatResult<MyStruct, u8> {
+                    pub fn new() -> Result<MyStruct, u8> {
                         unimplemented!()
                     }
                 }

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -53,7 +53,7 @@ pub fn return_type_form(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) -> 
             }
         }
 
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             let ok_form = return_type_form(ok, in_path, env);
             let err_form = return_type_form(err, in_path, env);
 

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -73,7 +73,7 @@ pub fn type_size_alignment(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) 
             }
             _ => unreachable!("Cannot have non-pointer types inside Option"),
         },
-        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
+        ast::TypeName::Result(ok, err, _) => {
             let (_, size_align) = result_ok_offset_size_align(ok, err, in_path, env);
             size_align
         }

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -73,7 +73,7 @@ pub fn type_size_alignment(typ: &ast::TypeName, in_path: &ast::Path, env: &Env) 
             }
             _ => unreachable!("Cannot have non-pointer types inside Option"),
         },
-        ast::TypeName::Result(ok, err) => {
+        ast::TypeName::Result(ok, err) | ast::TypeName::DiplomatResult(ok, err) => {
             let (_, size_align) = result_ok_offset_size_align(ok, err, in_path, env);
             size_align
         }

--- a/tool/tests/dotnet_target.rs
+++ b/tool/tests/dotnet_target.rs
@@ -59,11 +59,11 @@ fn generation_using_default_config() {
             struct MyStruct;
 
             impl MyStruct {
-                pub fn new_slice(v: &[f64]) -> DiplomatResult<Box<MyStruct>, Box<MyLibError>> {
+                pub fn new_slice(v: &[f64]) -> Result<Box<MyStruct>, Box<MyLibError>> {
                     unimplemented!()
                 }
 
-                pub fn set_slice(&mut self, new_slice: &[f64]) -> DiplomatResult<(), Box<MyLibError>> {
+                pub fn set_slice(&mut self, new_slice: &[f64]) -> Result<(), Box<MyLibError>> {
                     unimplemented!()
                 }
             }
@@ -89,11 +89,11 @@ fn generation_using_library_config() {
             struct MyStruct;
 
             impl MyStruct {
-                pub fn new_slice(v: &[f64]) -> DiplomatResult<Box<MyStruct>, Box<MyLibError>> {
+                pub fn new_slice(v: &[f64]) -> Result<Box<MyStruct>, Box<MyLibError>> {
                     unimplemented!()
                 }
 
-                pub fn set_slice(&mut self, new_slice: &[f64]) -> DiplomatResult<(), Box<MyLibError>> {
+                pub fn set_slice(&mut self, new_slice: &[f64]) -> Result<(), Box<MyLibError>> {
                     unimplemented!()
                 }
             }
@@ -113,19 +113,19 @@ fn setters_getters_properties() {
             struct Bar;
 
             impl Bar {
-                pub fn get_foo(&self) -> DiplomatResult<Box<Foo>, ()> {
+                pub fn get_foo(&self) -> Result<Box<Foo>, ()> {
                     unimplemented!()
                 }
 
-                pub fn set_foo(&mut self, foo: &Foo) -> DiplomatResult<(), ()> {
+                pub fn set_foo(&mut self, foo: &Foo) -> Result<(), ()> {
                     unimplemented!()
                 }
 
-                pub fn get_name(&self, out: &mut DiplomatWriteable) -> DiplomatResult<(), ()> {
+                pub fn get_name(&self, out: &mut DiplomatWriteable) -> Result<(), ()> {
                     unimplemented!()
                 }
 
-                pub fn set_name(&mut self, new_name: &str) -> DiplomatResult<(), ()> {
+                pub fn set_name(&mut self, new_name: &str) -> Result<(), ()> {
                     unimplemented!()
                 }
             }
@@ -325,7 +325,7 @@ fn method_writeable_out() {
                     unimplemented!()
                 }
 
-                pub fn write_result(&self, out: &mut DiplomatWriteable) -> DiplomatResult<(), u8> {
+                pub fn write_result(&self, out: &mut DiplomatWriteable) -> Result<(), u8> {
                     unimplemented!()
                 }
 
@@ -472,7 +472,7 @@ fn result_types() {
             }
 
             impl MyStruct {
-                pub fn new() -> DiplomatResult<MyStruct, u8> {
+                pub fn new() -> Result<MyStruct, u8> {
                     unimplemented!()
                 }
             }
@@ -548,15 +548,15 @@ fn error_handling() {
             }
 
             impl MyStruct {
-                pub fn foo(&self) -> DiplomatResult<u32, MyModuleError> {
+                pub fn foo(&self) -> Result<u32, MyModuleError> {
                     unimplemented!()
                 }
 
-                pub fn bar(&self) -> DiplomatResult<char, MyModuleOpaqueError> {
+                pub fn bar(&self) -> Result<char, MyModuleOpaqueError> {
                     unimplemented!()
                 }
 
-                pub fn baz(&self) -> DiplomatResult<(), ()> {
+                pub fn baz(&self) -> Result<(), ()> {
                     unimplemented!()
                 }
             }
@@ -575,12 +575,12 @@ fn almost_properties() {
 
             impl MyStruct {
                 /// This should not generate a property
-                pub fn get_foo_by_key(&self, key: &str) -> DiplomatResult<u64, ()> {
+                pub fn get_foo_by_key(&self, key: &str) -> Result<u64, ()> {
                     unimplemented!()
                 }
 
                 /// This should not generate a property
-                pub fn set_foo_by_key(&self, key: &str, foo: i64) -> DiplomatResult<(), ()> {
+                pub fn set_foo_by_key(&self, key: &str, foo: i64) -> Result<(), ()> {
                     unimplemented!()
                 }
 


### PR DESCRIPTION
### `Result`
Functions can now return `Result<T,E>` instead of `DiplomatResult<T,E>`. The `extern "C"` wrappers automatically insert `.into()`s. This reduces syntactic complexity for clients as they can now use `?`.

### Flushing
The `extern "C"` wrappers now call `.flush()` on all `DiplomatWriteable` inputs. This eliminates an error source and boilerplate.