### PR TITLE
Adding `str` support back

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -396,6 +396,7 @@ pub enum TypeName {
 pub enum StringEncoding {
     UnvalidatedUtf8,
     UnvalidatedUtf16,
+    Utf8,
 }
 
 impl TypeName {
@@ -514,6 +515,11 @@ impl TypeName {
                 ))
                 .unwrap()
             }
+            TypeName::StrReference(lifetime, StringEncoding::Utf8) => syn::parse_str(&format!(
+                "{}str",
+                ReferenceDisplay(lifetime, &Mutability::Immutable)
+            ))
+            .unwrap(),
             TypeName::PrimitiveSlice(lifetime, mutability, name) => {
                 let primitive_name = PRIMITIVE_TO_STRING.get(name).unwrap();
                 let formatted_str = format!(
@@ -549,14 +555,16 @@ impl TypeName {
                 let mutability = Mutability::from_syn(&r.mutability);
 
                 let name = r.elem.to_token_stream().to_string();
-                if name.starts_with("DiplomatStr") {
+                if name.starts_with("DiplomatStr") || name == "str" {
                     if mutability.is_mutable() {
-                        panic!("mutable `DiplomatStr*` references are disallowed");
+                        panic!("mutable string references are disallowed");
                     }
                     if name == "DiplomatStr" {
                         return TypeName::StrReference(lifetime, StringEncoding::UnvalidatedUtf8);
                     } else if name == "DiplomatStr16" {
                         return TypeName::StrReference(lifetime, StringEncoding::UnvalidatedUtf16);
+                    } else if name == "str" {
+                        return TypeName::StrReference(lifetime, StringEncoding::Utf8);
                     }
                 }
                 if let syn::Type::Slice(slice) = &*r.elem {
@@ -948,6 +956,13 @@ impl fmt::Display for TypeName {
                 write!(
                     f,
                     "{}DiplomatStr16",
+                    ReferenceDisplay(lifetime, &Mutability::Immutable)
+                )
+            }
+            TypeName::StrReference(lifetime, StringEncoding::Utf8) => {
+                write!(
+                    f,
+                    "{}str",
                     ReferenceDisplay(lifetime, &Mutability::Immutable)
                 )
             }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -396,6 +396,7 @@ pub enum TypeName {
 pub enum StringEncoding {
     UnvalidatedUtf8,
     UnvalidatedUtf16,
+    /// The caller guarantees that they're passing valid UTF-8, under penalty of UB
     Utf8,
 }
 

--- a/feature_tests/c/include/BorrowedFields.h
+++ b/feature_tests/c/include/BorrowedFields.h
@@ -13,6 +13,7 @@ namespace capi {
 typedef struct BorrowedFields {
     DiplomatU16View a;
     DiplomatStringView b;
+    DiplomatStringView c;
 } BorrowedFields;
 #ifdef __cplusplus
 } // namespace capi

--- a/feature_tests/c/include/MyString.h
+++ b/feature_tests/c/include/MyString.h
@@ -21,6 +21,8 @@ extern "C" {
 
 MyString* MyString_new(const char* v_data, size_t v_len);
 
+MyString* MyString_new_unsafe(const char* v_data, size_t v_len);
+
 void MyString_set_str(MyString* self, const char* new_str_data, size_t new_str_len);
 
 void MyString_get_str(const MyString* self, DiplomatWriteable* writeable);

--- a/feature_tests/c2/include/BorrowedFields.d.h
+++ b/feature_tests/c2/include/BorrowedFields.d.h
@@ -16,6 +16,7 @@ extern "C" {
 typedef struct BorrowedFields {
   struct { const wchar_t* data; size_t len; } a;
   struct { const char* data; size_t len; } b;
+  struct { const char* data; size_t len; } c;
 } BorrowedFields;
 
 

--- a/feature_tests/c2/include/MyString.h
+++ b/feature_tests/c2/include/MyString.h
@@ -17,6 +17,8 @@ extern "C" {
 
 MyString* MyString_new(const char* v_data, size_t v_len);
 
+MyString* MyString_new_unsafe(const char* v_data, size_t v_len);
+
 void MyString_set_str(MyString* self, const char* new_str_data, size_t new_str_len);
 
 void MyString_get_str(const MyString* self, DiplomatWriteable* writeable);

--- a/feature_tests/cpp/docs/source/lifetimes_ffi.rst
+++ b/feature_tests/cpp/docs/source/lifetimes_ffi.rst
@@ -9,6 +9,9 @@
 
     .. cpp:member:: std::string_view b
 
+    .. cpp:member:: std::string_view c
+        Warning: Setting ill-formed UTF-8 is undefined behavior (and may be memory-unsafe).
+
 .. cpp:struct:: BorrowedFieldsReturning
 
     .. cpp:member:: std::string_view bytes

--- a/feature_tests/cpp/docs/source/slices_ffi.rst
+++ b/feature_tests/cpp/docs/source/slices_ffi.rst
@@ -17,6 +17,11 @@
     .. cpp:function:: static MyString new_(const std::string_view v)
 
 
+    .. cpp:function:: static MyString new_unsafe(const std::string_view v)
+
+        Warning: Passing ill-formed UTF-8 is undefined behavior (and may be memory-unsafe).
+
+
     .. cpp:function:: void set_str(const std::string_view new_str)
 
 

--- a/feature_tests/cpp/include/BorrowedFields.h
+++ b/feature_tests/cpp/include/BorrowedFields.h
@@ -13,6 +13,7 @@ namespace capi {
 typedef struct BorrowedFields {
     DiplomatU16View a;
     DiplomatStringView b;
+    DiplomatStringView c;
 } BorrowedFields;
 #ifdef __cplusplus
 } // namespace capi

--- a/feature_tests/cpp/include/BorrowedFields.hpp
+++ b/feature_tests/cpp/include/BorrowedFields.hpp
@@ -16,6 +16,7 @@ struct BorrowedFields {
  public:
   const diplomat::span<const uint16_t> a;
   std::string_view b;
+  std::string_view c;
 };
 
 

--- a/feature_tests/cpp/include/Foo.hpp
+++ b/feature_tests/cpp/include/Foo.hpp
@@ -82,6 +82,6 @@ inline BorrowedFieldsReturning Foo::as_returning() const {
 }
 inline Foo Foo::extract_from_fields(BorrowedFields fields) {
   BorrowedFields diplomat_wrapped_struct_fields = fields;
-  return Foo(capi::Foo_extract_from_fields(capi::BorrowedFields{ .a = { diplomat_wrapped_struct_fields.a.data(), diplomat_wrapped_struct_fields.a.size() }, .b = { diplomat_wrapped_struct_fields.b.data(), diplomat_wrapped_struct_fields.b.size() } }));
+  return Foo(capi::Foo_extract_from_fields(capi::BorrowedFields{ .a = { diplomat_wrapped_struct_fields.a.data(), diplomat_wrapped_struct_fields.a.size() }, .b = { diplomat_wrapped_struct_fields.b.data(), diplomat_wrapped_struct_fields.b.size() }, .c = { diplomat_wrapped_struct_fields.c.data(), diplomat_wrapped_struct_fields.c.size() } }));
 }
 #endif

--- a/feature_tests/cpp/include/MyString.h
+++ b/feature_tests/cpp/include/MyString.h
@@ -21,6 +21,8 @@ extern "C" {
 
 MyString* MyString_new(const char* v_data, size_t v_len);
 
+MyString* MyString_new_unsafe(const char* v_data, size_t v_len);
+
 void MyString_set_str(MyString* self, const char* new_str_data, size_t new_str_len);
 
 void MyString_get_str(const MyString* self, DiplomatWriteable* writeable);

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -24,6 +24,7 @@ struct MyStringDeleter {
 class MyString {
  public:
   static MyString new_(const std::string_view v);
+  static MyString new_unsafe(const std::string_view v);
   void set_str(const std::string_view new_str);
   template<typename W> void get_str_to_writeable(W& writeable) const;
   std::string get_str() const;
@@ -40,6 +41,9 @@ class MyString {
 
 inline MyString MyString::new_(const std::string_view v) {
   return MyString(capi::MyString_new(v.data(), v.size()));
+}
+inline MyString MyString::new_unsafe(const std::string_view v) {
+  return MyString(capi::MyString_new_unsafe(v.data(), v.size()));
 }
 inline void MyString::set_str(const std::string_view new_str) {
   capi::MyString_set_str(this->inner.get(), new_str.data(), new_str.size());

--- a/feature_tests/cpp2/include/BorrowedFields.d.h
+++ b/feature_tests/cpp2/include/BorrowedFields.d.h
@@ -16,6 +16,7 @@ extern "C" {
 typedef struct BorrowedFields {
   struct { const wchar_t* data; size_t len; } a;
   struct { const char* data; size_t len; } b;
+  struct { const char* data; size_t len; } c;
 } BorrowedFields;
 
 

--- a/feature_tests/cpp2/include/BorrowedFields.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFields.d.hpp
@@ -14,6 +14,7 @@
 struct BorrowedFields {
   std::wstring_view a;
   std::string_view b;
+  std::string_view c;
 
   inline capi::BorrowedFields AsFFI() const;
   inline static BorrowedFields FromFFI(capi::BorrowedFields c_struct);

--- a/feature_tests/cpp2/include/BorrowedFields.hpp
+++ b/feature_tests/cpp2/include/BorrowedFields.hpp
@@ -20,6 +20,8 @@ inline capi::BorrowedFields BorrowedFields::AsFFI() const {
     .a_size = a.size(),
     .b_data = b.data(),
     .b_size = b.size(),
+    .c_data = c.data(),
+    .c_size = c.size(),
   };
 }
 
@@ -27,6 +29,7 @@ inline BorrowedFields BorrowedFields::FromFFI(capi::BorrowedFields c_struct) {
   return BorrowedFields {
     .a = std::wstring_view(c_struct.a_data, c_struct.a_size),
     .b = std::string_view(c_struct.b_data, c_struct.b_size),
+    .c = std::string_view(c_struct.c_data, c_struct.c_size),
   };
 }
 

--- a/feature_tests/cpp2/include/MyString.d.hpp
+++ b/feature_tests/cpp2/include/MyString.d.hpp
@@ -16,6 +16,8 @@ public:
 
   inline static std::unique_ptr<MyString> new_(std::string_view v);
 
+  inline static std::unique_ptr<MyString> new_unsafe(std::string_view v);
+
   inline void set_str(std::string_view new_str);
 
   inline std::string get_str() const;

--- a/feature_tests/cpp2/include/MyString.h
+++ b/feature_tests/cpp2/include/MyString.h
@@ -17,6 +17,8 @@ extern "C" {
 
 MyString* MyString_new(const char* v_data, size_t v_len);
 
+MyString* MyString_new_unsafe(const char* v_data, size_t v_len);
+
 void MyString_set_str(MyString* self, const char* new_str_data, size_t new_str_len);
 
 void MyString_get_str(const MyString* self, DiplomatWriteable* writeable);

--- a/feature_tests/cpp2/include/MyString.hpp
+++ b/feature_tests/cpp2/include/MyString.hpp
@@ -19,6 +19,12 @@ inline std::unique_ptr<MyString> MyString::new_(std::string_view v) {
   return std::unique_ptr<MyString>(MyString::FromFFI(result));
 }
 
+inline std::unique_ptr<MyString> MyString::new_unsafe(std::string_view v) {
+  auto result = capi::MyString_new_unsafe(v.data(),
+    v.size());
+  return std::unique_ptr<MyString>(MyString::FromFFI(result));
+}
+
 inline void MyString::set_str(std::string_view new_str) {
   capi::MyString_set_str(this->AsFFI(),
     new_str.data(),

--- a/feature_tests/dart/lib/BorrowedFields.g.dart
+++ b/feature_tests/dart/lib/BorrowedFields.g.dart
@@ -8,6 +8,7 @@ part of 'lib.g.dart';
 final class _BorrowedFieldsFfi extends ffi.Struct {
   external _SliceFfiUtf16 a;
   external _SliceFfi2Utf8 b;
+  external _SliceFfi2Utf8 c;
 }
 
 final class BorrowedFields {
@@ -39,15 +40,25 @@ final class BorrowedFields {
     _underlying.b = bSlice;
   }
 
+  String get c => _underlying.c._asDart;
+  set c(String c) {
+    final alloc = ffi2.calloc;
+    alloc.free(_underlying.c._bytes);
+    final cSlice = _SliceFfi2Utf8._fromDart(c, alloc);
+    _underlying.c = cSlice;
+  }
+
   @override
   bool operator ==(Object other) =>
       other is BorrowedFields &&
       other._underlying.a == _underlying.a &&
-      other._underlying.b == _underlying.b;
+      other._underlying.b == _underlying.b &&
+      other._underlying.c == _underlying.c;
 
   @override
   int get hashCode => Object.hashAll([
         _underlying.a,
         _underlying.b,
+        _underlying.c,
       ]);
 }

--- a/feature_tests/dart/lib/MyString.g.dart
+++ b/feature_tests/dart/lib/MyString.g.dart
@@ -27,6 +27,19 @@ final class MyString implements ffi.Finalizable {
     _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>('MyString_new')
       .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
 
+  factory MyString.unsafe(String v) {
+    final temp = ffi2.Arena();
+    final vView = v.utf8View;;
+    final result = _MyString_new_unsafe(vView.pointer(temp), vView.length);
+    temp.releaseAll();
+    return MyString._(result);
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _MyString_new_unsafe =
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>('MyString_new_unsafe')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
+
   void setStr(String newStr) {
     final temp = ffi2.Arena();
     final newStrView = newStr.utf8View;;

--- a/feature_tests/dotnet/Lib/Generated/MyString.cs
+++ b/feature_tests/dotnet/Lib/Generated/MyString.cs
@@ -46,6 +46,23 @@ public partial class MyString: IDisposable
         }
     }
 
+    /// <returns>
+    /// A <c>MyString</c> allocated on Rust side.
+    /// </returns>
+    public static MyString NewUnsafe(string v)
+    {
+        unsafe
+        {
+            byte[] vBuf = DiplomatUtils.StringToUtf8(v);
+            nuint vBufLength = (nuint)vBuf.Length;
+            fixed (byte* vBufPtr = vBuf)
+            {
+                Raw.MyString* retVal = Raw.MyString.NewUnsafe(vBufPtr, vBufLength);
+                return new MyString(retVal);
+            }
+        }
+    }
+
     public void SetStr(string newStr)
     {
         unsafe

--- a/feature_tests/dotnet/Lib/Generated/RawBorrowedFields.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawBorrowedFields.cs
@@ -19,4 +19,6 @@ public partial struct BorrowedFields
     public ushort[] a;
 
     public string b;
+
+    public string c;
 }

--- a/feature_tests/dotnet/Lib/Generated/RawMyString.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawMyString.cs
@@ -19,6 +19,9 @@ public partial struct MyString
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "MyString_new", ExactSpelling = true)]
     public static unsafe extern MyString* New(byte* v, nuint vSz);
 
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "MyString_new_unsafe", ExactSpelling = true)]
+    public static unsafe extern MyString* NewUnsafe(ushort* v, nuint vSz);
+
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "MyString_set_str", ExactSpelling = true)]
     public static unsafe extern void SetStr(MyString* self, byte* newStr, nuint newStrSz);
 

--- a/feature_tests/js/api/BorrowedFields.d.ts
+++ b/feature_tests/js/api/BorrowedFields.d.ts
@@ -4,4 +4,5 @@
 export class BorrowedFields {
   a: string;
   b: string;
+  c: string;
 }

--- a/feature_tests/js/api/BorrowedFields.js
+++ b/feature_tests/js/api/BorrowedFields.js
@@ -11,5 +11,9 @@ export class BorrowedFields {
       const [ptr, size] = new Uint32Array(wasm.memory.buffer, underlying + 8, 2);
       return diplomatRuntime.readString8(wasm, ptr, size);
     })();
+    this.c = (() => {
+      const [ptr, size] = new Uint32Array(wasm.memory.buffer, underlying + 16, 2);
+      return diplomatRuntime.readString8(wasm, ptr, size);
+    })();
   }
 }

--- a/feature_tests/js/api/Foo.js
+++ b/feature_tests/js/api/Foo.js
@@ -48,6 +48,8 @@ export class Foo {
     const buf_field_a_arg_fields = diplomatRuntime.DiplomatBuf.str16(wasm, field_a_arg_fields, 2);
     const field_b_arg_fields = arg_fields["b"];
     const buf_field_b_arg_fields = diplomatRuntime.DiplomatBuf.str8(wasm, field_b_arg_fields);
-    return new Foo(wasm.Foo_extract_from_fields(buf_field_a_arg_fields.ptr, buf_field_a_arg_fields.size, buf_field_b_arg_fields.ptr, buf_field_b_arg_fields.size), true, [buf_field_a_arg_fields, buf_field_b_arg_fields]);
+    const field_c_arg_fields = arg_fields["c"];
+    const buf_field_c_arg_fields = diplomatRuntime.DiplomatBuf.str8(wasm, field_c_arg_fields);
+    return new Foo(wasm.Foo_extract_from_fields(buf_field_a_arg_fields.ptr, buf_field_a_arg_fields.size, buf_field_b_arg_fields.ptr, buf_field_b_arg_fields.size, buf_field_c_arg_fields.ptr, buf_field_c_arg_fields.size), true, [buf_field_a_arg_fields, buf_field_b_arg_fields, buf_field_c_arg_fields]);
   }
 }

--- a/feature_tests/js/api/MyString.d.ts
+++ b/feature_tests/js/api/MyString.d.ts
@@ -9,6 +9,10 @@ export class MyString {
 
   /**
    */
+  static new_unsafe(v: string): MyString;
+
+  /**
+   */
   set_str(new_str: string): void;
 
   /**

--- a/feature_tests/js/api/MyString.js
+++ b/feature_tests/js/api/MyString.js
@@ -22,6 +22,13 @@ export class MyString {
     return diplomat_out;
   }
 
+  static new_unsafe(arg_v) {
+    const buf_arg_v = diplomatRuntime.DiplomatBuf.str8(wasm, arg_v);
+    const diplomat_out = new MyString(wasm.MyString_new_unsafe(buf_arg_v.ptr, buf_arg_v.size), true, []);
+    buf_arg_v.free();
+    return diplomat_out;
+  }
+
   set_str(arg_new_str) {
     const buf_arg_new_str = diplomatRuntime.DiplomatBuf.str8(wasm, arg_new_str);
     wasm.MyString_set_str(this.underlying, buf_arg_new_str.ptr, buf_arg_new_str.size);

--- a/feature_tests/js/docs/source/lifetimes_ffi.rst
+++ b/feature_tests/js/docs/source/lifetimes_ffi.rst
@@ -9,6 +9,8 @@
 
     .. js:attribute:: b
 
+    .. js:attribute:: c
+
 .. js:class:: BorrowedFieldsReturning
 
     .. js:attribute:: bytes

--- a/feature_tests/js/docs/source/slices_ffi.rst
+++ b/feature_tests/js/docs/source/slices_ffi.rst
@@ -13,6 +13,8 @@
 
     .. js:function:: new(v)
 
+    .. js:function:: new_unsafe(v)
+
     .. js:method:: set_str(new_str)
 
     .. js:method:: get_str()

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -10,6 +10,7 @@ pub mod ffi {
     pub struct BorrowedFields<'a> {
         a: &'a DiplomatStr16,
         b: &'a DiplomatStr,
+        c: &'a str,
     }
 
     pub struct BorrowedFieldsReturning<'a> {

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -11,6 +11,10 @@ mod ffi {
             Box::new(Self(String::from_utf8(v.to_owned()).unwrap()))
         }
 
+        pub fn new_unsafe(v: &str) -> Box<MyString> {
+            Box::new(Self(v.to_string()))
+        }
+
         pub fn set_str(&mut self, new_str: &DiplomatStr) {
             self.0 = String::from_utf8(new_str.to_owned()).unwrap();
         }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -17,13 +17,17 @@ fn gen_params_at_boundary(param: &ast::Param, expanded_params: &mut Vec<FnArg>) 
     match &param.ty {
         ast::TypeName::StrReference(
             ..,
-            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::UnvalidatedUtf16,
+            ast::StringEncoding::UnvalidatedUtf8
+            | ast::StringEncoding::UnvalidatedUtf16
+            | ast::StringEncoding::Utf8,
         )
         | ast::TypeName::PrimitiveSlice(..) => {
             let data_type = if let ast::TypeName::PrimitiveSlice(.., prim) = &param.ty {
                 ast::TypeName::Primitive(*prim).to_syn().to_token_stream()
-            } else if let ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) =
-                &param.ty
+            } else if let ast::TypeName::StrReference(
+                _,
+                ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+            ) = &param.ty
             {
                 quote! { u8 }
             } else if let ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) =
@@ -108,6 +112,9 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
                         unsafe { core::slice::from_raw_parts(#data_ident, #len_ident) }
                     },
                 }
+            } else if let ast::TypeName(_, ast::StringEncoding::Utf8) = &param.ty {
+                // The FFI guarantees this, by either validating, or communicating this requirement to the user.
+                quote! {unsafe { core::str::from_utf8_unchecked(core::slice::from_raw_parts(#data_ident, #len_ident))} }
             } else {
                 quote! {unsafe { core::slice::from_raw_parts(#data_ident, #len_ident) } }
             };

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -112,7 +112,7 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
                         unsafe { core::slice::from_raw_parts(#data_ident, #len_ident) }
                     },
                 }
-            } else if let ast::TypeName(_, ast::StringEncoding::Utf8) = &param.ty {
+            } else if let ast::TypeName::StrReference(_, ast::StringEncoding::Utf8) = &param.ty {
                 // The FFI guarantees this, by either validating, or communicating this requirement to the user.
                 quote! {unsafe { core::str::from_utf8_unchecked(core::slice::from_raw_parts(#data_ident, #len_ident))} }
             } else {

--- a/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
+++ b/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
@@ -26,8 +26,13 @@ mod ffi {
     #[no_mangle]
     extern "C" fn Baz_destroy<'x: 'y, 'y>(this: Box<Baz<'x, 'y>>) {}
     #[no_mangle]
-    extern "C" fn Foo_new<'a>(x: &'a str) -> Box<Foo<'a>> {
-        Foo::new(x)
+    extern "C" fn Foo_new<'a>(x_diplomat_data: *const u8, x_diplomat_len: usize) -> Box<Foo<'a>> {
+        Foo::new(unsafe {
+            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+                x_diplomat_data,
+                x_diplomat_len,
+            ))
+        })
     }
     #[no_mangle]
     extern "C" fn Foo_get_bar<'a: 'b, 'b>(this: &'b Foo<'a>) -> Box<Bar<'b, 'a>> {

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -82,7 +82,11 @@ pub fn gen_method<W: fmt::Write>(
             write!(out, ", ")?;
         }
 
-        if let ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) = &param.ty {
+        if let ast::TypeName::StrReference(
+            _,
+            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+        ) = &param.ty
+        {
             write!(out, "const char* {0}_data, size_t {0}_len", param.name)?;
         } else if let ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) =
             &param.ty

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -53,9 +53,10 @@ pub fn gen_type<W: fmt::Write>(
         }
 
         ast::TypeName::Writeable => write!(out, "DiplomatWriteable")?,
-        ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) => {
-            write!(out, "DiplomatStringView")?
-        }
+        ast::TypeName::StrReference(
+            _,
+            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+        ) => write!(out, "DiplomatStringView")?,
         ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) => {
             write!(out, "DiplomatU16View")?
         }
@@ -102,9 +103,10 @@ pub fn name_for_type(typ: &ast::TypeName) -> ast::Ident {
             name_for_type(err)
         )),
         ast::TypeName::Writeable => ast::Ident::from("writeable"),
-        ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) => {
-            ast::Ident::from("str_ref8")
-        }
+        ast::TypeName::StrReference(
+            _,
+            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+        ) => ast::Ident::from("str_ref8"),
         ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) => {
             ast::Ident::from("str_ref16")
         }

--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -110,6 +110,7 @@ impl<'tcx> CFormatter<'tcx> {
             Type::Struct(s) => self.fmt_type_name(P::id_for_path(s)),
             Type::Enum(e) => self.fmt_type_name(e.tcx_id.into()),
             Type::Slice(hir::Slice::Str(_, StringEncoding::UnvalidatedUtf8)) => "str_ref8".into(),
+            Type::Slice(hir::Slice::Str(_, StringEncoding::Utf8)) => "str_refv8".into(),
             Type::Slice(hir::Slice::Str(_, StringEncoding::UnvalidatedUtf16)) => "str_ref16".into(),
             Type::Slice(hir::Slice::Primitive(borrow, p)) => {
                 let constness = borrow.mutability.if_mut_else("", "const_");

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -237,7 +237,10 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
     ) -> Vec<(Cow<'ccx, str>, Cow<'a, str>)> {
         let param_name = self.cx.formatter.fmt_param_name(ident);
         match ty {
-            Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8)) if !is_struct => {
+            Type::Slice(hir::Slice::Str(
+                _,
+                hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+            )) if !is_struct => {
                 vec![
                     ("const char*".into(), format!("{param_name}_data").into()),
                     ("size_t".into(), format!("{param_name}_len").into()),
@@ -322,7 +325,10 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             }
             Type::Slice(ref s) => {
                 let ptr_ty = match s {
-                    hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8) => "char".into(),
+                    hir::Slice::Str(
+                        _,
+                        hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+                    ) => "char".into(),
                     hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16) => "wchar_t".into(),
                     hir::Slice::Primitive(_, prim) => self.cx.formatter.fmt_primitive_as_c(*prim),
                     &_ => unreachable!("unknown AST/HIR variant"),

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -203,7 +203,10 @@ pub fn gen_rust_to_cpp<W: Write>(
             todo!("Returning references from Rust to C++ is not currently supported")
         }
         ast::TypeName::Writeable => panic!("Returning writeables is not supported"),
-        ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) => {
+        ast::TypeName::StrReference(
+            _,
+            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+        ) => {
             let raw_value_id = format!("diplomat_str_raw_{path}");
             writeln!(out, "capi::DiplomatStringView {raw_value_id} = {cpp};").unwrap();
 

--- a/tool/src/cpp/types.rs
+++ b/tool/src/cpp/types.rs
@@ -155,7 +155,10 @@ fn gen_type_inner<W: fmt::Write>(
             write!(out, "capi::DiplomatWriteable")?;
         }
 
-        ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) => {
+        ast::TypeName::StrReference(
+            _,
+            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+        ) => {
             let maybe_const = if in_struct { "" } else { "const " };
             write!(out, "{maybe_const}{}", library_config.string_view.expr)?;
         }

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -454,9 +454,10 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
                     .insert(self.cx.formatter.fmt_impl_header_path(id));
                 type_name
             }
-            Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8)) => {
-                self.cx.formatter.fmt_borrowed_utf8_str()
-            }
+            Type::Slice(hir::Slice::Str(
+                _,
+                hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+            )) => self.cx.formatter.fmt_borrowed_utf8_str(),
             Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16)) => {
                 self.cx.formatter.fmt_borrowed_utf16_str()
             }
@@ -644,7 +645,10 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
                 // Note: The impl file is imported in gen_type_name().
                 format!("{type_name}::FromFFI({var_name})").into()
             }
-            Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8)) => {
+            Type::Slice(hir::Slice::Str(
+                _,
+                hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+            )) => {
                 let string_view = self.cx.formatter.fmt_borrowed_utf8_str();
                 format!("{string_view}({var_name}_data, {var_name}_size)").into()
             }

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -651,9 +651,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             Type::Opaque(..) | Type::Struct(..) | Type::Enum(..) => {
                 format!("{dart_name}._underlying").into()
             }
-            Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8)) => {
-                format!("{dart_name}.utf8View;").into()
-            }
+            Type::Slice(hir::Slice::Str(
+                _,
+                hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+            )) => format!("{dart_name}.utf8View;").into(),
             Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16)) => {
                 format!("{dart_name}.utf16View;").into()
             }

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -545,9 +545,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
                 }
                 self.formatter.fmt_enum_as_ffi(cast).into()
             }
-            Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8)) => {
-                self.formatter.fmt_utf8_primitive().into()
-            }
+            Type::Slice(hir::Slice::Str(
+                _,
+                hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+            )) => self.formatter.fmt_utf8_primitive().into(),
             Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16)) => {
                 self.formatter.fmt_utf16_primitive().into()
             }
@@ -667,9 +668,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
         };
 
         let slice_ty = match slice {
-            hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8) => {
-                self.formatter.fmt_utf8_slice_type()
-            }
+            hir::Slice::Str(
+                _,
+                hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+            ) => self.formatter.fmt_utf8_slice_type(),
             hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16) => {
                 self.formatter.fmt_utf16_slice_type()
             }
@@ -678,9 +680,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
         };
 
         let ffi_type = match slice {
-            hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8) => {
-                self.formatter.fmt_utf8_primitive()
-            }
+            hir::Slice::Str(
+                _,
+                hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+            ) => self.formatter.fmt_utf8_primitive(),
             hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16) => {
                 self.formatter.fmt_utf16_primitive()
             }
@@ -689,7 +692,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
         };
 
         let to_dart = match slice {
-            hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8) => {
+            hir::Slice::Str(
+                _,
+                hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
+            ) => {
                 self.imports
                     .insert(self.formatter.fmt_import("dart:convert"));
                 "Utf8Decoder().convert(_bytes.cast<ffi.Uint8>().asTypedList(_length))"
@@ -705,7 +711,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
         };
 
         let from_dart = match slice {
-            hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8) => concat!(
+            hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8) => concat!(
                 "final units = Utf8Encoder().convert(value);\n",
                 "slice._length = units.length;\n",
                 // TODO: Figure out why Pointer<Utf8> cannot be allocated

--- a/tool/src/dotnet/types.rs
+++ b/tool/src/dotnet/types.rs
@@ -49,7 +49,10 @@ pub fn gen_type_name(
             write!(out, "DiplomatWriteable")
         }
 
-        ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) => {
+        ast::TypeName::StrReference(
+            _,
+            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+        ) => {
             write!(out, "string")
         }
 
@@ -112,9 +115,10 @@ pub fn name_for_type(typ: &ast::TypeName) -> ast::Ident {
             ast::Ident::from(format!("Result{}{}", name_for_type(ok), name_for_type(err)))
         }
         ast::TypeName::Writeable => ast::Ident::from("Writeable"),
-        ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) => {
-            ast::Ident::from("StrRef8")
-        }
+        ast::TypeName::StrReference(
+            _,
+            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+        ) => ast::Ident::from("StrRef8"),
         ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) => {
             ast::Ident::from("RefMutPrimSliceU16")
         }

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -513,8 +513,8 @@ impl fmt::Display for InvocationIntoJs<'_> {
                     ReturnTypeForm::Empty => unreachable!(),
                 }
             }
-            ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) => self.display_slice(SliceKind::Str).fmt(f),
-                ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) => self.display_slice(SliceKind::Str16).fmt(f),
+            ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8) => self.display_slice(SliceKind::Str).fmt(f),
+            ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) => self.display_slice(SliceKind::Str16).fmt(f),
             ast::TypeName::PrimitiveSlice(.., prim) => {
                 self.display_slice(SliceKind::Primitive(prim.into())).fmt(f)
             }
@@ -789,9 +789,10 @@ impl fmt::Display for UnderlyingIntoJs<'_> {
                 todo!("Result in a buffer")
             }
             ast::TypeName::Writeable => todo!("Writeable in a buffer"),
-            ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf8) => {
-                self.display_slice(SliceKind::Str).fmt(f)
-            }
+            ast::TypeName::StrReference(
+                _,
+                ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::Utf8,
+            ) => self.display_slice(SliceKind::Str).fmt(f),
             ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) => {
                 self.display_slice(SliceKind::Str16).fmt(f)
             }

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -502,7 +502,9 @@ pub fn gen_ts_type<W: fmt::Write>(
         ast::TypeName::Writeable => unreachable!(),
         ast::TypeName::StrReference(
             _,
-            ast::StringEncoding::UnvalidatedUtf8 | ast::StringEncoding::UnvalidatedUtf16,
+            ast::StringEncoding::UnvalidatedUtf8
+            | ast::StringEncoding::UnvalidatedUtf16
+            | ast::StringEncoding::Utf8,
         ) => out.write_str("string")?,
         ast::TypeName::PrimitiveSlice(.., prim) => match prim {
             ast::PrimitiveType::i8 => write!(out, "Int8Array")?,


### PR DESCRIPTION
Diplomat will generate C++ docs that say invalid UTF-8 is UB. However, this is not inline documentation, so I'm not super happy with this.

#57