### PR TITLE
Add ErrorStore for HIR tools to track error sources

### DIFF
--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -1,5 +1,6 @@
 //! This module contains functions for formatting types
 
+use super::ty::ResultType;
 use diplomat_core::hir::{self, OpaqueOwner, Type, TypeContext, TypeId};
 use std::borrow::Cow;
 
@@ -28,6 +29,12 @@ impl<'tcx> CFormatter<'tcx> {
     pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
         // Currently don't do anything fancy
         // Eventually apply rename rules and such
+        self.tcx.resolve_type(id).name().as_str().into()
+    }
+
+    /// Resolve and format a named type for use in diagnostics
+    /// (don't apply rename rules and such)
+    pub fn fmt_type_name_diagnostics(&self, id: TypeId) -> Cow<'tcx, str> {
         self.tcx.resolve_type(id).name().as_str().into()
     }
     /// Resolve and format the name of a type for use in header names: decl version
@@ -113,6 +120,21 @@ impl<'tcx> CFormatter<'tcx> {
 
     pub fn fmt_result_name(&self, ok_ty_name: &str, err_ty_name: &str) -> String {
         format!("diplomat_result_{ok_ty_name}_{err_ty_name}")
+    }
+
+    pub fn fmt_result_for_diagnostics(&self, r: ResultType) -> String {
+        let ok = if let Some(ok) = r.0 {
+            self.fmt_type_name_uniquely(ok)
+        } else {
+            "()".into()
+        };
+        let err = if let Some(err) = r.1 {
+            self.fmt_type_name_uniquely(err)
+        } else {
+            "()".into()
+        };
+
+        format!("Result<{ok},{err}>")
     }
 
     /// Get the primitive type as a C type

--- a/tool/src/c2/mod.rs
+++ b/tool/src/c2/mod.rs
@@ -4,7 +4,7 @@ mod ty;
 
 pub use self::formatter::CFormatter;
 
-use crate::common::FileMap;
+use crate::common::{ErrorStore, FileMap};
 use diplomat_core::hir::TypeContext;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -17,6 +17,8 @@ pub struct CContext<'tcx> {
     pub files: FileMap,
     // The results needed by various methods
     pub result_store: RefCell<HashMap<String, ty::ResultType<'tcx>>>,
+
+    pub errors: ErrorStore<'tcx, String>,
 }
 
 impl<'tcx> CContext<'tcx> {
@@ -26,6 +28,7 @@ impl<'tcx> CContext<'tcx> {
             files,
             formatter: CFormatter::new(tcx),
             result_store: Default::default(),
+            errors: ErrorStore::default(),
         }
     }
 

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -16,14 +16,19 @@ impl<'tcx> super::CContext<'tcx> {
             decl_header: &mut decl_header,
             impl_header: &mut impl_header,
         };
+
+        let _guard = self.errors.set_context_ty(ty.name().as_str().into());
         match ty {
             TypeDef::Enum(e) => context.gen_enum_def(e, id),
             TypeDef::Opaque(o) => context.gen_opaque_def(o, id),
             TypeDef::Struct(s) => context.gen_struct_def(s, id),
             TypeDef::OutStruct(s) => context.gen_struct_def(s, id),
         }
-
         for method in ty.methods() {
+            let _guard = self.errors.set_context_method(
+                self.formatter.fmt_type_name_diagnostics(id),
+                method.name.as_str().into(),
+            );
             context.gen_method(id, method);
         }
 
@@ -48,6 +53,9 @@ impl<'tcx> super::CContext<'tcx> {
     }
 
     pub fn gen_result(&self, name: &str, ty: ResultType) {
+        let _guard = self
+            .errors
+            .set_context_ty(self.formatter.fmt_result_for_diagnostics(ty).into());
         let header_path = self.formatter.fmt_result_header_path(name);
         let mut header = Header::new(header_path.clone());
         let mut dummy_header = Header::new("".to_string());

--- a/tool/src/common/mod.rs
+++ b/tool/src/common/mod.rs
@@ -6,8 +6,10 @@
 //! should live in the c2 module, not here.
 
 use core::mem;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt;
 
 /// This type abstracts over files being written to.
 #[derive(Default)]
@@ -34,5 +36,82 @@ impl FileMap {
             panic!("File map already contains {}", name)
         }
         self.files.borrow_mut().insert(name, contents);
+    }
+}
+
+/// This type acts as a "store" for errors, which can be appended to.
+/// Keeps track of the context in which an error was generated.
+///
+/// You can use [`set_context_ty()`] and [`set_context_method()`] to set the context
+/// as a type or method. They will return scope guards that will automatically pop the stack
+/// once they go out of scope, so you don't have to worry about errors originating from code
+/// that does not set a context.
+#[derive(Default)]
+pub struct ErrorStore<'tcx, E> {
+    /// The stack of contexts reached so far
+    context: RefCell<ErrorContext<'tcx>>,
+    errors: RefCell<Vec<(ErrorContext<'tcx>, E)>>,
+}
+
+impl<'tcx, E> ErrorStore<'tcx, E> {
+    /// Set the context to a named type. Will return a scope guard that will automatically
+    /// clear the context on drop.
+    pub fn set_context_ty<'a>(&'a self, ty: Cow<'tcx, str>) -> ErrorContextGuard<'a, 'tcx, E> {
+        let new = ErrorContext { ty, method: None };
+        let old = mem::replace(&mut *self.context.borrow_mut(), new);
+        ErrorContextGuard(self, old)
+    }
+    /// Set the context to a named method. Will return a scope guard that will automatically
+    /// clear the context on drop.
+    pub fn set_context_method<'a>(
+        &'a self,
+        ty: Cow<'tcx, str>,
+        method: Cow<'tcx, str>,
+    ) -> ErrorContextGuard<'a, 'tcx, E> {
+        let new = ErrorContext {
+            ty,
+            method: Some(method),
+        };
+
+        let old = mem::replace(&mut *self.context.borrow_mut(), new);
+        ErrorContextGuard(self, old)
+    }
+
+    pub fn push_error(&self, error: E) {
+        self.errors
+            .borrow_mut()
+            .push((self.context.borrow().clone(), error));
+    }
+
+    pub fn take_all(&self) -> Vec<(impl fmt::Display + 'tcx, E)> {
+        mem::take(&mut self.errors.borrow_mut())
+    }
+}
+
+/// The context in which an error was discovered
+#[derive(Default, Clone)]
+struct ErrorContext<'tcx> {
+    ty: Cow<'tcx, str>,
+    method: Option<Cow<'tcx, str>>,
+}
+
+impl<'tcx> fmt::Display for ErrorContext<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let ty = &self.ty;
+        if let Some(ref method) = self.method {
+            write!(f, "{ty}::{method}")
+        } else {
+            ty.fmt(f)
+        }
+    }
+}
+
+/// Scope guard terminating the context created `set_context_*` method on [`ErrorStore`]
+#[must_use]
+pub struct ErrorContextGuard<'a, 'tcx, E>(&'a ErrorStore<'tcx, E>, ErrorContext<'tcx>);
+
+impl<'a, 'tcx, E> Drop for ErrorContextGuard<'a, 'tcx, E> {
+    fn drop(&mut self) {
+        let _ = mem::replace(&mut *self.0.context.borrow_mut(), mem::take(&mut self.1));
     }
 }

--- a/tool/src/cpp2/formatter.rs
+++ b/tool/src/cpp2/formatter.rs
@@ -30,6 +30,13 @@ impl<'tcx> Cpp2Formatter<'tcx> {
         // Eventually apply rename rules and such
         self.c.tcx().resolve_type(id).name().as_str().into()
     }
+
+    /// Resolve and format a named type for use in diagnostics
+    /// (don't apply rename rules and such)
+    pub fn fmt_type_name_diagnostics(&self, id: TypeId) -> Cow<'tcx, str> {
+        self.c.fmt_type_name_diagnostics(id)
+    }
+
     /// Resolve and format the name of a type for use in header names
     pub fn fmt_decl_header_path(&self, id: TypeId) -> String {
         let type_name = self.fmt_type_name(id);

--- a/tool/src/cpp2/mod.rs
+++ b/tool/src/cpp2/mod.rs
@@ -2,7 +2,7 @@ mod formatter;
 mod header;
 mod ty;
 
-use crate::common::FileMap;
+use crate::common::{ErrorStore, FileMap};
 use diplomat_core::hir::TypeContext;
 use formatter::Cpp2Formatter;
 
@@ -12,6 +12,7 @@ pub struct Cpp2Context<'tcx> {
     pub tcx: &'tcx TypeContext,
     pub formatter: Cpp2Formatter<'tcx>,
     pub files: FileMap,
+    pub errors: ErrorStore<'tcx, String>,
 }
 
 impl<'tcx> Cpp2Context<'tcx> {
@@ -20,6 +21,7 @@ impl<'tcx> Cpp2Context<'tcx> {
             tcx,
             files,
             formatter: Cpp2Formatter::new(tcx),
+            errors: ErrorStore::default(),
         }
     }
 

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -20,12 +20,14 @@ impl<'tcx> super::Cpp2Context<'tcx> {
             decl_header: &mut decl_header,
             impl_header: &mut impl_header,
         };
