### PR TITLE
Introduce `DiplomatStr`

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -381,7 +381,7 @@ pub enum TypeName {
     /// A `Result<T, E>` or `diplomat_runtime::DiplomatWriteable` type. If the bool is true, it's `Result`
     Result(Box<TypeName>, Box<TypeName>, bool),
     Writeable,
-    /// A `&str` type.
+    /// A `&DiplomatWtf8` type.
     StrReference(Lifetime),
     /// A `&[T]` type, where `T` is a primitive.
     PrimitiveSlice(Lifetime, Mutability, PrimitiveType),
@@ -494,7 +494,7 @@ impl TypeName {
                 diplomat_runtime::DiplomatWriteable
             },
             TypeName::StrReference(lifetime) => syn::parse_str(&format!(
-                "{}str",
+                "{}DiplomatWtf8",
                 ReferenceDisplay(lifetime, &Mutability::Immutable)
             ))
             .unwrap(),
@@ -522,7 +522,7 @@ impl TypeName {
     /// - If the type is a path with a single element [`Result`], returns a [`TypeName::Result`] with the type parameters recursively converted
     /// - If the type is a path equal to [`diplomat_runtime::DiplomatResult`], returns a [`TypeName::DiplomatResult`] with the type parameters recursively converted
     /// - If the type is a path equal to [`diplomat_runtime::DiplomatWriteable`], returns a [`TypeName::Writeable`]
-    /// - If the type is a reference to `str`, returns a [`TypeName::StrReference`]
+    /// - If the type is a reference to `DiplomatWtf8`, returns a [`TypeName::StrReference`]
     /// - If the type is a reference to a slice of a Rust primitive, returns a [`TypeName::PrimitiveSlice`]
     /// - If the type is a reference (`&` or `&mut`), returns a [`TypeName::Reference`] with the referenced type recursively converted
     /// - Otherwise, assume that the reference is to a [`CustomType`] in either the current module or another one, returns a [`TypeName::Named`]
@@ -919,7 +919,7 @@ impl fmt::Display for TypeName {
             TypeName::StrReference(lifetime) => {
                 write!(
                     f,
-                    "{}str",
+                    "{}DiplomatWtf8",
                     ReferenceDisplay(lifetime, &Mutability::Immutable)
                 )
             }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -381,7 +381,7 @@ pub enum TypeName {
     /// A `Result<T, E>` or `diplomat_runtime::DiplomatWriteable` type. If the bool is true, it's `Result`
     Result(Box<TypeName>, Box<TypeName>, bool),
     Writeable,
-    /// A `&DiplomatWtf8` type.
+    /// A `&DiplomatStr` type.
     StrReference(Lifetime),
     /// A `&[T]` type, where `T` is a primitive.
     PrimitiveSlice(Lifetime, Mutability, PrimitiveType),
@@ -494,7 +494,7 @@ impl TypeName {
                 diplomat_runtime::DiplomatWriteable
             },
             TypeName::StrReference(lifetime) => syn::parse_str(&format!(
-                "{}DiplomatWtf8",
+                "{}DiplomatStr",
                 ReferenceDisplay(lifetime, &Mutability::Immutable)
             ))
             .unwrap(),
@@ -522,7 +522,7 @@ impl TypeName {
     /// - If the type is a path with a single element [`Result`], returns a [`TypeName::Result`] with the type parameters recursively converted
     /// - If the type is a path equal to [`diplomat_runtime::DiplomatResult`], returns a [`TypeName::DiplomatResult`] with the type parameters recursively converted
     /// - If the type is a path equal to [`diplomat_runtime::DiplomatWriteable`], returns a [`TypeName::Writeable`]
-    /// - If the type is a reference to `DiplomatWtf8`, returns a [`TypeName::StrReference`]
+    /// - If the type is a reference to `DiplomatStr`, returns a [`TypeName::StrReference`]
     /// - If the type is a reference to a slice of a Rust primitive, returns a [`TypeName::PrimitiveSlice`]
     /// - If the type is a reference (`&` or `&mut`), returns a [`TypeName::Reference`] with the referenced type recursively converted
     /// - Otherwise, assume that the reference is to a [`CustomType`] in either the current module or another one, returns a [`TypeName::Named`]
@@ -532,9 +532,9 @@ impl TypeName {
                 let lifetime = Lifetime::from(&r.lifetime);
                 let mutability = Mutability::from_syn(&r.mutability);
 
-                if r.elem.to_token_stream().to_string() == "DiplomatWtf8" {
+                if r.elem.to_token_stream().to_string() == "DiplomatStr" {
                     if mutability.is_mutable() {
-                        panic!("mutable `DiplomatWtf8` references are disallowed");
+                        panic!("mutable `DiplomatStr` references are disallowed");
                     }
                     return TypeName::StrReference(lifetime);
                 }
@@ -919,7 +919,7 @@ impl fmt::Display for TypeName {
             TypeName::StrReference(lifetime) => {
                 write!(
                     f,
-                    "{}DiplomatWtf8",
+                    "{}DiplomatStr",
                     ReferenceDisplay(lifetime, &Mutability::Immutable)
                 )
             }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -532,9 +532,9 @@ impl TypeName {
                 let lifetime = Lifetime::from(&r.lifetime);
                 let mutability = Mutability::from_syn(&r.mutability);
 
-                if r.elem.to_token_stream().to_string() == "str" {
+                if r.elem.to_token_stream().to_string() == "DiplomatWtf8" {
                     if mutability.is_mutable() {
-                        panic!("mutable `str` references are disallowed");
+                        panic!("mutable `DiplomatWtf8` references are disallowed");
                     }
                     return TypeName::StrReference(lifetime);
                 }

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -442,11 +442,11 @@ mod tests {
             mod ffi {
                 #[diplomat::opaque]
                 struct Opaque<'a> {
-                    s: &'a str,
+                    s: &'a DiplomatWtf8,
                 }
 
                 struct Struct<'a> {
-                    s: &'a str,
+                    s: &'a DiplomatWtf8,
                 }
 
                 #[diplomat::out]
@@ -455,14 +455,14 @@ mod tests {
                 }
 
                 impl<'a> OutStruct<'a> {
-                    pub fn new(s: &'a str) -> Self {
+                    pub fn new(s: &'a DiplomatWtf8) -> Self {
                         Self { inner: Box::new(Opaque { s }) }
                     }
 
                 }
 
                 impl<'a> Struct<'a> {
-                    pub fn rustc_elision(self, s: &str) -> &str {
+                    pub fn rustc_elision(self, s: &DiplomatWtf8) -> &DiplomatWtf8 {
                         s
                     }
                 }
@@ -483,12 +483,12 @@ mod tests {
                 struct Input<'p, 'q> {
                     p_data: &'p Opaque,
                     q_data: &'q Opaque,
-                    name: &'static str,
+                    name: &'static DiplomatWtf8,
                     inner: Inner<'q>,
                 }
 
                 struct Inner<'a> {
-                    more_data: &'a str,
+                    more_data: &'a DiplomatWtf8,
                 }
 
                 struct Output<'p,'q> {
@@ -497,7 +497,7 @@ mod tests {
                 }
 
                 impl<'a, 'b> Input<'a, 'b> {
-                    pub fn as_output(self, _s: &'static str) -> Output<'b, 'a> {
+                    pub fn as_output(self, _s: &'static DiplomatWtf8) -> Output<'b, 'a> {
                         Output { data: self.data }
                     }
 

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -442,11 +442,11 @@ mod tests {
             mod ffi {
                 #[diplomat::opaque]
                 struct Opaque<'a> {
-                    s: &'a DiplomatWtf8,
+                    s: &'a DiplomatStr,
                 }
 
                 struct Struct<'a> {
-                    s: &'a DiplomatWtf8,
+                    s: &'a DiplomatStr,
                 }
 
                 #[diplomat::out]
@@ -455,14 +455,14 @@ mod tests {
                 }
 
                 impl<'a> OutStruct<'a> {
-                    pub fn new(s: &'a DiplomatWtf8) -> Self {
+                    pub fn new(s: &'a DiplomatStr) -> Self {
                         Self { inner: Box::new(Opaque { s }) }
                     }
 
                 }
 
                 impl<'a> Struct<'a> {
-                    pub fn rustc_elision(self, s: &DiplomatWtf8) -> &DiplomatWtf8 {
+                    pub fn rustc_elision(self, s: &DiplomatStr) -> &DiplomatStr {
                         s
                     }
                 }
@@ -483,12 +483,12 @@ mod tests {
                 struct Input<'p, 'q> {
                     p_data: &'p Opaque,
                     q_data: &'q Opaque,
-                    name: &'static DiplomatWtf8,
+                    name: &'static DiplomatStr,
                     inner: Inner<'q>,
                 }
 
                 struct Inner<'a> {
-                    more_data: &'a DiplomatWtf8,
+                    more_data: &'a DiplomatStr,
                 }
 
                 struct Output<'p,'q> {
@@ -497,7 +497,7 @@ mod tests {
                 }
 
                 impl<'a, 'b> Input<'a, 'b> {
-                    pub fn as_output(self, _s: &'static DiplomatWtf8) -> Output<'b, 'a> {
+                    pub fn as_output(self, _s: &'static DiplomatStr) -> Output<'b, 'a> {
                         Output { data: self.data }
                     }
 

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -33,7 +33,7 @@ pub enum SelfType {
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum Slice {
-    /// A string slice, e.g. `&DiplomatWtf8`.
+    /// A string slice, e.g. `&DiplomatStr`.
     Str(MaybeStatic<TypeLifetime>),
 
     /// A primitive slice, e.g. `&mut [u8]`.

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -33,7 +33,7 @@ pub enum SelfType {
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum Slice {
-    /// A string slice, e.g. `&str`.
+    /// A string slice, e.g. `&DiplomatWtf8`.
     Str(MaybeStatic<TypeLifetime>),
 
     /// A primitive slice, e.g. `&mut [u8]`.

--- a/example/c/include/ICU4XLocale.h
+++ b/example/c/include/ICU4XLocale.h
@@ -20,8 +20,6 @@ extern "C" {
 #endif
 
 ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
-
-ICU4XLocale* ICU4XLocale_new_from_bytes(const uint8_t* bytes_data, size_t bytes_len);
 void ICU4XLocale_destroy(ICU4XLocale* self);
 
 #ifdef __cplusplus

--- a/example/c2/include/ICU4XLocale.h
+++ b/example/c2/include/ICU4XLocale.h
@@ -17,8 +17,6 @@ extern "C" {
 
 ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
 
-ICU4XLocale* ICU4XLocale_new_from_bytes(const uint8_t* bytes_data, size_t bytes_len);
-
 void ICU4XLocale_destroy(ICU4XLocale* self);
 
 

--- a/example/cpp/docs/source/locale_ffi.rst
+++ b/example/cpp/docs/source/locale_ffi.rst
@@ -12,8 +12,3 @@
 
         Construct an :cpp:class:`ICU4XLocale` from a locale identifier represented as a string.
 
-
-    .. cpp:function:: static ICU4XLocale new_from_bytes(const diplomat::span<const uint8_t> bytes)
-
-        Construct an :cpp:class:`ICU4XLocale` from a locale identifier represented as bytes.
-

--- a/example/cpp/include/ICU4XLocale.h
+++ b/example/cpp/include/ICU4XLocale.h
@@ -20,8 +20,6 @@ extern "C" {
 #endif
 
 ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
-
-ICU4XLocale* ICU4XLocale_new_from_bytes(const uint8_t* bytes_data, size_t bytes_len);
 void ICU4XLocale_destroy(ICU4XLocale* self);
 
 #ifdef __cplusplus

--- a/example/cpp/include/ICU4XLocale.hpp
+++ b/example/cpp/include/ICU4XLocale.hpp
@@ -34,11 +34,6 @@ class ICU4XLocale {
    * Construct an [`ICU4XLocale`] from a locale identifier represented as a string.
    */
   static ICU4XLocale new_(const std::string_view name);
-
-  /**
-   * Construct an [`ICU4XLocale`] from a locale identifier represented as bytes.
-   */
-  static ICU4XLocale new_from_bytes(const diplomat::span<const uint8_t> bytes);
   inline const capi::ICU4XLocale* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XLocale* AsFFIMut() { return this->inner.get(); }
   inline ICU4XLocale(capi::ICU4XLocale* i) : inner(i) {}
@@ -52,8 +47,5 @@ class ICU4XLocale {
 
 inline ICU4XLocale ICU4XLocale::new_(const std::string_view name) {
   return ICU4XLocale(capi::ICU4XLocale_new(name.data(), name.size()));
-}
-inline ICU4XLocale ICU4XLocale::new_from_bytes(const diplomat::span<const uint8_t> bytes) {
-  return ICU4XLocale(capi::ICU4XLocale_new_from_bytes(bytes.data(), bytes.size()));
 }
 #endif

--- a/example/cpp2/include/ICU4XLocale.d.hpp
+++ b/example/cpp2/include/ICU4XLocale.d.hpp
@@ -16,8 +16,6 @@ public:
 
   inline static std::unique_ptr<ICU4XLocale> new_(std::string_view name);
 
-  inline static std::unique_ptr<ICU4XLocale> new_from_bytes(diplomat::span<const uint8_t> bytes);
-
   inline const capi::ICU4XLocale* AsFFI() const;
   inline capi::ICU4XLocale* AsFFI();
   inline static const ICU4XLocale* FromFFI(const capi::ICU4XLocale* ptr);

--- a/example/cpp2/include/ICU4XLocale.h
+++ b/example/cpp2/include/ICU4XLocale.h
@@ -17,8 +17,6 @@ extern "C" {
 
 ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
 
-ICU4XLocale* ICU4XLocale_new_from_bytes(const uint8_t* bytes_data, size_t bytes_len);
-
 void ICU4XLocale_destroy(ICU4XLocale* self);
 
 

--- a/example/cpp2/include/ICU4XLocale.hpp
+++ b/example/cpp2/include/ICU4XLocale.hpp
@@ -19,12 +19,6 @@ inline std::unique_ptr<ICU4XLocale> ICU4XLocale::new_(std::string_view name) {
   return std::unique_ptr<ICU4XLocale>(ICU4XLocale::FromFFI(result));
 }
 
-inline std::unique_ptr<ICU4XLocale> ICU4XLocale::new_from_bytes(diplomat::span<const uint8_t> bytes) {
-  auto result = capi::ICU4XLocale_new_from_bytes(bytes.data(),
-    bytes.size());
-  return std::unique_ptr<ICU4XLocale>(ICU4XLocale::FromFFI(result));
-}
-
 inline const capi::ICU4XLocale* ICU4XLocale::AsFFI() const {
   return reinterpret_cast<const capi::ICU4XLocale*>(this);
 }

--- a/example/dart/lib/ICU4XLocale.g.dart
+++ b/example/dart/lib/ICU4XLocale.g.dart
@@ -30,18 +30,4 @@ final class ICU4XLocale implements ffi.Finalizable {
   static final _ICU4XLocale_new =
     _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, ffi.Size)>>('ICU4XLocale_new')
       .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, int)>(isLeaf: true);
-
-  /// Construct an [`ICU4XLocale`] from a locale identifier represented as bytes.
-  factory ICU4XLocale.fromBytes(Uint8List bytes) {
-    final alloc = ffi2.Arena();
-    final bytesSlice = _SliceFfiUint8._fromDart(bytes, alloc);
-    final result = _ICU4XLocale_new_from_bytes(bytesSlice._bytes, bytesSlice._length);
-    alloc.releaseAll();
-    return ICU4XLocale._(result);
-  }
-
-  // ignore: non_constant_identifier_names
-  static final _ICU4XLocale_new_from_bytes =
-    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>('ICU4XLocale_new_from_bytes')
-      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
 }

--- a/example/dart/lib/lib.g.dart
+++ b/example/dart/lib/lib.g.dart
@@ -96,47 +96,6 @@ final class _SliceFfi2Utf8 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 }
 
-final class _SliceFfiUint8 extends ffi.Struct {
-  external ffi.Pointer<ffi.Uint8> _bytes;
-
-  @ffi.Size()
-  external int _length;
-
-  /// Produces a slice from a Dart object. The Dart object's data is copied into the given allocator
-  /// as it cannot be borrowed directly, and gets freed with the slice object.
-  // ignore: unused_element
-  static _SliceFfiUint8 _fromDart(Uint8List value, ffi.Allocator allocator) {
-    final pointer = allocator<_SliceFfiUint8>();
-    final slice = pointer.ref;
-    slice._length = value.length;
-    slice._bytes = allocator(slice._length);
-    slice._bytes.asTypedList(slice._length).setAll(0, value);
-    return slice;
-  }
-
-  // ignore: unused_element
-  Uint8List get _asDart => _bytes.asTypedList(_length);
-
-  // This is expensive
-  @override
-  bool operator ==(Object other) {
-    if (other is! _SliceFfiUint8 || other._length != _length) {
-      return false;
-    }
-
-    for (var i = 0; i < _length; i++) {
-      if (other._bytes[i] != _bytes[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  // This is cheap
-  @override
-  int get hashCode => _length.hashCode;
-}
-
 /// An unspecified error value
 class VoidError {}
 

--- a/example/js/lib/api/ICU4XLocale.d.ts
+++ b/example/js/lib/api/ICU4XLocale.d.ts
@@ -12,10 +12,4 @@ export class ICU4XLocale {
    * Construct an {@link ICU4XLocale `ICU4XLocale`} from a locale identifier represented as a string.
    */
   static new(name: string): ICU4XLocale;
-
-  /**
-
-   * Construct an {@link ICU4XLocale `ICU4XLocale`} from a locale identifier represented as bytes.
-   */
-  static new_from_bytes(bytes: Uint8Array): ICU4XLocale;
 }

--- a/example/js/lib/api/ICU4XLocale.js
+++ b/example/js/lib/api/ICU4XLocale.js
@@ -21,11 +21,4 @@ export class ICU4XLocale {
     buf_arg_name.free();
     return diplomat_out;
   }
-
-  static new_from_bytes(arg_bytes) {
-    const buf_arg_bytes = diplomatRuntime.DiplomatBuf.slice(wasm, arg_bytes, 1);
-    const diplomat_out = new ICU4XLocale(wasm.ICU4XLocale_new_from_bytes(buf_arg_bytes.ptr, buf_arg_bytes.size), true, []);
-    buf_arg_bytes.free();
-    return diplomat_out;
-  }
 }

--- a/example/js/lib/docs/source/locale_ffi.rst
+++ b/example/js/lib/docs/source/locale_ffi.rst
@@ -12,10 +12,3 @@
 
         Construct an :js:class:`ICU4XLocale` from a locale identifier represented as a string.
 
-
-    .. js:function:: new_from_bytes(bytes)
-
-        Construct an :js:class:`ICU4XLocale` from a locale identifier represented as bytes.
-
-        - Note: ``bytes`` should be an ArrayBuffer or TypedArray corresponding to the slice type expected by Rust.
-

--- a/example/src/locale.rs
+++ b/example/src/locale.rs
@@ -1,7 +1,6 @@
 #[diplomat::bridge]
 pub mod ffi {
     use icu::locid::Locale;
-    use std::str::FromStr;
 
     #[diplomat::opaque]
     /// An ICU4X Locale, capable of representing strings like `"en-US"`.
@@ -10,13 +9,8 @@ pub mod ffi {
 
     impl ICU4XLocale {
         /// Construct an [`ICU4XLocale`] from a locale identifier represented as a string.
-        pub fn new(name: &str) -> Box<ICU4XLocale> {
-            Box::new(ICU4XLocale(Locale::from_str(name).unwrap()))
-        }
-
-        /// Construct an [`ICU4XLocale`] from a locale identifier represented as bytes.
-        pub fn new_from_bytes(bytes: &[u8]) -> Box<ICU4XLocale> {
-            Box::new(ICU4XLocale(Locale::try_from_bytes(bytes).unwrap()))
+        pub fn new(name: &DiplomatWtf8) -> Box<ICU4XLocale> {
+            Box::new(ICU4XLocale(Locale::try_from_bytes(name).unwrap()))
         }
     }
 }

--- a/example/src/locale.rs
+++ b/example/src/locale.rs
@@ -9,7 +9,7 @@ pub mod ffi {
 
     impl ICU4XLocale {
         /// Construct an [`ICU4XLocale`] from a locale identifier represented as a string.
-        pub fn new(name: &DiplomatWtf8) -> Box<ICU4XLocale> {
+        pub fn new(name: &DiplomatStr) -> Box<ICU4XLocale> {
             Box::new(ICU4XLocale(Locale::try_from_bytes(name).unwrap()))
         }
     }

--- a/feature_tests/Cargo.toml
+++ b/feature_tests/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Manish Goregaokar <manishsmail@gmail.com>",
     "Quinn Okabayashi <QnnOkabayashi@users.noreply.github.com>"
 ]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["staticlib", "rlib", "cdylib"]

--- a/feature_tests/c/include/BorrowedFieldsReturning.h
+++ b/feature_tests/c/include/BorrowedFieldsReturning.h
@@ -11,7 +11,7 @@ namespace capi {
 #endif
 
 typedef struct BorrowedFieldsReturning {
-    DiplomatU8View bytes;
+    DiplomatStringView bytes;
 } BorrowedFieldsReturning;
 #ifdef __cplusplus
 } // namespace capi

--- a/feature_tests/c2/include/BorrowedFieldsReturning.d.h
+++ b/feature_tests/c2/include/BorrowedFieldsReturning.d.h
@@ -14,7 +14,7 @@ extern "C" {
 
 
 typedef struct BorrowedFieldsReturning {
-  struct { const uint8_t* data; size_t len; } bytes;
+  struct { const char* data; size_t len; } bytes;
 } BorrowedFieldsReturning;
 
 

--- a/feature_tests/cpp/docs/source/lifetimes_ffi.rst
+++ b/feature_tests/cpp/docs/source/lifetimes_ffi.rst
@@ -11,7 +11,7 @@
 
 .. cpp:struct:: BorrowedFieldsReturning
 
-    .. cpp:member:: const diplomat::span<const uint8_t> bytes
+    .. cpp:member:: std::string_view bytes
 
 .. cpp:class:: Foo
 

--- a/feature_tests/cpp/include/BorrowedFieldsReturning.h
+++ b/feature_tests/cpp/include/BorrowedFieldsReturning.h
@@ -11,7 +11,7 @@ namespace capi {
 #endif
 
 typedef struct BorrowedFieldsReturning {
-    DiplomatU8View bytes;
+    DiplomatStringView bytes;
 } BorrowedFieldsReturning;
 #ifdef __cplusplus
 } // namespace capi

--- a/feature_tests/cpp/include/BorrowedFieldsReturning.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsReturning.hpp
@@ -14,7 +14,7 @@
 
 struct BorrowedFieldsReturning {
  public:
-  const diplomat::span<const uint8_t> bytes;
+  std::string_view bytes;
 };
 
 

--- a/feature_tests/cpp/include/Foo.hpp
+++ b/feature_tests/cpp/include/Foo.hpp
@@ -76,9 +76,9 @@ inline Foo Foo::new_static(const std::string_view x) {
 }
 inline BorrowedFieldsReturning Foo::as_returning() const {
   capi::BorrowedFieldsReturning diplomat_raw_struct_out_value = capi::Foo_as_returning(this->inner.get());
-  capi::DiplomatU8View diplomat_slice_raw_out_value_bytes = diplomat_raw_struct_out_value.bytes;
-  diplomat::span<const uint8_t> slice(diplomat_slice_raw_out_value_bytes.data, diplomat_slice_raw_out_value_bytes.len);
-  return BorrowedFieldsReturning{ .bytes = std::move(slice) };
+  capi::DiplomatStringView diplomat_str_raw_out_value_bytes = diplomat_raw_struct_out_value.bytes;
+  std::string_view str(diplomat_str_raw_out_value_bytes.data, diplomat_str_raw_out_value_bytes.len);
+  return BorrowedFieldsReturning{ .bytes = std::move(str) };
 }
 inline Foo Foo::extract_from_fields(BorrowedFields fields) {
   BorrowedFields diplomat_wrapped_struct_fields = fields;

--- a/feature_tests/cpp2/include/BorrowedFieldsReturning.d.h
+++ b/feature_tests/cpp2/include/BorrowedFieldsReturning.d.h
@@ -14,7 +14,7 @@ extern "C" {
 
 
 typedef struct BorrowedFieldsReturning {
-  struct { const uint8_t* data; size_t len; } bytes;
+  struct { const char* data; size_t len; } bytes;
 } BorrowedFieldsReturning;
 
 

--- a/feature_tests/cpp2/include/BorrowedFieldsReturning.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsReturning.d.hpp
@@ -12,7 +12,7 @@
 
 
 struct BorrowedFieldsReturning {
-  diplomat::span<const uint8_t> bytes;
+  std::string_view bytes;
 
   inline capi::BorrowedFieldsReturning AsFFI() const;
   inline static BorrowedFieldsReturning FromFFI(capi::BorrowedFieldsReturning c_struct);

--- a/feature_tests/cpp2/include/BorrowedFieldsReturning.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsReturning.hpp
@@ -23,7 +23,7 @@ inline capi::BorrowedFieldsReturning BorrowedFieldsReturning::AsFFI() const {
 
 inline BorrowedFieldsReturning BorrowedFieldsReturning::FromFFI(capi::BorrowedFieldsReturning c_struct) {
   return BorrowedFieldsReturning {
-    .bytes = diplomat::span<const uint8_t>(c_struct.bytes_data, c_struct.bytes_size),
+    .bytes = std::string_view(c_struct.bytes_data, c_struct.bytes_size),
   };
 }
 

--- a/feature_tests/dart/lib/BorrowedFieldsReturning.g.dart
+++ b/feature_tests/dart/lib/BorrowedFieldsReturning.g.dart
@@ -6,7 +6,7 @@
 part of 'lib.g.dart';
 
 final class _BorrowedFieldsReturningFfi extends ffi.Struct {
-  external _SliceFfiUint8 bytes;
+  external _SliceFfi2Utf8 bytes;
 }
 
 final class BorrowedFieldsReturning {
@@ -22,11 +22,11 @@ final class BorrowedFieldsReturning {
     return result;
   }
 
-  Uint8List get bytes => _underlying.bytes._asDart;
-  set bytes(Uint8List bytes) {
+  String get bytes => _underlying.bytes._asDart;
+  set bytes(String bytes) {
     final alloc = ffi2.calloc;
     alloc.free(_underlying.bytes._bytes);
-    final bytesSlice = _SliceFfiUint8._fromDart(bytes, alloc);
+    final bytesSlice = _SliceFfi2Utf8._fromDart(bytes, alloc);
     _underlying.bytes = bytesSlice;
   }
 

--- a/feature_tests/dart/lib/lib.g.dart
+++ b/feature_tests/dart/lib/lib.g.dart
@@ -254,47 +254,6 @@ final class _SliceFfiUint16 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 }
 
-final class _SliceFfiUint8 extends ffi.Struct {
-  external ffi.Pointer<ffi.Uint8> _bytes;
-
-  @ffi.Size()
-  external int _length;
-
-  /// Produces a slice from a Dart object. The Dart object's data is copied into the given allocator
-  /// as it cannot be borrowed directly, and gets freed with the slice object.
-  // ignore: unused_element
-  static _SliceFfiUint8 _fromDart(Uint8List value, ffi.Allocator allocator) {
-    final pointer = allocator<_SliceFfiUint8>();
-    final slice = pointer.ref;
-    slice._length = value.length;
-    slice._bytes = allocator(slice._length);
-    slice._bytes.asTypedList(slice._length).setAll(0, value);
-    return slice;
-  }
-
-  // ignore: unused_element
-  Uint8List get _asDart => _bytes.asTypedList(_length);
-
-  // This is expensive
-  @override
-  bool operator ==(Object other) {
-    if (other is! _SliceFfiUint8 || other._length != _length) {
-      return false;
-    }
-
-    for (var i = 0; i < _length; i++) {
-      if (other._bytes[i] != _bytes[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  // This is cheap
-  @override
-  int get hashCode => _length.hashCode;
-}
-
 /// An unspecified error value
 class VoidError {}
 

--- a/feature_tests/dotnet/Lib/Generated/RawBorrowedFieldsReturning.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawBorrowedFieldsReturning.cs
@@ -16,5 +16,5 @@ public partial struct BorrowedFieldsReturning
 {
     private const string NativeLib = "diplomat_feature_tests";
 
-    public byte[] bytes;
+    public string bytes;
 }

--- a/feature_tests/js/api/BorrowedFieldsReturning.d.ts
+++ b/feature_tests/js/api/BorrowedFieldsReturning.d.ts
@@ -2,5 +2,5 @@
 /**
  */
 export class BorrowedFieldsReturning {
-  bytes: Uint8Array;
+  bytes: string;
 }

--- a/feature_tests/js/api/BorrowedFieldsReturning.js
+++ b/feature_tests/js/api/BorrowedFieldsReturning.js
@@ -5,7 +5,7 @@ export class BorrowedFieldsReturning {
   constructor(underlying, edges_a) {
     this.bytes = (() => {
       const [ptr, size] = new Uint32Array(wasm.memory.buffer, underlying, 2);
-      return new Uint8Array(wasm.memory.buffer, ptr, size);
+      return diplomatRuntime.readString(wasm, ptr, size);
     })();
   }
 }

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -1,7 +1,7 @@
 #[diplomat::bridge]
 pub mod ffi {
     #[diplomat::opaque]
-    pub struct Foo<'a>(&'a str);
+    pub struct Foo<'a>(&'a DiplomatWtf8);
 
     #[diplomat::opaque]
     #[diplomat::transparent_convert]
@@ -9,14 +9,14 @@ pub mod ffi {
 
     pub struct BorrowedFields<'a> {
         a: &'a [u16],
-        b: &'a str,
+        b: &'a DiplomatWtf8,
     }
 
     pub struct BorrowedFieldsReturning<'a> {
-        bytes: &'a [u8],
+        bytes: &'a DiplomatWtf8,
     }
     impl<'a> Foo<'a> {
-        pub fn new(x: &'a str) -> Box<Self> {
+        pub fn new(x: &'a DiplomatWtf8) -> Box<Self> {
             Box::new(Foo(x))
         }
 
@@ -24,14 +24,12 @@ pub mod ffi {
             Box::new(Bar(self))
         }
 
-        pub fn new_static(x: &'static str) -> Box<Self> {
+        pub fn new_static(x: &'static DiplomatWtf8) -> Box<Self> {
             Box::new(Foo(x))
         }
 
         pub fn as_returning(&self) -> BorrowedFieldsReturning<'a> {
-            BorrowedFieldsReturning {
-                bytes: self.0.as_bytes(),
-            }
+            BorrowedFieldsReturning { bytes: self.0 }
         }
 
         pub fn extract_from_fields(fields: BorrowedFields<'a>) -> Box<Self> {

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -1,7 +1,7 @@
 #[diplomat::bridge]
 pub mod ffi {
     #[diplomat::opaque]
-    pub struct Foo<'a>(&'a DiplomatWtf8);
+    pub struct Foo<'a>(&'a DiplomatStr);
 
     #[diplomat::opaque]
     #[diplomat::transparent_convert]
@@ -9,14 +9,14 @@ pub mod ffi {
 
     pub struct BorrowedFields<'a> {
         a: &'a [u16],
-        b: &'a DiplomatWtf8,
+        b: &'a DiplomatStr,
     }
 
     pub struct BorrowedFieldsReturning<'a> {
-        bytes: &'a DiplomatWtf8,
+        bytes: &'a DiplomatStr,
     }
     impl<'a> Foo<'a> {
-        pub fn new(x: &'a DiplomatWtf8) -> Box<Self> {
+        pub fn new(x: &'a DiplomatStr) -> Box<Self> {
             Box::new(Foo(x))
         }
 
@@ -24,7 +24,7 @@ pub mod ffi {
             Box::new(Bar(self))
         }
 
-        pub fn new_static(x: &'static DiplomatWtf8) -> Box<Self> {
+        pub fn new_static(x: &'static DiplomatStr) -> Box<Self> {
             Box::new(Foo(x))
         }
 

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -7,12 +7,12 @@ mod ffi {
     struct MyString(String);
 
     impl MyString {
-        pub fn new(v: &str) -> Box<MyString> {
-            Box::new(Self(v.to_owned()))
+        pub fn new(v: &DiplomatWtf8) -> Box<MyString> {
+            Box::new(Self(String::from_utf8(v.to_owned()).unwrap()))
         }
 
-        pub fn set_str(&mut self, new_str: &str) {
-            self.0 = new_str.to_owned();
+        pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
+            self.0 = String::from_utf8(new_str.to_owned()).unwrap();
         }
 
         pub fn get_str(&self, writeable: &mut DiplomatWriteable) {

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -7,11 +7,11 @@ mod ffi {
     struct MyString(String);
 
     impl MyString {
-        pub fn new(v: &DiplomatWtf8) -> Box<MyString> {
+        pub fn new(v: &DiplomatStr) -> Box<MyString> {
             Box::new(Self(String::from_utf8(v.to_owned()).unwrap()))
         }
 
-        pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
+        pub fn set_str(&mut self, new_str: &DiplomatStr) {
             self.0 = String::from_utf8(new_str.to_owned()).unwrap();
         }
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -97,12 +97,7 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
                     },
                 }
             } else {
-                // TODO(#57): don't just unwrap? or should we assume that the other side gives us a good value?
-                quote! {
-                    core::str::from_utf8(unsafe {
-                        core::slice::from_raw_parts(#data_ident, #len_ident)
-                    }).unwrap()
-                }
+                quote! {unsafe { core::slice::from_raw_parts(#data_ident, #len_ident) } }
             };
             expanded_params.push(parse2(tokens).unwrap());
         }
@@ -465,7 +460,7 @@ mod tests {
                     struct Foo {}
 
                     impl Foo {
-                        pub fn from_str(s: &str) {
+                        pub fn from_str(s: &DiplomatWtf8) {
                             unimplemented!()
                         }
                     }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -460,7 +460,7 @@ mod tests {
                     struct Foo {}
 
                     impl Foo {
-                        pub fn from_str(s: &DiplomatWtf8) {
+                        pub fn from_str(s: &DiplomatStr) {
                             unimplemented!()
                         }
                     }

--- a/macro/src/snapshots/diplomat__tests__method_taking_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_str.snap
@@ -1,12 +1,12 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn from_str(s : & DiplomatWtf8) { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn from_str(s : & DiplomatStr) { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
     struct Foo {}
     impl Foo {
-        pub fn from_str(s: &DiplomatWtf8) {
+        pub fn from_str(s: &DiplomatStr) {
             unimplemented!()
         }
     }

--- a/macro/src/snapshots/diplomat__tests__method_taking_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_str.snap
@@ -1,24 +1,19 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn from_str(s : & str) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn from_str(s : & DiplomatWtf8) { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
     struct Foo {}
     impl Foo {
-        pub fn from_str(s: &str) {
+        pub fn from_str(s: &DiplomatWtf8) {
             unimplemented!()
         }
     }
     use diplomat_runtime::*;
     #[no_mangle]
     extern "C" fn Foo_from_str(s_diplomat_data: *const u8, s_diplomat_len: usize) {
-        Foo::from_str(
-            core::str::from_utf8(unsafe {
-                core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len)
-            })
-            .unwrap(),
-        )
+        Foo::from_str(unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) })
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
+++ b/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
@@ -26,13 +26,8 @@ mod ffi {
     #[no_mangle]
     extern "C" fn Baz_destroy<'x: 'y, 'y>(this: Box<Baz<'x, 'y>>) {}
     #[no_mangle]
-    extern "C" fn Foo_new<'a>(x_diplomat_data: *const u8, x_diplomat_len: usize) -> Box<Foo<'a>> {
-        Foo::new(
-            core::str::from_utf8(unsafe {
-                core::slice::from_raw_parts(x_diplomat_data, x_diplomat_len)
-            })
-            .unwrap(),
-        )
+    extern "C" fn Foo_new<'a>(x: &'a str) -> Box<Foo<'a>> {
+        Foo::new(x)
     }
     #[no_mangle]
     extern "C" fn Foo_get_bar<'a: 'b, 'b>(this: &'b Foo<'a>) -> Box<Bar<'b, 'a>> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,6 +16,8 @@ pub use result::DiplomatResult;
 
 pub type DiplomatChar = u32;
 
+pub type DiplomatWtf8 = [u8];
+
 /// Allocates a buffer of a given size in Rust's memory.
 ///
 /// # Safety

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,7 +16,7 @@ pub use result::DiplomatResult;
 
 pub type DiplomatChar = u32;
 
-pub type DiplomatWtf8 = [u8];
+pub type DiplomatStr = [u8];
 
 /// Allocates a buffer of a given size in Rust's memory.
 ///

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -170,11 +170,11 @@ mod tests {
                 struct MyStruct(UnknownType);
 
                 impl MyStruct {
-                    pub fn new_str(v: &str) -> Box<MyStruct> {
+                    pub fn new_str(v: &DiplomatWtf8) -> Box<MyStruct> {
                         unimplemented!()
                     }
 
-                    pub fn set_str(&mut self, new_str: &str) {
+                    pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
                         unimplemented!()
                     }
                 }

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -170,11 +170,11 @@ mod tests {
                 struct MyStruct(UnknownType);
 
                 impl MyStruct {
-                    pub fn new_str(v: &DiplomatWtf8) -> Box<MyStruct> {
+                    pub fn new_str(v: &DiplomatStr) -> Box<MyStruct> {
                         unimplemented!()
                     }
 
-                    pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
+                    pub fn set_str(&mut self, new_str: &DiplomatStr) {
                         unimplemented!()
                     }
                 }

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -490,11 +490,11 @@ mod tests {
                 struct MyStruct(UnknownType);
 
                 impl MyStruct {
-                    pub fn new_str(v: &DiplomatWtf8) -> Box<MyStruct> {
+                    pub fn new_str(v: &DiplomatStr) -> Box<MyStruct> {
                         unimplemented!()
                     }
 
-                    pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
+                    pub fn set_str(&mut self, new_str: &DiplomatStr) {
                         unimplemented!()
                     }
                 }

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -490,11 +490,11 @@ mod tests {
                 struct MyStruct(UnknownType);
 
                 impl MyStruct {
-                    pub fn new_str(v: &str) -> Box<MyStruct> {
+                    pub fn new_str(v: &DiplomatWtf8) -> Box<MyStruct> {
                         unimplemented!()
                     }
 
-                    pub fn set_str(&mut self, new_str: &str) {
+                    pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
                         unimplemented!()
                     }
                 }

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -277,7 +277,7 @@ mod tests {
                 struct MyStruct;
 
                 impl MyStruct {
-                    pub fn new(v: &DiplomatWtf8) -> MyStruct {
+                    pub fn new(v: &DiplomatStr) -> MyStruct {
                         unimplemented!()
                     }
                 }

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -277,7 +277,7 @@ mod tests {
                 struct MyStruct;
 
                 impl MyStruct {
-                    pub fn new(v: &str) -> MyStruct {
+                    pub fn new(v: &DiplomatWtf8) -> MyStruct {
                         unimplemented!()
                     }
                 }

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -879,15 +879,15 @@ mod tests {
             #[diplomat::bridge]
             mod ffi {
                 pub struct MyStruct<'a> {
-                    s: &'a str,
+                    s: &'a DiplomatWtf8,
                 }
 
                 impl<'a> MyStruct<'a> {
-                    pub fn new(s: &'a str) -> Self {
+                    pub fn new(s: &'a DiplomatWtf8) -> Self {
                         Self { s }
                     }
 
-                    pub fn get(self) -> &'a str {
+                    pub fn get(self) -> &'a DiplomatWtf8 {
                         self.s
                     }
                 }

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -879,15 +879,15 @@ mod tests {
             #[diplomat::bridge]
             mod ffi {
                 pub struct MyStruct<'a> {
-                    s: &'a DiplomatWtf8,
+                    s: &'a DiplomatStr,
                 }
 
                 impl<'a> MyStruct<'a> {
-                    pub fn new(s: &'a DiplomatWtf8) -> Self {
+                    pub fn new(s: &'a DiplomatStr) -> Self {
                         Self { s }
                     }
 
-                    pub fn get(self) -> &'a DiplomatWtf8 {
+                    pub fn get(self) -> &'a DiplomatStr {
                         self.s
                     }
                 }

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -730,11 +730,11 @@ mod tests {
                 struct MyStruct(UnknownType);
 
                 impl MyStruct {
-                    pub fn new_str(v: &str) -> Box<MyStruct> {
+                    pub fn new_str(v: &DiplomatWtf8) -> Box<MyStruct> {
                         unimplemented!()
                     }
 
-                    pub fn set_str(&mut self, new_str: &str) {
+                    pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
                         unimplemented!()
                     }
                 }

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -730,11 +730,11 @@ mod tests {
                 struct MyStruct(UnknownType);
 
                 impl MyStruct {
-                    pub fn new_str(v: &DiplomatWtf8) -> Box<MyStruct> {
+                    pub fn new_str(v: &DiplomatStr) -> Box<MyStruct> {
                         unimplemented!()
                     }
 
-                    pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
+                    pub fn set_str(&mut self, new_str: &DiplomatStr) {
                         unimplemented!()
                     }
                 }

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -156,7 +156,7 @@ mod tests {
                 }
 
                 impl MyStruct {
-                    pub fn new(v: &DiplomatWtf8) -> MyStruct {
+                    pub fn new(v: &DiplomatStr) -> MyStruct {
                         unimplemented!()
                     }
                 }

--- a/tool/src/js/types.rs
+++ b/tool/src/js/types.rs
@@ -156,7 +156,7 @@ mod tests {
                 }
 
                 impl MyStruct {
-                    pub fn new(v: &str) -> MyStruct {
+                    pub fn new(v: &DiplomatWtf8) -> MyStruct {
                         unimplemented!()
                     }
                 }

--- a/tool/tests/dotnet_target.rs
+++ b/tool/tests/dotnet_target.rs
@@ -125,7 +125,7 @@ fn setters_getters_properties() {
                     unimplemented!()
                 }
 
-                pub fn set_name(&mut self, new_name: &DiplomatWtf8) -> Result<(), ()> {
+                pub fn set_name(&mut self, new_name: &DiplomatStr) -> Result<(), ()> {
                     unimplemented!()
                 }
             }
@@ -271,11 +271,11 @@ fn method_taking_str() {
             struct MyStruct(UnknownType);
 
             impl MyStruct {
-                pub fn new_str(v: &DiplomatWtf8) -> Box<MyStruct> {
+                pub fn new_str(v: &DiplomatStr) -> Box<MyStruct> {
                     unimplemented!()
                 }
 
-                pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
+                pub fn set_str(&mut self, new_str: &DiplomatStr) {
                     unimplemented!()
                 }
             }
@@ -489,7 +489,7 @@ fn string_reference() {
             struct MyStruct;
 
             impl MyStruct {
-                pub fn new(v: &DiplomatWtf8) -> MyStruct {
+                pub fn new(v: &DiplomatStr) -> MyStruct {
                     unimplemented!()
                 }
             }
@@ -575,22 +575,22 @@ fn almost_properties() {
 
             impl MyStruct {
                 /// This should not generate a property
-                pub fn get_foo_by_key(&self, key: &DiplomatWtf8) -> Result<u64, ()> {
+                pub fn get_foo_by_key(&self, key: &DiplomatStr) -> Result<u64, ()> {
                     unimplemented!()
                 }
 
                 /// This should not generate a property
-                pub fn set_foo_by_key(&self, key: &DiplomatWtf8, foo: i64) -> Result<(), ()> {
+                pub fn set_foo_by_key(&self, key: &DiplomatStr, foo: i64) -> Result<(), ()> {
                     unimplemented!()
                 }
 
                 /// This should not generate a property
-                pub fn get_str_by_key(&self, key: &DiplomatWtf8, writer: &mut DiplomatWriteable) {
+                pub fn get_str_by_key(&self, key: &DiplomatStr, writer: &mut DiplomatWriteable) {
                     unimplemented!()
                 }
 
                 /// This should not generate a property
-                pub fn set_str_by_key(&self, key: &DiplomatWtf8, s: &DiplomatWtf8) {
+                pub fn set_str_by_key(&self, key: &DiplomatStr, s: &DiplomatStr) {
                     unimplemented!()
                 }
             }

--- a/tool/tests/dotnet_target.rs
+++ b/tool/tests/dotnet_target.rs
@@ -125,7 +125,7 @@ fn setters_getters_properties() {
                     unimplemented!()
                 }
 
-                pub fn set_name(&mut self, new_name: &str) -> Result<(), ()> {
+                pub fn set_name(&mut self, new_name: &DiplomatWtf8) -> Result<(), ()> {
                     unimplemented!()
                 }
             }
@@ -271,11 +271,11 @@ fn method_taking_str() {
             struct MyStruct(UnknownType);
 
             impl MyStruct {
-                pub fn new_str(v: &str) -> Box<MyStruct> {
+                pub fn new_str(v: &DiplomatWtf8) -> Box<MyStruct> {
                     unimplemented!()
                 }
 
-                pub fn set_str(&mut self, new_str: &str) {
+                pub fn set_str(&mut self, new_str: &DiplomatWtf8) {
                     unimplemented!()
                 }
             }
@@ -489,7 +489,7 @@ fn string_reference() {
             struct MyStruct;
 
             impl MyStruct {
-                pub fn new(v: &str) -> MyStruct {
+                pub fn new(v: &DiplomatWtf8) -> MyStruct {
                     unimplemented!()
                 }
             }
@@ -575,22 +575,22 @@ fn almost_properties() {
 
             impl MyStruct {
                 /// This should not generate a property
-                pub fn get_foo_by_key(&self, key: &str) -> Result<u64, ()> {
+                pub fn get_foo_by_key(&self, key: &DiplomatWtf8) -> Result<u64, ()> {
                     unimplemented!()
                 }
 
                 /// This should not generate a property
-                pub fn set_foo_by_key(&self, key: &str, foo: i64) -> Result<(), ()> {
+                pub fn set_foo_by_key(&self, key: &DiplomatWtf8, foo: i64) -> Result<(), ()> {
                     unimplemented!()
                 }
 
                 /// This should not generate a property
-                pub fn get_str_by_key(&self, key: &str, writer: &mut DiplomatWriteable) {
+                pub fn get_str_by_key(&self, key: &DiplomatWtf8, writer: &mut DiplomatWriteable) {
                     unimplemented!()
                 }
 
                 /// This should not generate a property
-                pub fn set_str_by_key(&self, key: &str, s: &str) {
+                pub fn set_str_by_key(&self, key: &DiplomatWtf8, s: &DiplomatWtf8) {
                     unimplemented!()
                 }
             }


### PR DESCRIPTION
#57 

The existing usage of `str` in Diplomat is that it basically represents WTF8 on the ABI. This PR pushes the validation from the diplomat glue into the Rust library, which might be able to handle invalid UTF-8, so validation might not be necessary.

My plan is to add `DiplomatStr16` next. If we want to we can add `str` back, but this time the glue code would do an unsafe unwrap, and these APIs should only be enabled if the caller can do validation, and should be documented to be UB if used incorrectly.