### PR TITLE
Support for Diplomat attributes

### DIFF
--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -141,7 +141,10 @@ impl Parse for DiplomatBackendAttrCfg {
                     ))
                 } else {
                     let value: LitStr = input.parse()?;
-                    Ok(DiplomatBackendAttrCfg::NameValue(name.to_string(), value.value()))
+                    Ok(DiplomatBackendAttrCfg::NameValue(
+                        name.to_string(),
+                        value.value(),
+                    ))
                 }
             } else {
                 Ok(DiplomatBackendAttrCfg::BackendName(name.to_string()))

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -1,29 +1,35 @@
 //! This module contains utilities for dealing with Rust attributes
 
-use serde::ser::{Serialize, SerializeStruct, Serializer};
-use syn::Attribute;
+use serde::ser::{SerializeStruct, Serializer};
+use serde::Serialize;
+use syn::parse::{Error as ParseError, Parse, ParseStream};
+use syn::{Attribute, Ident, LitStr, Meta, Token};
 
+/// The list of attributes on a type
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
 pub struct Attrs {
     pub cfg: Vec<Attribute>,
+    pub attrs: Vec<DiplomatAttr>,
 }
 
 impl Attrs {
     fn add_attr(&mut self, attr: Attr) {
         match attr {
             Attr::Cfg(attr) => self.cfg.push(attr),
+            Attr::DiplomatAttr(attr) => self.attrs.push(attr),
         }
     }
 
+    /// Merge attributes that should be inherited from the parent
     pub(crate) fn merge_parent_attrs(&mut self, other: &Attrs) {
         self.cfg.extend(other.cfg.iter().cloned())
     }
-    pub(crate) fn add_attrs<'a>(&mut self, attrs: &[Attribute]) {
+    pub(crate) fn add_attrs(&mut self, attrs: &[Attribute]) {
         for attr in syn_attr_to_ast_attr(attrs) {
             self.add_attr(attr)
         }
     }
-    pub(crate) fn from_attrs<'a>(attrs: &[Attribute]) -> Self {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> Self {
         let mut this = Self::default();
         this.add_attrs(attrs);
         this
@@ -38,14 +44,21 @@ impl From<&[Attribute]> for Attrs {
 
 enum Attr {
     Cfg(Attribute),
+    DiplomatAttr(DiplomatAttr),
     // More goes here
 }
 
 fn syn_attr_to_ast_attr(attrs: &[Attribute]) -> impl Iterator<Item = Attr> + '_ {
     let cfg_path: syn::Path = syn::parse_str("cfg").unwrap();
+    let dattr_path: syn::Path = syn::parse_str("diplomat::attr").unwrap();
     attrs.iter().filter_map(move |a| {
         if a.path() == &cfg_path {
             Some(Attr::Cfg(a.clone()))
+        } else if a.path() == &dattr_path {
+            Some(Attr::DiplomatAttr(
+                a.parse_args()
+                    .expect("Failed to parse malformed diplomat::attr"),
+            ))
         } else {
             None
         }
@@ -66,5 +79,127 @@ impl Serialize for Attrs {
             .collect();
         state.serialize_field("cfg", &cfg)?;
         state.end()
+    }
+}
+
+/// A `#[diplomat::attr(...)]` attribute
+///
+/// Its contents must start with single element that is a CFG-expression
+/// (so it may contain `foo = bar`, `foo = "bar"`, `ident`, `*` atoms,
+/// and `all()`, `not()`, and `any()` combiners), and then be followed by one
+/// or more backend-specific attributes, which can be any valid meta-item
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
+pub struct DiplomatAttr {
+    pub cfg: DiplomatAttrCfg,
+    #[serde(serialize_with = "serialize_meta")]
+    pub attr: Meta,
+}
+
+fn serialize_meta<S>(m: &Meta, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    quote::quote!(#m).to_string().serialize(s)
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
+pub enum DiplomatAttrCfg {
+    Not(Box<DiplomatAttrCfg>),
+    Any(Vec<DiplomatAttrCfg>),
+    All(Vec<DiplomatAttrCfg>),
+    Star,
+    BackendName(String),
+    NameValue(String, String),
+}
+
+impl Parse for DiplomatAttrCfg {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(Ident) {
+            let name: Ident = input.parse()?;
+            if name == "not" {
+                let content;
+                let _paren = syn::parenthesized!(content in input);
+                Ok(DiplomatAttrCfg::Not(Box::new(content.parse()?)))
+            } else if name == "any" || name == "all" {
+                let content;
+                let _paren = syn::parenthesized!(content in input);
+                let list = content.parse_terminated(Self::parse, Token![,])?;
+                let vec = list.into_iter().collect();
+                if name == "any" {
+                    Ok(DiplomatAttrCfg::Any(vec))
+                } else {
+                    Ok(DiplomatAttrCfg::All(vec))
+                }
+            } else {
+                if input.peek(Token![=]) {
+                    let _t: Token![=] = input.parse()?;
+                    if input.peek(Ident) {
+                        let value: Ident = input.parse()?;
+                        Ok(DiplomatAttrCfg::NameValue(
+                            name.to_string(),
+                            value.to_string(),
+                        ))
+                    } else {
+                        let value: LitStr = input.parse()?;
+                        Ok(DiplomatAttrCfg::NameValue(name.to_string(), value.value()))
+                    }
+                } else {
+                    Ok(DiplomatAttrCfg::BackendName(name.to_string()))
+                }
+            }
+        } else if lookahead.peek(Token![*]) {
+            let _t: Token![*] = input.parse()?;
+            Ok(DiplomatAttrCfg::Star)
+        } else {
+            Err(ParseError::new(
+                input.span(),
+                "CFG portion of #[diplomat::attr] fails to parse",
+            ))
+        }
+    }
+}
+
+/// Meant to be used with Attribute::parse_args()
+impl Parse for DiplomatAttr {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let cfg = input.parse()?;
+        let _comma: Token![,] = input.parse()?;
+        let attr = input.parse()?;
+        Ok(Self { cfg, attr })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta;
+
+    use syn;
+
+    use crate::ast::Ident;
+
+    use super::{DiplomatAttr, DiplomatAttrCfg};
+
+    #[test]
+    fn test_cfgs() {
+        let attr_cfg: DiplomatAttrCfg = syn::parse_quote!(*);
+        insta::assert_yaml_snapshot!(attr_cfg);
+        let attr_cfg: DiplomatAttrCfg = syn::parse_quote!(cpp);
+        insta::assert_yaml_snapshot!(attr_cfg);
+        let attr_cfg: DiplomatAttrCfg = syn::parse_quote!(has = overloading);
+        insta::assert_yaml_snapshot!(attr_cfg);
+        let attr_cfg: DiplomatAttrCfg = syn::parse_quote!(has = "overloading");
+        insta::assert_yaml_snapshot!(attr_cfg);
+        let attr_cfg: DiplomatAttrCfg =
+            syn::parse_quote!(any(all(*, cpp, has="overloading"), not(js)));
+        insta::assert_yaml_snapshot!(attr_cfg);
+    }
+
+    #[test]
+    fn test_attr() {
+        let attr: syn::Attribute =
+            syn::parse_quote!(#[diplomat::attr(any(cpp, has = "overloading"), namespacing)]);
+        let attr: DiplomatAttr = attr.parse_args().unwrap();
+        insta::assert_yaml_snapshot!(attr);
     }
 }

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -70,7 +70,7 @@ impl Serialize for Attrs {
     where
         S: Serializer,
     {
-        // 3 is the number of fields in the struct.
+        // 1 is the number of fields in the struct.
         let mut state = serializer.serialize_struct("Attrs", 1)?;
         let cfg: Vec<_> = self
             .cfg

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -1,10 +1,70 @@
 //! This module contains utilities for dealing with Rust attributes
 
+use serde::ser::{Serialize, SerializeStruct, Serializer};
 use syn::Attribute;
 
-pub(crate) fn extract_cfg_attrs(attrs: &[Attribute]) -> impl Iterator<Item = String> + '_ {
-    attrs
-        .iter()
-        .filter(|&a| a.path().is_ident("cfg"))
-        .map(|a| quote::quote!(#a).to_string())
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
+pub struct Attrs {
+    pub cfg: Vec<Attribute>,
+}
+
+impl Attrs {
+    fn add_attr(&mut self, attr: Attr) {
+        match attr {
+            Attr::Cfg(attr) => self.cfg.push(attr),
+        }
+    }
+
+    pub(crate) fn merge_parent_attrs(&mut self, other: &Attrs) {
+        self.cfg.extend(other.cfg.iter().cloned())
+    }
+    pub(crate) fn add_attrs<'a>(&mut self, attrs: &[Attribute]) {
+        for attr in syn_attr_to_ast_attr(attrs) {
+            self.add_attr(attr)
+        }
+    }
+    pub(crate) fn from_attrs<'a>(attrs: &[Attribute]) -> Self {
+        let mut this = Self::default();
+        this.add_attrs(attrs);
+        this
+    }
+}
+
+impl From<&[Attribute]> for Attrs {
+    fn from(other: &[Attribute]) -> Self {
+        Self::from_attrs(other)
+    }
+}
+
+enum Attr {
+    Cfg(Attribute),
+    // More goes here
+}
+
+fn syn_attr_to_ast_attr(attrs: &[Attribute]) -> impl Iterator<Item = Attr> + '_ {
+    let cfg_path: syn::Path = syn::parse_str("cfg").unwrap();
+    attrs.iter().filter_map(move |a| {
+        if a.path() == &cfg_path {
+            Some(Attr::Cfg(a.clone()))
+        } else {
+            None
+        }
+    })
+}
+
+impl Serialize for Attrs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // 3 is the number of fields in the struct.
+        let mut state = serializer.serialize_struct("Attrs", 1)?;
+        let cfg: Vec<_> = self
+            .cfg
+            .iter()
+            .map(|a| quote::quote!(#a).to_string())
+            .collect();
+        state.serialize_field("cfg", &cfg)?;
+        state.end()
+    }
 }

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -92,7 +92,7 @@ impl Serialize for Attrs {
 pub struct DiplomatAttr {
     pub cfg: DiplomatAttrCfg,
     #[serde(serialize_with = "serialize_meta")]
-    pub attr: Meta,
+    pub meta: Meta,
 }
 
 fn serialize_meta<S>(m: &Meta, s: S) -> Result<S::Ok, S::Error>
@@ -163,8 +163,8 @@ impl Parse for DiplomatAttr {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let cfg = input.parse()?;
         let _comma: Token![,] = input.parse()?;
-        let attr = input.parse()?;
-        Ok(Self { cfg, attr })
+        let meta = input.parse()?;
+        Ok(Self { cfg, meta })
     }
 }
 

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -131,22 +131,20 @@ impl Parse for DiplomatAttrCfg {
                 } else {
                     Ok(DiplomatAttrCfg::All(vec))
                 }
-            } else {
-                if input.peek(Token![=]) {
-                    let _t: Token![=] = input.parse()?;
-                    if input.peek(Ident) {
-                        let value: Ident = input.parse()?;
-                        Ok(DiplomatAttrCfg::NameValue(
-                            name.to_string(),
-                            value.to_string(),
-                        ))
-                    } else {
-                        let value: LitStr = input.parse()?;
-                        Ok(DiplomatAttrCfg::NameValue(name.to_string(), value.value()))
-                    }
+            } else if input.peek(Token![=]) {
+                let _t: Token![=] = input.parse()?;
+                if input.peek(Ident) {
+                    let value: Ident = input.parse()?;
+                    Ok(DiplomatAttrCfg::NameValue(
+                        name.to_string(),
+                        value.to_string(),
+                    ))
                 } else {
-                    Ok(DiplomatAttrCfg::BackendName(name.to_string()))
+                    let value: LitStr = input.parse()?;
+                    Ok(DiplomatAttrCfg::NameValue(name.to_string(), value.value()))
                 }
+            } else {
+                Ok(DiplomatAttrCfg::BackendName(name.to_string()))
             }
         } else if lookahead.peek(Token![*]) {
             let _t: Token![*] = input.parse()?;
@@ -175,8 +173,6 @@ mod tests {
     use insta;
 
     use syn;
-
-    use crate::ast::Ident;
 
     use super::{DiplomatAttr, DiplomatAttrCfg};
 

--- a/core/src/ast/enums.rs
+++ b/core/src/ast/enums.rs
@@ -1,18 +1,18 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use super::docs::Docs;
-use super::{attrs, Ident, Method};
+use super::{Attrs, Ident, Method};
 use quote::ToTokens;
 
 /// A fieldless enum declaration in an FFI module.
-#[derive(Clone, Serialize, Deserialize, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Serialize, Debug, Hash, PartialEq, Eq)]
 pub struct Enum {
     pub name: Ident,
     pub docs: Docs,
     /// A list of variants of the enum. (name, discriminant, docs)
     pub variants: Vec<(Ident, isize, Docs)>,
     pub methods: Vec<Method>,
-    pub cfg_attrs: Vec<String>,
+    pub attrs: Attrs,
 }
 
 impl From<&syn::ItemEnum> for Enum {
@@ -27,7 +27,6 @@ impl From<&syn::ItemEnum> for Enum {
             panic!("Enums cannot have generic parameters");
         }
 
-        let cfg_attrs = attrs::extract_cfg_attrs(&enm.attrs).collect();
         Enum {
             name: (&enm.ident).into(),
             docs: Docs::from_attrs(&enm.attrs),
@@ -60,7 +59,7 @@ impl From<&syn::ItemEnum> for Enum {
                 })
                 .collect(),
             methods: vec![],
-            cfg_attrs,
+            attrs: (&*enm.attrs).into(),
         }
     }
 }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -379,7 +379,7 @@ mod tests {
 
     use crate::ast::Ident;
 
-    use super::{Method, Path, PathType};
+    use super::{Attrs, Method, Path, PathType};
 
     #[test]
     fn static_methods() {
@@ -393,7 +393,7 @@ mod tests {
             },
             PathType::new(Path::empty().sub_path(Ident::from("MyStructContainingMethod"))),
             None,
-            &[]
+            &Attrs::default()
         ));
 
         insta::assert_yaml_snapshot!(Method::from_syn(
@@ -409,7 +409,7 @@ mod tests {
             },
             PathType::new(Path::empty().sub_path(Ident::from("MyStructContainingMethod"))),
             None,
-            &[]
+            &Attrs::default()
         ));
     }
 
@@ -426,7 +426,7 @@ mod tests {
             },
             PathType::new(Path::empty().sub_path(Ident::from("MyStructContainingMethod"))),
             None,
-            &[]
+            &Attrs::default()
         ));
     }
 
@@ -440,7 +440,7 @@ mod tests {
             },
             PathType::new(Path::empty().sub_path(Ident::from("MyStructContainingMethod"))),
             None,
-            &[]
+            &Attrs::default()
         ));
 
         insta::assert_yaml_snapshot!(Method::from_syn(
@@ -452,7 +452,7 @@ mod tests {
             },
             PathType::new(Path::empty().sub_path(Ident::from("MyStructContainingMethod"))),
             None,
-            &[]
+            &Attrs::default()
         ));
     }
 
