### PR TITLE
Support cfgs for custom types and impls at the macro level

### DIFF
--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -1,0 +1,10 @@
+//! This module contains utilities for dealing with Rust attributes
+
+use syn::Attribute;
+
+pub(crate) fn extract_cfg_attrs(attrs: &[Attribute]) -> impl Iterator<Item = String> + '_ {
+    attrs
+        .iter()
+        .filter(|&a| a.path == syn::parse_str("cfg").unwrap())
+        .map(|a| quote::quote!(#a).to_string())
+}

--- a/core/src/ast/enums.rs
+++ b/core/src/ast/enums.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::docs::Docs;
-use super::{Ident, Method};
+use super::{attrs, Ident, Method};
 use quote::ToTokens;
 
 /// A fieldless enum declaration in an FFI module.
@@ -12,6 +12,7 @@ pub struct Enum {
     /// A list of variants of the enum. (name, discriminant, docs)
     pub variants: Vec<(Ident, isize, Docs)>,
     pub methods: Vec<Method>,
+    pub cfg_attrs: Vec<String>,
 }
 
 impl From<&syn::ItemEnum> for Enum {
@@ -25,6 +26,8 @@ impl From<&syn::ItemEnum> for Enum {
             // and update the `CustomType::lifetimes` API accordingly.
             panic!("Enums cannot have generic parameters");
         }
+
+        let cfg_attrs = attrs::extract_cfg_attrs(&enm.attrs).collect();
         Enum {
             name: (&enm.ident).into(),
             docs: Docs::from_attrs(&enm.attrs),
@@ -57,6 +60,7 @@ impl From<&syn::ItemEnum> for Enum {
                 })
                 .collect(),
             methods: vec![],
+            cfg_attrs,
         }
     }
 }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::ops::ControlFlow;
 
+use super::attrs;
 use super::docs::Docs;
 use super::{Ident, Lifetime, LifetimeEnv, Mutability, Path, PathType, TypeName, ValidityError};
 use crate::Env;
@@ -95,12 +96,7 @@ impl Method {
             params: all_params,
             return_type: return_ty,
             lifetime_env,
-            cfg: m
-                .attrs
-                .iter()
-                .filter(|&a| a.path == syn::parse_str("cfg").unwrap())
-                .map(|a| quote::quote!(#a).to_string())
-                .collect(),
+            cfg: attrs::extract_cfg_attrs(&m.attrs).collect(),
         }
     }
 

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -2,6 +2,8 @@
 /// generates a simplified version of the Rust AST that captures special
 /// types such as opaque structs, [`Box`], and [`Result`] with utilities
 /// for handling such types.
+pub(crate) mod attrs;
+
 mod methods;
 pub use methods::{BorrowedParams, Method, Param, SelfParam};
 

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use syn::{ImplItem, Item, ItemMod, UseTree, Visibility};
 
 use super::{
-    CustomType, Enum, Ident, Method, ModSymbol, Mutability, OpaqueStruct, Path, PathType, RustLink,
-    Struct, ValidityError,
+    attrs, CustomType, Enum, Ident, Method, ModSymbol, Mutability, OpaqueStruct, Path, PathType,
+    RustLink, Struct, ValidityError,
 };
 use crate::environment::*;
 
@@ -176,6 +176,7 @@ impl Module {
                             syn::Type::Path(s) => PathType::from(s),
                             _ => panic!("Self type not found"),
                         };
+                        let cfg_attrs: Vec<_> = attrs::extract_cfg_attrs(&imp.attrs).collect();
 
                         let mut new_methods = imp
                             .items
@@ -185,7 +186,7 @@ impl Module {
                                 _ => None,
                             })
                             .filter(|m| matches!(m.vis, Visibility::Public(_)))
-                            .map(|m| Method::from_syn(m, self_path.clone(), Some(&imp.generics)))
+                            .map(|m| Method::from_syn(m, self_path.clone(), Some(&imp.generics), &cfg_attrs))
                             .collect();
 
                         let self_ident = self_path.path.elements.last().unwrap();

