### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Manish Goregaokar <manishsmail@gmail.com>",
     "Quinn Okabayashi <QnnOkabayashi@users.noreply.github.com>"
 ]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/diplomat_core/"
 edition = "2021"
 keywords = ["ffi", "codegen"]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
     "Quinn Okabayashi <QnnOkabayashi@users.noreply.github.com>"
 ]
 edition = "2018"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/diplomat_core/"
 keywords = ["ffi", "codegen"]
 categories = ["development-tools"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
     "Quinn Okabayashi <QnnOkabayashi@users.noreply.github.com>"
 ]
 edition = "2018"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/diplomat_core/"
 keywords = ["ffi", "codegen"]
 categories = ["development-tools"]

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
     "Quinn Okabayashi <QnnOkabayashi@users.noreply.github.com>"
 ]
 edition = "2018"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/diplomat_core/"
 keywords = ["ffi", "codegen"]
 categories = ["development-tools"]


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields