### PR TITLE
Fix typedef in result

### DIFF
--- a/example/c/include/diplomat_result_box_ICU4XFixedDecimalFormatter_void.h
+++ b/example/c/include/diplomat_result_box_ICU4XFixedDecimalFormatter_void.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter;
+#include "ICU4XFixedDecimalFormatter.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/example/cpp/include/diplomat_result_box_ICU4XFixedDecimalFormatter_void.h
+++ b/example/cpp/include/diplomat_result_box_ICU4XFixedDecimalFormatter_void.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter;
+#include "ICU4XFixedDecimalFormatter.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/feature_tests/c/include/OptionStruct.h
+++ b/feature_tests/c/include/OptionStruct.h
@@ -6,8 +6,8 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct OptionOpaque OptionOpaque;
-typedef struct OptionOpaqueChar OptionOpaqueChar;
+#include "OptionOpaque.h"
+#include "OptionOpaqueChar.h"
 #ifdef __cplusplus
 namespace capi {
 #endif
@@ -21,8 +21,8 @@ typedef struct OptionStruct {
 #ifdef __cplusplus
 } // namespace capi
 #endif
-typedef struct OptionOpaque OptionOpaque;
-typedef struct OptionOpaqueChar OptionOpaqueChar;
+#include "OptionOpaque.h"
+#include "OptionOpaqueChar.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/feature_tests/c/include/diplomat_result_ErrorEnum_box_ResultOpaque.h
+++ b/feature_tests/c/include/diplomat_result_ErrorEnum_box_ResultOpaque.h
@@ -7,7 +7,7 @@
 #include "diplomat_runtime.h"
 
 #include "ErrorEnum.h"
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/feature_tests/c/include/diplomat_result_box_ResultOpaque_ErrorEnum.h
+++ b/feature_tests/c/include/diplomat_result_box_ResultOpaque_ErrorEnum.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #include "ErrorEnum.h"
 #ifdef __cplusplus
 namespace capi {

--- a/feature_tests/c/include/diplomat_result_box_ResultOpaque_ErrorStruct.h
+++ b/feature_tests/c/include/diplomat_result_box_ResultOpaque_ErrorStruct.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #include "ErrorStruct.h"
 #ifdef __cplusplus
 namespace capi {

--- a/feature_tests/c/include/diplomat_result_box_ResultOpaque_void.h
+++ b/feature_tests/c/include/diplomat_result_box_ResultOpaque_void.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/feature_tests/c/include/diplomat_result_void_box_ResultOpaque.h
+++ b/feature_tests/c/include/diplomat_result_void_box_ResultOpaque.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/feature_tests/cpp/include/OptionStruct.h
+++ b/feature_tests/cpp/include/OptionStruct.h
@@ -6,8 +6,8 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct OptionOpaque OptionOpaque;
-typedef struct OptionOpaqueChar OptionOpaqueChar;
+#include "OptionOpaque.h"
+#include "OptionOpaqueChar.h"
 #ifdef __cplusplus
 namespace capi {
 #endif
@@ -21,8 +21,8 @@ typedef struct OptionStruct {
 #ifdef __cplusplus
 } // namespace capi
 #endif
-typedef struct OptionOpaque OptionOpaque;
-typedef struct OptionOpaqueChar OptionOpaqueChar;
+#include "OptionOpaque.h"
+#include "OptionOpaqueChar.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/feature_tests/cpp/include/diplomat_result_ErrorEnum_box_ResultOpaque.h
+++ b/feature_tests/cpp/include/diplomat_result_ErrorEnum_box_ResultOpaque.h
@@ -7,7 +7,7 @@
 #include "diplomat_runtime.h"
 
 #include "ErrorEnum.h"
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/feature_tests/cpp/include/diplomat_result_box_ResultOpaque_ErrorEnum.h
+++ b/feature_tests/cpp/include/diplomat_result_box_ResultOpaque_ErrorEnum.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #include "ErrorEnum.h"
 #ifdef __cplusplus
 namespace capi {

--- a/feature_tests/cpp/include/diplomat_result_box_ResultOpaque_ErrorStruct.h
+++ b/feature_tests/cpp/include/diplomat_result_box_ResultOpaque_ErrorStruct.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #include "ErrorStruct.h"
 #ifdef __cplusplus
 namespace capi {

--- a/feature_tests/cpp/include/diplomat_result_box_ResultOpaque_void.h
+++ b/feature_tests/cpp/include/diplomat_result_box_ResultOpaque_void.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/feature_tests/cpp/include/diplomat_result_void_box_ResultOpaque.h
+++ b/feature_tests/cpp/include/diplomat_result_void_box_ResultOpaque.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct ResultOpaque ResultOpaque;
+#include "ResultOpaque.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Bar.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Bar.h.snap
@@ -10,7 +10,7 @@ expression: out_texts.get(out).unwrap()
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct Foo Foo;
+#include "Foo.h"
 #ifdef __cplusplus
 namespace capi {
 #endif
@@ -21,7 +21,7 @@ typedef struct Bar {
 #ifdef __cplusplus
 } // namespace capi
 #endif
-typedef struct Foo Foo;
+#include "Foo.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__option_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__option_types@MyStruct.h.snap
@@ -20,7 +20,6 @@ typedef struct MyStruct {
 #ifdef __cplusplus
 } // namespace capi
 #endif
-typedef struct MyStruct MyStruct;
 #ifdef __cplusplus
 namespace capi {
 extern "C" {

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__pointer_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__pointer_types@MyStruct.h.snap
@@ -10,7 +10,7 @@ expression: out_texts.get(out).unwrap()
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct MyOpaqueStruct MyOpaqueStruct;
+#include "MyOpaqueStruct.h"
 #ifdef __cplusplus
 namespace capi {
 #endif
@@ -21,7 +21,6 @@ typedef struct MyStruct {
 #ifdef __cplusplus
 } // namespace capi
 #endif
-typedef struct MyOpaqueStruct MyOpaqueStruct;
 #include "MyOpaqueStruct.h"
 #ifdef __cplusplus
 namespace capi {

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__result_types@diplomat_result_box_MyStruct_uint8_t.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__result_types@diplomat_result_box_MyStruct_uint8_t.h.snap
@@ -10,7 +10,7 @@ expression: out_texts.get(out).unwrap()
 #include <stdbool.h>
 #include "diplomat_runtime.h"
 
-typedef struct MyStruct MyStruct;
+#include "MyStruct.h"
 #ifdef __cplusplus
 namespace capi {
 extern "C" {


### PR DESCRIPTION
Fixes #393

Including the `.h` instead of defining a typedef correctly puts the typedef into the `capi` namespace in C++.