--- a/core/src/ast/snapshots/diplomat_core__ast__enums__tests__enum_with_discr.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__enums__tests__enum_with_discr.snap
@@ -29,4 +29,5 @@ variants:
     - - ""
       - []
 methods: []
+cfg_attrs: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__enums__tests__simple_enum.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__enums__tests__simple_enum.snap
@@ -21,4 +21,5 @@ variants:
     - - Some more docs.
       - []
 methods: []
+cfg_attrs: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__cfged_method.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__cfged_method.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)]\n                #[cfg(any(feature = \"foo\", not(feature = \"bar\")))] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None)"
+expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)]\n                #[cfg(any(feature = \"foo\", not(feature = \"bar\")))] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
 ---
 name: foo
 docs:
@@ -27,6 +27,6 @@ params:
         lifetimes: []
 return_type: ~
 lifetime_env: {}
-cfg:
+cfg_attrs:
   - "# [cfg (any (feature = \"foo\" , not (feature = \"bar\")))]"
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(& mut self, x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None)"
+expression: "Method::from_syn(&syn::parse_quote! {\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(& mut self, x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
 ---
 name: foo
 docs:
@@ -36,5 +36,5 @@ params:
 return_type:
   Primitive: u64
 lifetime_env: {}
-cfg: []
+cfg_attrs: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                fn foo(& self, x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None)"
+expression: "Method::from_syn(&syn::parse_quote! {\n                fn foo(& self, x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
 ---
 name: foo
 docs:
@@ -29,5 +29,5 @@ params:
         lifetimes: []
 return_type: ~
 lifetime_env: {}
-cfg: []
+cfg_attrs: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                /// Some more docs.\n                ///\n                /// Even more docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInEnum)] fn\n                foo(x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None)"
+expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                /// Some more docs.\n                ///\n                /// Even more docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInEnum)] fn\n                foo(x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
 ---
 name: foo
 docs:
@@ -28,5 +28,5 @@ params:
 return_type:
   Primitive: u64
 lifetime_env: {}
-cfg: []
+cfg_attrs: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None)"
+expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
 ---
 name: foo
 docs:
@@ -27,5 +27,5 @@ params:
         lifetimes: []
 return_type: ~
 lifetime_env: {}
-cfg: []
+cfg_attrs: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
@@ -17,6 +17,7 @@ modules:
           fields: []
           methods: []
           output_only: false
+          cfg_attrs: []
     sub_modules: []
   other:
     name: other

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
@@ -23,7 +23,8 @@ declared_types:
           params: []
           return_type: ~
           lifetime_env: {}
-          cfg: []
+          cfg_attrs: []
       output_only: false
+      cfg_attrs: []
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -44,7 +44,7 @@ declared_types:
                   - NonOpaqueStruct
               lifetimes: []
           lifetime_env: {}
-          cfg: []
+          cfg_attrs: []
         - name: set_a
           docs:
             - ""
@@ -65,8 +65,9 @@ declared_types:
                 Primitive: i32
           return_type: ~
           lifetime_env: {}
-          cfg: []
+          cfg_attrs: []
       output_only: false
+      cfg_attrs: []
   OpaqueStruct:
     Opaque:
       name: OpaqueStruct
@@ -90,7 +91,7 @@ declared_types:
                     - OpaqueStruct
                 lifetimes: []
           lifetime_env: {}
-          cfg: []
+          cfg_attrs: []
         - name: get_string
           docs:
             - ""
@@ -113,7 +114,8 @@ declared_types:
                   - String
               lifetimes: []
           lifetime_env: {}
-          cfg: []
+          cfg_attrs: []
       mutability: Immutable
+      cfg_attrs: []
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
@@ -28,4 +28,5 @@ fields:
       - []
 methods: []
 output_only: true
