### PR TITLE
Ignoring pointer of empty slices

### DIFF
--- a/macro/src/snapshots/diplomat__tests__method_taking_mutable_slice.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_mutable_slice.snap
@@ -13,7 +13,11 @@ mod ffi {
     use diplomat_runtime::*;
     #[no_mangle]
     extern "C" fn Foo_fill_slice(s_diplomat_data: *mut f64, s_diplomat_len: usize) {
-        Foo::fill_slice(unsafe { core::slice::from_raw_parts_mut(s_diplomat_data, s_diplomat_len) })
+        Foo::fill_slice(if s_diplomat_len == 0 {
+            &mut []
+        } else {
+            unsafe { core::slice::from_raw_parts_mut(s_diplomat_data, s_diplomat_len) }
+        })
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/macro/src/snapshots/diplomat__tests__method_taking_slice.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_slice.snap
@@ -13,7 +13,11 @@ mod ffi {
     use diplomat_runtime::*;
     #[no_mangle]
     extern "C" fn Foo_from_slice(s_diplomat_data: *const f64, s_diplomat_len: usize) {
-        Foo::from_slice(unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) })
+        Foo::from_slice(if s_diplomat_len == 0 {
+            &[]
+        } else {
+            unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) }
+        })
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}

--- a/macro/src/snapshots/diplomat__tests__method_taking_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_str.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn from_str(s : & DiplomatStr) { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn from_str(s : & DiplomatStr) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -13,7 +13,11 @@ mod ffi {
     use diplomat_runtime::*;
     #[no_mangle]
     extern "C" fn Foo_from_str(s_diplomat_data: *const u8, s_diplomat_len: usize) {
-        Foo::from_str(unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) })
+        Foo::from_str(if s_diplomat_len == 0 {
+            &[]
+        } else {
+            unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) }
+        })
     }
     #[no_mangle]
     extern "C" fn Foo_destroy(this: Box<Foo>) {}


### PR DESCRIPTION
Currently the slice `(null, 0)` leads to UB. However I want clients to be able to use this, as it's convenient and it usually works in the C universe.