### PR TITLE
Use correct Sphinx names in JS

### DIFF
--- a/example/js/lib/docs/source/data_provider_ffi.rst
+++ b/example/js/lib/docs/source/data_provider_ffi.rst
@@ -8,12 +8,12 @@
     See the `Rust documentation for icu_provider <https://unicode-org.github.io/icu4x-docs/doc/icu_provider/index.html>`__ for more information.
 
 
-    .. js:staticfunction:: new_static()
+    .. js:function:: new_static()
 
         See the `Rust documentation for get_static_provider <https://unicode-org.github.io/icu4x-docs/doc/icu_testdata/fn.get_static_provider.html>`__ for more information.
 
 
-    .. js:staticfunction:: returns_result()
+    .. js:function:: returns_result()
 
         This exists as a regression test for https://github.com/rust-diplomat/diplomat/issues/155
 

--- a/example/js/lib/docs/source/decimal_ffi.rst
+++ b/example/js/lib/docs/source/decimal_ffi.rst
@@ -8,14 +8,14 @@
     See the `Rust documentation for FixedDecimalFormatter <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html>`__ for more information.
 
 
-    .. js:staticfunction:: try_new(locale, provider, options)
+    .. js:function:: try_new(locale, provider, options)
 
         Creates a new :js:class:`ICU4XFixedDecimalFormatter` from locale data.
 
         See the `Rust documentation for try_new <https://unicode-org.github.io/icu4x-docs/doc/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new>`__ for more information.
 
 
-    .. js:function:: format_write(value)
+    .. js:method:: format_write(value)
 
         Formats a :js:class:`ICU4XFixedDecimal` to a string.
 
@@ -28,6 +28,6 @@
 
     .. js:attribute:: some_other_config
 
-    .. js:staticfunction:: default()
+    .. js:function:: default()
 
 .. js:class:: ICU4XFixedDecimalGroupingStrategy

--- a/example/js/lib/docs/source/fixed_decimal_ffi.rst
+++ b/example/js/lib/docs/source/fixed_decimal_ffi.rst
@@ -6,19 +6,19 @@
     See the `Rust documentation for FixedDecimal <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/struct.FixedDecimal.html>`__ for more information.
 
 
-    .. js:staticfunction:: new(v)
+    .. js:function:: new(v)
 
         Construct an :js:class:`ICU4XFixedDecimal` from an integer.
 
 
-    .. js:function:: multiply_pow10(power)
+    .. js:method:: multiply_pow10(power)
 
         Multiply the :js:class:`ICU4XFixedDecimal` by a given power of ten.
 
         See the `Rust documentation for multiply_pow10 <https://unicode-org.github.io/icu4x-docs/doc/fixed_decimal/struct.FixedDecimal.html#method.multiply_pow10>`__ for more information.
 
 
-    .. js:function:: to_string()
+    .. js:method:: to_string()
 
         Format the :js:class:`ICU4XFixedDecimal` as a string.
 

--- a/example/js/lib/docs/source/locale_ffi.rst
+++ b/example/js/lib/docs/source/locale_ffi.rst
@@ -8,12 +8,12 @@
     See the `Rust documentation for Locale <https://unicode-org.github.io/icu4x-docs/doc/icu/locid/struct.Locale.html>`__ for more information.
 
 
-    .. js:staticfunction:: new(name)
+    .. js:function:: new(name)
 
         Construct an :js:class:`ICU4XLocale` from a locale identifier represented as a string.
 
 
-    .. js:staticfunction:: new_from_bytes(bytes)
+    .. js:function:: new_from_bytes(bytes)
 
         Construct an :js:class:`ICU4XLocale` from a locale identifier represented as bytes.
 

--- a/feature_tests/js/docs/source/lifetimes_ffi.rst
+++ b/feature_tests/js/docs/source/lifetimes_ffi.rst
@@ -15,40 +15,40 @@
 
 .. js:class:: Foo
 
-    .. js:staticfunction:: new(x)
+    .. js:function:: new(x)
 