@@ -462,7 +462,7 @@ mod tests {
                 &syn::parse_quote! { $($tokens)* },
                 PathType::new(Path::empty().sub_path(Ident::from("MyStructContainingMethod"))),
                 None,
-                &[]
+                &Attrs::default()
             );
 
             let borrowed_params = method.borrowed_params();

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -2,7 +2,8 @@
 /// generates a simplified version of the Rust AST that captures special
 /// types such as opaque structs, [`Box`], and [`Result`] with utilities
 /// for handling such types.
-pub(crate) mod attrs;
+mod attrs;
+pub use attrs::Attrs;
 
 mod methods;
 pub use methods::{BorrowedParams, Method, Param, SelfParam};

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -2,7 +2,7 @@
 /// generates a simplified version of the Rust AST that captures special
 /// types such as opaque structs, [`Box`], and [`Result`] with utilities
 /// for handling such types.
-mod attrs;
+pub mod attrs;
 pub use attrs::Attrs;
 
 mod methods;

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -2,11 +2,11 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write as _;
 
 use quote::ToTokens;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use syn::{ImplItem, Item, ItemMod, UseTree, Visibility};
 
 use super::{
-    attrs, CustomType, Enum, Ident, Method, ModSymbol, Mutability, OpaqueStruct, Path, PathType,
+    Attrs, CustomType, Enum, Ident, Method, ModSymbol, Mutability, OpaqueStruct, Path, PathType,
     RustLink, Struct, ValidityError,
 };
 use crate::environment::*;
