### PR TITLE
Add explicit keyword for generated constructor

### DIFF
--- a/example/cpp/include/ICU4XDataProvider.hpp
+++ b/example/cpp/include/ICU4XDataProvider.hpp
@@ -41,7 +41,7 @@ class ICU4XDataProvider {
   static diplomat::result<std::monostate, std::monostate> returns_result();
   inline const capi::ICU4XDataProvider* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XDataProvider* AsFFIMut() { return this->inner.get(); }
-  inline ICU4XDataProvider(capi::ICU4XDataProvider* i) : inner(i) {}
+  inline explicit ICU4XDataProvider(capi::ICU4XDataProvider* i) : inner(i) {}
   ICU4XDataProvider() = default;
   ICU4XDataProvider(ICU4XDataProvider&&) noexcept = default;
   ICU4XDataProvider& operator=(ICU4XDataProvider&& other) noexcept = default;

--- a/example/cpp/include/ICU4XFixedDecimal.hpp
+++ b/example/cpp/include/ICU4XFixedDecimal.hpp
@@ -55,7 +55,7 @@ class ICU4XFixedDecimal {
   diplomat::result<std::string, std::monostate> to_string() const;
   inline const capi::ICU4XFixedDecimal* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XFixedDecimal* AsFFIMut() { return this->inner.get(); }
-  inline ICU4XFixedDecimal(capi::ICU4XFixedDecimal* i) : inner(i) {}
+  inline explicit ICU4XFixedDecimal(capi::ICU4XFixedDecimal* i) : inner(i) {}
   ICU4XFixedDecimal() = default;
   ICU4XFixedDecimal(ICU4XFixedDecimal&&) noexcept = default;
   ICU4XFixedDecimal& operator=(ICU4XFixedDecimal&& other) noexcept = default;

--- a/example/cpp/include/ICU4XFixedDecimalFormatter.hpp
+++ b/example/cpp/include/ICU4XFixedDecimalFormatter.hpp
@@ -56,7 +56,7 @@ class ICU4XFixedDecimalFormatter {
   std::string format_write(const ICU4XFixedDecimal& value) const;
   inline const capi::ICU4XFixedDecimalFormatter* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XFixedDecimalFormatter* AsFFIMut() { return this->inner.get(); }
-  inline ICU4XFixedDecimalFormatter(capi::ICU4XFixedDecimalFormatter* i) : inner(i) {}
+  inline explicit ICU4XFixedDecimalFormatter(capi::ICU4XFixedDecimalFormatter* i) : inner(i) {}
   ICU4XFixedDecimalFormatter() = default;
   ICU4XFixedDecimalFormatter(ICU4XFixedDecimalFormatter&&) noexcept = default;
   ICU4XFixedDecimalFormatter& operator=(ICU4XFixedDecimalFormatter&& other) noexcept = default;

--- a/example/cpp/include/ICU4XLocale.hpp
+++ b/example/cpp/include/ICU4XLocale.hpp
@@ -36,7 +36,7 @@ class ICU4XLocale {
   static ICU4XLocale new_(const std::string_view name);
   inline const capi::ICU4XLocale* AsFFI() const { return this->inner.get(); }
   inline capi::ICU4XLocale* AsFFIMut() { return this->inner.get(); }
-  inline ICU4XLocale(capi::ICU4XLocale* i) : inner(i) {}
+  inline explicit ICU4XLocale(capi::ICU4XLocale* i) : inner(i) {}
   ICU4XLocale() = default;
   ICU4XLocale(ICU4XLocale&&) noexcept = default;
   ICU4XLocale& operator=(ICU4XLocale&& other) noexcept = default;

--- a/feature_tests/cpp/include/AttrOpaque1.hpp
+++ b/feature_tests/cpp/include/AttrOpaque1.hpp
@@ -26,7 +26,7 @@ class AttrOpaque1 {
   void method_disabledcpp() const;
   inline const capi::AttrOpaque1* AsFFI() const { return this->inner.get(); }
   inline capi::AttrOpaque1* AsFFIMut() { return this->inner.get(); }
-  inline AttrOpaque1(capi::AttrOpaque1* i) : inner(i) {}
+  inline explicit AttrOpaque1(capi::AttrOpaque1* i) : inner(i) {}
   AttrOpaque1() = default;
   AttrOpaque1(AttrOpaque1&&) noexcept = default;
   AttrOpaque1& operator=(AttrOpaque1&& other) noexcept = default;

--- a/feature_tests/cpp/include/AttrOpaque2.hpp
+++ b/feature_tests/cpp/include/AttrOpaque2.hpp
@@ -24,7 +24,7 @@ class AttrOpaque2 {
  public:
   inline const capi::AttrOpaque2* AsFFI() const { return this->inner.get(); }
   inline capi::AttrOpaque2* AsFFIMut() { return this->inner.get(); }
-  inline AttrOpaque2(capi::AttrOpaque2* i) : inner(i) {}
+  inline explicit AttrOpaque2(capi::AttrOpaque2* i) : inner(i) {}
   AttrOpaque2() = default;
   AttrOpaque2(AttrOpaque2&&) noexcept = default;
   AttrOpaque2& operator=(AttrOpaque2&& other) noexcept = default;

--- a/feature_tests/cpp/include/Bar.hpp
+++ b/feature_tests/cpp/include/Bar.hpp
@@ -24,7 +24,7 @@ class Bar {
  public:
   inline const capi::Bar* AsFFI() const { return this->inner.get(); }
   inline capi::Bar* AsFFIMut() { return this->inner.get(); }
-  inline Bar(capi::Bar* i) : inner(i) {}
+  inline explicit Bar(capi::Bar* i) : inner(i) {}
   Bar() = default;
   Bar(Bar&&) noexcept = default;
   Bar& operator=(Bar&& other) noexcept = default;

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -28,7 +28,7 @@ class Float64Vec {
   void set_value(const diplomat::span<const double> new_slice);
   inline const capi::Float64Vec* AsFFI() const { return this->inner.get(); }
   inline capi::Float64Vec* AsFFIMut() { return this->inner.get(); }
-  inline Float64Vec(capi::Float64Vec* i) : inner(i) {}
+  inline explicit Float64Vec(capi::Float64Vec* i) : inner(i) {}
   Float64Vec() = default;
   Float64Vec(Float64Vec&&) noexcept = default;
   Float64Vec& operator=(Float64Vec&& other) noexcept = default;

--- a/feature_tests/cpp/include/Foo.hpp
+++ b/feature_tests/cpp/include/Foo.hpp
@@ -53,7 +53,7 @@ class Foo {
   static Foo extract_from_fields(BorrowedFields fields);
   inline const capi::Foo* AsFFI() const { return this->inner.get(); }
   inline capi::Foo* AsFFIMut() { return this->inner.get(); }
-  inline Foo(capi::Foo* i) : inner(i) {}
+  inline explicit Foo(capi::Foo* i) : inner(i) {}
   Foo() = default;
   Foo(Foo&&) noexcept = default;
   Foo& operator=(Foo&& other) noexcept = default;

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -34,7 +34,7 @@ class MyString {
   std::string get_str() const;
   inline const capi::MyString* AsFFI() const { return this->inner.get(); }
   inline capi::MyString* AsFFIMut() { return this->inner.get(); }
-  inline MyString(capi::MyString* i) : inner(i) {}
+  inline explicit MyString(capi::MyString* i) : inner(i) {}
   MyString() = default;
   MyString(MyString&&) noexcept = default;
   MyString& operator=(MyString&& other) noexcept = default;

--- a/feature_tests/cpp/include/One.hpp
+++ b/feature_tests/cpp/include/One.hpp
@@ -81,7 +81,7 @@ class One {
   static One implicit_bounds_deep(const One& explicit_, const One& implicit_1, const One& implicit_2, const One& nohold);
   inline const capi::One* AsFFI() const { return this->inner.get(); }
   inline capi::One* AsFFIMut() { return this->inner.get(); }
-  inline One(capi::One* i) : inner(i) {}
+  inline explicit One(capi::One* i) : inner(i) {}
   One() = default;
   One(One&&) noexcept = default;
   One& operator=(One&& other) noexcept = default;

--- a/feature_tests/cpp/include/Opaque.hpp
+++ b/feature_tests/cpp/include/Opaque.hpp
@@ -39,7 +39,7 @@ class Opaque {
   static ImportedStruct returns_imported();
   inline const capi::Opaque* AsFFI() const { return this->inner.get(); }
   inline capi::Opaque* AsFFIMut() { return this->inner.get(); }
-  inline Opaque(capi::Opaque* i) : inner(i) {}
+  inline explicit Opaque(capi::Opaque* i) : inner(i) {}
   Opaque() = default;
   Opaque(Opaque&&) noexcept = default;
   Opaque& operator=(Opaque&& other) noexcept = default;

--- a/feature_tests/cpp/include/OptionOpaque.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.hpp
@@ -32,7 +32,7 @@ class OptionOpaque {
   static bool option_opaque_argument(const OptionOpaque* arg);
   inline const capi::OptionOpaque* AsFFI() const { return this->inner.get(); }
   inline capi::OptionOpaque* AsFFIMut() { return this->inner.get(); }
-  inline OptionOpaque(capi::OptionOpaque* i) : inner(i) {}
+  inline explicit OptionOpaque(capi::OptionOpaque* i) : inner(i) {}
   OptionOpaque() = default;
   OptionOpaque(OptionOpaque&&) noexcept = default;
   OptionOpaque& operator=(OptionOpaque&& other) noexcept = default;

--- a/feature_tests/cpp/include/OptionOpaqueChar.hpp
+++ b/feature_tests/cpp/include/OptionOpaqueChar.hpp
@@ -25,7 +25,7 @@ class OptionOpaqueChar {
   void assert_char(char32_t ch) const;
   inline const capi::OptionOpaqueChar* AsFFI() const { return this->inner.get(); }
   inline capi::OptionOpaqueChar* AsFFIMut() { return this->inner.get(); }
-  inline OptionOpaqueChar(capi::OptionOpaqueChar* i) : inner(i) {}
+  inline explicit OptionOpaqueChar(capi::OptionOpaqueChar* i) : inner(i) {}
   OptionOpaqueChar() = default;
   OptionOpaqueChar(OptionOpaqueChar&&) noexcept = default;
   OptionOpaqueChar& operator=(OptionOpaqueChar&& other) noexcept = default;

--- a/feature_tests/cpp/include/RefList.hpp
+++ b/feature_tests/cpp/include/RefList.hpp
@@ -31,7 +31,7 @@ class RefList {
   static RefList node(const RefListParameter& data);
   inline const capi::RefList* AsFFI() const { return this->inner.get(); }
   inline capi::RefList* AsFFIMut() { return this->inner.get(); }
-  inline RefList(capi::RefList* i) : inner(i) {}
+  inline explicit RefList(capi::RefList* i) : inner(i) {}
   RefList() = default;
   RefList(RefList&&) noexcept = default;
   RefList& operator=(RefList&& other) noexcept = default;

--- a/feature_tests/cpp/include/RefListParameter.hpp
+++ b/feature_tests/cpp/include/RefListParameter.hpp
@@ -24,7 +24,7 @@ class RefListParameter {
  public:
   inline const capi::RefListParameter* AsFFI() const { return this->inner.get(); }
   inline capi::RefListParameter* AsFFIMut() { return this->inner.get(); }
-  inline RefListParameter(capi::RefListParameter* i) : inner(i) {}
+  inline explicit RefListParameter(capi::RefListParameter* i) : inner(i) {}
   RefListParameter() = default;
   RefListParameter(RefListParameter&&) noexcept = default;
   RefListParameter& operator=(RefListParameter&& other) noexcept = default;

--- a/feature_tests/cpp/include/ResultOpaque.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.hpp
@@ -36,7 +36,7 @@ class ResultOpaque {
   void assert_integer(int32_t i) const;
   inline const capi::ResultOpaque* AsFFI() const { return this->inner.get(); }
   inline capi::ResultOpaque* AsFFIMut() { return this->inner.get(); }
-  inline ResultOpaque(capi::ResultOpaque* i) : inner(i) {}
+  inline explicit ResultOpaque(capi::ResultOpaque* i) : inner(i) {}
   ResultOpaque() = default;
   ResultOpaque(ResultOpaque&&) noexcept = default;
   ResultOpaque& operator=(ResultOpaque&& other) noexcept = default;

--- a/feature_tests/cpp/include/Two.hpp
+++ b/feature_tests/cpp/include/Two.hpp
@@ -24,7 +24,7 @@ class Two {
  public:
   inline const capi::Two* AsFFI() const { return this->inner.get(); }
   inline capi::Two* AsFFIMut() { return this->inner.get(); }
-  inline Two(capi::Two* i) : inner(i) {}
+  inline explicit Two(capi::Two* i) : inner(i) {}
   Two() = default;
   Two(Two&&) noexcept = default;
   Two& operator=(Two&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__enum_conversion@Foo.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__enum_conversion@Foo.hpp.snap
@@ -30,7 +30,7 @@ class Foo {
   MyStruct get_struct() const;
   inline const capi::Foo* AsFFI() const { return this->inner.get(); }
   inline capi::Foo* AsFFIMut() { return this->inner.get(); }
-  inline Foo(capi::Foo* i) : inner(i) {}
+  inline explicit Foo(capi::Foo* i) : inner(i) {}
   Foo() = default;
   Foo(Foo&&) noexcept = default;
   Foo& operator=(Foo&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__option_conversion@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__option_conversion@MyStruct.hpp.snap
@@ -30,7 +30,7 @@ class MyStruct {
   std::optional<MyStruct> create() const;
   inline const capi::MyStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyStruct(capi::MyStruct* i) : inner(i) {}
+  inline explicit MyStruct(capi::MyStruct* i) : inner(i) {}
   MyStruct() = default;
   MyStruct(MyStruct&&) noexcept = default;
   MyStruct& operator=(MyStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__option_conversion_using_library_config@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__conversions__tests__option_conversion_using_library_config@MyStruct.hpp.snap
@@ -33,7 +33,7 @@ class MyStruct {
   mozilla::Maybe<MyStruct> create() const;
   inline const capi::MyStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyStruct(capi::MyStruct* i) : inner(i) {}
+  inline explicit MyStruct(capi::MyStruct* i) : inner(i) {}
   MyStruct() = default;
   MyStruct(MyStruct&&) noexcept = default;
   MyStruct& operator=(MyStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_slice@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_slice@MyStruct.hpp.snap
@@ -31,7 +31,7 @@ class MyStruct {
   void set_slice(const diplomat::span<const double> new_slice);
   inline const capi::MyStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyStruct(capi::MyStruct* i) : inner(i) {}
+  inline explicit MyStruct(capi::MyStruct* i) : inner(i) {}
   MyStruct() = default;
   MyStruct(MyStruct&&) noexcept = default;
   MyStruct& operator=(MyStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_slice_using_library_config@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_slice_using_library_config@MyStruct.hpp.snap
@@ -34,7 +34,7 @@ class MyStruct {
   void set_slice(const mozilla::Span<const double> new_slice);
   inline const capi::MyStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyStruct(capi::MyStruct* i) : inner(i) {}
+  inline explicit MyStruct(capi::MyStruct* i) : inner(i) {}
   MyStruct() = default;
   MyStruct(MyStruct&&) noexcept = default;
   MyStruct& operator=(MyStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_str@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_taking_str@MyStruct.hpp.snap
@@ -31,7 +31,7 @@ class MyStruct {
   void set_str(const std::string_view new_str);
   inline const capi::MyStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyStruct(capi::MyStruct* i) : inner(i) {}
+  inline explicit MyStruct(capi::MyStruct* i) : inner(i) {}
   MyStruct() = default;
   MyStruct(MyStruct&&) noexcept = default;
   MyStruct& operator=(MyStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_writeable_out@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__method_writeable_out@MyStruct.hpp.snap
@@ -35,7 +35,7 @@ class MyStruct {
   uint8_t write_no_rearrange(capi::DiplomatWriteable& out) const;
   inline const capi::MyStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyStruct(capi::MyStruct* i) : inner(i) {}
+  inline explicit MyStruct(capi::MyStruct* i) : inner(i) {}
   MyStruct() = default;
   MyStruct(MyStruct&&) noexcept = default;
   MyStruct& operator=(MyStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__simple_opaque_struct@MyStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__structs__tests__simple_opaque_struct@MyStruct.hpp.snap
@@ -32,7 +32,7 @@ class MyStruct {
   void set_b(uint8_t b);
   inline const capi::MyStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyStruct(capi::MyStruct* i) : inner(i) {}
+  inline explicit MyStruct(capi::MyStruct* i) : inner(i) {}
   MyStruct() = default;
   MyStruct(MyStruct&&) noexcept = default;
   MyStruct& operator=(MyStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_methods@Foo.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__tests__cross_module_struct_methods@Foo.hpp.snap
@@ -30,7 +30,7 @@ class Foo {
   Bar to_bar() const;
   inline const capi::Foo* AsFFI() const { return this->inner.get(); }
   inline capi::Foo* AsFFIMut() { return this->inner.get(); }
-  inline Foo(capi::Foo* i) : inner(i) {}
+  inline explicit Foo(capi::Foo* i) : inner(i) {}
   Foo() = default;
   Foo(Foo&&) noexcept = default;
   Foo& operator=(Foo&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__option_types@MyOpaqueStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__option_types@MyOpaqueStruct.hpp.snap
@@ -28,7 +28,7 @@ class MyOpaqueStruct {
  public:
   inline const capi::MyOpaqueStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyOpaqueStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyOpaqueStruct(capi::MyOpaqueStruct* i) : inner(i) {}
+  inline explicit MyOpaqueStruct(capi::MyOpaqueStruct* i) : inner(i) {}
   MyOpaqueStruct() = default;
   MyOpaqueStruct(MyOpaqueStruct&&) noexcept = default;
   MyOpaqueStruct& operator=(MyOpaqueStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__option_types_using_library_config@MyOpaqueStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__option_types_using_library_config@MyOpaqueStruct.hpp.snap
@@ -31,7 +31,7 @@ class MyOpaqueStruct {
  public:
   inline const capi::MyOpaqueStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyOpaqueStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyOpaqueStruct(capi::MyOpaqueStruct* i) : inner(i) {}
+  inline explicit MyOpaqueStruct(capi::MyOpaqueStruct* i) : inner(i) {}
   MyOpaqueStruct() = default;
   MyOpaqueStruct(MyOpaqueStruct&&) noexcept = default;
   MyOpaqueStruct& operator=(MyOpaqueStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__pointer_types@MyOpaqueStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__pointer_types@MyOpaqueStruct.hpp.snap
@@ -28,7 +28,7 @@ class MyOpaqueStruct {
  public:
   inline const capi::MyOpaqueStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyOpaqueStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyOpaqueStruct(capi::MyOpaqueStruct* i) : inner(i) {}
+  inline explicit MyOpaqueStruct(capi::MyOpaqueStruct* i) : inner(i) {}
   MyOpaqueStruct() = default;
   MyOpaqueStruct(MyOpaqueStruct&&) noexcept = default;
   MyOpaqueStruct& operator=(MyOpaqueStruct&& other) noexcept = default;

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyOpaqueStruct.hpp.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__types__tests__result_types@MyOpaqueStruct.hpp.snap
@@ -28,7 +28,7 @@ class MyOpaqueStruct {
  public:
   inline const capi::MyOpaqueStruct* AsFFI() const { return this->inner.get(); }
   inline capi::MyOpaqueStruct* AsFFIMut() { return this->inner.get(); }
-  inline MyOpaqueStruct(capi::MyOpaqueStruct* i) : inner(i) {}
+  inline explicit MyOpaqueStruct(capi::MyOpaqueStruct* i) : inner(i) {}
   MyOpaqueStruct() = default;
   MyOpaqueStruct(MyOpaqueStruct&&) noexcept = default;
   MyOpaqueStruct& operator=(MyOpaqueStruct&& other) noexcept = default;

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -90,7 +90,7 @@ pub fn gen_struct<W: fmt::Write>(
 
                 writeln!(
                     &mut public_body,
-                    "inline {}(capi::{}* i) : inner(i) {{}}",
+                    "inline explicit {}(capi::{}* i) : inner(i) {{}}",
                     opaque.name, opaque.name
                 )?;
                 writeln!(


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1868324

I would like to add explicit keyword to generated C++ constructor.