### PR TITLE
Dart: remove usage of `Utf8` and `Utf16` types

### DIFF
--- a/example/dart/lib/ICU4XFixedDecimalFormatterOptions.g.dart
+++ b/example/dart/lib/ICU4XFixedDecimalFormatterOptions.g.dart
@@ -15,7 +15,6 @@ final class _ICU4XFixedDecimalFormatterOptionsFfi extends ffi.Struct {
 final class ICU4XFixedDecimalFormatterOptions {
   final _ICU4XFixedDecimalFormatterOptionsFfi _underlying;
 
-  // ignore: unused_element
   ICU4XFixedDecimalFormatterOptions._(this._underlying);
 
   factory ICU4XFixedDecimalFormatterOptions() {

--- a/example/dart/lib/ICU4XLocale.g.dart
+++ b/example/dart/lib/ICU4XLocale.g.dart
@@ -19,15 +19,15 @@ final class ICU4XLocale implements ffi.Finalizable {
 
   /// Construct an [`ICU4XLocale`] from a locale identifier represented as a string.
   factory ICU4XLocale(String name) {
-    final alloc = ffi2.Arena();
-    final nameSlice = _SliceUtf8._fromDart(name, alloc);
-    final result = _ICU4XLocale_new(nameSlice._bytes, nameSlice._length);
-    alloc.releaseAll();
+    final temp = ffi2.Arena();
+    final nameLength = name.utf8Length;
+    final result = _ICU4XLocale_new(Utf8Encoder().allocConvert(temp, name, length: nameLength), nameLength);
+    temp.releaseAll();
     return ICU4XLocale._(result);
   }
 
   // ignore: non_constant_identifier_names
   static final _ICU4XLocale_new =
-    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, ffi.Size)>>('ICU4XLocale_new')
-      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, int)>(isLeaf: true);
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>('ICU4XLocale_new')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
 }

--- a/example/dart/lib/lib.g.dart
+++ b/example/dart/lib/lib.g.dart
@@ -3,12 +3,12 @@
 // https://github.com/dart-lang/sdk/issues/53946
 // ignore_for_file: non_native_function_type_argument_to_pointer
 
-import 'dart:convert';
-import 'dart:core' as core;
-import 'dart:core' show int, double, bool, String, Object, override;
-import 'dart:ffi' as ffi;
-import 'dart:typed_data';
-import 'package:ffi/ffi.dart' as ffi2 show Arena, calloc;
+import 'dart:convert'  ;
+import 'dart:core'as core;
+import 'dart:core'show int, double, bool, String, Object, override;
+import 'dart:ffi'as ffi;
+import 'dart:typed_data'  ;
+import 'package:ffi/ffi.dart'as ffi2 show Arena, calloc;
 part 'ICU4XDataProvider.g.dart';
 part 'ICU4XFixedDecimal.g.dart';
 part 'ICU4XFixedDecimalFormatter.g.dart';

--- a/example/dart/lib/lib.g.dart
+++ b/example/dart/lib/lib.g.dart
@@ -4,9 +4,11 @@
 // ignore_for_file: non_native_function_type_argument_to_pointer
 
 import 'dart:convert';
+import 'dart:core' as core;
+import 'dart:core' show int, double, bool, String, Object, override;
 import 'dart:ffi' as ffi;
 import 'dart:typed_data';
-import 'package:ffi/ffi.dart' as ffi2;
+import 'package:ffi/ffi.dart' as ffi2 show Arena, calloc;
 part 'ICU4XDataProvider.g.dart';
 part 'ICU4XFixedDecimal.g.dart';
 part 'ICU4XFixedDecimalFormatter.g.dart';
@@ -34,7 +36,99 @@ typedef RuneList = Uint32List;
 late final ffi.Pointer<T> Function<T extends ffi.NativeType>(String) _capi;
 void init(String path) => _capi = ffi.DynamicLibrary.open(path).lookup;
 
-final _callocFree = Finalizer(ffi2.calloc.free);
+final _callocFree = core.Finalizer(ffi2.calloc.free);
+
+extension _AllocConvert on Utf8Encoder {
+  ffi.Pointer<ffi.Uint8> allocConvert(ffi.Allocator alloc, String string, {int? length}) {
+      final l = length ?? string.utf8Length;
+      return alloc<ffi.Uint8>(l)..asTypedList(l).setAll(0, convert(string));
+   }
+}
+
+extension _Utf8Length on String {
+  int get utf8Length {
+    var length = 0;
+    for (var rune in runes) {
+      if (rune < 0x80) {
+        length += 1;
+      } else if (rune < 0x800) {
+        length += 2;
+      } else if (rune < 0x10000) {
+        length += 3;
+      } else {
+        length += 4;
+      }
+    }
+    return length;
+  }
+}
+
+extension _CopyString on String {
+  ffi.Pointer<ffi.Uint16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, codeUnits);
+  }
+}
+
+extension _CopyInt8List on Int8List {
+  ffi.Pointer<ffi.Int8> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int8>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt16List on Int16List {
+  ffi.Pointer<ffi.Int16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int16>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt32List on Int32List {
+  ffi.Pointer<ffi.Int32> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int32>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt64List on Int64List {
+  ffi.Pointer<ffi.Int64> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int64>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint8List on Uint8List {
+  ffi.Pointer<ffi.Uint8> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint16List on Uint16List {
+  ffi.Pointer<ffi.Uint16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint32List on Uint32List {
+  ffi.Pointer<ffi.Uint32> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint32>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint64List on Uint64List {
+  ffi.Pointer<ffi.Uint64> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint64>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyFloat32List on Float32List {
+  ffi.Pointer<ffi.Float> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Float>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyFloat64List on Float64List {
+  ffi.Pointer<ffi.Double> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Double>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
 
 final class _ResultOpaqueVoidUnion extends ffi.Union {
   external ffi.Pointer<ffi.Opaque> ok;
@@ -54,60 +148,6 @@ final class _ResultVoidVoid extends ffi.Struct {
   external bool isOk;
 }
 
-final class _SliceUtf8 extends ffi.Struct {
-  external ffi.Pointer<ffi2.Utf8> _bytes;
-
-  @ffi.Size()
-  external int _length;
-
-  /// Produces a slice from a Dart object. The Dart object's data is copied into the given allocator
-  /// as it cannot be borrowed directly, and gets freed with the slice object.
-  // ignore: unused_element
-  static _SliceUtf8 _fromDart(String value, ffi.Allocator allocator) {
-    final pointer = allocator<_SliceUtf8>();
-    final slice = pointer.ref;
-    slice._length = 0;
-    for (var rune in value.runes) {
-      if (rune < 0x80) {
-        slice._length += 1;
-      } else if (rune < 0x800) {
-        slice._length += 2;
-      } else if (rune < 0x10000) {
-        slice._length += 3;
-      } else {
-        slice._length += 4;
-      }
-    }
-    // https://github.com/dart-lang/ffi/issues/223
-    slice._bytes = allocator<ffi.Uint8>(slice._length).cast();
-    // https://github.com/dart-lang/sdk/issues/49470
-    slice._bytes.cast<ffi.Uint8>().asTypedList(slice._length).setAll(0, Utf8Encoder().convert(value));
-    return slice;
-  }
-
-  // ignore: unused_element
-  String get _asDart => Utf8Decoder().convert(_bytes.cast<ffi.Uint8>().asTypedList(_length));
-
-  // This is expensive
-  @override
-  bool operator ==(Object other) {
-    if (other is! _SliceUtf8 || other._length != _length) {
-      return false;
-    }
-
-    for (var i = 0; i < _length; i++) {
-      if (other._bytes.cast<ffi.Uint8>()[i] != _bytes.cast<ffi.Uint8>()[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  // This is cheap
-  @override
-  int get hashCode => _length.hashCode;
-}
-
 /// An unspecified error value
 class VoidError {}
 
@@ -120,7 +160,7 @@ final class _Writeable {
     .asFunction<ffi.Pointer<ffi.Opaque> Function(int)>();
 
   String finalize() {
-    final string = _getBytes(_underlying).toDartString(length: _len(_underlying));
+    final string = Utf8Decoder().convert(_getBytes(_underlying).asTypedList(_len(_underlying)));
     _destroy(_underlying);
     return string;
   }
@@ -129,8 +169,8 @@ final class _Writeable {
     .asFunction<int Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
   static final _getBytes = 
-    _capi<ffi.NativeFunction<ffi.Pointer<ffi2.Utf8> Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_get_bytes')
-    .asFunction<ffi.Pointer<ffi2.Utf8> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_get_bytes')
+    .asFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
   static final _destroy =
     _capi<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_destroy')
     .asFunction<void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);

--- a/feature_tests/dart/lib/BorrowedFields.g.dart
+++ b/feature_tests/dart/lib/BorrowedFields.g.dart
@@ -13,7 +13,6 @@ final class _BorrowedFieldsFfi extends ffi.Struct {
 final class BorrowedFields {
   final _BorrowedFieldsFfi _underlying;
 
-  // ignore: unused_element
   BorrowedFields._(this._underlying);
 
   factory BorrowedFields() {
@@ -23,20 +22,18 @@ final class BorrowedFields {
     return result;
   }
 
-  String get a => _underlying.a._asDart;
+  String get a => core.String.fromCharCodes(_underlying.a._pointer.asTypedList(_underlying.a._length));
   set a(String a) {
-    final alloc = ffi2.calloc;
-    alloc.free(_underlying.a._bytes);
-    final aSlice = _SliceUtf16._fromDart(a, alloc);
-    _underlying.a = aSlice;
+    ffi2.calloc.free(_underlying.a._pointer);
+    _underlying.a._length = a.length;
+    _underlying.a._pointer = a.copy(ffi2.calloc);
   }
 
-  String get b => _underlying.b._asDart;
+  String get b => Utf8Decoder().convert(_underlying.b._pointer.asTypedList(_underlying.b._length));
   set b(String b) {
-    final alloc = ffi2.calloc;
-    alloc.free(_underlying.b._bytes);
-    final bSlice = _SliceUtf8._fromDart(b, alloc);
-    _underlying.b = bSlice;
+    ffi2.calloc.free(_underlying.b._pointer);
+    _underlying.b._length = b.utf8Length;
+    _underlying.b._pointer = Utf8Encoder().allocConvert(ffi2.calloc, b, length: _underlying.b._length);
   }
 
   @override

--- a/feature_tests/dart/lib/BorrowedFieldsReturning.g.dart
+++ b/feature_tests/dart/lib/BorrowedFieldsReturning.g.dart
@@ -12,7 +12,6 @@ final class _BorrowedFieldsReturningFfi extends ffi.Struct {
 final class BorrowedFieldsReturning {
   final _BorrowedFieldsReturningFfi _underlying;
 
-  // ignore: unused_element
   BorrowedFieldsReturning._(this._underlying);
 
   factory BorrowedFieldsReturning() {
@@ -22,12 +21,11 @@ final class BorrowedFieldsReturning {
     return result;
   }
 
-  String get bytes => _underlying.bytes._asDart;
+  String get bytes => Utf8Decoder().convert(_underlying.bytes._pointer.asTypedList(_underlying.bytes._length));
   set bytes(String bytes) {
-    final alloc = ffi2.calloc;
-    alloc.free(_underlying.bytes._bytes);
-    final bytesSlice = _SliceUtf8._fromDart(bytes, alloc);
-    _underlying.bytes = bytesSlice;
+    ffi2.calloc.free(_underlying.bytes._pointer);
+    _underlying.bytes._length = bytes.utf8Length;
+    _underlying.bytes._pointer = Utf8Encoder().allocConvert(ffi2.calloc, bytes, length: _underlying.bytes._length);
   }
 
   @override

--- a/feature_tests/dart/lib/ErrorStruct.g.dart
+++ b/feature_tests/dart/lib/ErrorStruct.g.dart
@@ -15,7 +15,6 @@ final class _ErrorStructFfi extends ffi.Struct {
 final class ErrorStruct {
   final _ErrorStructFfi _underlying;
 
-  // ignore: unused_element
   ErrorStruct._(this._underlying);
 
   factory ErrorStruct() {

--- a/feature_tests/dart/lib/Float64Vec.g.dart
+++ b/feature_tests/dart/lib/Float64Vec.g.dart
@@ -15,10 +15,9 @@ final class Float64Vec implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(_capi('Float64Vec_destroy'));
 
   factory Float64Vec(Float64List v) {
-    final alloc = ffi2.Arena();
-    final vSlice = _SliceDouble._fromDart(v, alloc);
-    final result = _Float64Vec_new(vSlice._bytes, vSlice._length);
-    alloc.releaseAll();
+    final temp = ffi2.Arena();
+    final result = _Float64Vec_new(v.copy(temp), v.length);
+    temp.releaseAll();
     return Float64Vec._(result);
   }
 
@@ -28,10 +27,9 @@ final class Float64Vec implements ffi.Finalizable {
       .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Double>, int)>(isLeaf: true);
 
   void fillSlice(Float64List v) {
-    final alloc = ffi2.Arena();
-    final vSlice = _SliceDouble._fromDart(v, alloc);
-    _Float64Vec_fill_slice(_underlying, vSlice._bytes, vSlice._length);
-    alloc.releaseAll();
+    final temp = ffi2.Arena();
+    _Float64Vec_fill_slice(_underlying, v.copy(temp), v.length);
+    temp.releaseAll();
   }
 
   // ignore: non_constant_identifier_names
@@ -40,10 +38,9 @@ final class Float64Vec implements ffi.Finalizable {
       .asFunction<void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Double>, int)>(isLeaf: true);
 
   void setValue(Float64List newSlice) {
-    final alloc = ffi2.Arena();
-    final newSliceSlice = _SliceDouble._fromDart(newSlice, alloc);
-    _Float64Vec_set_value(_underlying, newSliceSlice._bytes, newSliceSlice._length);
-    alloc.releaseAll();
+    final temp = ffi2.Arena();
+    _Float64Vec_set_value(_underlying, newSlice.copy(temp), newSlice.length);
+    temp.releaseAll();
   }
 
   // ignore: non_constant_identifier_names

--- a/feature_tests/dart/lib/Foo.g.dart
+++ b/feature_tests/dart/lib/Foo.g.dart
@@ -15,17 +15,17 @@ final class Foo implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(_capi('Foo_destroy'));
 
   factory Foo(String x) {
-    final alloc = ffi2.Arena();
-    final xSlice = _SliceUtf8._fromDart(x, alloc);
-    final result = _Foo_new(xSlice._bytes, xSlice._length);
-    alloc.releaseAll();
+    final temp = ffi2.Arena();
+    final xLength = x.utf8Length;
+    final result = _Foo_new(Utf8Encoder().allocConvert(temp, x, length: xLength), xLength);
+    temp.releaseAll();
     return Foo._(result);
   }
 
   // ignore: non_constant_identifier_names
   static final _Foo_new =
-    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, ffi.Size)>>('Foo_new')
-      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, int)>(isLeaf: true);
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>('Foo_new')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
 
   Bar get getBar {
     final result = _Foo_get_bar(_underlying);
@@ -38,17 +38,17 @@ final class Foo implements ffi.Finalizable {
       .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
   factory Foo.static_(String x) {
-    final alloc = ffi2.Arena();
-    final xSlice = _SliceUtf8._fromDart(x, alloc);
-    final result = _Foo_new_static(xSlice._bytes, xSlice._length);
-    alloc.releaseAll();
+    final temp = ffi2.Arena();
+    final xLength = x.utf8Length;
+    final result = _Foo_new_static(Utf8Encoder().allocConvert(temp, x, length: xLength), xLength);
+    temp.releaseAll();
     return Foo._(result);
   }
 
   // ignore: non_constant_identifier_names
   static final _Foo_new_static =
-    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, ffi.Size)>>('Foo_new_static')
-      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, int)>(isLeaf: true);
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>('Foo_new_static')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
 
   BorrowedFieldsReturning get asReturning {
     final result = _Foo_as_returning(_underlying);

--- a/feature_tests/dart/lib/ImportedStruct.g.dart
+++ b/feature_tests/dart/lib/ImportedStruct.g.dart
@@ -15,7 +15,6 @@ final class _ImportedStructFfi extends ffi.Struct {
 final class ImportedStruct {
   final _ImportedStructFfi _underlying;
 
-  // ignore: unused_element
   ImportedStruct._(this._underlying);
 
   factory ImportedStruct() {

--- a/feature_tests/dart/lib/MyString.g.dart
+++ b/feature_tests/dart/lib/MyString.g.dart
@@ -15,29 +15,29 @@ final class MyString implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(_capi('MyString_destroy'));
 
   factory MyString(String v) {
-    final alloc = ffi2.Arena();
-    final vSlice = _SliceUtf8._fromDart(v, alloc);
-    final result = _MyString_new(vSlice._bytes, vSlice._length);
-    alloc.releaseAll();
+    final temp = ffi2.Arena();
+    final vLength = v.utf8Length;
+    final result = _MyString_new(Utf8Encoder().allocConvert(temp, v, length: vLength), vLength);
+    temp.releaseAll();
     return MyString._(result);
   }
 
   // ignore: non_constant_identifier_names
   static final _MyString_new =
-    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, ffi.Size)>>('MyString_new')
-      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi2.Utf8>, int)>(isLeaf: true);
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>('MyString_new')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
 
   void setStr(String newStr) {
-    final alloc = ffi2.Arena();
-    final newStrSlice = _SliceUtf8._fromDart(newStr, alloc);
-    _MyString_set_str(_underlying, newStrSlice._bytes, newStrSlice._length);
-    alloc.releaseAll();
+    final temp = ffi2.Arena();
+    final newStrLength = newStr.utf8Length;
+    _MyString_set_str(_underlying, Utf8Encoder().allocConvert(temp, newStr, length: newStrLength), newStrLength);
+    temp.releaseAll();
   }
 
   // ignore: non_constant_identifier_names
   static final _MyString_set_str =
-    _capi<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi2.Utf8>, ffi.Size)>>('MyString_set_str')
-      .asFunction<void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi2.Utf8>, int)>(isLeaf: true);
+    _capi<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Uint8>, ffi.Size)>>('MyString_set_str')
+      .asFunction<void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
 
   String get getStr {
     final writeable = _Writeable();

--- a/feature_tests/dart/lib/MyStruct.g.dart
+++ b/feature_tests/dart/lib/MyStruct.g.dart
@@ -25,7 +25,6 @@ final class _MyStructFfi extends ffi.Struct {
 final class MyStruct {
   final _MyStructFfi _underlying;
 
-  // ignore: unused_element
   MyStruct._(this._underlying);
 
   factory MyStruct() {

--- a/feature_tests/dart/lib/OptionStruct.g.dart
+++ b/feature_tests/dart/lib/OptionStruct.g.dart
@@ -16,35 +16,15 @@ final class _OptionStructFfi extends ffi.Struct {
 final class OptionStruct {
   final _OptionStructFfi _underlying;
 
-  // ignore: unused_element
   OptionStruct._(this._underlying);
 
-  factory OptionStruct() {
-    final pointer = ffi2.calloc<_OptionStructFfi>();
-    final result = OptionStruct._(pointer.ref);
-    _callocFree.attach(result, pointer.cast());
-    return result;
-  }
-
   OptionOpaque? get a => _underlying.a.address == 0 ? null : OptionOpaque._(_underlying.a);
-  set a(OptionOpaque? a) {
-    _underlying.a = a == null ? ffi.Pointer.fromAddress(0) : a._underlying;
-  }
 
   OptionOpaqueChar? get b => _underlying.b.address == 0 ? null : OptionOpaqueChar._(_underlying.b);
-  set b(OptionOpaqueChar? b) {
-    _underlying.b = b == null ? ffi.Pointer.fromAddress(0) : b._underlying;
-  }
 
   int get c => _underlying.c;
-  set c(int c) {
-    _underlying.c = c;
-  }
 
   OptionOpaque? get d => _underlying.d.address == 0 ? null : OptionOpaque._(_underlying.d);
-  set d(OptionOpaque? d) {
-    _underlying.d = d == null ? ffi.Pointer.fromAddress(0) : d._underlying;
-  }
 
   @override
   bool operator ==(Object other) =>

--- a/feature_tests/dart/lib/lib.g.dart
+++ b/feature_tests/dart/lib/lib.g.dart
@@ -3,12 +3,12 @@
 // https://github.com/dart-lang/sdk/issues/53946
 // ignore_for_file: non_native_function_type_argument_to_pointer
 
-import 'dart:convert';
-import 'dart:core' as core;
-import 'dart:core' show int, double, bool, String, Object, override;
-import 'dart:ffi' as ffi;
-import 'dart:typed_data';
-import 'package:ffi/ffi.dart' as ffi2 show Arena, calloc;
+import 'dart:convert'  ;
+import 'dart:core'as core;
+import 'dart:core'show int, double, bool, String, Object, override;
+import 'dart:ffi'as ffi;
+import 'dart:typed_data'  ;
+import 'package:ffi/ffi.dart'as ffi2 show Arena, calloc;
 part 'AttrEnum.g.dart';
 part 'AttrOpaque1.g.dart';
 part 'AttrOpaque2.g.dart';

--- a/feature_tests/dart/lib/lib.g.dart
+++ b/feature_tests/dart/lib/lib.g.dart
@@ -4,9 +4,11 @@
 // ignore_for_file: non_native_function_type_argument_to_pointer
 
 import 'dart:convert';
+import 'dart:core' as core;
+import 'dart:core' show int, double, bool, String, Object, override;
 import 'dart:ffi' as ffi;
 import 'dart:typed_data';
-import 'package:ffi/ffi.dart' as ffi2;
+import 'package:ffi/ffi.dart' as ffi2 show Arena, calloc;
 part 'AttrEnum.g.dart';
 part 'AttrOpaque1.g.dart';
 part 'AttrOpaque2.g.dart';
@@ -53,7 +55,99 @@ typedef RuneList = Uint32List;
 late final ffi.Pointer<T> Function<T extends ffi.NativeType>(String) _capi;
 void init(String path) => _capi = ffi.DynamicLibrary.open(path).lookup;
 
-final _callocFree = Finalizer(ffi2.calloc.free);
+final _callocFree = core.Finalizer(ffi2.calloc.free);
+
+extension _AllocConvert on Utf8Encoder {
+  ffi.Pointer<ffi.Uint8> allocConvert(ffi.Allocator alloc, String string, {int? length}) {
+      final l = length ?? string.utf8Length;
+      return alloc<ffi.Uint8>(l)..asTypedList(l).setAll(0, convert(string));
+   }
+}
+
+extension _Utf8Length on String {
+  int get utf8Length {
+    var length = 0;
+    for (var rune in runes) {
+      if (rune < 0x80) {
+        length += 1;
+      } else if (rune < 0x800) {
+        length += 2;
+      } else if (rune < 0x10000) {
+        length += 3;
+      } else {
+        length += 4;
+      }
+    }
+    return length;
+  }
+}
+
+extension _CopyString on String {
+  ffi.Pointer<ffi.Uint16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, codeUnits);
+  }
+}
+
+extension _CopyInt8List on Int8List {
+  ffi.Pointer<ffi.Int8> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int8>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt16List on Int16List {
+  ffi.Pointer<ffi.Int16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int16>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt32List on Int32List {
+  ffi.Pointer<ffi.Int32> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int32>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt64List on Int64List {
+  ffi.Pointer<ffi.Int64> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int64>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint8List on Uint8List {
+  ffi.Pointer<ffi.Uint8> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint16List on Uint16List {
+  ffi.Pointer<ffi.Uint16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint32List on Uint32List {
+  ffi.Pointer<ffi.Uint32> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint32>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint64List on Uint64List {
+  ffi.Pointer<ffi.Uint64> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint64>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyFloat32List on Float32List {
+  ffi.Pointer<ffi.Float> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Float>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyFloat64List on Float64List {
+  ffi.Pointer<ffi.Double> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Double>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
 
 final class _ResultInt32OpaqueUnion extends ffi.Union {
   @ffi.Int32()
@@ -130,68 +224,11 @@ final class _ResultVoidOpaque extends ffi.Struct {
   external bool isOk;
 }
 
-final class _SliceDouble extends ffi.Struct {
-  external ffi.Pointer<ffi.Double> _bytes;
-
-  @ffi.Size()
-  external int _length;
-
-  /// Produces a slice from a Dart object. The Dart object's data is copied into the given allocator
-  /// as it cannot be borrowed directly, and gets freed with the slice object.
-  // ignore: unused_element
-  static _SliceDouble _fromDart(Float64List value, ffi.Allocator allocator) {
-    final pointer = allocator<_SliceDouble>();
-    final slice = pointer.ref;
-    slice._length = value.length;
-    slice._bytes = allocator(slice._length);
-    slice._bytes.asTypedList(slice._length).setAll(0, value);
-    return slice;
-  }
-
-  // ignore: unused_element
-  Float64List get _asDart => _bytes.asTypedList(_length);
-
-  // This is expensive
-  @override
-  bool operator ==(Object other) {
-    if (other is! _SliceDouble || other._length != _length) {
-      return false;
-    }
-
-    for (var i = 0; i < _length; i++) {
-      if (other._bytes[i] != _bytes[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  // This is cheap
-  @override
-  int get hashCode => _length.hashCode;
-}
-
 final class _SliceUtf16 extends ffi.Struct {
-  external ffi.Pointer<ffi2.Utf16> _bytes;
+  external ffi.Pointer<ffi.Uint16> _pointer;
 
   @ffi.Size()
   external int _length;
-
-  /// Produces a slice from a Dart object. The Dart object's data is copied into the given allocator
-  /// as it cannot be borrowed directly, and gets freed with the slice object.
-  // ignore: unused_element
-  static _SliceUtf16 _fromDart(String value, ffi.Allocator allocator) {
-    final pointer = allocator<_SliceUtf16>();
-    final slice = pointer.ref;
-    slice._length = value.length;
-    // https://github.com/dart-lang/ffi/issues/223
-    slice._bytes = allocator<ffi.Uint16>(slice._length).cast();
-    slice._bytes.cast<ffi.Uint16>().asTypedList(slice._length).setAll(0, value.codeUnits);
-    return slice;
-  }
-
-  // ignore: unused_element
-  String get _asDart => String.fromCharCodes(_bytes.cast<ffi.Uint16>().asTypedList(_length));
 
   // This is expensive
   @override
@@ -201,7 +238,7 @@ final class _SliceUtf16 extends ffi.Struct {
     }
 
     for (var i = 0; i < _length; i++) {
-      if (other._bytes.cast<ffi.Uint16>()[i] != _bytes.cast<ffi.Uint16>()[i]) {
+      if (other._pointer[i] != _pointer[i]) {
         return false;
       }
     }
@@ -214,38 +251,10 @@ final class _SliceUtf16 extends ffi.Struct {
 }
 
 final class _SliceUtf8 extends ffi.Struct {
-  external ffi.Pointer<ffi2.Utf8> _bytes;
+  external ffi.Pointer<ffi.Uint8> _pointer;
 
   @ffi.Size()
   external int _length;
-
-  /// Produces a slice from a Dart object. The Dart object's data is copied into the given allocator
-  /// as it cannot be borrowed directly, and gets freed with the slice object.
-  // ignore: unused_element
-  static _SliceUtf8 _fromDart(String value, ffi.Allocator allocator) {
-    final pointer = allocator<_SliceUtf8>();
-    final slice = pointer.ref;
-    slice._length = 0;
-    for (var rune in value.runes) {
-      if (rune < 0x80) {
-        slice._length += 1;
-      } else if (rune < 0x800) {
-        slice._length += 2;
-      } else if (rune < 0x10000) {
-        slice._length += 3;
-      } else {
-        slice._length += 4;
-      }
-    }
-    // https://github.com/dart-lang/ffi/issues/223
-    slice._bytes = allocator<ffi.Uint8>(slice._length).cast();
-    // https://github.com/dart-lang/sdk/issues/49470
-    slice._bytes.cast<ffi.Uint8>().asTypedList(slice._length).setAll(0, Utf8Encoder().convert(value));
-    return slice;
-  }
-
-  // ignore: unused_element
-  String get _asDart => Utf8Decoder().convert(_bytes.cast<ffi.Uint8>().asTypedList(_length));
 
   // This is expensive
   @override
@@ -255,7 +264,7 @@ final class _SliceUtf8 extends ffi.Struct {
     }
 
     for (var i = 0; i < _length; i++) {
-      if (other._bytes.cast<ffi.Uint8>()[i] != _bytes.cast<ffi.Uint8>()[i]) {
+      if (other._pointer[i] != _pointer[i]) {
         return false;
       }
     }
@@ -279,7 +288,7 @@ final class _Writeable {
     .asFunction<ffi.Pointer<ffi.Opaque> Function(int)>();
 
   String finalize() {
-    final string = _getBytes(_underlying).toDartString(length: _len(_underlying));
+    final string = Utf8Decoder().convert(_getBytes(_underlying).asTypedList(_len(_underlying)));
     _destroy(_underlying);
     return string;
   }
@@ -288,8 +297,8 @@ final class _Writeable {
     .asFunction<int Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
   static final _getBytes = 
-    _capi<ffi.NativeFunction<ffi.Pointer<ffi2.Utf8> Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_get_bytes')
-    .asFunction<ffi.Pointer<ffi2.Utf8> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_get_bytes')
+    .asFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
   static final _destroy =
     _capi<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_destroy')
     .asFunction<void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);

--- a/tool/src/dart/formatter.rs
+++ b/tool/src/dart/formatter.rs
@@ -23,6 +23,7 @@ pub(super) struct DartFormatter<'tcx> {
 
 const INVALID_METHOD_NAMES: &[&str] = &["new", "static"];
 const INVALID_FIELD_NAMES: &[&str] = &["new", "static"];
+const DISALLOWED_CORE_TYPES: &[&str] = &["Object", "String"];
 
 impl<'tcx> DartFormatter<'tcx> {
     pub fn new(
@@ -41,12 +42,12 @@ impl<'tcx> DartFormatter<'tcx> {
         format!("{name}.g.dart")
     }
 
-    pub fn fmt_import(&self, path: &str) -> Cow<'static, str> {
-        format!("import '{path}';").into()
-    }
-
-    pub fn fmt_renamed_import(&self, path: &str, name: &str) -> Cow<'static, str> {
-        format!("import '{path}' as {name};").into()
+    pub fn fmt_import(&self, path: &str, as_show_hide: &str) -> Cow<'static, str> {
+        format!(
+            "import '{path}'{}{as_show_hide};",
+            if as_show_hide.is_empty() { "" } else { " " }
+        )
+        .into()
     }
 
     pub fn fmt_part_of_lib(&self) -> Cow<'static, str> {
@@ -54,7 +55,7 @@ impl<'tcx> DartFormatter<'tcx> {
     }
 
     pub fn fmt_part(&self, part: &str) -> Cow<'static, str> {
-        format!("part '{}';", self.fmt_file_name(part)).into()
+        format!("part '{}';", part).into()
     }
 
     pub fn fmt_docs(&self, docs: &hir::Docs) -> String {
@@ -76,7 +77,7 @@ impl<'tcx> DartFormatter<'tcx> {
     /// Resolve and format a named type for use in code
     pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
         let resolved = self.c.tcx().resolve_type(id);
-        if let Some(rename) = resolved.attrs().rename.as_ref() {
+        let candidate: Cow<'tcx, str> = if let Some(rename) = resolved.attrs().rename.as_ref() {
             rename.into()
         } else if let Some(strip_prefix) = self.strip_prefix.as_ref() {
             resolved
@@ -87,7 +88,13 @@ impl<'tcx> DartFormatter<'tcx> {
                 .into()
         } else {
             resolved.name().as_str().into()
+        };
+
+        if DISALLOWED_CORE_TYPES.contains(&&*candidate) {
+            panic!("{candidate:?} is not a valid Dart type name. Please rename.");
         }
+
+        candidate
     }
 
     /// Resolve and format a named type for use in diagnostics
@@ -166,11 +173,11 @@ impl<'tcx> DartFormatter<'tcx> {
     }
 
     pub fn fmt_utf8_primitive(&self) -> &'static str {
-        "ffi2.Utf8"
+        "ffi.Uint8"
     }
 
     pub fn fmt_utf16_primitive(&self) -> &'static str {
-        "ffi2.Utf16"
+        "ffi.Uint16"
     }
 
     pub fn fmt_void(&self) -> &'static str {
@@ -190,11 +197,7 @@ impl<'tcx> DartFormatter<'tcx> {
     }
 
     pub fn fmt_usize(&self, cast: bool) -> &'static str {
-        if cast {
-            "int"
-        } else {
-            "ffi.Size"
-        }
+        self.fmt_primitive_as_ffi(hir::PrimitiveType::IntSize(hir::IntSizeType::Usize), cast)
     }
 
     pub fn fmt_type_as_ident(&self, ty: Option<&str>) -> String {
@@ -214,7 +217,8 @@ impl<'tcx> DartFormatter<'tcx> {
             match prim {
                 PrimitiveType::Bool => "bool",
                 PrimitiveType::Char => "Rune",
-                PrimitiveType::Int(_) | PrimitiveType::IntSize(_) => "int",
+                PrimitiveType::Int(_) | PrimitiveType::IntSize(IntSizeType::Usize) => "int",
+                PrimitiveType::IntSize(IntSizeType::Isize) => panic!("isize not supported in Dart"),
                 PrimitiveType::Int128(_) => panic!("i128 not supported in Dart"),
                 PrimitiveType::Float(_) => "double",
             }
@@ -231,8 +235,7 @@ impl<'tcx> DartFormatter<'tcx> {
                 PrimitiveType::Int(IntType::I64) => "ffi.Int64",
                 PrimitiveType::Int(IntType::U64) => "ffi.Uint64",
                 PrimitiveType::Int128(_) => panic!("i128 not supported in Dart"),
-                // TODO: is there a usize type?
-                PrimitiveType::IntSize(IntSizeType::Isize) => "ffi.Size",
+                PrimitiveType::IntSize(IntSizeType::Isize) => panic!("isize not supported in Dart"),
                 PrimitiveType::IntSize(IntSizeType::Usize) => "ffi.Size",
                 PrimitiveType::Float(FloatType::F32) => "ffi.Float",
                 PrimitiveType::Float(FloatType::F64) => "ffi.Double",
@@ -241,8 +244,9 @@ impl<'tcx> DartFormatter<'tcx> {
     }
 
     pub fn fmt_primitive_list_type(&self, prim: hir::PrimitiveType) -> &'static str {
-        use diplomat_core::hir::{FloatType, IntType, PrimitiveType};
+        use diplomat_core::hir::{FloatType, IntSizeType, IntType, PrimitiveType};
         match prim {
+            PrimitiveType::Bool => panic!("bool not supported in lists"),
             PrimitiveType::Char => "RuneList",
             PrimitiveType::Int(IntType::I8) => "Int8List",
             PrimitiveType::Int(IntType::U8) => "Uint8List",
@@ -253,16 +257,17 @@ impl<'tcx> DartFormatter<'tcx> {
             PrimitiveType::Int(IntType::I64) => "Int64List",
             PrimitiveType::Int(IntType::U64) => "Uint64List",
             PrimitiveType::Int128(_) => panic!("i128 not supported in Dart"),
-            PrimitiveType::IntSize(_) => "SizeList",
+            PrimitiveType::IntSize(IntSizeType::Isize) => panic!("isize not supported in Dart"),
+            PrimitiveType::IntSize(IntSizeType::Usize) => "core.List<int>", // no typed list
             PrimitiveType::Float(FloatType::F32) => "Float32List",
             PrimitiveType::Float(FloatType::F64) => "Float64List",
-            _ => panic!("Primitive {:?} not supported in lists", prim),
         }
     }
 
     pub fn fmt_slice_type(&self, prim: hir::PrimitiveType) -> &'static str {
-        use diplomat_core::hir::{FloatType, IntType, PrimitiveType};
+        use diplomat_core::hir::{FloatType, IntSizeType, IntType, PrimitiveType};
         match prim {
+            PrimitiveType::Bool => panic!("bool not supported in lists"),
             PrimitiveType::Char => "_SliceRune",
             PrimitiveType::Int(IntType::I8) => "_SliceInt8",
             PrimitiveType::Int(IntType::U8) => "_SliceUint8",
@@ -273,10 +278,10 @@ impl<'tcx> DartFormatter<'tcx> {
             PrimitiveType::Int(IntType::I64) => "_SliceInt64",
             PrimitiveType::Int(IntType::U64) => "_SliceUint64",
             PrimitiveType::Int128(_) => panic!("i128 not supported in Dart"),
-            PrimitiveType::IntSize(_) => self.fmt_primitive_list_type(prim),
+            PrimitiveType::IntSize(IntSizeType::Usize) => "_SliceSize",
+            PrimitiveType::IntSize(_) => panic!("isize not supported in Dart"),
             PrimitiveType::Float(FloatType::F32) => "_SliceFloat",
             PrimitiveType::Float(FloatType::F64) => "_SliceDouble",
-            _ => panic!("Primitive {:?} not supported in lists", prim),
         }
     }
 

--- a/tool/src/dart/formatter.rs
+++ b/tool/src/dart/formatter.rs
@@ -42,10 +42,11 @@ impl<'tcx> DartFormatter<'tcx> {
         format!("{name}.g.dart")
     }
 
-    pub fn fmt_import(&self, path: &str, as_show_hide: &str) -> Cow<'static, str> {
+    pub fn fmt_import(&self, path: &str, as_show_hide: Option<&str>) -> Cow<'static, str> {
         format!(
-            "import '{path}'{}{as_show_hide};",
-            if as_show_hide.is_empty() { "" } else { " " }
+            "import '{path}'{}{};",
+            if as_show_hide.is_some() { "" } else { " " },
+            if let Some(s) = as_show_hide { s } else { " " },
         )
         .into()
     }

--- a/tool/templates/dart/init.dart
+++ b/tool/templates/dart/init.dart
@@ -19,4 +19,95 @@ typedef RuneList = Uint32List;
 late final ffi.Pointer<T> Function<T extends ffi.NativeType>(String) _capi;
 void init(String path) => _capi = ffi.DynamicLibrary.open(path).lookup;
 
-final _callocFree = Finalizer(ffi2.calloc.free);
+final _callocFree = core.Finalizer(ffi2.calloc.free);
+
+extension _AllocConvert on Utf8Encoder {
+  ffi.Pointer<ffi.Uint8> allocConvert(ffi.Allocator alloc, String string, {int? length}) {
+      final l = length ?? string.utf8Length;
+      return alloc<ffi.Uint8>(l)..asTypedList(l).setAll(0, convert(string));
+   }
+}
+
+extension _Utf8Length on String {
+  int get utf8Length {
+    var length = 0;
+    for (var rune in runes) {
+      if (rune < 0x80) {
+        length += 1;
+      } else if (rune < 0x800) {
+        length += 2;
+      } else if (rune < 0x10000) {
+        length += 3;
+      } else {
+        length += 4;
+      }
+    }
+    return length;
+  }
+}
+
+extension _CopyString on String {
+  ffi.Pointer<ffi.Uint16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, codeUnits);
+  }
+}
+
+extension _CopyInt8List on Int8List {
+  ffi.Pointer<ffi.Int8> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int8>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt16List on Int16List {
+  ffi.Pointer<ffi.Int16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int16>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt32List on Int32List {
+  ffi.Pointer<ffi.Int32> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int32>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyInt64List on Int64List {
+  ffi.Pointer<ffi.Int64> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Int64>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint8List on Uint8List {
+  ffi.Pointer<ffi.Uint8> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint16List on Uint16List {
+  ffi.Pointer<ffi.Uint16> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint32List on Uint32List {
+  ffi.Pointer<ffi.Uint32> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint32>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyUint64List on Uint64List {
+  ffi.Pointer<ffi.Uint64> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Uint64>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyFloat32List on Float32List {
+  ffi.Pointer<ffi.Float> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Float>(length)..asTypedList(length).setAll(0, this);
+  }
+}
+
+extension _CopyFloat64List on Float64List {
+  ffi.Pointer<ffi.Double> copy(ffi.Allocator alloc) {
+    return alloc<ffi.Double>(length)..asTypedList(length).setAll(0, this);
+  }
+}

--- a/tool/templates/dart/method.dart.jinja
+++ b/tool/templates/dart/method.dart.jinja
@@ -2,10 +2,10 @@
   /// {{m.docs.replace('\n', "\n  ")}}
   {%- endif %}
   {{ m.declaration }} {
-    {%- for slice_conversion in m.slice_conversions %}
-    {%- if loop.first %}
-    final alloc = ffi2.Arena();
+    {%- if m.needs_arena %}
+    final temp = ffi2.Arena();
     {%- endif %}
+    {%- for slice_conversion in m.slice_conversions %}
     {{ slice_conversion }}
     {%- endfor %}
     {%- if m.method.is_writeable() %}
@@ -20,8 +20,8 @@
         {{ param }}
         {%- endfor -%}
     );
-    {%- if !m.slice_conversions.is_empty() %}
-    alloc.releaseAll();
+    {%- if m.needs_arena %}
+    temp.releaseAll();
     {%- endif %}
     {%- match m.return_expression %}
     {%- when Some with (statement) %}

--- a/tool/templates/dart/slice.dart.jinja
+++ b/tool/templates/dart/slice.dart.jinja
@@ -1,24 +1,8 @@
 final class {{slice_ty}} extends ffi.Struct {
-  external ffi.Pointer<{{ffi_type}}> _bytes;
+  external ffi.Pointer<{{ffi_type}}> _pointer;
 
   @ffi.Size()
   external int _length;
-
-  {% if !from_dart.is_empty() -%}
-  /// Produces a slice from a Dart object. The Dart object's data is copied into the given allocator
-  /// as it cannot be borrowed directly, and gets freed with the slice object.
-  // ignore: unused_element
-  static {{slice_ty}} _fromDart({{dart_ty}} value, ffi.Allocator allocator) {
-    final pointer = allocator<{{slice_ty}}>();
-    final slice = pointer.ref;
-    {{from_dart.replace("\n", "\n    ")}}
-    return slice;
-  }
-
-  {% endif -%}
-
-  // ignore: unused_element
-  {{dart_ty}} get _asDart => {{to_dart}};
 
   // This is expensive
   @override
@@ -28,13 +12,7 @@ final class {{slice_ty}} extends ffi.Struct {
     }
 
     for (var i = 0; i < _length; i++) {
-      {%- if ffi_type == "ffi2.Utf8" %}
-      if (other._bytes.cast<ffi.Uint8>()[i] != _bytes.cast<ffi.Uint8>()[i]) {
-      {%- else if ffi_type == "ffi2.Utf16" %}
-      if (other._bytes.cast<ffi.Uint16>()[i] != _bytes.cast<ffi.Uint16>()[i]) {
-      {%- else %}
-      if (other._bytes[i] != _bytes[i]) {
-      {%- endif %}
+      if (other._pointer[i] != _pointer[i]) {
         return false;
       }
     }

--- a/tool/templates/dart/struct.dart.jinja
+++ b/tool/templates/dart/struct.dart.jinja
@@ -15,30 +15,27 @@ final class _{{type_name}}Ffi extends ffi.Struct {
 final class {{type_name}} {
   final _{{type_name}}Ffi _underlying;
 
-  // ignore: unused_element
   {{type_name}}._(this._underlying);
+  {%- if mutable %}
 
+  {# https://github.com/dart-lang/sdk/issues/45697 -#}
   factory {{type_name}}() {
     final pointer = ffi2.calloc<_{{type_name}}Ffi>();
     final result = {{type_name}}._(pointer.ref);
     _callocFree.attach(result, pointer.cast());
     return result;
   }
-
+  {%- endif %}
   {%- for field in fields %}
 
   {{field.dart_type_name}} get {{field.name}} => {{ field.get_expression }};
+  {%- if mutable %}
   set {{field.name}}({{field.dart_type_name}} {{field.name}}) {
-    {%- if !field.set_slice_conversions.is_empty() %}
-    final alloc = ffi2.calloc;
-    alloc.free(_underlying.{{field.name}}._bytes);
-    {# TODO: What if the field is a struct containing a pointer? #}
-    {%- endif %}
-    {%- for conversion in field.set_slice_conversions -%}
-    {{ conversion }}
+    {%- for set_expression in field.set_expressions %}
+    {{set_expression}}
     {%- endfor %}
-    _underlying.{{field.name}} = {{field.set_expression}};
   }
+  {%- endif %}
   {%- endfor %}
 
   {%- for m in methods %}

--- a/tool/templates/dart/writeable.dart
+++ b/tool/templates/dart/writeable.dart
@@ -7,7 +7,7 @@ final class _Writeable {
     .asFunction<ffi.Pointer<ffi.Opaque> Function(int)>();
 
   String finalize() {
-    final string = _getBytes(_underlying).toDartString(length: _len(_underlying));
+    final string = Utf8Decoder().convert(_getBytes(_underlying).asTypedList(_len(_underlying)));
     _destroy(_underlying);
     return string;
   }
@@ -16,8 +16,8 @@ final class _Writeable {
     .asFunction<int Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 
   static final _getBytes = 
-    _capi<ffi.NativeFunction<ffi.Pointer<ffi2.Utf8> Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_get_bytes')
-    .asFunction<ffi.Pointer<ffi2.Utf8> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_get_bytes')
+    .asFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
   static final _destroy =
     _capi<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>>('diplomat_buffer_writeable_destroy')
     .asFunction<void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true);


### PR DESCRIPTION
These types are not as convenient for us to use as I thought, as they represent complete null-terminated strings, instead of individual code points. As such they are not allocatable, and the conversion functions for them use null-termination. It's easier to work with `Uint8` and `Uint16`.

I also isolated all allocations that should be removed in the future into extension methods in `lib.g.dart`:
* https://github.com/dart-lang/sdk/issues/49470
* https://github.com/dart-lang/sdk/issues/44589
* https://github.com/dart-lang/sdk/issues/39787