+cfg_attrs: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { :: core :: my_type :: Foo })"
+expression: "TypeName::from_syn(&syn::parse_quote! { :: core :: my_type :: Foo }, None)"
 ---
 Named:
   path:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-3.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-3.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { :: core :: my_type :: Foo < 'test > })"
+expression: "TypeName::from_syn(&syn::parse_quote! { :: core :: my_type :: Foo < 'test > },\n    None)"
 ---
 Named:
   path:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-4.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-4.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Option < Ref < 'object >> })"
+expression: "TypeName::from_syn(&syn::parse_quote! { Option < Ref < 'object >> }, None)"
 ---
 Option:
   Named:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-5.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-5.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Foo < 'a, 'b, 'c, 'd > })"
+expression: "TypeName::from_syn(&syn::parse_quote! { Foo < 'a, 'b, 'c, 'd > }, None)"
 ---
 Named:
   path:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-6.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-6.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! {\n                very :: long :: path :: to :: my :: Type < 'x, 'y, 'z >\n            })"
+expression: "TypeName::from_syn(&syn::parse_quote! {\n                very :: long :: path :: to :: my :: Type < 'x, 'y, 'z >\n            }, None)"
 ---
 Named:
   path:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Foo < 'a, 'b > })"
+expression: "TypeName::from_syn(&syn::parse_quote! { Foo < 'a, 'b > }, None)"
 ---
 Named:
   path:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Box < MyLocalStruct > })"
+expression: "TypeName::from_syn(&syn::parse_quote! { Box < MyLocalStruct > }, None)"
 ---
 Box:
   Named:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_boxes.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Box < i32 > }).unwrap())"
-
+expression: "TypeName::from_syn(&syn::parse_quote! { Box < i32 > }, None)"
 ---
 Box:
   Primitive: i32

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_named.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_named.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { MyLocalStruct })"
+expression: "TypeName::from_syn(&syn::parse_quote! { MyLocalStruct }, None)"
 ---
 Named:
   path:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Option < MyLocalStruct > })"
+expression: "TypeName::from_syn(&syn::parse_quote! { Option < MyLocalStruct > }, None)"
 ---
 Option:
   Named:

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { Option < i32 > })"
-
+expression: "TypeName::from_syn(&syn::parse_quote! { Option < i32 > }, None)"
 ---
 Option:
   Primitive: i32

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_primitives-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_primitives-2.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { usize }).unwrap())"
-
+expression: "TypeName::from_syn(&syn::parse_quote! { usize }, None)"
 ---
 Primitive: usize
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_primitives-3.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_primitives-3.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { bool }).unwrap())"
-
+expression: "TypeName::from_syn(&syn::parse_quote! { bool }, None)"
 ---
 Primitive: bool
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_primitives.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_primitives.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from(&syn::parse_quote! { i32 }).unwrap())"
-
+expression: "TypeName::from_syn(&syn::parse_quote! { i32 }, None)"
 ---
 Primitive: i32
 

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__non_opaque_move.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__non_opaque_move.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/validity.rs
 expression: output
-
 ---
 A non-opaque type was found behind a Box or reference, these can only be handled by-move as they get converted at the FFI boundary: NonOpaque
 A non-opaque type was found behind a Box or reference, these can only be handled by-move as they get converted at the FFI boundary: NonOpaque

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__opaque_checks_with_error.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__opaque_checks_with_error.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/validity.rs
 expression: output
-
 ---
 An opaque type crossed the FFI boundary as a value: OpaqueStruct
 An opaque type crossed the FFI boundary as a value: OpaqueStruct

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__opaque_checks_with_safe_use.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__opaque_checks_with_safe_use.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/validity.rs
 expression: output
-
 ---
 A non-opaque zero-sized struct or enum has been defined: ffi::NonOpaqueStruct
 

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__opaque_ffi.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__opaque_ffi.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/validity.rs
 expression: output