-    .. js:function:: get_bar()
+    .. js:method:: get_bar()
 
-    .. js:staticfunction:: new_static(x)
+    .. js:function:: new_static(x)
         - Warning: This method leaks memory. The parameter `x` will not be freed as it is required to live for the duration of the program.
 
 
-    .. js:function:: as_returning()
+    .. js:method:: as_returning()
 
-    .. js:staticfunction:: extract_from_fields(fields)
+    .. js:function:: extract_from_fields(fields)
 
 .. js:class:: One
 
-    .. js:staticfunction:: transitivity(hold, nohold)
+    .. js:function:: transitivity(hold, nohold)
 
-    .. js:staticfunction:: cycle(hold, nohold)
+    .. js:function:: cycle(hold, nohold)
 
-    .. js:staticfunction:: many_dependents(a, b, c, d, nohold)
+    .. js:function:: many_dependents(a, b, c, d, nohold)
 
-    .. js:staticfunction:: return_outlives_param(hold, nohold)
+    .. js:function:: return_outlives_param(hold, nohold)
 
-    .. js:staticfunction:: diamond_top(top, left, right, bottom)
+    .. js:function:: diamond_top(top, left, right, bottom)
 
-    .. js:staticfunction:: diamond_left(top, left, right, bottom)
+    .. js:function:: diamond_left(top, left, right, bottom)
 
-    .. js:staticfunction:: diamond_right(top, left, right, bottom)
+    .. js:function:: diamond_right(top, left, right, bottom)
 
-    .. js:staticfunction:: diamond_bottom(top, left, right, bottom)
+    .. js:function:: diamond_bottom(top, left, right, bottom)
 
-    .. js:staticfunction:: diamond_and_nested_types(a, b, c, d, nohold)
+    .. js:function:: diamond_and_nested_types(a, b, c, d, nohold)
 
-    .. js:staticfunction:: implicit_bounds(explicit_hold, implicit_hold, nohold)
+    .. js:function:: implicit_bounds(explicit_hold, implicit_hold, nohold)
 
-    .. js:staticfunction:: implicit_bounds_deep(explicit_, implicit_1, implicit_2, nohold)
+    .. js:function:: implicit_bounds_deep(explicit_, implicit_1, implicit_2, nohold)
 
 .. js:class:: Two

--- a/feature_tests/js/docs/source/option_ffi.rst
+++ b/feature_tests/js/docs/source/option_ffi.rst
@@ -3,21 +3,21 @@
 
 .. js:class:: OptionOpaque
 
-    .. js:staticfunction:: new(i)
+    .. js:function:: new(i)
 
-    .. js:staticfunction:: new_none()
+    .. js:function:: new_none()
 
-    .. js:staticfunction:: new_struct()
+    .. js:function:: new_struct()
 
-    .. js:staticfunction:: new_struct_nones()
+    .. js:function:: new_struct_nones()
 
-    .. js:function:: assert_integer(i)
+    .. js:method:: assert_integer(i)
 
-    .. js:staticfunction:: option_opaque_argument(arg)
+    .. js:function:: option_opaque_argument(arg)
 
 .. js:class:: OptionOpaqueChar
 
-    .. js:function:: assert_char(ch)
+    .. js:method:: assert_char(ch)
 
 .. js:class:: OptionStruct
 

--- a/feature_tests/js/docs/source/result_ffi.rst
+++ b/feature_tests/js/docs/source/result_ffi.rst
@@ -11,18 +11,18 @@
 
 .. js:class:: ResultOpaque
 
-    .. js:staticfunction:: new(i)
+    .. js:function:: new(i)
 
-    .. js:staticfunction:: new_failing_foo()
+    .. js:function:: new_failing_foo()
 
-    .. js:staticfunction:: new_failing_bar()
+    .. js:function:: new_failing_bar()
 
-    .. js:staticfunction:: new_failing_unit()
+    .. js:function:: new_failing_unit()
 
-    .. js:staticfunction:: new_failing_struct(i)
+    .. js:function:: new_failing_struct(i)
 
