### PR TITLE
Clean up lowering to focus on LoweringContext type

### DIFF
--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -97,7 +97,7 @@
 //! [Nomicon]: https://doc.rust-lang.org/nomicon/lifetime-elision.html
 
 use super::{
-    lower_ident, Lifetime, LifetimeEnv, LoweringError, MaybeStatic, MethodLifetime, TypeLifetime,
+    lower_ident, Lifetime, LifetimeEnv, LoweringContext, MaybeStatic, MethodLifetime, TypeLifetime,
     TypeLifetimes,
 };
 use crate::ast;
@@ -181,7 +181,7 @@ pub(super) struct BaseLifetimeLowerer<'ast> {
 /// is lowered into its HIR representation, if present. According to elision
 /// rules, this reference has the highest precedence as the lifetime that
 /// goes into elision in the output, and so it's checked first.
-pub struct SelfParamLifetimeLowerer<'ast> {
+pub(super) struct SelfParamLifetimeLowerer<'ast> {
     base: BaseLifetimeLowerer<'ast>,
 }
 
@@ -192,7 +192,7 @@ pub struct SelfParamLifetimeLowerer<'ast> {
 /// didn't claim the potential output elided lifetime, then if there's a
 /// single lifetime (elided or not) in the inputs, it will claim the
 /// potential output elided lifetime.
-pub struct ParamLifetimeLowerer<'ast> {
+pub(super) struct ParamLifetimeLowerer<'ast> {
     elision_source: ElisionSource,
     base: BaseLifetimeLowerer<'ast>,
 }
@@ -205,7 +205,7 @@ pub struct ParamLifetimeLowerer<'ast> {
 /// that lifetime. If none did and there is elision in the output, then
 /// rustc should have errored and said the elision was ambiguous, meaning
 /// that state should be impossible so it panics.
-pub struct ReturnLifetimeLowerer<'ast> {
+pub(super) struct ReturnLifetimeLowerer<'ast> {
     elision_source: ElisionSource,
     base: BaseLifetimeLowerer<'ast>,
 }