-
 ---
 An opaque type crossed the FFI boundary as a value: MyOpaqueStruct
 An opaque type crossed the FFI boundary as a value: MyOpaqueStruct

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__option_valid.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__option_valid.snap
@@ -1,6 +1,5 @@
 ---
 source: core/src/ast/validity.rs
 expression: output
-
 ---
 

--- a/core/src/ast/snapshots/diplomat_core__ast__validity__tests__zst_non_opaque.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__validity__tests__zst_non_opaque.snap
@@ -1,7 +1,6 @@
 ---
 source: core/src/ast/validity.rs
 expression: output
-
 ---
 A non-opaque zero-sized struct or enum has been defined: ffi::OpaqueEnum
 A non-opaque zero-sized struct or enum has been defined: ffi::OpaqueStruct

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -44,6 +44,14 @@ impl CustomType {
         }
     }
 
+    pub fn cfg_attrs(&self) -> &[String] {
+        match self {
+            CustomType::Struct(strct) => &strct.cfg_attrs,
+            CustomType::Opaque(strct) => &strct.cfg_attrs,
+            CustomType::Enum(enm) => &enm.cfg_attrs,
+        }
+    }
+
     /// Get the doc lines of the custom type.
     pub fn docs(&self) -> &Docs {
         match self {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -190,7 +190,7 @@ fn gen_custom_type_method(strct: &ast::CustomType, m: &ast::Method) -> Item {
         })
         .collect::<Vec<_>>();
 
-    let cfg = m.cfg.iter().fold(quote!(), |prev, attr| {
+    let cfg = m.cfg_attrs.iter().fold(quote!(), |prev, attr| {
         let attr = attr.parse::<proc_macro2::TokenStream>().unwrap();
         quote!(#prev #attr)
     });
@@ -624,6 +624,24 @@ mod tests {
                 mod ffi {
                     struct Foo {}
 
+                    impl Foo {
+                        #[cfg(feature = "foo")]
+                        pub fn bar(s: u8) {
+                            unimplemented!()
+                        }
+                    }
+                }
+            })
+            .to_token_stream()
+            .to_string()
+        ));
+
+        insta::assert_display_snapshot!(rustfmt_code(
+            &gen_bridge(parse_quote! {
+                mod ffi {
+                    struct Foo {}
+
+                    #[cfg(feature = "bar")]
                     impl Foo {
                         #[cfg(feature = "foo")]
                         pub fn bar(s: u8) {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -7,6 +7,13 @@ use diplomat_core::ast;
 mod enum_convert;
 mod transparent_convert;
 
+fn cfgs_to_stream(attrs: &[String]) -> proc_macro2::TokenStream {
+    attrs.iter().fold(quote!(), |prev, attr| {
+        let attr = attr.parse::<proc_macro2::TokenStream>().unwrap();
+        quote!(#prev #attr)
+    })
+}
+
 fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) {
     match &param.ty {
         ast::TypeName::StrReference(_) | ast::TypeName::PrimitiveSlice(..) => {
@@ -190,10 +197,7 @@ fn gen_custom_type_method(strct: &ast::CustomType, m: &ast::Method) -> Item {
         })
         .collect::<Vec<_>>();
 
-    let cfg = m.cfg_attrs.iter().fold(quote!(), |prev, attr| {
-        let attr = attr.parse::<proc_macro2::TokenStream>().unwrap();
-        quote!(#prev #attr)
-    });
+    let cfg = cfgs_to_stream(&m.cfg_attrs);
 
     if writeable_flushes.is_empty() {
         Item::Fn(syn::parse_quote! {
@@ -327,10 +331,13 @@ fn gen_bridge(input: ItemMod) -> ItemMod {
             (quote! {}, quote! {})
         };
 
+        let cfg = cfgs_to_stream(custom_type.cfg_attrs());
+
         // for now, body is empty since all we need to do is drop the box
         // TODO(#13): change to take a `*mut` and handle DST boxes appropriately
         new_contents.push(Item::Fn(syn::parse_quote! {
             #[no_mangle]
+            #cfg
             extern "C" fn #destroy_ident#lifetime_defs(this: Box<#type_ident#lifetimes>) {}
         }));
     }
@@ -644,6 +651,27 @@ mod tests {
                     #[cfg(feature = "bar")]
                     impl Foo {
                         #[cfg(feature = "foo")]
+                        pub fn bar(s: u8) {
+                            unimplemented!()
+                        }
+                    }
+                }
+            })
+            .to_token_stream()
+            .to_string()
+        ));
+    }
+
+    #[test]
+    fn cfgd_struct() {
+        insta::assert_display_snapshot!(rustfmt_code(
+            &gen_bridge(parse_quote! {
+                mod ffi {
+                    #[diplomat::opaque]
+                    #[cfg(feature = "foo")]
+                    struct Foo {}
+                    #[cfg(feature = "foo")]
+                    impl Foo {
                         pub fn bar(s: u8) {
                             unimplemented!()
                         }

--- a/macro/src/snapshots/diplomat__tests__cfgd_struct.snap
+++ b/macro/src/snapshots/diplomat__tests__cfgd_struct.snap
@@ -1,0 +1,23 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                #[diplomat :: opaque] #[cfg(feature = \"foo\")] struct Foo {}\n                                #[cfg(feature = \"foo\")] impl Foo\n                                { pub fn bar(s : u8) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
+---
+mod ffi {
+    #[cfg(feature = "foo")]
+    struct Foo {}
+    #[cfg(feature = "foo")]
+    impl Foo {
+        pub fn bar(s: u8) {
+            unimplemented!()
+        }
+    }
+    #[no_mangle]
+    #[cfg(feature = "foo")]
+    extern "C" fn Foo_bar(s: u8) {
+        Foo::bar(s)
+    }
+    #[no_mangle]
+    #[cfg(feature = "foo")]
+    extern "C" fn Foo_destroy(this: Box<Foo>) {}
+}
+

--- a/macro/src/snapshots/diplomat__tests__cfged_method-2.snap
+++ b/macro/src/snapshots/diplomat__tests__cfged_method-2.snap
@@ -1,7 +1,6 @@
 ---
 source: macro/src/lib.rs
 expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} #[cfg(feature = \"bar\")] impl Foo\n                                {\n                                    #[cfg(feature = \"foo\")] pub fn bar(s : u8)\n                                    { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
-
 ---
 mod ffi {
     #[repr(C)]

--- a/macro/src/snapshots/diplomat__tests__cfged_method-2.snap.new
+++ b/macro/src/snapshots/diplomat__tests__cfged_method-2.snap.new
@@ -1,0 +1,25 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} #[cfg(feature = \"bar\")] impl Foo\n                                {\n                                    #[cfg(feature = \"foo\")] pub fn bar(s : u8)\n                                    { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+
+---
+mod ffi {
+    #[repr(C)]
+    struct Foo {}
+    #[cfg(feature = "bar")]
+    impl Foo {
+        #[cfg(feature = "foo")]
+        pub fn bar(s: u8) {
+            unimplemented!()
+        }
+    }
+    #[no_mangle]
+    #[cfg(feature = "bar")]
+    #[cfg(feature = "foo")]
+    extern "C" fn Foo_bar(s: u8) {
+        Foo::bar(s)
+    }
+    #[no_mangle]
+    extern "C" fn Foo_destroy(this: Box<Foo>) {}
+}
+


### PR DESCRIPTION
The diplomat macro runs *before* CFGs are resolved; so it will codegen everything it sees.

This builds on https://github.com/rust-diplomat/diplomat/pull/308 so that if something has CFGs they get copied over to all new items being generated (just methods).

Needed for https://github.com/unicode-org/icu4x/pull/3216