### PR TITLE
Validate `char`s

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -120,8 +120,8 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
         }
         ast::TypeName::Primitive(ast::PrimitiveType::char) => {
             let name = &param.name;
-                // TODO(#318): don't just unwrap? or should we assume that the other side gives us a good value?
-                expanded_params.push(parse2(quote! { char::from_u32(#name).unwrap() }).unwrap());
+            // TODO(#318): don't just unwrap? or should we assume that the other side gives us a good value?
+            expanded_params.push(parse2(quote! { char::from_u32(#name).unwrap() }).unwrap());
         }
         _ => {
             expanded_params.push(Expr::Path(ExprPath {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -63,6 +63,14 @@ fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) 
                 ),
             }));
         }
+        ast::TypeName::Primitive(ast::PrimitiveType::char) => gen_params_at_boundary(
+            &{
+                let mut p = param.clone();
+                p.ty = ast::TypeName::Primitive(ast::PrimitiveType::u32);
+                p
+            },
+            expanded_params,
+        ),
         o => {
             expanded_params.push(FnArg::Typed(PatType {
                 attrs: vec![],
@@ -99,9 +107,9 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
             } else {
                 // TODO(#57): don't just unwrap? or should we assume that the other side gives us a good value?
                 quote! {
-                    unsafe {
-                        core::str::from_utf8(core::slice::from_raw_parts(#data_ident, #len_ident)).unwrap()
-                    }
+                    core::str::from_utf8(unsafe {
+                        core::slice::from_raw_parts(#data_ident, #len_ident)
+                    }).unwrap()
                 }
             };
             expanded_params.push(parse2(tokens).unwrap());
@@ -109,6 +117,11 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
         ast::TypeName::Result(_, _, _) => {
             let param = &param.name;
             expanded_params.push(parse2(quote!(#param.into())).unwrap());
+        }
+        ast::TypeName::Primitive(ast::PrimitiveType::char) => {
+            let name = &param.name;
+                // TODO(#318): don't just unwrap? or should we assume that the other side gives us a good value?
+                expanded_params.push(parse2(quote! { char::from_u32(#name).unwrap() }).unwrap());
         }
         _ => {
             expanded_params.push(Expr::Path(ExprPath {

--- a/macro/src/snapshots/diplomat__tests__method_taking_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_str.snap
@@ -12,10 +12,12 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Foo_from_str(s_diplomat_data: *const u8, s_diplomat_len: usize) {
-        Foo::from_str(unsafe {
-            core::str::from_utf8(core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len))
-                .unwrap()
-        })
+        Foo::from_str(
+            core::str::from_utf8(unsafe {
+                core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len)
+            })
+            .unwrap(),
+        )
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
+++ b/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
@@ -26,10 +26,12 @@ mod ffi {
     extern "C" fn Baz_destroy<'x: 'y, 'y>(this: Box<Baz<'x, 'y>>) {}
     #[no_mangle]
     extern "C" fn Foo_new<'a>(x_diplomat_data: *const u8, x_diplomat_len: usize) -> Box<Foo<'a>> {
-        Foo::new(unsafe {
-            core::str::from_utf8(core::slice::from_raw_parts(x_diplomat_data, x_diplomat_len))
-                .unwrap()
-        })
+        Foo::new(
+            core::str::from_utf8(unsafe {
+                core::slice::from_raw_parts(x_diplomat_data, x_diplomat_len)
+            })
+            .unwrap(),
+        )
     }
     #[no_mangle]
     extern "C" fn Foo_get_bar<'a: 'b, 'b>(this: &'b Foo<'a>) -> Box<Bar<'b, 'a>> {


### PR DESCRIPTION
Changing the ABI from `char` to `u32`, which are compatible, and then trying to convert.

#318