@@ -246,14 +246,11 @@ impl<'ast> BaseLifetimeLowerer<'ast> {
 
 impl<'ast> SelfParamLifetimeLowerer<'ast> {
     /// Returns a new [`SelfParamLifetimeLowerer`].
-    pub fn new(
-        lifetime_env: &'ast ast::LifetimeEnv,
-        errors: &mut Vec<LoweringError>,
-    ) -> Option<Self> {
+    pub fn new(lifetime_env: &'ast ast::LifetimeEnv, ctx: &mut LoweringContext) -> Option<Self> {
         let mut hir_nodes = Some(SmallVec::new());
 
         for ast_node in lifetime_env.nodes.iter() {
-            let lifetime = lower_ident(ast_node.lifetime.name(), "named lifetime", errors);
+            let lifetime = lower_ident(ast_node.lifetime.name(), "named lifetime", ctx);
             match (lifetime, &mut hir_nodes) {
                 (Some(lifetime), Some(hir_nodes)) => {
                     hir_nodes.push(Lifetime::new(

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -97,7 +97,7 @@
 //! [Nomicon]: https://doc.rust-lang.org/nomicon/lifetime-elision.html
 
 use super::{
-    lower_ident, Lifetime, LifetimeEnv, LoweringContext, MaybeStatic, MethodLifetime, TypeLifetime,
+    Lifetime, LifetimeEnv, LoweringContext, MaybeStatic, MethodLifetime, TypeLifetime,
     TypeLifetimes,
 };
 use crate::ast;
@@ -250,7 +250,7 @@ impl<'ast> SelfParamLifetimeLowerer<'ast> {
         let mut hir_nodes = Some(SmallVec::new());
 
         for ast_node in lifetime_env.nodes.iter() {
-            let lifetime = lower_ident(ast_node.lifetime.name(), "named lifetime", ctx);
+            let lifetime = ctx.lower_ident(ast_node.lifetime.name(), "named lifetime");
             match (lifetime, &mut hir_nodes) {
                 (Some(lifetime), Some(hir_nodes)) => {
                     hir_nodes.push(Lifetime::new(

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -31,54 +31,42 @@ impl fmt::Display for LoweringError {
     }
 }
 
-/// Lowers an [`ast::Ident`]s into an [`hir::IdentBuf`].
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-pub(super) fn lower_ident(
-    ident: &ast::Ident,
-    context: &'static str,
-    ctx: &mut LoweringContext,
-) -> Option<IdentBuf> {
-    match ident.as_str().ck() {
-        Ok(name) => Some(name.to_owned()),
-        Err(e) => {
-            ctx.errors.push(LoweringError::Other(format!(
-                "Ident `{ident}` from {context} could not be turned into a Rust ident: {e}"
-            )));
-            None
-        }
-    }
-}
-
 pub(super) struct LoweringContext<'ast, 'errors> {
     pub lookup_id: &'ast LookupId<'ast>,
     pub errors: &'errors mut Vec<LoweringError>,
     pub env: &'ast Env,
 }
 
-/// Lowers an AST definition.
-pub(super) trait TypeLowerer: Sized {
-    /// Type of the AST definition that gets lowered.
-    type AstDef;
-
-    /// Lowers the AST definition into `Self`.
+impl<'ast, 'errors> LoweringContext<'ast, 'errors> {
+    /// Lowers an [`ast::Ident`]s into an [`hir::IdentBuf`].
     ///
     /// If there are any errors, they're pushed to `errors` and `None` is returned.
-    fn lower(
-        ast_def: &Self::AstDef,
-        in_path: &ast::Path,
-        ctx: &mut LoweringContext,
-    ) -> Option<Self>;
+    pub(super) fn lower_ident(
+        &mut self,
+        ident: &ast::Ident,
+        context: &'static str,
+    ) -> Option<IdentBuf> {
+        match ident.as_str().ck() {
+            Ok(name) => Some(name.to_owned()),
+            Err(e) => {
+                self.errors.push(LoweringError::Other(format!(
+                    "Ident `{ident}` from {context} could not be turned into a Rust ident: {e}"
+                )));
+                None
+            }
+        }
+    }
 
     /// Lowers multiple items at once
-    fn lower_all(
-        ast_defs: &[(&ast::Path, &Self::AstDef)],
-        ctx: &mut LoweringContext,
-    ) -> Option<Vec<Self>> {
+    fn lower_all<Ast, Hir>(
+        &mut self,
+        ast_defs: &[(&ast::Path, &'ast Ast)],
+        lower: impl Fn(&mut Self, &'ast Ast, &ast::Path) -> Option<Hir>,
+    ) -> Option<Vec<Hir>> {
         let mut hir_types = Some(Vec::with_capacity(ast_defs.len()));
 
         for (in_path, ast_def) in ast_defs {
-            let hir_type = Self::lower(ast_def, in_path, ctx);
+            let hir_type = lower(self, ast_def, in_path);
 
             match (hir_type, &mut hir_types) {
                 (Some(hir_type), Some(hir_types)) => hir_types.push(hir_type),
@@ -88,22 +76,39 @@ pub(super) trait TypeLowerer: Sized {
 
         hir_types
     }
-}
 
-impl TypeLowerer for EnumDef {
-    type AstDef = ast::Enum;
+    pub(super) fn lower_all_enums(
+        &mut self,
+        ast_defs: &[(&ast::Path, &'ast ast::Enum)],
+    ) -> Option<Vec<EnumDef>> {
+        self.lower_all(ast_defs, Self::lower_enum)
+    }
+    pub(super) fn lower_all_structs(
+        &mut self,
+        ast_defs: &[(&ast::Path, &'ast ast::Struct)],
+    ) -> Option<Vec<StructDef>> {
+        self.lower_all(ast_defs, Self::lower_struct)
+    }
+    pub(super) fn lower_all_out_structs(
+        &mut self,
+        ast_defs: &[(&ast::Path, &'ast ast::Struct)],
+    ) -> Option<Vec<OutStructDef>> {
+        self.lower_all(ast_defs, Self::lower_out_struct)
+    }
+    pub(super) fn lower_all_opaques(
+        &mut self,
+        ast_defs: &[(&ast::Path, &'ast ast::OpaqueStruct)],
+    ) -> Option<Vec<OpaqueDef>> {
+        self.lower_all(ast_defs, Self::lower_opaque)
+    }
 
-    fn lower(
-        ast_enum: &Self::AstDef,
-        in_path: &ast::Path,
-        ctx: &mut LoweringContext,
-    ) -> Option<Self> {
-        let name = lower_ident(&ast_enum.name, "enum name", ctx);
+    fn lower_enum(&mut self, ast_enum: &'ast ast::Enum, in_path: &ast::Path) -> Option<EnumDef> {
+        let name = self.lower_ident(&ast_enum.name, "enum name");
 
         let mut variants = Some(Vec::with_capacity(ast_enum.variants.len()));
 
         for (ident, discriminant, docs) in ast_enum.variants.iter() {
-            let name = lower_ident(ident, "enum variant", ctx);
+            let name = self.lower_ident(ident, "enum variant");
 
             match (name, &mut variants) {
                 (Some(name), Some(variants)) => {
@@ -117,7 +122,7 @@ impl TypeLowerer for EnumDef {
             }
         }
 
-        let methods = lower_all_methods(&ast_enum.methods[..], in_path, ctx);
+        let methods = self.lower_all_methods(&ast_enum.methods[..], in_path);
 
         Some(EnumDef::new(
             ast_enum.docs.clone(),
@@ -126,36 +131,28 @@ impl TypeLowerer for EnumDef {
             methods?,
         ))
     }
-}
 
-impl TypeLowerer for OpaqueDef {
-    type AstDef = ast::OpaqueStruct;
-
-    fn lower(
-        ast_opaque: &Self::AstDef,
+    fn lower_opaque(
+        &mut self,
+        ast_opaque: &'ast ast::OpaqueStruct,
         in_path: &ast::Path,
-        ctx: &mut LoweringContext,
-    ) -> Option<Self> {
-        let name = lower_ident(&ast_opaque.name, "opaque name", ctx);
+    ) -> Option<OpaqueDef> {
+        let name = self.lower_ident(&ast_opaque.name, "opaque name");
 
-        let methods = lower_all_methods(&ast_opaque.methods[..], in_path, ctx);
+        let methods = self.lower_all_methods(&ast_opaque.methods[..], in_path);
 
         Some(OpaqueDef::new(ast_opaque.docs.clone(), name?, methods?))
     }
-}
 
-impl TypeLowerer for StructDef {
-    type AstDef = ast::Struct;
-
-    fn lower(
-        ast_struct: &Self::AstDef,
+    fn lower_struct(
+        &mut self,
+        ast_struct: &'ast ast::Struct,
         in_path: &ast::Path,
-        ctx: &mut LoweringContext,
-    ) -> Option<Self> {
-        let name = lower_ident(&ast_struct.name, "struct name", ctx);
+    ) -> Option<StructDef> {
+        let name = self.lower_ident(&ast_struct.name, "struct name");
 
         let fields = if ast_struct.fields.is_empty() {
-            ctx.errors.push(LoweringError::Other(format!(
+            self.errors.push(LoweringError::Other(format!(
                 "struct `{}` is a ZST because it has no fields",
                 ast_struct.name
             )));
@@ -164,8 +161,8 @@ impl TypeLowerer for StructDef {
             let mut fields = Some(Vec::with_capacity(ast_struct.fields.len()));
 
             for (name, ty, docs) in ast_struct.fields.iter() {
-                let name = lower_ident(name, "struct field name", ctx);
-                let ty = lower_type(ty, Some(&mut &ast_struct.lifetimes), in_path, ctx);
+                let name = self.lower_ident(name, "struct field name");
+                let ty = self.lower_type(ty, Some(&mut &ast_struct.lifetimes), in_path);
 
                 match (name, ty, &mut fields) {
                     (Some(name), Some(ty), Some(fields)) => fields.push(StructField {
@@ -180,7 +177,7 @@ impl TypeLowerer for StructDef {
             fields
         };
 
-        let methods = lower_all_methods(&ast_struct.methods[..], in_path, ctx);
+        let methods = self.lower_all_methods(&ast_struct.methods[..], in_path);
 
         Some(StructDef::new(
             ast_struct.docs.clone(),
@@ -189,20 +186,16 @@ impl TypeLowerer for StructDef {
             methods?,
         ))
     }
-}
 
-impl TypeLowerer for OutStructDef {
-    type AstDef = ast::Struct;
-
-    fn lower(
-        ast_out_struct: &Self::AstDef,
+    fn lower_out_struct(
+        &mut self,
+        ast_out_struct: &'ast ast::Struct,
         in_path: &ast::Path,
-        ctx: &mut LoweringContext,
-    ) -> Option<Self> {
-        let name = lower_ident(&ast_out_struct.name, "out-struct name", ctx);
+    ) -> Option<OutStructDef> {
+        let name = self.lower_ident(&ast_out_struct.name, "out-struct name");
 
         let fields = if ast_out_struct.fields.is_empty() {
-            ctx.errors.push(LoweringError::Other(format!(
+            self.errors.push(LoweringError::Other(format!(
                 "struct `{}` is a ZST because it has no fields",
                 ast_out_struct.name
             )));
@@ -211,8 +204,8 @@ impl TypeLowerer for OutStructDef {
             let mut fields = Some(Vec::with_capacity(ast_out_struct.fields.len()));
 
             for (name, ty, docs) in ast_out_struct.fields.iter() {
-                let name = lower_ident(name, "out-struct field name", ctx);
-                let ty = lower_out_type(ty, Some(&mut &ast_out_struct.lifetimes), in_path, ctx);
+                let name = self.lower_ident(name, "out-struct field name");
+                let ty = self.lower_out_type(ty, Some(&mut &ast_out_struct.lifetimes), in_path);
 
                 match (name, ty, &mut fields) {
                     (Some(name), Some(ty), Some(fields)) => fields.push(OutStructField {
@@ -227,7 +220,7 @@ impl TypeLowerer for OutStructDef {
             fields
         };
 
-        let methods = lower_all_methods(&ast_out_struct.methods[..], in_path, ctx);
+        let methods = self.lower_all_methods(&ast_out_struct.methods[..], in_path);
 
         Some(OutStructDef::new(
             ast_out_struct.docs.clone(),
@@ -236,171 +229,165 @@ impl TypeLowerer for OutStructDef {
             methods?,
         ))
     }
-}
 
-/// Lowers an [`ast::Method`]s an [`hir::Method`].
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-fn lower_method(
-    method: &ast::Method,
-    in_path: &ast::Path,
-    ctx: &mut LoweringContext,
-) -> Option<Method> {
-    let name = lower_ident(&method.name, "method name", ctx);
+    /// Lowers an [`ast::Method`]s an [`hir::Method`].
+    ///
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
+    fn lower_method(&mut self, method: &'ast ast::Method, in_path: &ast::Path) -> Option<Method> {
+        let name = self.lower_ident(&method.name, "method name");
 
-    let (ast_params, takes_writeable) = match method.params.split_last() {
-        Some((last, remaining)) if last.is_writeable() => (remaining, true),
-        _ => (&method.params[..], false),
-    };
+        let (ast_params, takes_writeable) = match method.params.split_last() {
+            Some((last, remaining)) if last.is_writeable() => (remaining, true),
+            _ => (&method.params[..], false),
+        };
 
-    let self_param_ltl = SelfParamLifetimeLowerer::new(&method.lifetime_env, ctx);
+        let self_param_ltl = SelfParamLifetimeLowerer::new(&method.lifetime_env, self);
 
-    let (param_self, param_ltl) = if let Some(self_param) = method.self_param.as_ref() {
-        lower_self_param(
-            self_param,
-            self_param_ltl,
-            &method.full_path_name,
+        let (param_self, param_ltl) = if let Some(self_param) = method.self_param.as_ref() {
+            self.lower_self_param(self_param, self_param_ltl, &method.full_path_name, in_path)
+                .map(|(param_self, param_ltl)| (Some(Some(param_self)), Some(param_ltl)))
+                .unwrap_or((None, None))
+        } else {
+            (
+                Some(None),
+                self_param_ltl.map(SelfParamLifetimeLowerer::no_self_ref),
+            )
+        };
+
+        let (params, return_ltl) = self
+            .lower_many_params(ast_params, param_ltl, in_path)
+            .map(|(params, return_ltl)| (Some(params), Some(return_ltl)))
+            .unwrap_or((None, None));
+
+        let (output, lifetime_env) = self.lower_return_type(
+            method.return_type.as_ref(),
+            takes_writeable,
+            return_ltl,
             in_path,
-            ctx,
-        )
-        .map(|(param_self, param_ltl)| (Some(Some(param_self)), Some(param_ltl)))
-        .unwrap_or((None, None))
-    } else {
-        (
-            Some(None),
-            self_param_ltl.map(SelfParamLifetimeLowerer::no_self_ref),
-        )
-    };
+        )?;
 
-    let (params, return_ltl) = lower_many_params(ast_params, param_ltl, in_path, ctx)
-        .map(|(params, return_ltl)| (Some(params), Some(return_ltl)))
-        .unwrap_or((None, None));
-
-    let (output, lifetime_env) = lower_return_type(
-        method.return_type.as_ref(),
-        takes_writeable,
-        return_ltl,
-        in_path,
-        ctx,
-    )?;
-
-    Some(Method {
-        docs: method.docs.clone(),
-        name: name?,
-        lifetime_env,
-        param_self: param_self?,
-        params: params?,
-        output,
-    })
-}
-
-/// Lowers many [`ast::Method`]s into a vector of [`hir::Method`]s.
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-fn lower_all_methods(
-    ast_methods: &[ast::Method],
-    in_path: &ast::Path,
-    ctx: &mut LoweringContext,
-) -> Option<Vec<Method>> {
-    let mut methods = Some(Vec::with_capacity(ast_methods.len()));
-
-    for method in ast_methods {
-        let method = lower_method(method, in_path, ctx);
-        match (method, &mut methods) {
-            (Some(method), Some(methods)) => {
-                methods.push(method);
-            }
-            _ => methods = None,
-        }
+        Some(Method {
+            docs: method.docs.clone(),
+            name: name?,
+            lifetime_env,
+            param_self: param_self?,
+            params: params?,
+            output,
+        })
     }
 
-    methods
-}
+    /// Lowers many [`ast::Method`]s into a vector of [`hir::Method`]s.
+    ///
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
+    fn lower_all_methods(
+        &mut self,
+        ast_methods: &'ast [ast::Method],
+        in_path: &ast::Path,
+    ) -> Option<Vec<Method>> {
+        let mut methods = Some(Vec::with_capacity(ast_methods.len()));
 
-/// Lowers an [`ast::TypeName`]s into a [`hir::Type`].
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-fn lower_type<L: LifetimeLowerer>(
-    ty: &ast::TypeName,
-    ltl: Option<&mut L>,
-    in_path: &ast::Path,
-    ctx: &mut LoweringContext,
-) -> Option<Type> {
-    match ty {
-        ast::TypeName::Primitive(prim) => Some(Type::Primitive(PrimitiveType::from_ast(*prim))),
-        ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-            match path.resolve(in_path, &ctx.env) {
-                ast::CustomType::Struct(strct) => {
-                    if let Some(tcx_id) = ctx.lookup_id.resolve_struct(strct) {
-                        let lifetimes = ltl?.lower_generics(&path.lifetimes[..], ty.is_self());
-
-                        Some(Type::Struct(StructPath::new(lifetimes, tcx_id)))
-                    } else if ctx.lookup_id.resolve_out_struct(strct).is_some() {
-                        ctx.errors.push(LoweringError::Other(format!("found struct in input that is marked with #[diplomat::out]: {ty} in {path}")));
-                        None
-                    } else {
-                        unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
-                    }
+        for method in ast_methods {
+            let method = self.lower_method(method, in_path);
+            match (method, &mut methods) {
+                (Some(method), Some(methods)) => {
+                    methods.push(method);
                 }
-                ast::CustomType::Opaque(_) => {
-                    ctx.errors.push(LoweringError::Other(format!(
-                        "Opaque passed by value in input: {path}"
-                    )));
-                    None
-                }
-                ast::CustomType::Enum(enm) => {
-                    let tcx_id = ctx
-                        .lookup_id
-                        .resolve_enum(enm)
-                        .expect("can't find enum in lookup map, which contains all enums from env");
-
-                    Some(Type::Enum(EnumPath::new(tcx_id)))
-                }
+                _ => methods = None,
             }
         }
-        ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
+
+        methods
+    }
+
+    /// Lowers an [`ast::TypeName`]s into a [`hir::Type`].
+    ///
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
+    fn lower_type<L: LifetimeLowerer>(
+        &mut self,
+        ty: &ast::TypeName,
+        ltl: Option<&mut L>,
+        in_path: &ast::Path,
+    ) -> Option<Type> {
+        match ty {
+            ast::TypeName::Primitive(prim) => Some(Type::Primitive(PrimitiveType::from_ast(*prim))),
             ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                match path.resolve(in_path, &ctx.env) {
-                    ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
-                        let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
-                        let lifetimes = ltl.lower_generics(&path.lifetimes[..], ref_ty.is_self());
-                        let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
+                match path.resolve(in_path, &self.env) {
+                    ast::CustomType::Struct(strct) => {
+                        if let Some(tcx_id) = self.lookup_id.resolve_struct(strct) {
+                            let lifetimes = ltl?.lower_generics(&path.lifetimes[..], ty.is_self());
+
+                            Some(Type::Struct(StructPath::new(lifetimes, tcx_id)))
+                        } else if self.lookup_id.resolve_out_struct(strct).is_some() {
+                            self.errors.push(LoweringError::Other(format!("found struct in input that is marked with #[diplomat::out]: {ty} in {path}")));
+                            None
+                        } else {
+                            unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
+                        }
+                    }
+                    ast::CustomType::Opaque(_) => {
+                        self.errors.push(LoweringError::Other(format!(
+                            "Opaque passed by value in input: {path}"
+                        )));
+                        None
+                    }
+                    ast::CustomType::Enum(enm) => {
+                        let tcx_id = self.lookup_id.resolve_enum(enm).expect(
+                            "can't find enum in lookup map, which contains all enums from env",
+                        );
+
+                        Some(Type::Enum(EnumPath::new(tcx_id)))
+                    }
+                }
+            }
+            ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
+                ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+                    match path.resolve(in_path, &self.env) {
+                        ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
+                            let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
+                            let lifetimes =
+                                ltl.lower_generics(&path.lifetimes[..], ref_ty.is_self());
+                            let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
-                        Type::Opaque(OpaquePath::new(lifetimes, Optional(false), borrow, tcx_id))
-                    }),
-                    _ => {
-                        ctx.errors.push(LoweringError::Other(format!("found &T in input where T is a custom type, but not opaque. T = {ref_ty}")));
-                        None
+                            Type::Opaque(OpaquePath::new(
+                                lifetimes,
+                                Optional(false),
+                                borrow,
+                                tcx_id,
+                            ))
+                        }),
+                        _ => {
+                            self.errors.push(LoweringError::Other(format!("found &T in input where T is a custom type, but not opaque. T = {ref_ty}")));
+                            None
+                        }
                     }
                 }
-            }
-            _ => {
-                ctx.errors.push(LoweringError::Other(format!("found &T in input where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
-                None
-            }
-        },
-        ast::TypeName::Box(box_ty) => {
-            ctx.errors.push(match box_ty.as_ref() {
+                _ => {
+                    self.errors.push(LoweringError::Other(format!("found &T in input where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                    None
+                }
+            },
+            ast::TypeName::Box(box_ty) => {
+                self.errors.push(match box_ty.as_ref() {
                 ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                    match path.resolve(in_path, &ctx.env) {
+                    match path.resolve(in_path, &self.env) {
                         ast::CustomType::Opaque(_) => LoweringError::Other(format!("found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = {path}")),
                         _ => LoweringError::Other(format!("found Box<T> in input where T is a custom type but not opaque. non-opaques can't be behind pointers, and opaques in inputs can't be owned. T = {path}")),
                     }
                 }
                 _ => LoweringError::Other(format!("found Box<T> in input where T isn't a custom type. T = {box_ty}")),
             });
-            None
-        }
-        ast::TypeName::Option(opt_ty) => {
-            match opt_ty.as_ref() {
+                None
+            }
+            ast::TypeName::Option(opt_ty) => {
+                match opt_ty.as_ref() {
                 ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
-                    ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => match path.resolve(in_path, &ctx.env) {
+                    ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => match path.resolve(in_path, &self.env) {
                         ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                             let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
                             let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
-                            let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
+                            let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
                                     "can't find opaque in lookup map, which contains all opaques from env",
                                 );
 
@@ -412,163 +399,164 @@ fn lower_type<L: LifetimeLowerer>(
                             ))
                         }),
                         _ => {
-                            ctx.errors.push(LoweringError::Other(format!("found Option<&T> in input where T is a custom type, but it's not opaque. T = {ref_ty}")));
+                            self.errors.push(LoweringError::Other(format!("found Option<&T> in input where T is a custom type, but it's not opaque. T = {ref_ty}")));
                             None
                         }
                     },
                     _ => {
-                        ctx.errors.push(LoweringError::Other(format!("found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                        self.errors.push(LoweringError::Other(format!("found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
                         None
                     }
                 },
                 ast::TypeName::Box(box_ty) => {
                     // we could see whats in the box here too
-                    ctx.errors.push(LoweringError::Other(format!("found Option<Box<T>> in input, but box isn't allowed in inputs. T = {box_ty}")));
+                    self.errors.push(LoweringError::Other(format!("found Option<Box<T>> in input, but box isn't allowed in inputs. T = {box_ty}")));
                     None
                 }
                 _ => {
-                    ctx.errors.push(LoweringError::Other(format!("found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
+                    self.errors.push(LoweringError::Other(format!("found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
                     None
                 }
             }
-        }
-        ast::TypeName::Result(_, _, _) => {
-            ctx.errors.push(LoweringError::Other(
-                "Results can only appear as the top-level return type of methods".into(),
-            ));
-            None
-        }
-        ast::TypeName::Writeable => {
-            ctx.errors.push(LoweringError::Other(
-                "Writeables can only appear as the last parameter of a method".into(),
-            ));
-            None
-        }
-        ast::TypeName::StrReference(lifetime) => {
-            Some(Type::Slice(Slice::Str(ltl?.lower_lifetime(lifetime))))
-        }
-        ast::TypeName::PrimitiveSlice(lifetime, mutability, prim) => {
-            let borrow = Borrow::new(ltl?.lower_lifetime(lifetime), *mutability);
-            let prim = PrimitiveType::from_ast(*prim);
+            }
+            ast::TypeName::Result(_, _, _) => {
+                self.errors.push(LoweringError::Other(
+                    "Results can only appear as the top-level return type of methods".into(),
+                ));
+                None
+            }
+            ast::TypeName::Writeable => {
+                self.errors.push(LoweringError::Other(
+                    "Writeables can only appear as the last parameter of a method".into(),
+                ));
+                None
+            }
+            ast::TypeName::StrReference(lifetime) => {
+                Some(Type::Slice(Slice::Str(ltl?.lower_lifetime(lifetime))))
+            }
+            ast::TypeName::PrimitiveSlice(lifetime, mutability, prim) => {
+                let borrow = Borrow::new(ltl?.lower_lifetime(lifetime), *mutability);
+                let prim = PrimitiveType::from_ast(*prim);
 
-            Some(Type::Slice(Slice::Primitive(borrow, prim)))
-        }
-        ast::TypeName::Unit => {
-            ctx.errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
-            None
+                Some(Type::Slice(Slice::Primitive(borrow, prim)))
+            }
+            ast::TypeName::Unit => {
+                self.errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
+                None
+            }
         }
     }
-}
 
-/// Lowers an [`ast::TypeName`]s into an [`hir::OutType`].
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-fn lower_out_type<L: LifetimeLowerer>(
-    ty: &ast::TypeName,
-    ltl: Option<&mut L>,
-    in_path: &ast::Path,
-    ctx: &mut LoweringContext,
-) -> Option<OutType> {
-    match ty {
-        ast::TypeName::Primitive(prim) => Some(OutType::Primitive(PrimitiveType::from_ast(*prim))),
-        ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-            match path.resolve(in_path, &ctx.env) {
-                ast::CustomType::Struct(strct) => {
-                    let lifetimes = ltl?.lower_generics(&path.lifetimes, ty.is_self());
-
-                    if let Some(tcx_id) = ctx.lookup_id.resolve_struct(strct) {
-                        Some(OutType::Struct(ReturnableStructPath::Struct(
-                            StructPath::new(lifetimes, tcx_id),
-                        )))
-                    } else if let Some(tcx_id) = ctx.lookup_id.resolve_out_struct(strct) {
-                        Some(OutType::Struct(ReturnableStructPath::OutStruct(
-                            OutStructPath::new(lifetimes, tcx_id),
-                        )))
-                    } else {
-                        unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
-                    }
-                }
-                ast::CustomType::Opaque(_) => {
-                    ctx.errors.push(LoweringError::Other(format!(
-                        "Opaque passed by value in input: {path}"
-                    )));
-                    None
-                }
-                ast::CustomType::Enum(enm) => {
-                    let tcx_id = ctx
-                        .lookup_id
-                        .resolve_enum(enm)
-                        .expect("can't find enum in lookup map, which contains all enums from env");
-
-                    Some(OutType::Enum(EnumPath::new(tcx_id)))
-                }
+    /// Lowers an [`ast::TypeName`]s into an [`hir::OutType`].
+    ///
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
+    fn lower_out_type<L: LifetimeLowerer>(
+        &mut self,
+        ty: &ast::TypeName,
+        ltl: Option<&mut L>,
+        in_path: &ast::Path,
+    ) -> Option<OutType> {
+        match ty {
+            ast::TypeName::Primitive(prim) => {
+                Some(OutType::Primitive(PrimitiveType::from_ast(*prim)))
             }
-        }
-        ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
             ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                match path.resolve(in_path, &ctx.env) {
-                    ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
-                        let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
-                        let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
-                        let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
-                            "can't find opaque in lookup map, which contains all opaques from env",
-                        );
+                match path.resolve(in_path, &self.env) {
+                    ast::CustomType::Struct(strct) => {
+                        let lifetimes = ltl?.lower_generics(&path.lifetimes, ty.is_self());
 
-                        OutType::Opaque(OpaquePath::new(
-                            lifetimes,
-                            Optional(false),
-                            MaybeOwn::Borrow(borrow),
-                            tcx_id,
-                        ))
-                    }),
-                    _ => {
-                        ctx.errors.push(LoweringError::Other(format!("found &T in output where T is a custom type, but not opaque. T = {ref_ty}")));
+                        if let Some(tcx_id) = self.lookup_id.resolve_struct(strct) {
+                            Some(OutType::Struct(ReturnableStructPath::Struct(
+                                StructPath::new(lifetimes, tcx_id),
+                            )))
+                        } else if let Some(tcx_id) = self.lookup_id.resolve_out_struct(strct) {
+                            Some(OutType::Struct(ReturnableStructPath::OutStruct(
+                                OutStructPath::new(lifetimes, tcx_id),
+                            )))
+                        } else {
+                            unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
+                        }
+                    }
+                    ast::CustomType::Opaque(_) => {
+                        self.errors.push(LoweringError::Other(format!(
+                            "Opaque passed by value in input: {path}"
+                        )));
                         None
                     }
-                }
-            }
-            _ => {
-                ctx.errors.push(LoweringError::Other(format!("found &T in output where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
-                None
-            }
-        },
-        ast::TypeName::Box(box_ty) => match box_ty.as_ref() {
-            ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                match path.resolve(in_path, &ctx.env) {
-                    ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
-                        let lifetimes = ltl.lower_generics(&path.lifetimes, box_ty.is_self());
-                        let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
-                            "can't find opaque in lookup map, which contains all opaques from env",
+                    ast::CustomType::Enum(enm) => {
+                        let tcx_id = self.lookup_id.resolve_enum(enm).expect(
+                            "can't find enum in lookup map, which contains all enums from env",
                         );
 
-                        OutType::Opaque(OpaquePath::new(
-                            lifetimes,
-                            Optional(true),
-                            MaybeOwn::Own,
-                            tcx_id,
-                        ))
-                    }),
-                    _ => {
-                        ctx.errors.push(LoweringError::Other(format!("found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = {path}")));
-                        None
+                        Some(OutType::Enum(EnumPath::new(tcx_id)))
                     }
                 }
             }
-            _ => {
-                ctx.errors.push(LoweringError::Other(format!(
-                    "found Box<T> in output where T isn't a custom type. T = {box_ty}"
-                )));
-                None
-            }
-        },
-        ast::TypeName::Option(opt_ty) => match opt_ty.as_ref() {
             ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
                 ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                    match path.resolve(in_path, &ctx.env) {
+                    match path.resolve(in_path, &self.env) {
                         ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                             let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
                             let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
-                            let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
+                            let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
+                            "can't find opaque in lookup map, which contains all opaques from env",
+                        );
+
+                            OutType::Opaque(OpaquePath::new(
+                                lifetimes,
+                                Optional(false),
+                                MaybeOwn::Borrow(borrow),
+                                tcx_id,
+                            ))
+                        }),
+                        _ => {
+                            self.errors.push(LoweringError::Other(format!("found &T in output where T is a custom type, but not opaque. T = {ref_ty}")));
+                            None
+                        }
+                    }
+                }
+                _ => {
+                    self.errors.push(LoweringError::Other(format!("found &T in output where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                    None
+                }
+            },
+            ast::TypeName::Box(box_ty) => match box_ty.as_ref() {
+                ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+                    match path.resolve(in_path, &self.env) {
+                        ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
+                            let lifetimes = ltl.lower_generics(&path.lifetimes, box_ty.is_self());
+                            let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
+                            "can't find opaque in lookup map, which contains all opaques from env",
+                        );
+
+                            OutType::Opaque(OpaquePath::new(
+                                lifetimes,
+                                Optional(true),
+                                MaybeOwn::Own,
+                                tcx_id,
+                            ))
+                        }),
+                        _ => {
+                            self.errors.push(LoweringError::Other(format!("found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = {path}")));
+                            None
+                        }
+                    }
+                }
+                _ => {
+                    self.errors.push(LoweringError::Other(format!(
+                        "found Box<T> in output where T isn't a custom type. T = {box_ty}"
+                    )));
+                    None
+                }
+            },
+            ast::TypeName::Option(opt_ty) => match opt_ty.as_ref() {
+                ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
+                    ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+                        match path.resolve(in_path, &self.env) {
+                        ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
+                            let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
+                            let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
+                            let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
                                 "can't find opaque in lookup map, which contains all opaques from env",
                             );
 
@@ -580,239 +568,248 @@ fn lower_out_type<L: LifetimeLowerer>(
                             ))
                         }),
                         _ => {
-                            ctx.errors.push(LoweringError::Other(format!("found Option<&T> where T is a custom type, but it's not opaque. T = {ref_ty}")));
+                            self.errors.push(LoweringError::Other(format!("found Option<&T> where T is a custom type, but it's not opaque. T = {ref_ty}")));
                             None
                         }
                     }
-                }
-                _ => {
-                    ctx.errors.push(LoweringError::Other(format!("found Option<&T>, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
-                    None
-                }
-            },
-            ast::TypeName::Box(box_ty) => match box_ty.as_ref() {
-                ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                    match path.resolve(in_path, &ctx.env) {
-                        ast::CustomType::Opaque(opaque) => {
-                            let lifetimes = ltl?.lower_generics(&path.lifetimes, box_ty.is_self());
-                            let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
+                    }
+                    _ => {
+                        self.errors.push(LoweringError::Other(format!("found Option<&T>, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                        None
+                    }
+                },
+                ast::TypeName::Box(box_ty) => match box_ty.as_ref() {
+                    ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
+                        match path.resolve(in_path, &self.env) {
+                            ast::CustomType::Opaque(opaque) => {
+                                let lifetimes =
+                                    ltl?.lower_generics(&path.lifetimes, box_ty.is_self());
+                                let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
-                            Some(OutType::Opaque(OpaquePath::new(
-                                lifetimes,
-                                Optional(true),
-                                MaybeOwn::Own,
-                                tcx_id,
-                            )))
-                        }
-                        _ => {
-                            ctx.errors.push(LoweringError::Other(format!("found Option<Box<T>> where T is a custom type, but it's not opaque. T = {box_ty}")));
-                            None
+                                Some(OutType::Opaque(OpaquePath::new(
+                                    lifetimes,
+                                    Optional(true),
+                                    MaybeOwn::Own,
+                                    tcx_id,
+                                )))
+                            }
+                            _ => {
+                                self.errors.push(LoweringError::Other(format!("found Option<Box<T>> where T is a custom type, but it's not opaque. T = {box_ty}")));
+                                None
+                            }
                         }
                     }
-                }
+                    _ => {
+                        self.errors.push(LoweringError::Other(format!("found Option<Box<T>>, but T isn't a custom type and therefore not opaque. T = {box_ty}")));
+                        None
+                    }
+                },
                 _ => {
-                    ctx.errors.push(LoweringError::Other(format!("found Option<Box<T>>, but T isn't a custom type and therefore not opaque. T = {box_ty}")));
+                    self.errors.push(LoweringError::Other(format!("found Option<T>, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
                     None
                 }
             },
-            _ => {
-                ctx.errors.push(LoweringError::Other(format!("found Option<T>, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
+            ast::TypeName::Result(_, _, _) => {
+                self.errors.push(LoweringError::Other(
+                    "Results can only appear as the top-level return type of methods".into(),
+                ));
                 None
             }
-        },
-        ast::TypeName::Result(_, _, _) => {
-            ctx.errors.push(LoweringError::Other(
-                "Results can only appear as the top-level return type of methods".into(),
-            ));
-            None
-        }
-        ast::TypeName::Writeable => {
-            ctx.errors.push(LoweringError::Other(
-                "Writeables can only appear as the last parameter of a method".into(),
-            ));
-            None
-        }
-        ast::TypeName::StrReference(lifetime) => {
-            Some(OutType::Slice(Slice::Str(ltl?.lower_lifetime(lifetime))))
-        }
-        ast::TypeName::PrimitiveSlice(lifetime, mutability, prim) => {
-            let borrow = Borrow::new(ltl?.lower_lifetime(lifetime), *mutability);
-            let prim = PrimitiveType::from_ast(*prim);
+            ast::TypeName::Writeable => {
+                self.errors.push(LoweringError::Other(
+                    "Writeables can only appear as the last parameter of a method".into(),
+                ));
+                None
+            }
+            ast::TypeName::StrReference(lifetime) => {
+                Some(OutType::Slice(Slice::Str(ltl?.lower_lifetime(lifetime))))
+            }
+            ast::TypeName::PrimitiveSlice(lifetime, mutability, prim) => {
+                let borrow = Borrow::new(ltl?.lower_lifetime(lifetime), *mutability);
+                let prim = PrimitiveType::from_ast(*prim);
 
-            Some(OutType::Slice(Slice::Primitive(borrow, prim)))
-        }
-        ast::TypeName::Unit => {
-            ctx.errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
-            None
+                Some(OutType::Slice(Slice::Primitive(borrow, prim)))
+            }
+            ast::TypeName::Unit => {
+                self.errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
+                None
+            }
         }
     }
-}
 
-/// Lowers an [`ast::SelfParam`] into an [`hir::ParamSelf`].
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-fn lower_self_param<'ast>(
-    self_param: &ast::SelfParam,
-    self_param_ltl: Option<SelfParamLifetimeLowerer<'ast>>,
-    method_full_path: &ast::Ident, // for better error msg
-    in_path: &ast::Path,
-    ctx: &mut LoweringContext,
-) -> Option<(ParamSelf, ParamLifetimeLowerer<'ast>)> {
-    match self_param.path_type.resolve(in_path, &ctx.env) {
-        ast::CustomType::Struct(strct) => {
-            if let Some(tcx_id) = ctx.lookup_id.resolve_struct(strct) {
-                if self_param.reference.is_some() {
-                    ctx.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes a reference to a struct as a self parameter, which isn't allowed")));
-                    None
+    /// Lowers an [`ast::SelfParam`] into an [`hir::ParamSelf`].
+    ///
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
+    fn lower_self_param(
+        &mut self,
+        self_param: &ast::SelfParam,
+        self_param_ltl: Option<SelfParamLifetimeLowerer<'ast>>,
+        method_full_path: &ast::Ident, // for better error msg
+        in_path: &ast::Path,
+    ) -> Option<(ParamSelf, ParamLifetimeLowerer<'ast>)> {
+        match self_param.path_type.resolve(in_path, &self.env) {
+            ast::CustomType::Struct(strct) => {
+                if let Some(tcx_id) = self.lookup_id.resolve_struct(strct) {
+                    if self_param.reference.is_some() {
+                        self.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes a reference to a struct as a self parameter, which isn't allowed")));
+                        None
+                    } else {
+                        let mut param_ltl = self_param_ltl?.no_self_ref();
+
+                        // Even if we explicitly write out the type of `self` like
+                        // `self: Foo<'a>`, the `'a` is still not considered for
+                        // elision according to rustc, so is_self=true.
+                        let type_lifetimes =
+                            param_ltl.lower_generics(&self_param.path_type.lifetimes[..], true);
+
+                        Some((
+                            ParamSelf::new(SelfType::Struct(StructPath::new(
+                                type_lifetimes,
+                                tcx_id,
+                            ))),
+                            param_ltl,
+                        ))
+                    }
+                } else if self.lookup_id.resolve_out_struct(strct).is_some() {
+                    if let Some((lifetime, _)) = &self_param.reference {
+                        self.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed. Also, it's behind a reference, `{lifetime}`, but only opaques can be behind references")));
+                        None
+                    } else {
+                        self.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed")));
+                        None
+                    }
                 } else {
-                    let mut param_ltl = self_param_ltl?.no_self_ref();
-
-                    // Even if we explicitly write out the type of `self` like
-                    // `self: Foo<'a>`, the `'a` is still not considered for
-                    // elision according to rustc, so is_self=true.
-                    let type_lifetimes =
-                        param_ltl.lower_generics(&self_param.path_type.lifetimes[..], true);
-
-                    Some((
-                        ParamSelf::new(SelfType::Struct(StructPath::new(type_lifetimes, tcx_id))),
-                        param_ltl,
-                    ))
-                }
-            } else if ctx.lookup_id.resolve_out_struct(strct).is_some() {
-                if let Some((lifetime, _)) = &self_param.reference {
-                    ctx.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed. Also, it's behind a reference, `{lifetime}`, but only opaques can be behind references")));
-                    None
-                } else {
-                    ctx.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed")));
-                    None
-                }
-            } else {
-                unreachable!(
+                    unreachable!(
                     "struct `{}` wasn't found in the set of structs or out-structs, this is a bug.",
                     strct.name
                 );
+                }
             }
-        }
-        ast::CustomType::Opaque(opaque) => {
-            let tcx_id = ctx
-                .lookup_id
-                .resolve_opaque(opaque)
-                .expect("opaque is in env");
+            ast::CustomType::Opaque(opaque) => {
+                let tcx_id = self
+                    .lookup_id
+                    .resolve_opaque(opaque)
+                    .expect("opaque is in env");
 
-            if let Some((lifetime, mutability)) = &self_param.reference {
-                let (borrow_lifetime, mut param_ltl) = self_param_ltl?.lower_self_ref(lifetime);
-                let borrow = Borrow::new(borrow_lifetime, *mutability);
-                let lifetimes = param_ltl.lower_generics(&self_param.path_type.lifetimes, true);
+                if let Some((lifetime, mutability)) = &self_param.reference {
+                    let (borrow_lifetime, mut param_ltl) = self_param_ltl?.lower_self_ref(lifetime);
+                    let borrow = Borrow::new(borrow_lifetime, *mutability);
+                    let lifetimes = param_ltl.lower_generics(&self_param.path_type.lifetimes, true);
+
+                    Some((
+                        ParamSelf::new(SelfType::Opaque(OpaquePath::new(
+                            lifetimes,
+                            NonOptional,
+                            borrow,
+                            tcx_id,
+                        ))),
+                        param_ltl,
+                    ))
+                } else {
+                    self.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs")));
+                    None
+                }
+            }
+            ast::CustomType::Enum(enm) => {
+                let tcx_id = self.lookup_id.resolve_enum(enm).expect("enum is in env");
 
                 Some((
-                    ParamSelf::new(SelfType::Opaque(OpaquePath::new(
-                        lifetimes,
-                        NonOptional,
-                        borrow,
-                        tcx_id,
-                    ))),
-                    param_ltl,
+                    ParamSelf::new(SelfType::Enum(EnumPath::new(tcx_id))),
+                    self_param_ltl?.no_self_ref(),
                 ))
-            } else {
-                ctx.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs")));
-                None
             }
-        }
-        ast::CustomType::Enum(enm) => {
-            let tcx_id = ctx.lookup_id.resolve_enum(enm).expect("enum is in env");
-
-            Some((
-                ParamSelf::new(SelfType::Enum(EnumPath::new(tcx_id))),
-                self_param_ltl?.no_self_ref(),
-            ))
-        }
-    }
-}
-
-/// Lowers an [`ast::Param`] into an [`hir::Param`].
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-///
-/// Note that this expects that if there was a writeable param at the end in
-/// the method, it's not passed into here.
-fn lower_param<L: LifetimeLowerer>(
-    param: &ast::Param,
-    ltl: Option<&mut L>,
-    in_path: &ast::Path,
-    ctx: &mut LoweringContext,
-) -> Option<Param> {
-    let name = lower_ident(&param.name, "param name", ctx);
-    let ty = lower_type(&param.ty, ltl, in_path, ctx);
-
-    Some(Param::new(name?, ty?))
-}
-
-/// Lowers many [`ast::Param`]s into a vector of [`hir::Param`]s.
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-///
-/// Note that this expects that if there was a writeable param at the end in
-/// the method, `ast_params` was sliced to not include it. This happens in
-/// `lower_method`, the caller of this function.
-fn lower_many_params<'ast>(
-    ast_params: &[ast::Param],
-    mut param_ltl: Option<ParamLifetimeLowerer<'ast>>,
-    in_path: &ast::Path,
-    ctx: &mut LoweringContext,
-) -> Option<(Vec<Param>, ReturnLifetimeLowerer<'ast>)> {
-    let mut params = Some(Vec::with_capacity(ast_params.len()));
-
-    for param in ast_params {
-        let param = lower_param(param, param_ltl.as_mut(), in_path, ctx);
-
-        match (param, &mut params) {
-            (Some(param), Some(params)) => {
-                params.push(param);
-            }
-            _ => params = None,
         }
     }
 
-    Some((params?, param_ltl?.into_return_ltl()))
-}
+    /// Lowers an [`ast::Param`] into an [`hir::Param`].
+    ///
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
+    ///
+    /// Note that this expects that if there was a writeable param at the end in
+    /// the method, it's not passed into here.
+    fn lower_param<L: LifetimeLowerer>(
+        &mut self,
+        param: &ast::Param,
+        ltl: Option<&mut L>,
+        in_path: &ast::Path,
+    ) -> Option<Param> {
+        let name = self.lower_ident(&param.name, "param name");
+        let ty = self.lower_type(&param.ty, ltl, in_path);
 
-/// Lowers the return type of an [`ast::Method`] into a [`hir::ReturnFallability`].
-///
-/// If there are any errors, they're pushed to `errors` and `None` is returned.
-fn lower_return_type(
-    return_type: Option<&ast::TypeName>,
-    takes_writeable: bool,
-    mut return_ltl: Option<ReturnLifetimeLowerer<'_>>,
-    in_path: &ast::Path,
-    ctx: &mut LoweringContext,
-) -> Option<(ReturnType, LifetimeEnv)> {
-    let writeable_option = if takes_writeable {
-        Some(SuccessType::Writeable)
-    } else {
-        None
-    };
-    match return_type.unwrap_or(&ast::TypeName::Unit) {
-        ast::TypeName::Result(ok_ty, err_ty, _) => {
-            let ok_ty = match ok_ty.as_ref() {
-                ast::TypeName::Unit => Some(writeable_option),
-                ty => lower_out_type(ty, return_ltl.as_mut(), in_path, ctx)
-                    .map(|ty| Some(SuccessType::OutType(ty))),
-            };
-            let err_ty = match err_ty.as_ref() {
-                ast::TypeName::Unit => Some(None),
-                ty => lower_out_type(ty, return_ltl.as_mut(), in_path, ctx).map(Some),
-            };
+        Some(Param::new(name?, ty?))
+    }
 
-            match (ok_ty, err_ty) {
-                (Some(ok_ty), Some(err_ty)) => Some(ReturnType::Fallible(ok_ty, err_ty)),
-                _ => None,
+    /// Lowers many [`ast::Param`]s into a vector of [`hir::Param`]s.
+    ///
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
+    ///
+    /// Note that this expects that if there was a writeable param at the end in
+    /// the method, `ast_params` was sliced to not include it. This happens in
+    /// `self.lower_method`, the caller of this function.
+    fn lower_many_params(
+        &mut self,
+        ast_params: &[ast::Param],
+        mut param_ltl: Option<ParamLifetimeLowerer<'ast>>,
+        in_path: &ast::Path,
+    ) -> Option<(Vec<Param>, ReturnLifetimeLowerer<'ast>)> {
+        let mut params = Some(Vec::with_capacity(ast_params.len()));
+
+        for param in ast_params {
+            let param = self.lower_param(param, param_ltl.as_mut(), in_path);
+
+            match (param, &mut params) {
+                (Some(param), Some(params)) => {
+                    params.push(param);
+                }
+                _ => params = None,
             }
         }
-        ast::TypeName::Unit => Some(ReturnType::Infallible(writeable_option)),
-        ty => lower_out_type(ty, return_ltl.as_mut(), in_path, ctx)
-            .map(|ty| ReturnType::Infallible(Some(SuccessType::OutType(ty)))),
+
+        Some((params?, param_ltl?.into_return_ltl()))
     }
-    .and_then(|return_fallability| Some((return_fallability, return_ltl?.finish())))
+
+    /// Lowers the return type of an [`ast::Method`] into a [`hir::ReturnFallability`].
+    ///
+    /// If there are any errors, they're pushed to `errors` and `None` is returned.
+    fn lower_return_type(
+        &mut self,
+        return_type: Option<&ast::TypeName>,
+        takes_writeable: bool,
+        mut return_ltl: Option<ReturnLifetimeLowerer<'_>>,
+        in_path: &ast::Path,
+    ) -> Option<(ReturnType, LifetimeEnv)> {
+        let writeable_option = if takes_writeable {
+            Some(SuccessType::Writeable)
+        } else {
+            None
+        };
+        match return_type.unwrap_or(&ast::TypeName::Unit) {
+            ast::TypeName::Result(ok_ty, err_ty, _) => {
+                let ok_ty = match ok_ty.as_ref() {
+                    ast::TypeName::Unit => Some(writeable_option),
+                    ty => self
+                        .lower_out_type(ty, return_ltl.as_mut(), in_path)
+                        .map(|ty| Some(SuccessType::OutType(ty))),
+                };
+                let err_ty = match err_ty.as_ref() {
+                    ast::TypeName::Unit => Some(None),
+                    ty => self
+                        .lower_out_type(ty, return_ltl.as_mut(), in_path)
+                        .map(Some),
+                };
+
+                match (ok_ty, err_ty) {
+                    (Some(ok_ty), Some(err_ty)) => Some(ReturnType::Fallible(ok_ty, err_ty)),
+                    _ => None,
+                }
+            }
+            ast::TypeName::Unit => Some(ReturnType::Infallible(writeable_option)),
+            ty => self
+                .lower_out_type(ty, return_ltl.as_mut(), in_path)
+                .map(|ty| ReturnType::Infallible(Some(SuccessType::OutType(ty)))),
+        }
+        .and_then(|return_fallability| Some((return_fallability, return_ltl?.finish())))
+    }
 }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -34,20 +34,26 @@ impl fmt::Display for LoweringError {
 /// Lowers an [`ast::Ident`]s into an [`hir::IdentBuf`].
 ///
 /// If there are any errors, they're pushed to `errors` and `None` is returned.
-pub fn lower_ident(
+pub(super) fn lower_ident(
     ident: &ast::Ident,
     context: &'static str,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<IdentBuf> {
     match ident.as_str().ck() {
         Ok(name) => Some(name.to_owned()),
         Err(e) => {
-            errors.push(LoweringError::Other(format!(
+            ctx.errors.push(LoweringError::Other(format!(
                 "Ident `{ident}` from {context} could not be turned into a Rust ident: {e}"
             )));
             None
         }
     }
+}
+
+pub(super) struct LoweringContext<'ast, 'errors> {
+    pub lookup_id: &'ast LookupId<'ast>,
+    pub errors: &'errors mut Vec<LoweringError>,
+    pub env: &'ast Env,
 }
 
 /// Lowers an AST definition.
@@ -60,23 +66,19 @@ pub(super) trait TypeLowerer: Sized {
     /// If there are any errors, they're pushed to `errors` and `None` is returned.
     fn lower(
         ast_def: &Self::AstDef,
-        lookup_id: &LookupId,
         in_path: &ast::Path,
-        env: &Env,
-        errors: &mut Vec<LoweringError>,
+        ctx: &mut LoweringContext,
     ) -> Option<Self>;
 
     /// Lowers multiple items at once
     fn lower_all(
         ast_defs: &[(&ast::Path, &Self::AstDef)],
-        lookup_id: &LookupId,
-        env: &Env,
-        errors: &mut Vec<LoweringError>,
+        ctx: &mut LoweringContext,
     ) -> Option<Vec<Self>> {
         let mut hir_types = Some(Vec::with_capacity(ast_defs.len()));
 
         for (in_path, ast_def) in ast_defs {
-            let hir_type = Self::lower(ast_def, lookup_id, in_path, env, errors);
+            let hir_type = Self::lower(ast_def, in_path, ctx);
 
             match (hir_type, &mut hir_types) {
                 (Some(hir_type), Some(hir_types)) => hir_types.push(hir_type),
@@ -93,17 +95,15 @@ impl TypeLowerer for EnumDef {
 
     fn lower(
         ast_enum: &Self::AstDef,
-        lookup_id: &LookupId,
         in_path: &ast::Path,
-        env: &Env,
-        errors: &mut Vec<LoweringError>,
+        ctx: &mut LoweringContext,
     ) -> Option<Self> {
-        let name = lower_ident(&ast_enum.name, "enum name", errors);
+        let name = lower_ident(&ast_enum.name, "enum name", ctx);
 
         let mut variants = Some(Vec::with_capacity(ast_enum.variants.len()));
 
         for (ident, discriminant, docs) in ast_enum.variants.iter() {
-            let name = lower_ident(ident, "enum variant", errors);
+            let name = lower_ident(ident, "enum variant", ctx);
 
             match (name, &mut variants) {
                 (Some(name), Some(variants)) => {
@@ -117,7 +117,7 @@ impl TypeLowerer for EnumDef {
             }
         }
 
-        let methods = lower_all_methods(&ast_enum.methods[..], lookup_id, in_path, env, errors);
+        let methods = lower_all_methods(&ast_enum.methods[..], in_path, ctx);
 
         Some(EnumDef::new(
             ast_enum.docs.clone(),
@@ -133,14 +133,12 @@ impl TypeLowerer for OpaqueDef {
 
     fn lower(
         ast_opaque: &Self::AstDef,
-        lookup_id: &LookupId,
         in_path: &ast::Path,
-        env: &Env,
-        errors: &mut Vec<LoweringError>,
+        ctx: &mut LoweringContext,
     ) -> Option<Self> {
-        let name = lower_ident(&ast_opaque.name, "opaque name", errors);
+        let name = lower_ident(&ast_opaque.name, "opaque name", ctx);
 
-        let methods = lower_all_methods(&ast_opaque.methods[..], lookup_id, in_path, env, errors);
+        let methods = lower_all_methods(&ast_opaque.methods[..], in_path, ctx);
 
         Some(OpaqueDef::new(ast_opaque.docs.clone(), name?, methods?))
     }
@@ -151,15 +149,13 @@ impl TypeLowerer for StructDef {
 
     fn lower(
         ast_struct: &Self::AstDef,
-        lookup_id: &LookupId,
         in_path: &ast::Path,
-        env: &Env,
-        errors: &mut Vec<LoweringError>,
+        ctx: &mut LoweringContext,
     ) -> Option<Self> {
-        let name = lower_ident(&ast_struct.name, "struct name", errors);
+        let name = lower_ident(&ast_struct.name, "struct name", ctx);
 
         let fields = if ast_struct.fields.is_empty() {
-            errors.push(LoweringError::Other(format!(
+            ctx.errors.push(LoweringError::Other(format!(
                 "struct `{}` is a ZST because it has no fields",
                 ast_struct.name
             )));
@@ -168,15 +164,8 @@ impl TypeLowerer for StructDef {
             let mut fields = Some(Vec::with_capacity(ast_struct.fields.len()));
 
             for (name, ty, docs) in ast_struct.fields.iter() {
-                let name = lower_ident(name, "struct field name", errors);
-                let ty = lower_type(
-                    ty,
-                    Some(&mut &ast_struct.lifetimes),
-                    lookup_id,
-                    in_path,
-                    env,
-                    errors,
-                );
+                let name = lower_ident(name, "struct field name", ctx);
+                let ty = lower_type(ty, Some(&mut &ast_struct.lifetimes), in_path, ctx);
 
                 match (name, ty, &mut fields) {
                     (Some(name), Some(ty), Some(fields)) => fields.push(StructField {
@@ -191,7 +180,7 @@ impl TypeLowerer for StructDef {
             fields
         };
 
-        let methods = lower_all_methods(&ast_struct.methods[..], lookup_id, in_path, env, errors);
+        let methods = lower_all_methods(&ast_struct.methods[..], in_path, ctx);
 
         Some(StructDef::new(
             ast_struct.docs.clone(),
@@ -207,15 +196,13 @@ impl TypeLowerer for OutStructDef {
 
     fn lower(
         ast_out_struct: &Self::AstDef,
-        lookup_id: &LookupId,
         in_path: &ast::Path,
-        env: &Env,
-        errors: &mut Vec<LoweringError>,
+        ctx: &mut LoweringContext,
     ) -> Option<Self> {
-        let name = lower_ident(&ast_out_struct.name, "out-struct name", errors);
+        let name = lower_ident(&ast_out_struct.name, "out-struct name", ctx);
 
         let fields = if ast_out_struct.fields.is_empty() {
-            errors.push(LoweringError::Other(format!(
+            ctx.errors.push(LoweringError::Other(format!(
                 "struct `{}` is a ZST because it has no fields",
                 ast_out_struct.name
             )));
@@ -224,15 +211,8 @@ impl TypeLowerer for OutStructDef {
             let mut fields = Some(Vec::with_capacity(ast_out_struct.fields.len()));
 
             for (name, ty, docs) in ast_out_struct.fields.iter() {
-                let name = lower_ident(name, "out-struct field name", errors);
-                let ty = lower_out_type(
-                    ty,
-                    Some(&mut &ast_out_struct.lifetimes),
-                    lookup_id,
-                    in_path,
-                    env,
-                    errors,
-                );
+                let name = lower_ident(name, "out-struct field name", ctx);
+                let ty = lower_out_type(ty, Some(&mut &ast_out_struct.lifetimes), in_path, ctx);
 
                 match (name, ty, &mut fields) {
                     (Some(name), Some(ty), Some(fields)) => fields.push(OutStructField {
@@ -247,8 +227,7 @@ impl TypeLowerer for OutStructDef {
             fields
         };
 
-        let methods =
-            lower_all_methods(&ast_out_struct.methods[..], lookup_id, in_path, env, errors);
+        let methods = lower_all_methods(&ast_out_struct.methods[..], in_path, ctx);
 
         Some(OutStructDef::new(
             ast_out_struct.docs.clone(),
@@ -264,29 +243,25 @@ impl TypeLowerer for OutStructDef {
 /// If there are any errors, they're pushed to `errors` and `None` is returned.
 fn lower_method(
     method: &ast::Method,
-    lookup_id: &LookupId,
     in_path: &ast::Path,
-    env: &Env,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<Method> {
-    let name = lower_ident(&method.name, "method name", errors);
+    let name = lower_ident(&method.name, "method name", ctx);
 
     let (ast_params, takes_writeable) = match method.params.split_last() {
         Some((last, remaining)) if last.is_writeable() => (remaining, true),
         _ => (&method.params[..], false),
     };
 
-    let self_param_ltl = SelfParamLifetimeLowerer::new(&method.lifetime_env, errors);
+    let self_param_ltl = SelfParamLifetimeLowerer::new(&method.lifetime_env, ctx);
 
     let (param_self, param_ltl) = if let Some(self_param) = method.self_param.as_ref() {
         lower_self_param(
             self_param,
             self_param_ltl,
-            lookup_id,
             &method.full_path_name,
             in_path,
-            env,
-            errors,
+            ctx,
         )
         .map(|(param_self, param_ltl)| (Some(Some(param_self)), Some(param_ltl)))
         .unwrap_or((None, None))
@@ -297,19 +272,16 @@ fn lower_method(
         )
     };
 
-    let (params, return_ltl) =
-        lower_many_params(ast_params, param_ltl, lookup_id, in_path, env, errors)
-            .map(|(params, return_ltl)| (Some(params), Some(return_ltl)))
-            .unwrap_or((None, None));
+    let (params, return_ltl) = lower_many_params(ast_params, param_ltl, in_path, ctx)
+        .map(|(params, return_ltl)| (Some(params), Some(return_ltl)))
+        .unwrap_or((None, None));
 
     let (output, lifetime_env) = lower_return_type(
         method.return_type.as_ref(),
         takes_writeable,
         return_ltl,
-        lookup_id,
         in_path,
-        env,
-        errors,
+        ctx,
     )?;
 
     Some(Method {
@@ -327,15 +299,13 @@ fn lower_method(
 /// If there are any errors, they're pushed to `errors` and `None` is returned.
 fn lower_all_methods(
     ast_methods: &[ast::Method],
-    lookup_id: &LookupId,
     in_path: &ast::Path,
-    env: &Env,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<Vec<Method>> {
     let mut methods = Some(Vec::with_capacity(ast_methods.len()));
 
     for method in ast_methods {
-        let method = lower_method(method, lookup_id, in_path, env, errors);
+        let method = lower_method(method, in_path, ctx);
         match (method, &mut methods) {
             (Some(method), Some(methods)) => {
                 methods.push(method);
@@ -353,35 +323,34 @@ fn lower_all_methods(
 fn lower_type<L: LifetimeLowerer>(
     ty: &ast::TypeName,
     ltl: Option<&mut L>,
-    lookup_id: &LookupId,
     in_path: &ast::Path,
-    env: &Env,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<Type> {
     match ty {
         ast::TypeName::Primitive(prim) => Some(Type::Primitive(PrimitiveType::from_ast(*prim))),
         ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-            match path.resolve(in_path, env) {
+            match path.resolve(in_path, &ctx.env) {
                 ast::CustomType::Struct(strct) => {
-                    if let Some(tcx_id) = lookup_id.resolve_struct(strct) {
+                    if let Some(tcx_id) = ctx.lookup_id.resolve_struct(strct) {
                         let lifetimes = ltl?.lower_generics(&path.lifetimes[..], ty.is_self());
 
                         Some(Type::Struct(StructPath::new(lifetimes, tcx_id)))
-                    } else if lookup_id.resolve_out_struct(strct).is_some() {
-                        errors.push(LoweringError::Other(format!("found struct in input that is marked with #[diplomat::out]: {ty} in {path}")));
+                    } else if ctx.lookup_id.resolve_out_struct(strct).is_some() {
+                        ctx.errors.push(LoweringError::Other(format!("found struct in input that is marked with #[diplomat::out]: {ty} in {path}")));
                         None
                     } else {
                         unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
                     }
                 }
                 ast::CustomType::Opaque(_) => {
-                    errors.push(LoweringError::Other(format!(
+                    ctx.errors.push(LoweringError::Other(format!(
                         "Opaque passed by value in input: {path}"
                     )));
                     None
                 }
                 ast::CustomType::Enum(enm) => {
-                    let tcx_id = lookup_id
+                    let tcx_id = ctx
+                        .lookup_id
                         .resolve_enum(enm)
                         .expect("can't find enum in lookup map, which contains all enums from env");
 
@@ -391,31 +360,31 @@ fn lower_type<L: LifetimeLowerer>(
         }
         ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
             ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                match path.resolve(in_path, env) {
+                match path.resolve(in_path, &ctx.env) {
                     ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                         let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
                         let lifetimes = ltl.lower_generics(&path.lifetimes[..], ref_ty.is_self());
-                        let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                        let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
                         Type::Opaque(OpaquePath::new(lifetimes, Optional(false), borrow, tcx_id))
                     }),
                     _ => {
-                        errors.push(LoweringError::Other(format!("found &T in input where T is a custom type, but not opaque. T = {ref_ty}")));
+                        ctx.errors.push(LoweringError::Other(format!("found &T in input where T is a custom type, but not opaque. T = {ref_ty}")));
                         None
                     }
                 }
             }
             _ => {
-                errors.push(LoweringError::Other(format!("found &T in input where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                ctx.errors.push(LoweringError::Other(format!("found &T in input where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
                 None
             }
         },
         ast::TypeName::Box(box_ty) => {
-            errors.push(match box_ty.as_ref() {
+            ctx.errors.push(match box_ty.as_ref() {
                 ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                    match path.resolve(in_path, env) {
+                    match path.resolve(in_path, &ctx.env) {
                         ast::CustomType::Opaque(_) => LoweringError::Other(format!("found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = {path}")),
                         _ => LoweringError::Other(format!("found Box<T> in input where T is a custom type but not opaque. non-opaques can't be behind pointers, and opaques in inputs can't be owned. T = {path}")),
                     }
@@ -427,11 +396,11 @@ fn lower_type<L: LifetimeLowerer>(
         ast::TypeName::Option(opt_ty) => {
             match opt_ty.as_ref() {
                 ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
-                    ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => match path.resolve(in_path, env) {
+                    ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => match path.resolve(in_path, &ctx.env) {
                         ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                             let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
                             let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
-                            let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                            let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
                                     "can't find opaque in lookup map, which contains all opaques from env",
                                 );
 
@@ -443,34 +412,34 @@ fn lower_type<L: LifetimeLowerer>(
                             ))
                         }),
                         _ => {
-                            errors.push(LoweringError::Other(format!("found Option<&T> in input where T is a custom type, but it's not opaque. T = {ref_ty}")));
+                            ctx.errors.push(LoweringError::Other(format!("found Option<&T> in input where T is a custom type, but it's not opaque. T = {ref_ty}")));
                             None
                         }
                     },
                     _ => {
-                        errors.push(LoweringError::Other(format!("found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                        ctx.errors.push(LoweringError::Other(format!("found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
                         None
                     }
                 },
                 ast::TypeName::Box(box_ty) => {
                     // we could see whats in the box here too
-                    errors.push(LoweringError::Other(format!("found Option<Box<T>> in input, but box isn't allowed in inputs. T = {box_ty}")));
+                    ctx.errors.push(LoweringError::Other(format!("found Option<Box<T>> in input, but box isn't allowed in inputs. T = {box_ty}")));
                     None
                 }
                 _ => {
-                    errors.push(LoweringError::Other(format!("found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
+                    ctx.errors.push(LoweringError::Other(format!("found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
                     None
                 }
             }
         }
         ast::TypeName::Result(_, _, _) => {
-            errors.push(LoweringError::Other(
+            ctx.errors.push(LoweringError::Other(
                 "Results can only appear as the top-level return type of methods".into(),
             ));
             None
         }
         ast::TypeName::Writeable => {
-            errors.push(LoweringError::Other(
+            ctx.errors.push(LoweringError::Other(
                 "Writeables can only appear as the last parameter of a method".into(),
             ));
             None
@@ -485,7 +454,7 @@ fn lower_type<L: LifetimeLowerer>(
             Some(Type::Slice(Slice::Primitive(borrow, prim)))
         }
         ast::TypeName::Unit => {
-            errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
+            ctx.errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
             None
         }
     }
@@ -497,23 +466,21 @@ fn lower_type<L: LifetimeLowerer>(
 fn lower_out_type<L: LifetimeLowerer>(
     ty: &ast::TypeName,
     ltl: Option<&mut L>,
-    lookup_id: &LookupId,
     in_path: &ast::Path,
-    env: &Env,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<OutType> {
     match ty {
         ast::TypeName::Primitive(prim) => Some(OutType::Primitive(PrimitiveType::from_ast(*prim))),
         ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-            match path.resolve(in_path, env) {
+            match path.resolve(in_path, &ctx.env) {
                 ast::CustomType::Struct(strct) => {
                     let lifetimes = ltl?.lower_generics(&path.lifetimes, ty.is_self());
 
-                    if let Some(tcx_id) = lookup_id.resolve_struct(strct) {
+                    if let Some(tcx_id) = ctx.lookup_id.resolve_struct(strct) {
                         Some(OutType::Struct(ReturnableStructPath::Struct(
                             StructPath::new(lifetimes, tcx_id),
                         )))
-                    } else if let Some(tcx_id) = lookup_id.resolve_out_struct(strct) {
+                    } else if let Some(tcx_id) = ctx.lookup_id.resolve_out_struct(strct) {
                         Some(OutType::Struct(ReturnableStructPath::OutStruct(
                             OutStructPath::new(lifetimes, tcx_id),
                         )))
@@ -522,13 +489,14 @@ fn lower_out_type<L: LifetimeLowerer>(
                     }
                 }
                 ast::CustomType::Opaque(_) => {
-                    errors.push(LoweringError::Other(format!(
+                    ctx.errors.push(LoweringError::Other(format!(
                         "Opaque passed by value in input: {path}"
                     )));
                     None
                 }
                 ast::CustomType::Enum(enm) => {
-                    let tcx_id = lookup_id
+                    let tcx_id = ctx
+                        .lookup_id
                         .resolve_enum(enm)
                         .expect("can't find enum in lookup map, which contains all enums from env");
 
@@ -538,11 +506,11 @@ fn lower_out_type<L: LifetimeLowerer>(
         }
         ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
             ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                match path.resolve(in_path, env) {
+                match path.resolve(in_path, &ctx.env) {
                     ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                         let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
                         let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
-                        let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                        let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
@@ -554,22 +522,22 @@ fn lower_out_type<L: LifetimeLowerer>(
                         ))
                     }),
                     _ => {
-                        errors.push(LoweringError::Other(format!("found &T in output where T is a custom type, but not opaque. T = {ref_ty}")));
+                        ctx.errors.push(LoweringError::Other(format!("found &T in output where T is a custom type, but not opaque. T = {ref_ty}")));
                         None
                     }
                 }
             }
             _ => {
-                errors.push(LoweringError::Other(format!("found &T in output where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                ctx.errors.push(LoweringError::Other(format!("found &T in output where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
                 None
             }
         },
         ast::TypeName::Box(box_ty) => match box_ty.as_ref() {
             ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                match path.resolve(in_path, env) {
+                match path.resolve(in_path, &ctx.env) {
                     ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                         let lifetimes = ltl.lower_generics(&path.lifetimes, box_ty.is_self());
-                        let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                        let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
@@ -581,13 +549,13 @@ fn lower_out_type<L: LifetimeLowerer>(
                         ))
                     }),
                     _ => {
-                        errors.push(LoweringError::Other(format!("found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = {path}")));
+                        ctx.errors.push(LoweringError::Other(format!("found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = {path}")));
                         None
                     }
                 }
             }
             _ => {
-                errors.push(LoweringError::Other(format!(
+                ctx.errors.push(LoweringError::Other(format!(
                     "found Box<T> in output where T isn't a custom type. T = {box_ty}"
                 )));
                 None
@@ -596,11 +564,11 @@ fn lower_out_type<L: LifetimeLowerer>(
         ast::TypeName::Option(opt_ty) => match opt_ty.as_ref() {
             ast::TypeName::Reference(lifetime, mutability, ref_ty) => match ref_ty.as_ref() {
                 ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                    match path.resolve(in_path, env) {
+                    match path.resolve(in_path, &ctx.env) {
                         ast::CustomType::Opaque(opaque) => ltl.map(|ltl| {
                             let borrow = Borrow::new(ltl.lower_lifetime(lifetime), *mutability);
                             let lifetimes = ltl.lower_generics(&path.lifetimes, ref_ty.is_self());
-                            let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                            let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
                                 "can't find opaque in lookup map, which contains all opaques from env",
                             );
 
@@ -612,22 +580,22 @@ fn lower_out_type<L: LifetimeLowerer>(
                             ))
                         }),
                         _ => {
-                            errors.push(LoweringError::Other(format!("found Option<&T> where T is a custom type, but it's not opaque. T = {ref_ty}")));
+                            ctx.errors.push(LoweringError::Other(format!("found Option<&T> where T is a custom type, but it's not opaque. T = {ref_ty}")));
                             None
                         }
                     }
                 }
                 _ => {
-                    errors.push(LoweringError::Other(format!("found Option<&T>, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                    ctx.errors.push(LoweringError::Other(format!("found Option<&T>, but T isn't a custom type and therefore not opaque. T = {ref_ty}")));
                     None
                 }
             },
             ast::TypeName::Box(box_ty) => match box_ty.as_ref() {
                 ast::TypeName::Named(path) | ast::TypeName::SelfType(path) => {
-                    match path.resolve(in_path, env) {
+                    match path.resolve(in_path, &ctx.env) {
                         ast::CustomType::Opaque(opaque) => {
                             let lifetimes = ltl?.lower_generics(&path.lifetimes, box_ty.is_self());
-                            let tcx_id = lookup_id.resolve_opaque(opaque).expect(
+                            let tcx_id = ctx.lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
@@ -639,29 +607,29 @@ fn lower_out_type<L: LifetimeLowerer>(
                             )))
                         }
                         _ => {
-                            errors.push(LoweringError::Other(format!("found Option<Box<T>> where T is a custom type, but it's not opaque. T = {box_ty}")));
+                            ctx.errors.push(LoweringError::Other(format!("found Option<Box<T>> where T is a custom type, but it's not opaque. T = {box_ty}")));
                             None
                         }
                     }
                 }
                 _ => {
-                    errors.push(LoweringError::Other(format!("found Option<Box<T>>, but T isn't a custom type and therefore not opaque. T = {box_ty}")));
+                    ctx.errors.push(LoweringError::Other(format!("found Option<Box<T>>, but T isn't a custom type and therefore not opaque. T = {box_ty}")));
                     None
                 }
             },
             _ => {
-                errors.push(LoweringError::Other(format!("found Option<T>, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
+                ctx.errors.push(LoweringError::Other(format!("found Option<T>, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = {opt_ty}")));
                 None
             }
         },
         ast::TypeName::Result(_, _, _) => {
-            errors.push(LoweringError::Other(
+            ctx.errors.push(LoweringError::Other(
                 "Results can only appear as the top-level return type of methods".into(),
             ));
             None
         }
         ast::TypeName::Writeable => {
-            errors.push(LoweringError::Other(
+            ctx.errors.push(LoweringError::Other(
                 "Writeables can only appear as the last parameter of a method".into(),
             ));
             None
@@ -676,7 +644,7 @@ fn lower_out_type<L: LifetimeLowerer>(
             Some(OutType::Slice(Slice::Primitive(borrow, prim)))
         }
         ast::TypeName::Unit => {
-            errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
+            ctx.errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
             None
         }
     }
@@ -688,17 +656,15 @@ fn lower_out_type<L: LifetimeLowerer>(
 fn lower_self_param<'ast>(
     self_param: &ast::SelfParam,
     self_param_ltl: Option<SelfParamLifetimeLowerer<'ast>>,
-    lookup_id: &LookupId,
     method_full_path: &ast::Ident, // for better error msg
     in_path: &ast::Path,
-    env: &Env,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<(ParamSelf, ParamLifetimeLowerer<'ast>)> {
-    match self_param.path_type.resolve(in_path, env) {
+    match self_param.path_type.resolve(in_path, &ctx.env) {
         ast::CustomType::Struct(strct) => {
-            if let Some(tcx_id) = lookup_id.resolve_struct(strct) {
+            if let Some(tcx_id) = ctx.lookup_id.resolve_struct(strct) {
                 if self_param.reference.is_some() {
-                    errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes a reference to a struct as a self parameter, which isn't allowed")));
+                    ctx.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes a reference to a struct as a self parameter, which isn't allowed")));
                     None
                 } else {
                     let mut param_ltl = self_param_ltl?.no_self_ref();
@@ -714,12 +680,12 @@ fn lower_self_param<'ast>(
                         param_ltl,
                     ))
                 }
-            } else if lookup_id.resolve_out_struct(strct).is_some() {
+            } else if ctx.lookup_id.resolve_out_struct(strct).is_some() {
                 if let Some((lifetime, _)) = &self_param.reference {
-                    errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed. Also, it's behind a reference, `{lifetime}`, but only opaques can be behind references")));
+                    ctx.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed. Also, it's behind a reference, `{lifetime}`, but only opaques can be behind references")));
                     None
                 } else {
-                    errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed")));
+                    ctx.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an out-struct as the self parameter, which isn't allowed")));
                     None
                 }
             } else {
@@ -730,7 +696,10 @@ fn lower_self_param<'ast>(
             }
         }
         ast::CustomType::Opaque(opaque) => {
-            let tcx_id = lookup_id.resolve_opaque(opaque).expect("opaque is in env");
+            let tcx_id = ctx
+                .lookup_id
+                .resolve_opaque(opaque)
+                .expect("opaque is in env");
 
             if let Some((lifetime, mutability)) = &self_param.reference {
                 let (borrow_lifetime, mut param_ltl) = self_param_ltl?.lower_self_ref(lifetime);
@@ -747,12 +716,12 @@ fn lower_self_param<'ast>(
                     param_ltl,
                 ))
             } else {
-                errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs")));
+                ctx.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs")));
                 None
             }
         }
         ast::CustomType::Enum(enm) => {
-            let tcx_id = lookup_id.resolve_enum(enm).expect("enum is in env");
+            let tcx_id = ctx.lookup_id.resolve_enum(enm).expect("enum is in env");
 
             Some((
                 ParamSelf::new(SelfType::Enum(EnumPath::new(tcx_id))),
@@ -771,13 +740,11 @@ fn lower_self_param<'ast>(
 fn lower_param<L: LifetimeLowerer>(
     param: &ast::Param,
     ltl: Option<&mut L>,
-    lookup_id: &LookupId,
     in_path: &ast::Path,
-    env: &Env,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<Param> {
-    let name = lower_ident(&param.name, "param name", errors);
-    let ty = lower_type(&param.ty, ltl, lookup_id, in_path, env, errors);
+    let name = lower_ident(&param.name, "param name", ctx);
+    let ty = lower_type(&param.ty, ltl, in_path, ctx);
 
     Some(Param::new(name?, ty?))
 }
@@ -792,15 +759,13 @@ fn lower_param<L: LifetimeLowerer>(
 fn lower_many_params<'ast>(
     ast_params: &[ast::Param],
     mut param_ltl: Option<ParamLifetimeLowerer<'ast>>,
-    lookup_id: &LookupId,
     in_path: &ast::Path,
-    env: &Env,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<(Vec<Param>, ReturnLifetimeLowerer<'ast>)> {
     let mut params = Some(Vec::with_capacity(ast_params.len()));
 
     for param in ast_params {
-        let param = lower_param(param, param_ltl.as_mut(), lookup_id, in_path, env, errors);
+        let param = lower_param(param, param_ltl.as_mut(), in_path, ctx);
 
         match (param, &mut params) {
             (Some(param), Some(params)) => {
@@ -820,10 +785,8 @@ fn lower_return_type(
     return_type: Option<&ast::TypeName>,
     takes_writeable: bool,
     mut return_ltl: Option<ReturnLifetimeLowerer<'_>>,
-    lookup_id: &LookupId,
     in_path: &ast::Path,
-    env: &Env,
-    errors: &mut Vec<LoweringError>,
+    ctx: &mut LoweringContext,
 ) -> Option<(ReturnType, LifetimeEnv)> {
     let writeable_option = if takes_writeable {
         Some(SuccessType::Writeable)
@@ -834,13 +797,12 @@ fn lower_return_type(
         ast::TypeName::Result(ok_ty, err_ty, _) => {
             let ok_ty = match ok_ty.as_ref() {
                 ast::TypeName::Unit => Some(writeable_option),
-                ty => lower_out_type(ty, return_ltl.as_mut(), lookup_id, in_path, env, errors)
+                ty => lower_out_type(ty, return_ltl.as_mut(), in_path, ctx)
                     .map(|ty| Some(SuccessType::OutType(ty))),
             };
             let err_ty = match err_ty.as_ref() {
                 ast::TypeName::Unit => Some(None),
-                ty => lower_out_type(ty, return_ltl.as_mut(), lookup_id, in_path, env, errors)
-                    .map(Some),
+                ty => lower_out_type(ty, return_ltl.as_mut(), in_path, ctx).map(Some),
             };
 
             match (ok_ty, err_ty) {
@@ -849,7 +811,7 @@ fn lower_return_type(
             }
         }
         ast::TypeName::Unit => Some(ReturnType::Infallible(writeable_option)),
-        ty => lower_out_type(ty, return_ltl.as_mut(), lookup_id, in_path, env, errors)
+        ty => lower_out_type(ty, return_ltl.as_mut(), in_path, ctx)
             .map(|ty| ReturnType::Infallible(Some(SuccessType::OutType(ty)))),
     }
     .and_then(|return_fallability| Some((return_fallability, return_ltl?.finish())))

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1,6 +1,9 @@
 //! Store all the types contained in the HIR.
 
-use super::{EnumDef, LoweringError, OpaqueDef, OutStructDef, StructDef, TypeDef, TypeLowerer};
+use super::{
+    EnumDef, LoweringContext, LoweringError, OpaqueDef, OutStructDef, StructDef, TypeDef,
+    TypeLowerer,
+};
 #[allow(unused_imports)] // use in docs links
 use crate::hir;
 use crate::{ast, Env};
@@ -140,11 +143,16 @@ impl TypeContext {
             &ast_enums[..],
         );
 
-        let out_structs =
-            OutStructDef::lower_all(&ast_out_structs[..], &lookup_id, env, &mut errors);
-        let structs = StructDef::lower_all(&ast_structs[..], &lookup_id, env, &mut errors);
-        let opaques = OpaqueDef::lower_all(&ast_opaques[..], &lookup_id, env, &mut errors);
-        let enums = EnumDef::lower_all(&ast_enums[..], &lookup_id, env, &mut errors);
+        let mut ctx = LoweringContext {
+            lookup_id: &lookup_id,
+            env,
+            errors: &mut errors,
+        };
+
+        let out_structs = OutStructDef::lower_all(&ast_out_structs[..], &mut ctx);
+        let structs = StructDef::lower_all(&ast_structs[..], &mut ctx);
+        let opaques = OpaqueDef::lower_all(&ast_opaques[..], &mut ctx);
+        let enums = EnumDef::lower_all(&ast_enums[..], &mut ctx);
 
         match (out_structs, structs, opaques, enums) {
             (Some(out_structs), Some(structs), Some(opaques), Some(enums)) => {

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1,9 +1,6 @@
 //! Store all the types contained in the HIR.
 
-use super::{
-    EnumDef, LoweringContext, LoweringError, OpaqueDef, OutStructDef, StructDef, TypeDef,
-    TypeLowerer,
-};
+use super::{EnumDef, LoweringContext, LoweringError, OpaqueDef, OutStructDef, StructDef, TypeDef};
 #[allow(unused_imports)] // use in docs links
 use crate::hir;
 use crate::{ast, Env};
@@ -149,10 +146,10 @@ impl TypeContext {
             errors: &mut errors,
         };
 
-        let out_structs = OutStructDef::lower_all(&ast_out_structs[..], &mut ctx);
-        let structs = StructDef::lower_all(&ast_structs[..], &mut ctx);
-        let opaques = OpaqueDef::lower_all(&ast_opaques[..], &mut ctx);
-        let enums = EnumDef::lower_all(&ast_enums[..], &mut ctx);
+        let out_structs = ctx.lower_all_out_structs(&ast_out_structs[..]);
+        let structs = ctx.lower_all_structs(&ast_structs[..]);
+        let opaques = ctx.lower_all_opaques(&ast_opaques[..]);
+        let enums = ctx.lower_all_enums(&ast_enums[..]);
 
         match (out_structs, structs, opaques, enums) {
             (Some(out_structs), Some(structs), Some(opaques), Some(enums)) => {


### PR DESCRIPTION
For Diplomat Attributes I need to thread along more parameters, creating a context type so this becomes easier


(Was making this as a part of the attrs PR but realized it's large enough that it's worth splitting out into a separate PR)

Should not have any actual changes to behavior. First commit introduces LoweringContext type and makes everything use it, second commit moves all the free and trait functions to methods on LoweringContext.

I removed the TypeLowerer trait; it was not pulling its weight (it supplies boilerplate for three lowering methods, but not others. I replaced it with a generic higher order function)

The second commit is a large diff but its changes can be summarized as:

 - Take every free `lower_foo(...&mut ctx)` function and turn it into a method on `&mut LoweringContext`, updating callers
 - Remove `TypeLowerer` and move all `lower()` impls to `LoweringContext` in a way similar to above
 - Introduce `lower_all()` and use to specify `lower_all_structs()` (etc), to replace the `lower_all()` lost when removing `LoweringContext`.

`lower_all()` is the only non-refactory code introduced in the second commit