### PR TITLE
String fixes

### DIFF
--- a/feature_tests/c2/include/BorrowedFields.d.h
+++ b/feature_tests/c2/include/BorrowedFields.d.h
@@ -14,7 +14,7 @@ extern "C" {
 
 
 typedef struct BorrowedFields {
-  struct { const wchar_t* data; size_t len; } a;
+  struct { const char16_t* data; size_t len; } a;
   struct { const char* data; size_t len; } b;
   struct { const char* data; size_t len; } c;
 } BorrowedFields;

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -24,6 +24,10 @@ struct MyStringDeleter {
 class MyString {
  public:
   static MyString new_(const std::string_view v);
+
+  /**
+   * Warning: Passing ill-formed UTF-8 is undefined behavior (and may be memory-unsafe).
+   */
   static MyString new_unsafe(const std::string_view v);
   void set_str(const std::string_view new_str);
   template<typename W> void get_str_to_writeable(W& writeable) const;

--- a/feature_tests/cpp2/include/BorrowedFields.d.h
+++ b/feature_tests/cpp2/include/BorrowedFields.d.h
@@ -14,7 +14,7 @@ extern "C" {
 
 
 typedef struct BorrowedFields {
-  struct { const wchar_t* data; size_t len; } a;
+  struct { const char16_t* data; size_t len; } a;
   struct { const char* data; size_t len; } b;
   struct { const char* data; size_t len; } c;
 } BorrowedFields;

--- a/feature_tests/cpp2/include/BorrowedFields.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFields.d.hpp
@@ -12,7 +12,7 @@
 
 
 struct BorrowedFields {
-  std::wstring_view a;
+  std::u16string_view a;
   std::string_view b;
   std::string_view c;
 

--- a/feature_tests/cpp2/include/BorrowedFields.hpp
+++ b/feature_tests/cpp2/include/BorrowedFields.hpp
@@ -27,7 +27,7 @@ inline capi::BorrowedFields BorrowedFields::AsFFI() const {
 
 inline BorrowedFields BorrowedFields::FromFFI(capi::BorrowedFields c_struct) {
   return BorrowedFields {
-    .a = std::wstring_view(c_struct.a_data, c_struct.a_size),
+    .a = std::u16string_view(c_struct.a_data, c_struct.a_size),
     .b = std::string_view(c_struct.b_data, c_struct.b_size),
     .c = std::string_view(c_struct.c_data, c_struct.c_size),
   };

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -250,7 +250,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
                 if !is_struct =>
             {
                 vec![
-                    ("const wchar_t*".into(), format!("{param_name}_data").into()),
+                    ("const chat16_t*".into(), format!("{param_name}_data").into()),
                     ("size_t".into(), format!("{param_name}_len").into()),
                 ]
             }
@@ -329,7 +329,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
                         _,
                         hir::StringEncoding::UnvalidatedUtf8 | hir::StringEncoding::Utf8,
                     ) => "char".into(),
-                    hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16) => "wchar_t".into(),
+                    hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16) => "char16_t".into(),
                     hir::Slice::Primitive(_, prim) => self.cx.formatter.fmt_primitive_as_c(*prim),
                     &_ => unreachable!("unknown AST/HIR variant"),
                 };

--- a/tool/src/cpp2/formatter.rs
+++ b/tool/src/cpp2/formatter.rs
@@ -139,7 +139,7 @@ impl<'tcx> Cpp2Formatter<'tcx> {
 
     pub fn fmt_borrowed_utf16_str(&self) -> Cow<'static, str> {
         // TODO: This needs to change if an abstraction other than std::u16string_view is used
-        "std::wstring_view".into()
+        "std::u16string_view".into()
     }
 
     pub fn fmt_owned_str(&self) -> Cow<'static, str> {


### PR DESCRIPTION
Using `char16_t`/`u16string_view`, and adding UB warning to inline C++ docs.