### PR TITLE
refactor(tool): fix clippy warnings

### DIFF
--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -77,8 +77,13 @@ pub fn gen_bindings(
                 docs_url_gen,
                 &mut out,
             )?;
-            outs.insert(format!("Raw{}.cs", typ.name()), out_buf)
-                .and_then::<String, _>(|_| panic!("file created twice: Raw{}.cs", typ.name()));
+
+            if outs
+                .insert(format!("Raw{}.cs", typ.name()), out_buf)
+                .is_some()
+            {
+                panic!("file created twice: Raw{}.cs", typ.name())
+            }
         }
 
         for (in_path, typ) in results {
@@ -87,8 +92,13 @@ pub fn gen_bindings(
             let mut out = CodeWriter::new(&mut out_buf, INDENTATION, SCOPE_OPENING, SCOPE_CLOSING);
             raw::gen_header(&library_config, &mut out)?;
             raw::gen_result(typ, &in_path, env, &mut out)?;
-            outs.insert(format!("Raw{result_name}.cs"), out_buf)
-                .and_then::<String, _>(|_| panic!("file created twice: Raw{}.cs", result_name));
+
+            if outs
+                .insert(format!("Raw{result_name}.cs"), out_buf)
+                .is_some()
+            {
+                panic!("file created twice: Raw{}.cs", result_name)
+            }
         }
     }
 
@@ -100,8 +110,10 @@ pub fn gen_bindings(
             let mut out = CodeWriter::new(&mut out_buf, INDENTATION, SCOPE_OPENING, SCOPE_CLOSING);
             idiomatic::gen_header(&library_config, &mut out)?;
             idiomatic::gen(typ, in_path, env, &library_config, docs_url_gen, &mut out)?;
-            outs.insert(format!("{}.cs", typ.name()), out_buf)
-                .and_then::<String, _>(|_| panic!("file created twice: {}.cs", typ.name()));
+
+            if outs.insert(format!("{}.cs", typ.name()), out_buf).is_some() {
+                panic!("file created twice: {}.cs", typ.name())
+            }
         }
 
         for (in_path, typ) in errors {
@@ -111,8 +123,10 @@ pub fn gen_bindings(
             let mut out = CodeWriter::new(&mut out_buf, INDENTATION, SCOPE_OPENING, SCOPE_CLOSING);
             idiomatic::gen_header(&library_config, &mut out)?;
             idiomatic::gen_exception(env, &library_config, typ, &in_path, &mut out)?;
-            outs.insert(format!("{name}.cs"), out_buf)
-                .and_then::<String, _>(|_| panic!("file created twice: {}.cs", name));
+
+            if outs.insert(format!("{name}.cs"), out_buf).is_some() {
+                panic!("file created twice: {}.cs", name)
+            }
         }
     }
 


### PR DESCRIPTION
Hi!

Simply fixes the clippy warnings found in the dotnet module of the tool on the latest stable Rust toolchain (1.72).