### PR TITLE
Add parsing for rename attributes

### DIFF
--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -97,11 +97,13 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        rename: None,
                     },
                 },
             ],
             attrs: Attrs {
                 disable: false,
+                rename: None,
             },
         },
     ],
@@ -198,11 +200,13 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        rename: None,
                     },
                 },
             ],
             attrs: Attrs {
                 disable: false,
+                rename: None,
             },
         },
     ],
@@ -216,6 +220,7 @@ TypeContext {
             methods: [],
             attrs: Attrs {
                 disable: false,
+                rename: None,
             },
         },
     ],


### PR DESCRIPTION
Progress on https://github.com/rust-diplomat/diplomat/issues/234

Eventually I'd like to be able to apply this attribute to modules and support some kind of substitution pattern, so that you can mass-rename things in a module. Including things like camelcasing/etc. Not done in this PR.