+        let guard = self.errors.set_context_ty(ty.name().as_str().into());
         match ty {
             TypeDef::Enum(o) => context.gen_enum_def(o, id),
             TypeDef::Opaque(o) => context.gen_opaque_def(o, id),
             TypeDef::Struct(s) => context.gen_struct_def(s, id),
             TypeDef::OutStruct(s) => context.gen_struct_def(s, id),
         }
+        drop(guard);
 
         // In some cases like generating decls for `self` parameters,
         // a header will get its own forwards and includes. Instead of
@@ -300,6 +302,10 @@ inline {type_name} {type_name}::FromFFI({ctype} c_struct) {{
     }
 
     pub fn gen_method(&mut self, id: TypeId, method: &'tcx hir::Method) {
+        let _guard = self.cx.errors.set_context_method(
+            self.cx.formatter.fmt_type_name_diagnostics(id),
+            method.name.as_str().into(),
+        );
         let type_name = self.cx.formatter.fmt_type_name(id);
         let method_name = self.cx.formatter.fmt_method_name(method);
         let c_method_name = self.cx.formatter.fmt_c_method_name(id, method);


### PR DESCRIPTION
While a large part of the HIR design is that we should limit runtime errors during HIR generation, there are still reasons to generate errors during HIR generation.

In general, compiler errors should be batched up until it is not possible to continue: errors should not automatically break control flow. Typically in compiler design "until it is not possible to continue" is tricky to figure out: you really want to avoid the situation of one error ballooning into more errors because the error led to botched intermediate state. For example, in Rust you want to avoid an "unknown type" error due to a missing import to get compounded by a pile of "type does not have method blah" when you try to use the type. This is not a huge problem for Diplomat's codegen: e.g. if a type name cannot be fetched; that is no bother: we can always use a placeholder to let compilation continue so that all errors can be discovered. Diplomat only has three passes[^1], and there is only one pass in diplomat-tool[^2], so there is no issue with errors ballooning into more errors due to broken intermediate state. We're fine as long as we don't ignore errors _between_ passes, and if/when we add proper HIR lowering error handling (with Spans and all), we can make sure we handle that.


This adds an ErrorStore type that can be used in tool code to collect up errors and print them all at the end of tool generation (before the actual files are written). It's capable of tracking the context in which the error was generated, which is way nicer than backtraces and uses scope guards to automatically reset contexts.



This does not actually use ErrorStore anywhere yet, but I plan to use this while working on https://github.com/rust-diplomat/diplomat/issues/233. For context: I hope to implement disabling at the tool level rather than during lowering; the tool should still know about the type for diagnostics, but it should not generate anything for it and produce errors when asked to refer to the type elsewhere[^3]. We also have a bunch of unwraps in the code that could similarly be cleaned up; some of them reflect genuine program bugs, but others might be user issues. For example, we may wish to introduce stronger checks when reserved words are used (and we don't want to figure out replacement identifiers).


 [^1]: Parsing (makes AST), lowering (makes HIR), and codegen (makes backend-specific code files)
 [^2]: Technically cpp2 runs a c2 codegen pass and then a cpp2 codegen pass, and in the future will run a docs pass, but the outputs of these passes are independent of each other, so broken outputs can't cause problems.
 [^3]: There is a valid argument to be made that this should be done as a purely HIR lowering concern, and if we end up going that way I think that's fine, but this error handling code will be useful eventually.