@@ -59,7 +59,7 @@ impl DiplomatStructAttribute {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct Module {
     pub name: Ident,
     pub imports: Vec<(Path, Ident)>,
@@ -176,7 +176,7 @@ impl Module {
                             syn::Type::Path(s) => PathType::from(s),
                             _ => panic!("Self type not found"),
                         };
-                        let cfg_attrs: Vec<_> = attrs::extract_cfg_attrs(&imp.attrs).collect();
+                        let attrs = Attrs::from(&*imp.attrs);
 
                         let mut new_methods = imp
                             .items
@@ -186,7 +186,7 @@ impl Module {
                                 _ => None,
                             })
                             .filter(|m| matches!(m.vis, Visibility::Public(_)))
-                            .map(|m| Method::from_syn(m, self_path.clone(), Some(&imp.generics), &cfg_attrs))
+                            .map(|m| Method::from_syn(m, self_path.clone(), Some(&imp.generics), &attrs))
                             .collect();
 
                         let self_ident = self_path.path.elements.last().unwrap();
@@ -242,7 +242,7 @@ fn extract_imports(base_path: &Path, use_tree: &UseTree, out: &mut Vec<(Path, Id
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug)]
 pub struct File {
     pub modules: BTreeMap<String, Module>,
 }

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__attr.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__attr.snap
@@ -8,5 +8,5 @@ cfg:
     - NameValue:
         - has
         - overloading
-attr: namespacing
+meta: namespacing
 

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__attr.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__attr.snap
@@ -1,0 +1,12 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr
+---
+cfg:
+  Any:
+    - BackendName: cpp
+    - NameValue:
+        - has
+        - overloading
+attr: namespacing
+

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs-2.snap
@@ -1,0 +1,6 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr_cfg
+---
+BackendName: cpp
+

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs-3.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs-3.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr_cfg
+---
+NameValue:
+  - has
+  - overloading
+

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs-4.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs-4.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr_cfg
+---
+NameValue:
+  - has
+  - overloading
+

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs-5.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs-5.snap
@@ -1,0 +1,14 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr_cfg
+---
+Any:
+  - All:
+      - Star
+      - BackendName: cpp
+      - NameValue:
+          - has
+          - overloading
+  - Not:
+      BackendName: js
+

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__cfgs.snap
@@ -1,0 +1,6 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr_cfg
+---
+Star
+

--- a/core/src/ast/snapshots/diplomat_core__ast__enums__tests__enum_with_discr.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__enums__tests__enum_with_discr.snap
@@ -29,5 +29,6 @@ variants:
     - - ""
       - []
 methods: []
-cfg_attrs: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__enums__tests__simple_enum.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__enums__tests__simple_enum.snap
@@ -21,5 +21,6 @@ variants:
     - - Some more docs.
       - []
 methods: []
-cfg_attrs: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__cfged_method.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__cfged_method.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)]\n                #[cfg(any(feature = \"foo\", not(feature = \"bar\")))] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
+expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)]\n                #[cfg(any(feature = \"foo\", not(feature = \"bar\")))] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -27,6 +27,7 @@ params:
         lifetimes: []
 return_type: ~
 lifetime_env: {}