-    .. js:staticfunction:: new_in_err(i)
+    .. js:function:: new_in_err(i)
 
-    .. js:staticfunction:: new_in_enum_err(i)
+    .. js:function:: new_in_enum_err(i)
 
-    .. js:function:: assert_integer(i)
+    .. js:method:: assert_integer(i)

--- a/feature_tests/js/docs/source/selftype_ffi.rst
+++ b/feature_tests/js/docs/source/selftype_ffi.rst
@@ -3,6 +3,6 @@
 
 .. js:class:: RefList
 
-    .. js:staticfunction:: node(data)
+    .. js:function:: node(data)
 
 .. js:class:: RefListParameter

--- a/feature_tests/js/docs/source/slices_ffi.rst
+++ b/feature_tests/js/docs/source/slices_ffi.rst
@@ -3,22 +3,22 @@
 
 .. js:class:: Float64Vec
 
-    .. js:staticfunction:: new(v)
+    .. js:function:: new(v)
         - Note: ``v`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
 
 
-    .. js:function:: fill_slice(v)
+    .. js:method:: fill_slice(v)
         - Note: ``v`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
 
 
-    .. js:function:: set_value(new_slice)
+    .. js:method:: set_value(new_slice)
         - Note: ``new_slice`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
 
 
 .. js:class:: MyString
 
-    .. js:staticfunction:: new(v)
+    .. js:function:: new(v)
 
-    .. js:function:: set_str(new_str)
+    .. js:method:: set_str(new_str)
 
-    .. js:function:: get_str()
+    .. js:method:: get_str()

--- a/feature_tests/js/docs/source/structs_ffi.rst
+++ b/feature_tests/js/docs/source/structs_ffi.rst
@@ -19,13 +19,13 @@
 
     .. js:attribute:: g
 
-    .. js:staticfunction:: new()
+    .. js:function:: new()
 
 .. js:class:: Opaque
 
-    .. js:staticfunction:: new()
+    .. js:function:: new()
 
-    .. js:function:: assert_struct(s)
+    .. js:method:: assert_struct(s)
 
         See the `Rust documentation for something <https://docs.rs/Something/latest/struct.Something.html#method.something>`__ for more information.
 
@@ -34,6 +34,6 @@
         Additional information: `1 <https://docs.rs/Something/latest/struct.Something.html#method.something_small>`__, `2 <https://docs.rs/SomethingElse/latest/struct.SomethingElse.html#method.something>`__
 
 
-    .. js:staticfunction:: returns_usize()
+    .. js:function:: returns_usize()
 
-    .. js:staticfunction:: returns_imported()
+    .. js:function:: returns_imported()

--- a/tool/src/js/docs.rs
+++ b/tool/src/js/docs.rs
@@ -118,14 +118,14 @@ pub fn gen_method_docs<W: fmt::Write>(
     if method.self_param.is_some() {
         writeln!(
             out,
-            ".. js:function:: {}({})",
+            ".. js:method:: {}({})",
             method.name,
             param_names.join(", ")
         )?;
     } else {
         writeln!(
             out,
-            ".. js:staticfunction:: {}({})",
+            ".. js:function:: {}({})",
             method.name,
             param_names.join(", ")
         )?;

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__borrowing_opaque_owned_by_struct@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__borrowing_opaque_owned_by_struct@ffi.rst.snap
@@ -13,5 +13,5 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: x
 
-    .. js:staticfunction:: new(opaque)
+    .. js:function:: new(opaque)
 

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__str_borrowing@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__str_borrowing@ffi.rst.snap
@@ -9,7 +9,7 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: s
 
-    .. js:staticfunction:: new(s)
+    .. js:function:: new(s)
 
-    .. js:function:: get()
+    .. js:method:: get()
 

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__struct_borrowing@ffi.rst.snap
@@ -11,7 +11,7 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: y
 
-    .. js:function:: get_x()
+    .. js:method:: get_x()
 
 .. js:class:: PointTranspose
 
@@ -19,11 +19,11 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: transpose
 
-    .. js:staticfunction:: new(u, v)
+    .. js:function:: new(u, v)
 
-    .. js:function:: transpose()
+    .. js:method:: transpose()
 
-    .. js:function:: point()
+    .. js:method:: point()
 
 .. js:class:: Scalar
 

--- a/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__conversions__tests__unambiguous_names@ffi.rst.snap
@@ -11,7 +11,7 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: end
 
-    .. js:function:: do_stuff()
+    .. js:method:: do_stuff()
 
 .. js:class:: Point
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_returning_struct@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_returning_struct@ffi.rst.snap
@@ -7,7 +7,7 @@ expression: out_docs.get(out).unwrap()
 
 .. js:class:: MyStruct
 
-    .. js:function:: get_non_opaque()
+    .. js:method:: get_non_opaque()
 
 .. js:class:: NonOpaqueStruct
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_taking_str@ffi.rst.snap
@@ -12,7 +12,7 @@ expression: out_docs.get(out).unwrap()
     See the `Rust documentation for Batz <https://docs.rs/foo/latest/foo/bar/struct.Batz.html>`__ for more information.
 
 
-    .. js:staticfunction:: new_str(v)
+    .. js:function:: new_str(v)
 
-    .. js:function:: set_str(new_str)
+    .. js:method:: set_str(new_str)
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_writeable_out@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__method_writeable_out@ffi.rst.snap
@@ -7,9 +7,9 @@ expression: out_docs.get(out).unwrap()
 
 .. js:class:: MyStruct
 
-    .. js:function:: write()
+    .. js:method:: write()
 
-    .. js:function:: write_unit()
+    .. js:method:: write_unit()
 
-    .. js:function:: write_result()
+    .. js:method:: write_result()
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_non_opaque_struct@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_non_opaque_struct@ffi.rst.snap
@@ -11,9 +11,9 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: b
 
-    .. js:staticfunction:: new(a, b)
+    .. js:function:: new(a, b)
 
-    .. js:function:: get_a()
+    .. js:method:: get_a()
 
-    .. js:function:: set_b(b)
+    .. js:method:: set_b(b)
 

--- a/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_opaque_struct@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__structs__tests__simple_opaque_struct@ffi.rst.snap
@@ -7,9 +7,9 @@ expression: out_docs.get(out).unwrap()
 
 .. js:class:: MyStruct
 
-    .. js:staticfunction:: new(a, b)
+    .. js:function:: new(a, b)
 
-    .. js:function:: get_a()
+    .. js:method:: get_a()
 
-    .. js:function:: set_b(b)
+    .. js:method:: set_b(b)
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__pointer_types@ffi.rst.snap
@@ -13,5 +13,5 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: b
 
-    .. js:staticfunction:: new(foo, bar)
+    .. js:function:: new(foo, bar)
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__result_types@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__result_types@ffi.rst.snap
@@ -13,5 +13,5 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: b
 
-    .. js:staticfunction:: new()
+    .. js:function:: new()
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__string_reference@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__string_reference@ffi.rst.snap
@@ -11,5 +11,5 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: b
 
-    .. js:staticfunction:: new(v)
+    .. js:function:: new(v)
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__unit_type@ffi.rst.snap
@@ -11,5 +11,5 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: b
 
-    .. js:function:: something()
+    .. js:method:: something()
 

--- a/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@ffi.rst.snap
+++ b/tool/src/js/snapshots/diplomat_tool__js__types__tests__writeable_out@ffi.rst.snap
@@ -11,5 +11,5 @@ expression: out_docs.get(out).unwrap()
 
     .. js:attribute:: b
 
-    .. js:function:: write()
+    .. js:method:: write()
 


### PR DESCRIPTION
https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#directive-js-function


We have an annoying hack in ICU4X since `staticfunction` is a C++ thing: https://github.com/unicode-org/icu4x/blob/8db99af689f930045330dce145a3318cfb2c327b/tools/make/ffi.toml#L268