-cfg_attrs:
-  - "# [cfg (any (feature = \"foo\" , not (feature = \"bar\")))]"
+attrs:
+  cfg:
+    - "# [cfg (any (feature = \"foo\" , not (feature = \"bar\")))]"
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(& mut self, x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
+expression: "Method::from_syn(&syn::parse_quote! {\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(& mut self, x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -36,5 +36,6 @@ params:
 return_type:
   Primitive: u64
 lifetime_env: {}
-cfg_attrs: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                fn foo(& self, x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
+expression: "Method::from_syn(&syn::parse_quote! {\n                fn foo(& self, x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -29,5 +29,6 @@ params:
         lifetimes: []
 return_type: ~
 lifetime_env: {}
-cfg_attrs: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                /// Some more docs.\n                ///\n                /// Even more docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInEnum)] fn\n                foo(x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
+expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                /// Some more docs.\n                ///\n                /// Even more docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInEnum)] fn\n                foo(x : u64, y : MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -28,5 +28,6 @@ params:
 return_type:
   Primitive: u64
 lifetime_env: {}
-cfg_attrs: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &[])"
+expression: "Method::from_syn(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar :: batz, FnInStruct)] fn\n                foo(x : u64, y : MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -27,5 +27,6 @@ params:
         lifetimes: []
 return_type: ~
 lifetime_env: {}
-cfg_attrs: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
@@ -17,7 +17,8 @@ modules:
           fields: []
           methods: []
           output_only: false
-          cfg_attrs: []
+          attrs:
+            cfg: []
     sub_modules: []
   other:
     name: other

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
@@ -23,8 +23,10 @@ declared_types:
           params: []
           return_type: ~
           lifetime_env: {}
-          cfg_attrs: []
+          attrs:
+            cfg: []
       output_only: false
-      cfg_attrs: []
+      attrs:
+        cfg: []
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -44,7 +44,8 @@ declared_types:
                   - NonOpaqueStruct
               lifetimes: []
           lifetime_env: {}
-          cfg_attrs: []
+          attrs:
+            cfg: []
         - name: set_a
           docs:
             - ""
@@ -65,9 +66,11 @@ declared_types:
                 Primitive: i32
           return_type: ~
           lifetime_env: {}
-          cfg_attrs: []
+          attrs:
+            cfg: []
       output_only: false
-      cfg_attrs: []
+      attrs:
+        cfg: []
   OpaqueStruct:
     Opaque:
       name: OpaqueStruct
@@ -91,7 +94,8 @@ declared_types:
                     - OpaqueStruct
                 lifetimes: []
           lifetime_env: {}
-          cfg_attrs: []
+          attrs:
+            cfg: []
         - name: get_string
           docs:
             - ""
@@ -114,8 +118,10 @@ declared_types:
                   - String
               lifetimes: []
           lifetime_env: {}
-          cfg_attrs: []
+          attrs:
+            cfg: []
       mutability: Immutable
-      cfg_attrs: []
+      attrs:
+        cfg: []
 sub_modules: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
@@ -28,5 +28,6 @@ fields:
       - []
 methods: []
 output_only: true
-cfg_attrs: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -1,10 +1,10 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use super::docs::Docs;
-use super::{attrs, Ident, LifetimeEnv, Method, Mutability, PathType, TypeName};
+use super::{Attrs, Ident, LifetimeEnv, Method, Mutability, PathType, TypeName};
 
 /// A struct declaration in an FFI module that is not opaque.
-#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Debug)]
 pub struct Struct {
     pub name: Ident,
     pub docs: Docs,
@@ -12,7 +12,7 @@ pub struct Struct {
     pub fields: Vec<(Ident, TypeName, Docs)>,
     pub methods: Vec<Method>,
     pub output_only: bool,
-    pub cfg_attrs: Vec<String>,
+    pub attrs: Attrs,
 }
 
 impl Struct {
@@ -37,7 +37,6 @@ impl Struct {
             .collect();
 
         let lifetimes = LifetimeEnv::from_struct_item(strct, &fields[..]);
-        let cfg_attrs = attrs::extract_cfg_attrs(&strct.attrs).collect();
 
         Struct {
             name: (&strct.ident).into(),
@@ -46,7 +45,7 @@ impl Struct {
             fields,
             methods: vec![],
             output_only,
-            cfg_attrs,
+            attrs: (&*strct.attrs).into(),
         }
     }
 }
@@ -54,27 +53,26 @@ impl Struct {
 /// A struct annotated with [`diplomat::opaque`] whose fields are not visible.
 /// Opaque structs cannot be passed by-value across the FFI boundary, so they
 /// must be boxed or passed as references.
-#[derive(Clone, Serialize, Deserialize, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Serialize, Debug, Hash, PartialEq, Eq)]
 pub struct OpaqueStruct {
     pub name: Ident,
     pub docs: Docs,
     pub lifetimes: LifetimeEnv,
     pub methods: Vec<Method>,
     pub mutability: Mutability,
-    pub cfg_attrs: Vec<String>,
+    pub attrs: Attrs,
 }
 
 impl OpaqueStruct {
     /// Extract a [`OpaqueStruct`] metadata value from an AST node.
     pub fn new(strct: &syn::ItemStruct, mutability: Mutability) -> Self {
-        let cfg_attrs = attrs::extract_cfg_attrs(&strct.attrs).collect();
         OpaqueStruct {
             name: Ident::from(&strct.ident),
             docs: Docs::from_attrs(&strct.attrs),
             lifetimes: LifetimeEnv::from_struct_item(strct, &[]),
             methods: vec![],
             mutability,
-            cfg_attrs,
+            attrs: (&*strct.attrs).into(),
         }
     }
 }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -9,13 +9,13 @@ use std::fmt;
 use std::ops::ControlFlow;
 
 use super::{
-    Docs, Enum, Ident, Lifetime, LifetimeEnv, LifetimeTransitivity, Method, NamedLifetime,
+    Attrs, Docs, Enum, Ident, Lifetime, LifetimeEnv, LifetimeTransitivity, Method, NamedLifetime,
     OpaqueStruct, Path, RustLink, Struct, ValidityError,
 };
 use crate::Env;
 
 /// A type declared inside a Diplomat-annotated module.
-#[derive(Clone, Serialize, Deserialize, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Serialize, Debug, Hash, PartialEq, Eq)]
 pub enum CustomType {
     /// A non-opaque struct whose fields will be visible across the FFI boundary.
     Struct(Struct),
@@ -44,11 +44,11 @@ impl CustomType {
         }
     }
 
-    pub fn cfg_attrs(&self) -> &[String] {
+    pub fn attrs(&self) -> &Attrs {
         match self {
-            CustomType::Struct(strct) => &strct.cfg_attrs,
-            CustomType::Opaque(strct) => &strct.cfg_attrs,
-            CustomType::Enum(enm) => &enm.cfg_attrs,
+            CustomType::Struct(strct) => &strct.attrs,
+            CustomType::Opaque(strct) => &strct.attrs,
+            CustomType::Enum(enm) => &enm.attrs,
         }
     }
 
@@ -126,7 +126,7 @@ impl CustomType {
 
 /// A symbol declared in a module, which can either be a pointer to another path,
 /// or a custom type defined directly inside that module
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub enum ModSymbol {
     /// A symbol that is a pointer to another path.
     Alias(Path),

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -80,9 +80,9 @@ pub trait AttributeValidator {
     /// Provided, checks if type satisfies a `DiplomatAttrCfg`
     fn satisfies_cfg(&self, cfg: &DiplomatAttrCfg) -> bool {
         match *cfg {
-            DiplomatAttrCfg::Not(ref c) => !self.satisfies_cfg(&c),
-            DiplomatAttrCfg::Any(ref cs) => cs.iter().any(|c| self.satisfies_cfg(&c)),
-            DiplomatAttrCfg::All(ref cs) => cs.iter().all(|c| self.satisfies_cfg(&c)),
+            DiplomatAttrCfg::Not(ref c) => !self.satisfies_cfg(c),
+            DiplomatAttrCfg::Any(ref cs) => cs.iter().any(|c| self.satisfies_cfg(c)),
+            DiplomatAttrCfg::All(ref cs) => cs.iter().all(|c| self.satisfies_cfg(c)),
             DiplomatAttrCfg::Star => true,
             DiplomatAttrCfg::BackendName(ref n) => self.is_backend(n),
             DiplomatAttrCfg::NameValue(ref n, ref v) => self.is_name_value(n, v),

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1,0 +1,91 @@
+//! #[diplomat::attr] and other attributes
+
+use crate::ast;
+use crate::ast::attrs::DiplomatAttrCfg;
+use crate::hir::LoweringError;
+
+use syn::Meta;
+
+#[non_exhaustive]
+#[derive(Clone, Default)]
+pub struct Attrs {
+    pub disable: bool,
+    // more to be added: rename, namespace, etc
+}
+
+impl Attrs {
+    pub fn from_ast(
+        ast: &ast::Attrs,
+        validator: &impl AttributeValidator,
+        errors: &mut Vec<LoweringError>,
+    ) -> Self {
+        let mut this = Attrs::default();
+        let support = validator.attrs_supported();
+        for attr in &ast.attrs {
+            if validator.satisfies_cfg(&attr.cfg) {
+                match &attr.attr {
+                    Meta::Path(p) => {
+                        if p.is_ident("disable") {
+                            if this.disable {
+                                errors.push(LoweringError::Other(
+                                    "Duplicate `disable` attribute".into(),
+                                ));
+                            } else if !support.disabling {
+                                errors.push(LoweringError::Other(format!(
+                                    "`disable` not supported in backend {}",
+                                    validator.primary_name()
+                                )))
+                            } else {
+                                this.disable = true;
+                            }
+                        } else {
+                            errors.push(LoweringError::Other(format!(
+                                "Unknown diplomat attribute {p:?}: expected one of: `disable`"
+                            )));
+                        }
+                    }
+                    other => {
+                        errors.push(LoweringError::Other(format!(
+                            "Unknown diplomat attribute {other:?}: expected one of: `disable`"
+                        )));
+                    }
+                }
+            }
+        }
+
+        this
+    }
+}
+
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug)]
+pub struct BackendAttrSupport {
+    disabling: bool,
+    // more to be added: rename, namespace, etc
+}
+
+/// Defined by backends when validating attributes
+pub trait AttributeValidator {
+    /// The primary name of the backend, for use in diagnostics
+    fn primary_name(&self) -> &'static str;
+    /// Does this backend satisfy `cfg(backend_name)`?
+    /// (Backends are allowed to satisfy multiple backend names, useful when there
+    /// are multiple backends for a language)
+    fn is_backend(&self, backend_name: &str) -> bool;
+    /// does this backend satisfy cfg(name = value)?
+    fn is_name_value(&self, name: &str, value: &str) -> bool;
+    /// What backedn attrs does this support?
+    fn attrs_supported(&self) -> BackendAttrSupport;
+
+    /// Provided, checks if type satisfies a `DiplomatAttrCfg`
+    fn satisfies_cfg(&self, cfg: &DiplomatAttrCfg) -> bool {
+        match *cfg {
+            DiplomatAttrCfg::Not(ref c) => !self.satisfies_cfg(&c),
+            DiplomatAttrCfg::Any(ref cs) => cs.iter().any(|c| self.satisfies_cfg(&c)),
+            DiplomatAttrCfg::All(ref cs) => cs.iter().all(|c| self.satisfies_cfg(&c)),
+            DiplomatAttrCfg::Star => true,
+            DiplomatAttrCfg::BackendName(ref n) => self.is_backend(n),
+            DiplomatAttrCfg::NameValue(ref n, ref v) => self.is_name_value(n, v),
+        }
+    }
+}

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1,7 +1,7 @@
 //! #[diplomat::attr] and other attributes
 
 use crate::ast;
-use crate::ast::attrs::DiplomatAttrCfg;
+use crate::ast::attrs::DiplomatBackendAttrCfg;
 use crate::hir::LoweringError;
 
 use syn::Meta;
@@ -89,15 +89,15 @@ pub trait AttributeValidator {
     /// What backedn attrs does this support?
     fn attrs_supported(&self) -> BackendAttrSupport;
 
-    /// Provided, checks if type satisfies a `DiplomatAttrCfg`
-    fn satisfies_cfg(&self, cfg: &DiplomatAttrCfg) -> bool {
+    /// Provided, checks if type satisfies a `DiplomatBackendAttrCfg`
+    fn satisfies_cfg(&self, cfg: &DiplomatBackendAttrCfg) -> bool {
         match *cfg {
-            DiplomatAttrCfg::Not(ref c) => !self.satisfies_cfg(c),
-            DiplomatAttrCfg::Any(ref cs) => cs.iter().any(|c| self.satisfies_cfg(c)),
-            DiplomatAttrCfg::All(ref cs) => cs.iter().all(|c| self.satisfies_cfg(c)),
-            DiplomatAttrCfg::Star => true,
-            DiplomatAttrCfg::BackendName(ref n) => self.is_backend(n),
-            DiplomatAttrCfg::NameValue(ref n, ref v) => self.is_name_value(n, v),
+            DiplomatBackendAttrCfg::Not(ref c) => !self.satisfies_cfg(c),
+            DiplomatBackendAttrCfg::Any(ref cs) => cs.iter().any(|c| self.satisfies_cfg(c)),
+            DiplomatBackendAttrCfg::All(ref cs) => cs.iter().all(|c| self.satisfies_cfg(c)),
+            DiplomatBackendAttrCfg::Star => true,
+            DiplomatBackendAttrCfg::BackendName(ref n) => self.is_backend(n),
+            DiplomatBackendAttrCfg::NameValue(ref n, ref v) => self.is_name_value(n, v),
         }
     }
 

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -35,7 +35,7 @@ impl Attrs {
         let support = validator.attrs_supported();
         for attr in &ast.attrs {
             if validator.satisfies_cfg(&attr.cfg) {
-                match &attr.attr {
+                match &attr.meta {
                     Meta::Path(p) => {
                         if p.is_ident("disable") {
                             if this.disable {

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -1,6 +1,6 @@
 //! Type definitions for structs, output structs, opaque structs, and enums.
 
-use super::{Everywhere, IdentBuf, Method, OutputOnly, TyPosition, Type};
+use super::{Attrs, Everywhere, IdentBuf, Method, OutputOnly, TyPosition, Type};
 use crate::ast::Docs;
 
 pub enum ReturnableStructDef<'tcx> {
@@ -26,6 +26,7 @@ pub struct StructDef<P: TyPosition = Everywhere> {
     pub name: IdentBuf,
     pub fields: Vec<StructField<P>>,
     pub methods: Vec<Method>,
+    pub attrs: Attrs,
 }
 
 /// A struct whose contents are opaque across the FFI boundary, and can only
@@ -41,6 +42,7 @@ pub struct OpaqueDef {
     pub docs: Docs,
     pub name: IdentBuf,
     pub methods: Vec<Method>,
+    pub attrs: Attrs,
 }
 
 /// The enum type.
@@ -50,6 +52,7 @@ pub struct EnumDef {
     pub name: IdentBuf,
     pub variants: Vec<EnumVariant>,
     pub methods: Vec<Method>,
+    pub attrs: Attrs,
 }
 
 /// A field on a [`OutStruct`]s.
@@ -77,22 +80,25 @@ impl<P: TyPosition> StructDef<P> {
         name: IdentBuf,
         fields: Vec<StructField<P>>,
         methods: Vec<Method>,
+        attrs: Attrs,
     ) -> Self {
         Self {
             docs,
             name,
             fields,
             methods,
+            attrs,
         }
     }
 }
 
 impl OpaqueDef {
-    pub(super) fn new(docs: Docs, name: IdentBuf, methods: Vec<Method>) -> Self {
+    pub(super) fn new(docs: Docs, name: IdentBuf, methods: Vec<Method>, attrs: Attrs) -> Self {
         Self {
             docs,
             name,
             methods,
+            attrs,
         }
     }
 }
@@ -103,12 +109,14 @@ impl EnumDef {
         name: IdentBuf,
         variants: Vec<EnumVariant>,
         methods: Vec<Method>,
+        attrs: Attrs,
     ) -> Self {
         Self {
             docs,
             name,
             variants,
             methods,
+            attrs,
         }
     }
 }

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -417,7 +417,7 @@ mod tests {
 
             env.insert(crate::ast::Path::empty(), top_symbols);
 
-            let tcx = crate::hir::TypeContext::from_ast(&env).unwrap();
+            let tcx = crate::hir::TypeContext::from_ast(&env, crate::hir::BasicAttributeValidator::new("test-backend")).unwrap();
 
             tcx
         }}

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Write};
 use smallvec::SmallVec;
 
 use super::{
-    paths, Docs, Ident, IdentBuf, LifetimeEnv, MaybeStatic, MethodLifetime, MethodLifetimes,
+    paths, Attrs, Docs, Ident, IdentBuf, LifetimeEnv, MaybeStatic, MethodLifetime, MethodLifetimes,
     OutType, SelfType, Slice, Type, TypeContext, TypeLifetime, TypeLifetimes,
 };
 
@@ -19,6 +19,7 @@ pub struct Method {
     pub param_self: Option<ParamSelf>,
     pub params: Vec<Param>,
     pub output: ReturnType,
+    pub attrs: Attrs,
 }
 
 /// Type that the method returns.

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Enabled with the `"hir"` Cargo feature
 
+mod attrs;
 mod defs;
 mod elision;
 mod lifetimes;
@@ -12,6 +13,7 @@ mod primitives;
 mod ty_position;
 mod type_context;
 mod types;
+pub use attrs::*;
 pub use defs::*;
 pub(super) use elision::*;
 pub use lifetimes::*;

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -95,8 +95,14 @@ TypeContext {
                             ),
                         ),
                     ),
+                    attrs: Attrs {
+                        disable: false,
+                    },
                 },
             ],
+            attrs: Attrs {
+                disable: false,
+            },
         },
     ],
     structs: [
@@ -190,8 +196,14 @@ TypeContext {
                             ),
                         ),
                     ),
+                    attrs: Attrs {
+                        disable: false,
+                    },
                 },
             ],
+            attrs: Attrs {
+                disable: false,
+            },
         },
     ],
     opaques: [
@@ -202,6 +214,9 @@ TypeContext {
             ),
             name: "Opaque",
             methods: [],
+            attrs: Attrs {
+                disable: false,
+            },
         },
     ],
     enums: [],

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -7,9 +7,8 @@ use diplomat_core::ast;
 mod enum_convert;
 mod transparent_convert;
 
-fn cfgs_to_stream(attrs: &[String]) -> proc_macro2::TokenStream {
+fn cfgs_to_stream(attrs: &[Attribute]) -> proc_macro2::TokenStream {
     attrs.iter().fold(quote!(), |prev, attr| {
-        let attr = attr.parse::<proc_macro2::TokenStream>().unwrap();
         quote!(#prev #attr)
     })
 }
@@ -197,7 +196,7 @@ fn gen_custom_type_method(strct: &ast::CustomType, m: &ast::Method) -> Item {
         })
         .collect::<Vec<_>>();
 
-    let cfg = cfgs_to_stream(&m.cfg_attrs);
+    let cfg = cfgs_to_stream(&m.attrs.cfg);
 
     if writeable_flushes.is_empty() {
         Item::Fn(syn::parse_quote! {
@@ -331,7 +330,7 @@ fn gen_bridge(input: ItemMod) -> ItemMod {
             (quote! {}, quote! {})
         };
 
-        let cfg = cfgs_to_stream(custom_type.cfg_attrs());
+        let cfg = cfgs_to_stream(&custom_type.attrs().cfg);
 
         // for now, body is empty since all we need to do is drop the box
         // TODO(#13): change to take a `*mut` and handle DST boxes appropriately

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -8,9 +8,9 @@ mod enum_convert;
 mod transparent_convert;
 
 fn cfgs_to_stream(attrs: &[Attribute]) -> proc_macro2::TokenStream {
-    attrs.iter().fold(quote!(), |prev, attr| {
-        quote!(#prev #attr)
-    })
+    attrs
+        .iter()
+        .fold(quote!(), |prev, attr| quote!(#prev #attr))
 }
 
 fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) {
@@ -240,7 +240,7 @@ impl AttributeInfo {
                     if seg == "opaque" {
                         opaque = true;
                         return false;
-                    } else if seg == "rust_link" || seg == "out" {
+                    } else if seg == "rust_link" || seg == "out" || seg == "attr" {
                         // diplomat-tool reads these, not diplomat::bridge.
                         // throw them away so rustc doesn't complain about unknown attributes
                         return false;

--- a/macro/src/snapshots/diplomat__tests__cfged_method-2.snap
+++ b/macro/src/snapshots/diplomat__tests__cfged_method-2.snap
@@ -13,8 +13,8 @@ mod ffi {
         }
     }
     #[no_mangle]
-    #[cfg(feature = "bar")]
     #[cfg(feature = "foo")]
+    #[cfg(feature = "bar")]
     extern "C" fn Foo_bar(s: u8) {
         Foo::bar(s)
     }

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -139,7 +139,17 @@ fn main() -> std::io::Result<()> {
             dotnet::gen_bindings(&env, &opt.library_config, &docs_url_gen, &mut out_texts).unwrap()
         }
         "c2" | "cpp-c2" | "cpp2" => {
-            let tcx = match hir::TypeContext::from_ast(&env) {
+            let mut attr_validator = hir::BasicAttributeValidator::new(target_language);
+
+            if target_language == "c2" {
+                attr_validator.other_backend_names.push("c".into());
+            } else {
+                attr_validator.other_backend_names.push("cpp".into());
+            }
+            // cpp-c2 is a testing backend, we're not going to treat it as a real c/cpp backend
+            // since the ast-cpp backend doesn't know about attributes.
+
+            let tcx = match hir::TypeContext::from_ast(&env, attr_validator) {
                 Ok(context) => context,
                 Err(e) => {
                     for err in e {


### PR DESCRIPTION
What this contains:

 - AST attribute support
 - CFG support in ast attributes (`#[diplomat::attr(any(cpp, has=overloading), somethingsomething)]`)
 - Basic HIR types for attributes, with placeholder for "disable" attribute.
 - HIR lowering for attributes

What this does not contain:
 - Actual usage of attributes in backends (depends on https://github.com/rust-diplomat/diplomat/pull/330, and i would like to keep this PR small if possible)

Fixes https://github.com/rust-diplomat/diplomat/issues/235