### PR TITLE
Introduce `DiplomatByte`

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1041,6 +1041,8 @@ pub enum PrimitiveType {
     f64,
     bool,
     char,
+    /// a primitive byte that is not meant to be interpreted numerically
+    /// in languages that don't have fine-grained integer types
     byte,
 }
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1041,13 +1041,14 @@ pub enum PrimitiveType {
     f64,
     bool,
     char,
+    byte,
 }
 
 impl fmt::Display for PrimitiveType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             PrimitiveType::i8 => "i8",
-            PrimitiveType::u8 => "u8",
+            PrimitiveType::u8 | PrimitiveType::byte => "u8",
             PrimitiveType::i16 => "i16",
             PrimitiveType::u16 => "u16",
             PrimitiveType::i32 => "i32",
@@ -1068,7 +1069,7 @@ impl fmt::Display for PrimitiveType {
 }
 
 lazy_static! {
-    static ref PRIMITIVES_MAPPING: [(&'static str, PrimitiveType); 16] = [
+    static ref PRIMITIVES_MAPPING: [(&'static str, PrimitiveType); 17] = [
         ("i8", PrimitiveType::i8),
         ("u8", PrimitiveType::u8),
         ("i16", PrimitiveType::i16),
@@ -1085,6 +1086,7 @@ lazy_static! {
         ("f64", PrimitiveType::f64),
         ("bool", PrimitiveType::bool),
         ("DiplomatChar", PrimitiveType::char),
+        ("DiplomatByte", PrimitiveType::byte),
     ];
     static ref STRING_TO_PRIMITIVE: HashMap<&'static str, PrimitiveType> =
         PRIMITIVES_MAPPING.iter().cloned().collect();

--- a/core/src/hir/primitives.rs
+++ b/core/src/hir/primitives.rs
@@ -45,6 +45,7 @@ pub enum FloatType {
 pub enum PrimitiveType {
     Bool,
     Char,
+    Byte,
     Int(IntType),
     IntSize(IntSizeType),
     Int128(Int128Type),
@@ -116,6 +117,7 @@ impl PrimitiveType {
             ast::PrimitiveType::f64 => PrimitiveType::Float(FloatType::F64),
             ast::PrimitiveType::bool => PrimitiveType::Bool,
             ast::PrimitiveType::char => PrimitiveType::Char,
+            ast::PrimitiveType::byte => PrimitiveType::Byte,
         }
     }
 
@@ -124,6 +126,7 @@ impl PrimitiveType {
         match self {
             PrimitiveType::Bool => "bool",
             PrimitiveType::Char => "char",
+            PrimitiveType::Byte => "byte",
             PrimitiveType::Int(ty) => ty.as_str(),
             PrimitiveType::IntSize(ty) => ty.as_str(),
             PrimitiveType::Int128(ty) => ty.as_str(),

--- a/core/src/hir/primitives.rs
+++ b/core/src/hir/primitives.rs
@@ -45,6 +45,8 @@ pub enum FloatType {
 pub enum PrimitiveType {
     Bool,
     Char,
+    /// a primitive byte that is not meant to be interpreted numerically
+    /// in languages that don't have fine-grained integer types
     Byte,
     Int(IntType),
     IntSize(IntSizeType),

--- a/example/dart/lib/src/lib.g.dart
+++ b/example/dart/lib/src/lib.g.dart
@@ -3,12 +3,13 @@
 // https://github.com/dart-lang/sdk/issues/53946
 // ignore_for_file: non_native_function_type_argument_to_pointer
 
-import 'dart:convert'  ;
-import 'dart:core'as core;
-import 'dart:core'show int, double, bool, String, Object, override;
-import 'dart:ffi'as ffi;
-import 'dart:typed_data'  ;
-import 'package:ffi/ffi.dart'as ffi2 show Arena, calloc;
+import 'dart:convert';
+import 'dart:core' as core;
+import 'dart:core' show int, double, bool, String, Object, override;
+import 'dart:ffi' as ffi;
+import 'dart:math';
+import 'dart:typed_data';
+import 'package:ffi/ffi.dart' as ffi2 show Arena, calloc;
 part 'ICU4XDataProvider.g.dart';
 part 'ICU4XFixedDecimal.g.dart';
 part 'ICU4XFixedDecimalFormatter.g.dart';
@@ -30,21 +31,12 @@ part 'ICU4XLocale.g.dart';
 ///
 /// A [String] can be constructed from a [Rune] using [String.fromCharCode]. 
 typedef Rune = int;
-/// A list of [Rune]s.
-typedef RuneList = Uint32List;
 
 late final ffi.Pointer<T> Function<T extends ffi.NativeType>(String) _capi;
 void init(String path) => _capi = ffi.DynamicLibrary.open(path).lookup;
 
 // ignore: unused_element
 final _callocFree = core.Finalizer(ffi2.calloc.free);
-
-extension _UtfViews on String {
-  // ignore: unused_element
-  _Utf8View get utf8View => _Utf8View(this);
-  // ignore: unused_element
-  _Utf16View get utf16View => _Utf16View(this);
-}
 
 /// An unspecified error value
 // ignore: unused_element
@@ -56,6 +48,57 @@ class VoidError {
   int get hashCode => 1;
 }
 
+extension _View on ByteBuffer {
+  // ignore: unused_element
+  ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setRange(0, length, asUint8List());
+  }
+
+  int get length => lengthInBytes;
+}
+
+extension _UtfViews on String {
+  // ignore: unused_element
+  _Utf8View get utf8View => _Utf8View(this);
+  // ignore: unused_element
+  _Utf16View get utf16View => _Utf16View(this);
+}
+
+extension _NativeBoolViews on core.List<bool> {
+  // ignore: unused_element
+  _BoolListView get boolView => _BoolListView(this);
+}
+
+extension _NativeIntViews on core.List<int> {
+  // ignore: unused_element
+  _Int8ListView get int8View => _Int8ListView(this);
+  // ignore: unused_element
+  _Int16ListView get int16View => _Int16ListView(this);
+  // ignore: unused_element
+  _Int32ListView get int32View => _Int32ListView(this);
+  // ignore: unused_element
+  _Int64ListView get int64View => _Int64ListView(this);
+  // ignore: unused_element
+  _IsizeListView get isizeView => _IsizeListView(this);
+  // ignore: unused_element
+  _Uint8ListView get uint8View => _Uint8ListView(this);
+  // ignore: unused_element
+  _Uint16ListView get uint16View => _Uint16ListView(this);
+  // ignore: unused_element
+  _Uint32ListView get uint32View => _Uint32ListView(this);
+  // ignore: unused_element
+  _Uint64ListView get uint64View => _Uint64ListView(this);
+  // ignore: unused_element
+  _UsizeListView get usizeView => _UsizeListView(this);
+}
+
+extension _NativeFloatViews on core.List<double> {
+  // ignore: unused_element
+  _Float32ListView get float32View => _Float32ListView(this);
+  // ignore: unused_element
+  _Float64ListView get float64View => _Float64ListView(this);
+}
+
 // ignore: unused_element
 class _Utf8View {
   final Uint8List _codeUnits;
@@ -65,7 +108,7 @@ class _Utf8View {
 
   ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
     // Copies
-    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, _codeUnits);
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setRange(0, length, _codeUnits);
   }
 
   int get length => _codeUnits.length;
@@ -79,21 +122,21 @@ class _Utf16View {
 
   ffi.Pointer<ffi.Uint16> pointer(ffi.Allocator alloc) {
     // Copies
-    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, _codeUnits);
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setRange(0, length, _codeUnits);
   }
 
   int get length => _codeUnits.length;
 }
 
 // ignore: unused_element
-class _SizeListView {
-  final core.List<int> _values;
+class _BoolListView{
+  final core.List<bool> _values;
 
-  _SizeListView(this._values);
+  _BoolListView(this._values);
 
   // Copies
-  ffi.Pointer<ffi.Size> pointer(ffi.Allocator alloc) {
-    final pointer = alloc<ffi.Size>(_values.length);
+  ffi.Pointer<ffi.Bool> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.Bool>(_values.length);
     for (var i = 0; i < _values.length; i++) {
       pointer[i] = _values[i];
     }
@@ -103,74 +146,186 @@ class _SizeListView {
   int get length => _values.length;
 }
 
-extension _Int8ListFfi on Int8List {
+class _Int8ListView {
+  final core.List<int> _values;
+
+  _Int8ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int8> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int8>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int8>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int16ListFfi on Int16List {
+class _Int16ListView {
+  final core.List<int> _values;
+
+  _Int16ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int16> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int16>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int16>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int32ListFfi on Int32List {
+class _Int32ListView {
+  final core.List<int> _values;
+
+  _Int32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int32> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int32>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int32>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int64ListFfi on Int64List {
+class _Int64ListView {
+  final core.List<int> _values;
+
+  _Int64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int64> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int64>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int64>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint8ListFfi on Uint8List {
+// ignore: unused_element
+class _IsizeListView {
+  final core.List<int> _values;
+
+  _IsizeListView(this._values);
+
+  // Copies
+  ffi.Pointer<ffi.IntPtr> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.IntPtr>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = _values[i];
+    }
+    return pointer;
+  }
+
+  int get length => _values.length;
+}
+
+class _Uint8ListView {
+  final core.List<int> _values;
+
+  _Uint8ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint8>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(255, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint16ListFfi on Uint16List {
+class _Uint16ListView {
+  final core.List<int> _values;
+
+  _Uint16ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint16> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint16>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(65535, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint32ListFfi on Uint32List {
+class _Uint32ListView {
+  final core.List<int> _values;
+
+  _Uint32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint32> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint32>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint32>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(4294967295, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint64ListFfi on Uint64List {
+class _Uint64ListView {
+  final core.List<int> _values;
+
+  _Uint64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint64> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint64>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint64>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = max(0, _values[i]);
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Float32ListFfi on Float32List {
+// ignore: unused_element
+class _UsizeListView {
+  final core.List<int> _values;
+
+  _UsizeListView(this._values);
+
+  // Copies
+  ffi.Pointer<ffi.Size> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.Size>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = max(0, _values[i]);
+    }
+    return pointer;
+  }
+
+  int get length => _values.length;
+}
+
+class _Float32ListView {
+  final core.List<double> _values;
+
+  _Float32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Float> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Float>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Float>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Float64ListFfi on Float64List {
+class _Float64ListView {
+  final core.List<double> _values;
+
+  _Float64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Double> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Double>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Double>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
 

--- a/feature_tests/c/include/Float64Vec.h
+++ b/feature_tests/c/include/Float64Vec.h
@@ -21,9 +21,23 @@ extern "C" {
 
 Float64Vec* Float64Vec_new(const double* v_data, size_t v_len);
 
+Float64Vec* Float64Vec_new_bool(const bool* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_i16(const int16_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_u16(const uint16_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_isize(const intptr_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_usize(const size_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_f64_be_bytes(const uint8_t* v_data, size_t v_len);
+
 void Float64Vec_fill_slice(const Float64Vec* self, double* v_data, size_t v_len);
 
 void Float64Vec_set_value(Float64Vec* self, const double* new_slice_data, size_t new_slice_len);
+
+void Float64Vec_to_string(const Float64Vec* self, DiplomatWriteable* w);
 void Float64Vec_destroy(Float64Vec* self);
 
 #ifdef __cplusplus

--- a/feature_tests/c2/include/Float64Vec.h
+++ b/feature_tests/c2/include/Float64Vec.h
@@ -17,9 +17,23 @@ extern "C" {
 
 Float64Vec* Float64Vec_new(const double* v_data, size_t v_len);
 
+Float64Vec* Float64Vec_new_bool(const bool* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_i16(const int16_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_u16(const uint16_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_isize(const intptr_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_usize(const size_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_f64_be_bytes(const uint8_t* v_data, size_t v_len);
+
 void Float64Vec_fill_slice(const Float64Vec* self, double* v_data, size_t v_len);
 
 void Float64Vec_set_value(Float64Vec* self, const double* new_slice_data, size_t new_slice_len);
+
+void Float64Vec_to_string(const Float64Vec* self, DiplomatWriteable* writeable);
 
 void Float64Vec_destroy(Float64Vec* self);
 

--- a/feature_tests/cpp/docs/source/slices_ffi.rst
+++ b/feature_tests/cpp/docs/source/slices_ffi.rst
@@ -6,10 +6,34 @@
     .. cpp:function:: static Float64Vec new_(const diplomat::span<const double> v)
 
 
+    .. cpp:function:: static Float64Vec new_bool(const diplomat::span<const bool> v)
+
+
+    .. cpp:function:: static Float64Vec new_i16(const diplomat::span<const int16_t> v)
+
+
+    .. cpp:function:: static Float64Vec new_u16(const diplomat::span<const uint16_t> v)
+
+
+    .. cpp:function:: static Float64Vec new_isize(const diplomat::span<const intptr_t> v)
+
+
+    .. cpp:function:: static Float64Vec new_usize(const diplomat::span<const size_t> v)
+
+
+    .. cpp:function:: static Float64Vec new_f64_be_bytes(const diplomat::span<const uint8_t> v)
+
+
     .. cpp:function:: void fill_slice(diplomat::span<const double> v) const
 
 
     .. cpp:function:: void set_value(const diplomat::span<const double> new_slice)
+
+
+    .. cpp:function:: template<typename W> void to_string_to_writeable(W& w) const
+
+
+    .. cpp:function:: std::string to_string() const
 
 
 .. cpp:class:: MyString

--- a/feature_tests/cpp/include/Float64Vec.h
+++ b/feature_tests/cpp/include/Float64Vec.h
@@ -21,9 +21,23 @@ extern "C" {
 
 Float64Vec* Float64Vec_new(const double* v_data, size_t v_len);
 
+Float64Vec* Float64Vec_new_bool(const bool* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_i16(const int16_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_u16(const uint16_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_isize(const intptr_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_usize(const size_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_f64_be_bytes(const uint8_t* v_data, size_t v_len);
+
 void Float64Vec_fill_slice(const Float64Vec* self, double* v_data, size_t v_len);
 
 void Float64Vec_set_value(Float64Vec* self, const double* new_slice_data, size_t new_slice_len);
+
+void Float64Vec_to_string(const Float64Vec* self, DiplomatWriteable* w);
 void Float64Vec_destroy(Float64Vec* self);
 
 #ifdef __cplusplus

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -24,8 +24,16 @@ struct Float64VecDeleter {
 class Float64Vec {
  public:
   static Float64Vec new_(const diplomat::span<const double> v);
+  static Float64Vec new_bool(const diplomat::span<const bool> v);
+  static Float64Vec new_i16(const diplomat::span<const int16_t> v);
+  static Float64Vec new_u16(const diplomat::span<const uint16_t> v);
+  static Float64Vec new_isize(const diplomat::span<const intptr_t> v);
+  static Float64Vec new_usize(const diplomat::span<const size_t> v);
+  static Float64Vec new_f64_be_bytes(const diplomat::span<const uint8_t> v);
   void fill_slice(diplomat::span<const double> v) const;
   void set_value(const diplomat::span<const double> new_slice);
+  template<typename W> void to_string_to_writeable(W& w) const;
+  std::string to_string() const;
   inline const capi::Float64Vec* AsFFI() const { return this->inner.get(); }
   inline capi::Float64Vec* AsFFIMut() { return this->inner.get(); }
   inline explicit Float64Vec(capi::Float64Vec* i) : inner(i) {}
@@ -40,10 +48,38 @@ class Float64Vec {
 inline Float64Vec Float64Vec::new_(const diplomat::span<const double> v) {
   return Float64Vec(capi::Float64Vec_new(v.data(), v.size()));
 }
+inline Float64Vec Float64Vec::new_bool(const diplomat::span<const bool> v) {
+  return Float64Vec(capi::Float64Vec_new_bool(v.data(), v.size()));
+}
+inline Float64Vec Float64Vec::new_i16(const diplomat::span<const int16_t> v) {
+  return Float64Vec(capi::Float64Vec_new_i16(v.data(), v.size()));
+}
+inline Float64Vec Float64Vec::new_u16(const diplomat::span<const uint16_t> v) {
+  return Float64Vec(capi::Float64Vec_new_u16(v.data(), v.size()));
+}
+inline Float64Vec Float64Vec::new_isize(const diplomat::span<const intptr_t> v) {
+  return Float64Vec(capi::Float64Vec_new_isize(v.data(), v.size()));
+}
+inline Float64Vec Float64Vec::new_usize(const diplomat::span<const size_t> v) {
+  return Float64Vec(capi::Float64Vec_new_usize(v.data(), v.size()));
+}
+inline Float64Vec Float64Vec::new_f64_be_bytes(const diplomat::span<const uint8_t> v) {
+  return Float64Vec(capi::Float64Vec_new_f64_be_bytes(v.data(), v.size()));
+}
 inline void Float64Vec::fill_slice(diplomat::span<const double> v) const {
   capi::Float64Vec_fill_slice(this->inner.get(), v.data(), v.size());
 }
 inline void Float64Vec::set_value(const diplomat::span<const double> new_slice) {
   capi::Float64Vec_set_value(this->inner.get(), new_slice.data(), new_slice.size());
+}
+template<typename W> inline void Float64Vec::to_string_to_writeable(W& w) const {
+  capi::DiplomatWriteable w_writer = diplomat::WriteableTrait<W>::Construct(w);
+  capi::Float64Vec_to_string(this->inner.get(), &w_writer);
+}
+inline std::string Float64Vec::to_string() const {
+  std::string diplomat_writeable_string;
+  capi::DiplomatWriteable diplomat_writeable_out = diplomat::WriteableFromString(diplomat_writeable_string);
+  capi::Float64Vec_to_string(this->inner.get(), &diplomat_writeable_out);
+  return diplomat_writeable_string;
 }
 #endif

--- a/feature_tests/cpp2/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp2/include/Float64Vec.d.hpp
@@ -16,9 +16,23 @@ public:
 
   inline static std::unique_ptr<Float64Vec> new_(diplomat::span<const double> v);
 
+  inline static std::unique_ptr<Float64Vec> new_bool(diplomat::span<const bool> v);
+
+  inline static std::unique_ptr<Float64Vec> new_i16(diplomat::span<const int16_t> v);
+
+  inline static std::unique_ptr<Float64Vec> new_u16(diplomat::span<const uint16_t> v);
+
+  inline static std::unique_ptr<Float64Vec> new_isize(diplomat::span<const intptr_t> v);
+
+  inline static std::unique_ptr<Float64Vec> new_usize(diplomat::span<const size_t> v);
+
+  inline static std::unique_ptr<Float64Vec> new_f64_be_bytes(diplomat::span<const uint8_t> v);
+
   inline void fill_slice(diplomat::span<double> v) const;
 
   inline void set_value(diplomat::span<const double> new_slice);
+
+  inline std::string to_string() const;
 
   inline const capi::Float64Vec* AsFFI() const;
   inline capi::Float64Vec* AsFFI();

--- a/feature_tests/cpp2/include/Float64Vec.h
+++ b/feature_tests/cpp2/include/Float64Vec.h
@@ -17,9 +17,23 @@ extern "C" {
 
 Float64Vec* Float64Vec_new(const double* v_data, size_t v_len);
 
+Float64Vec* Float64Vec_new_bool(const bool* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_i16(const int16_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_u16(const uint16_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_isize(const intptr_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_usize(const size_t* v_data, size_t v_len);
+
+Float64Vec* Float64Vec_new_f64_be_bytes(const uint8_t* v_data, size_t v_len);
+
 void Float64Vec_fill_slice(const Float64Vec* self, double* v_data, size_t v_len);
 
 void Float64Vec_set_value(Float64Vec* self, const double* new_slice_data, size_t new_slice_len);
+
+void Float64Vec_to_string(const Float64Vec* self, DiplomatWriteable* writeable);
 
 void Float64Vec_destroy(Float64Vec* self);
 

--- a/feature_tests/cpp2/include/Float64Vec.hpp
+++ b/feature_tests/cpp2/include/Float64Vec.hpp
@@ -19,6 +19,42 @@ inline std::unique_ptr<Float64Vec> Float64Vec::new_(diplomat::span<const double>
   return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
 }
 
+inline std::unique_ptr<Float64Vec> Float64Vec::new_bool(diplomat::span<const bool> v) {
+  auto result = capi::Float64Vec_new_bool(v.data(),
+    v.size());
+  return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
+}
+
+inline std::unique_ptr<Float64Vec> Float64Vec::new_i16(diplomat::span<const int16_t> v) {
+  auto result = capi::Float64Vec_new_i16(v.data(),
+    v.size());
+  return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
+}
+
+inline std::unique_ptr<Float64Vec> Float64Vec::new_u16(diplomat::span<const uint16_t> v) {
+  auto result = capi::Float64Vec_new_u16(v.data(),
+    v.size());
+  return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
+}
+
+inline std::unique_ptr<Float64Vec> Float64Vec::new_isize(diplomat::span<const intptr_t> v) {
+  auto result = capi::Float64Vec_new_isize(v.data(),
+    v.size());
+  return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
+}
+
+inline std::unique_ptr<Float64Vec> Float64Vec::new_usize(diplomat::span<const size_t> v) {
+  auto result = capi::Float64Vec_new_usize(v.data(),
+    v.size());
+  return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
+}
+
+inline std::unique_ptr<Float64Vec> Float64Vec::new_f64_be_bytes(diplomat::span<const uint8_t> v) {
+  auto result = capi::Float64Vec_new_f64_be_bytes(v.data(),
+    v.size());
+  return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
+}
+
 inline void Float64Vec::fill_slice(diplomat::span<double> v) const {
   capi::Float64Vec_fill_slice(this->AsFFI(),
     v.data(),
@@ -29,6 +65,14 @@ inline void Float64Vec::set_value(diplomat::span<const double> new_slice) {
   capi::Float64Vec_set_value(this->AsFFI(),
     new_slice.data(),
     new_slice.size());
+}
+
+inline std::string Float64Vec::to_string() const {
+  std::string output;
+  capi::DiplomatWriteable writeable = diplomat::WriteableFromString(output);
+  capi::Float64Vec_to_string(this->AsFFI(),
+    &writeable);
+  return output;
 }
 
 inline const capi::Float64Vec* Float64Vec::AsFFI() const {

--- a/feature_tests/dart/lib/src/Float64Vec.g.dart
+++ b/feature_tests/dart/lib/src/Float64Vec.g.dart
@@ -14,9 +14,9 @@ final class Float64Vec implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(_capi('Float64Vec_destroy'));
 
-  factory Float64Vec(Float64List v) {
+  factory Float64Vec(core.List<double> v) {
     final temp = ffi2.Arena();
-    final vView = v;
+    final vView = v.float64View;
     final result = _Float64Vec_new(vView.pointer(temp), vView.length);
     temp.releaseAll();
     return Float64Vec._(result);
@@ -27,9 +27,87 @@ final class Float64Vec implements ffi.Finalizable {
     _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Double>, ffi.Size)>>('Float64Vec_new')
       .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Double>, int)>(isLeaf: true);
 
-  void fillSlice(Float64List v) {
+  factory Float64Vec.bool(core.List<bool> v) {
+    final temp = ffi2.Arena();
+    final vView = v.boolView;
+    final result = _Float64Vec_new_bool(vView.pointer(temp), vView.length);
+    temp.releaseAll();
+    return Float64Vec._(result);
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _Float64Vec_new_bool =
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Bool>, ffi.Size)>>('Float64Vec_new_bool')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Bool>, int)>(isLeaf: true);
+
+  factory Float64Vec.i16(core.List<int> v) {
+    final temp = ffi2.Arena();
+    final vView = v.int16View;
+    final result = _Float64Vec_new_i16(vView.pointer(temp), vView.length);
+    temp.releaseAll();
+    return Float64Vec._(result);
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _Float64Vec_new_i16 =
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Int16>, ffi.Size)>>('Float64Vec_new_i16')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Int16>, int)>(isLeaf: true);
+
+  factory Float64Vec.u16(core.List<int> v) {
+    final temp = ffi2.Arena();
+    final vView = v.uint16View;
+    final result = _Float64Vec_new_u16(vView.pointer(temp), vView.length);
+    temp.releaseAll();
+    return Float64Vec._(result);
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _Float64Vec_new_u16 =
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint16>, ffi.Size)>>('Float64Vec_new_u16')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint16>, int)>(isLeaf: true);
+
+  factory Float64Vec.isize(core.List<int> v) {
+    final temp = ffi2.Arena();
+    final vView = v.isizeView;
+    final result = _Float64Vec_new_isize(vView.pointer(temp), vView.length);
+    temp.releaseAll();
+    return Float64Vec._(result);
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _Float64Vec_new_isize =
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.IntPtr>, ffi.Size)>>('Float64Vec_new_isize')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.IntPtr>, int)>(isLeaf: true);
+
+  factory Float64Vec.usize(core.List<int> v) {
+    final temp = ffi2.Arena();
+    final vView = v.usizeView;
+    final result = _Float64Vec_new_usize(vView.pointer(temp), vView.length);
+    temp.releaseAll();
+    return Float64Vec._(result);
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _Float64Vec_new_usize =
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Size>, ffi.Size)>>('Float64Vec_new_usize')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Size>, int)>(isLeaf: true);
+
+  factory Float64Vec.f64BeBytes(ByteBuffer v) {
     final temp = ffi2.Arena();
     final vView = v;
+    final result = _Float64Vec_new_f64_be_bytes(vView.pointer(temp), vView.length);
+    temp.releaseAll();
+    return Float64Vec._(result);
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _Float64Vec_new_f64_be_bytes =
+    _capi<ffi.NativeFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>('Float64Vec_new_f64_be_bytes')
+      .asFunction<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, int)>(isLeaf: true);
+
+  void fillSlice(core.List<double> v) {
+    final temp = ffi2.Arena();
+    final vView = v.float64View;
     _Float64Vec_fill_slice(_underlying, vView.pointer(temp), vView.length);
     temp.releaseAll();
   }
@@ -39,9 +117,9 @@ final class Float64Vec implements ffi.Finalizable {
     _capi<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Double>, ffi.Size)>>('Float64Vec_fill_slice')
       .asFunction<void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Double>, int)>(isLeaf: true);
 
-  void setValue(Float64List newSlice) {
+  void setValue(core.List<double> newSlice) {
     final temp = ffi2.Arena();
-    final newSliceView = newSlice;
+    final newSliceView = newSlice.float64View;
     _Float64Vec_set_value(_underlying, newSliceView.pointer(temp), newSliceView.length);
     temp.releaseAll();
   }
@@ -50,4 +128,16 @@ final class Float64Vec implements ffi.Finalizable {
   static final _Float64Vec_set_value =
     _capi<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Double>, ffi.Size)>>('Float64Vec_set_value')
       .asFunction<void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Double>, int)>(isLeaf: true);
+
+  @override
+  String toString() {
+    final writeable = _Writeable();
+    _Float64Vec_to_string(_underlying, writeable._underlying);
+    return writeable.finalize();
+  }
+
+  // ignore: non_constant_identifier_names
+  static final _Float64Vec_to_string =
+    _capi<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>>('Float64Vec_to_string')
+      .asFunction<void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true);
 }

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -3,12 +3,13 @@
 // https://github.com/dart-lang/sdk/issues/53946
 // ignore_for_file: non_native_function_type_argument_to_pointer
 
-import 'dart:convert'  ;
-import 'dart:core'as core;
-import 'dart:core'show int, double, bool, String, Object, override;
-import 'dart:ffi'as ffi;
-import 'dart:typed_data'  ;
-import 'package:ffi/ffi.dart'as ffi2 show Arena, calloc;
+import 'dart:convert';
+import 'dart:core' as core;
+import 'dart:core' show int, double, bool, String, Object, override;
+import 'dart:ffi' as ffi;
+import 'dart:math';
+import 'dart:typed_data';
+import 'package:ffi/ffi.dart' as ffi2 show Arena, calloc;
 part 'AttrEnum.g.dart';
 part 'AttrOpaque1.g.dart';
 part 'AttrOpaque2.g.dart';
@@ -49,21 +50,12 @@ part 'UnimportedEnum.g.dart';
 ///
 /// A [String] can be constructed from a [Rune] using [String.fromCharCode]. 
 typedef Rune = int;
-/// A list of [Rune]s.
-typedef RuneList = Uint32List;
 
 late final ffi.Pointer<T> Function<T extends ffi.NativeType>(String) _capi;
 void init(String path) => _capi = ffi.DynamicLibrary.open(path).lookup;
 
 // ignore: unused_element
 final _callocFree = core.Finalizer(ffi2.calloc.free);
-
-extension _UtfViews on String {
-  // ignore: unused_element
-  _Utf8View get utf8View => _Utf8View(this);
-  // ignore: unused_element
-  _Utf16View get utf16View => _Utf16View(this);
-}
 
 /// An unspecified error value
 // ignore: unused_element
@@ -75,6 +67,57 @@ class VoidError {
   int get hashCode => 1;
 }
 
+extension _View on ByteBuffer {
+  // ignore: unused_element
+  ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setRange(0, length, asUint8List());
+  }
+
+  int get length => lengthInBytes;
+}
+
+extension _UtfViews on String {
+  // ignore: unused_element
+  _Utf8View get utf8View => _Utf8View(this);
+  // ignore: unused_element
+  _Utf16View get utf16View => _Utf16View(this);
+}
+
+extension _NativeBoolViews on core.List<bool> {
+  // ignore: unused_element
+  _BoolListView get boolView => _BoolListView(this);
+}
+
+extension _NativeIntViews on core.List<int> {
+  // ignore: unused_element
+  _Int8ListView get int8View => _Int8ListView(this);
+  // ignore: unused_element
+  _Int16ListView get int16View => _Int16ListView(this);
+  // ignore: unused_element
+  _Int32ListView get int32View => _Int32ListView(this);
+  // ignore: unused_element
+  _Int64ListView get int64View => _Int64ListView(this);
+  // ignore: unused_element
+  _IsizeListView get isizeView => _IsizeListView(this);
+  // ignore: unused_element
+  _Uint8ListView get uint8View => _Uint8ListView(this);
+  // ignore: unused_element
+  _Uint16ListView get uint16View => _Uint16ListView(this);
+  // ignore: unused_element
+  _Uint32ListView get uint32View => _Uint32ListView(this);
+  // ignore: unused_element
+  _Uint64ListView get uint64View => _Uint64ListView(this);
+  // ignore: unused_element
+  _UsizeListView get usizeView => _UsizeListView(this);
+}
+
+extension _NativeFloatViews on core.List<double> {
+  // ignore: unused_element
+  _Float32ListView get float32View => _Float32ListView(this);
+  // ignore: unused_element
+  _Float64ListView get float64View => _Float64ListView(this);
+}
+
 // ignore: unused_element
 class _Utf8View {
   final Uint8List _codeUnits;
@@ -84,7 +127,7 @@ class _Utf8View {
 
   ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
     // Copies
-    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, _codeUnits);
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setRange(0, length, _codeUnits);
   }
 
   int get length => _codeUnits.length;
@@ -98,21 +141,21 @@ class _Utf16View {
 
   ffi.Pointer<ffi.Uint16> pointer(ffi.Allocator alloc) {
     // Copies
-    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, _codeUnits);
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setRange(0, length, _codeUnits);
   }
 
   int get length => _codeUnits.length;
 }
 
 // ignore: unused_element
-class _SizeListView {
-  final core.List<int> _values;
+class _BoolListView{
+  final core.List<bool> _values;
 
-  _SizeListView(this._values);
+  _BoolListView(this._values);
 
   // Copies
-  ffi.Pointer<ffi.Size> pointer(ffi.Allocator alloc) {
-    final pointer = alloc<ffi.Size>(_values.length);
+  ffi.Pointer<ffi.Bool> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.Bool>(_values.length);
     for (var i = 0; i < _values.length; i++) {
       pointer[i] = _values[i];
     }
@@ -122,74 +165,186 @@ class _SizeListView {
   int get length => _values.length;
 }
 
-extension _Int8ListFfi on Int8List {
+class _Int8ListView {
+  final core.List<int> _values;
+
+  _Int8ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int8> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int8>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int8>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int16ListFfi on Int16List {
+class _Int16ListView {
+  final core.List<int> _values;
+
+  _Int16ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int16> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int16>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int16>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int32ListFfi on Int32List {
+class _Int32ListView {
+  final core.List<int> _values;
+
+  _Int32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int32> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int32>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int32>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int64ListFfi on Int64List {
+class _Int64ListView {
+  final core.List<int> _values;
+
+  _Int64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int64> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int64>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int64>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint8ListFfi on Uint8List {
+// ignore: unused_element
+class _IsizeListView {
+  final core.List<int> _values;
+
+  _IsizeListView(this._values);
+
+  // Copies
+  ffi.Pointer<ffi.IntPtr> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.IntPtr>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = _values[i];
+    }
+    return pointer;
+  }
+
+  int get length => _values.length;
+}
+
+class _Uint8ListView {
+  final core.List<int> _values;
+
+  _Uint8ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint8>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(255, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint16ListFfi on Uint16List {
+class _Uint16ListView {
+  final core.List<int> _values;
+
+  _Uint16ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint16> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint16>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(65535, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint32ListFfi on Uint32List {
+class _Uint32ListView {
+  final core.List<int> _values;
+
+  _Uint32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint32> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint32>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint32>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(4294967295, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint64ListFfi on Uint64List {
+class _Uint64ListView {
+  final core.List<int> _values;
+
+  _Uint64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint64> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint64>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint64>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = max(0, _values[i]);
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Float32ListFfi on Float32List {
+// ignore: unused_element
+class _UsizeListView {
+  final core.List<int> _values;
+
+  _UsizeListView(this._values);
+
+  // Copies
+  ffi.Pointer<ffi.Size> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.Size>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = max(0, _values[i]);
+    }
+    return pointer;
+  }
+
+  int get length => _values.length;
+}
+
+class _Float32ListView {
+  final core.List<double> _values;
+
+  _Float32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Float> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Float>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Float>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Float64ListFfi on Float64List {
+class _Float64ListView {
+  final core.List<double> _values;
+
+  _Float64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Double> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Double>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Double>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
 

--- a/feature_tests/dart/test/slice_test.dart
+++ b/feature_tests/dart/test/slice_test.dart
@@ -1,0 +1,37 @@
+import 'package:feature_tests/lib.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+import 'dart:typed_data';
+
+void main() {
+  init(path.absolute('../../target/debug/libdiplomat_feature_tests.so'));
+
+  test("double", () {
+    expect(Float64Vec([-10.0, double.maxFinite, double.infinity]).toString(), "[-10.0, 1.7976931348623157e308, inf]");
+  });
+
+  test("isize", () {
+    // max integer value
+    expect(Float64Vec.isize([-9223372036854775808, -1, 9223372036854775807]).toString(), "[-9.223372036854776e18, -1.0, 9.223372036854776e18]");
+  });
+
+  test("usize", () {
+    expect(Float64Vec.usize([-9223372036854775808, -1, 9223372036854775807]).toString(), "[0.0, 0.0, 9.223372036854776e18]");
+  });
+
+  test("i16", () {
+    expect(Float64Vec.i16([-10, 10]).toString(), "[-10.0, 10.0]");
+  });
+
+  test("u16", () {
+    expect(Float64Vec.u16([-10, 10]).toString(), "[0.0, 10.0]");
+  });
+
+  test("bool", () {
+    expect(Float64Vec.bool([true, false]).toString(), "[1.0, 0.0]");
+  });
+
+  test("bytes", () {
+    expect(Float64Vec.f64BeBytes(Uint8List.fromList([64, 40, 174, 20, 122, 225, 71, 174]).buffer).toString(), "[12.34]");
+  });
+}

--- a/feature_tests/dotnet/Lib/Generated/Float64Vec.cs
+++ b/feature_tests/dotnet/Lib/Generated/Float64Vec.cs
@@ -45,6 +45,102 @@ public partial class Float64Vec: IDisposable
         }
     }
 
+    /// <returns>
+    /// A <c>Float64Vec</c> allocated on Rust side.
+    /// </returns>
+    public static Float64Vec NewBool(bool[] v)
+    {
+        unsafe
+        {
+            nuint vLength = (nuint)v.Length;
+            fixed (bool* vPtr = v)
+            {
+                Raw.Float64Vec* retVal = Raw.Float64Vec.NewBool(vPtr, vLength);
+                return new Float64Vec(retVal);
+            }
+        }
+    }
+
+    /// <returns>
+    /// A <c>Float64Vec</c> allocated on Rust side.
+    /// </returns>
+    public static Float64Vec NewI16(short[] v)
+    {
+        unsafe
+        {
+            nuint vLength = (nuint)v.Length;
+            fixed (short* vPtr = v)
+            {
+                Raw.Float64Vec* retVal = Raw.Float64Vec.NewI16(vPtr, vLength);
+                return new Float64Vec(retVal);
+            }
+        }
+    }
+
+    /// <returns>
+    /// A <c>Float64Vec</c> allocated on Rust side.
+    /// </returns>
+    public static Float64Vec NewU16(ushort[] v)
+    {
+        unsafe
+        {
+            nuint vLength = (nuint)v.Length;
+            fixed (ushort* vPtr = v)
+            {
+                Raw.Float64Vec* retVal = Raw.Float64Vec.NewU16(vPtr, vLength);
+                return new Float64Vec(retVal);
+            }
+        }
+    }
+
+    /// <returns>
+    /// A <c>Float64Vec</c> allocated on Rust side.
+    /// </returns>
+    public static Float64Vec NewIsize(nint[] v)
+    {
+        unsafe
+        {
+            nuint vLength = (nuint)v.Length;
+            fixed (nint* vPtr = v)
+            {
+                Raw.Float64Vec* retVal = Raw.Float64Vec.NewIsize(vPtr, vLength);
+                return new Float64Vec(retVal);
+            }
+        }
+    }
+
+    /// <returns>
+    /// A <c>Float64Vec</c> allocated on Rust side.
+    /// </returns>
+    public static Float64Vec NewUsize(nuint[] v)
+    {
+        unsafe
+        {
+            nuint vLength = (nuint)v.Length;
+            fixed (nuint* vPtr = v)
+            {
+                Raw.Float64Vec* retVal = Raw.Float64Vec.NewUsize(vPtr, vLength);
+                return new Float64Vec(retVal);
+            }
+        }
+    }
+
+    /// <returns>
+    /// A <c>Float64Vec</c> allocated on Rust side.
+    /// </returns>
+    public static Float64Vec NewF64BeBytes(byte[] v)
+    {
+        unsafe
+        {
+            nuint vLength = (nuint)v.Length;
+            fixed (byte* vPtr = v)
+            {
+                Raw.Float64Vec* retVal = Raw.Float64Vec.NewF64BeBytes(vPtr, vLength);
+                return new Float64Vec(retVal);
+            }
+        }
+    }
+
     public void FillSlice(double[] v)
     {
         unsafe
@@ -74,6 +170,34 @@ public partial class Float64Vec: IDisposable
             {
                 Raw.Float64Vec.SetValue(_inner, newSlicePtr, newSliceLength);
             }
+        }
+    }
+
+    public void ToString(DiplomatWriteable w)
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Float64Vec");
+            }
+            Raw.Float64Vec.ToString(_inner, &w);
+        }
+    }
+
+    public string ToString()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Float64Vec");
+            }
+            DiplomatWriteable writeable = new DiplomatWriteable();
+            Raw.Float64Vec.ToString(_inner, &writeable);
+            string retVal = writeable.ToUnicode();
+            writeable.Dispose();
+            return retVal;
         }
     }
 

--- a/feature_tests/dotnet/Lib/Generated/RawFloat64Vec.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawFloat64Vec.cs
@@ -19,11 +19,32 @@ public partial struct Float64Vec
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_new", ExactSpelling = true)]
     public static unsafe extern Float64Vec* New(double* v, nuint vSz);
 
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_new_bool", ExactSpelling = true)]
+    public static unsafe extern Float64Vec* NewBool(bool* v, nuint vSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_new_i16", ExactSpelling = true)]
+    public static unsafe extern Float64Vec* NewI16(short* v, nuint vSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_new_u16", ExactSpelling = true)]
+    public static unsafe extern Float64Vec* NewU16(ushort* v, nuint vSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_new_isize", ExactSpelling = true)]
+    public static unsafe extern Float64Vec* NewIsize(nint* v, nuint vSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_new_usize", ExactSpelling = true)]
+    public static unsafe extern Float64Vec* NewUsize(nuint* v, nuint vSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_new_f64_be_bytes", ExactSpelling = true)]
+    public static unsafe extern Float64Vec* NewF64BeBytes(byte* v, nuint vSz);
+
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_fill_slice", ExactSpelling = true)]
     public static unsafe extern void FillSlice(Float64Vec* self, double* v, nuint vSz);
 
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_set_value", ExactSpelling = true)]
     public static unsafe extern void SetValue(Float64Vec* self, double* newSlice, nuint newSliceSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_to_string", ExactSpelling = true)]
+    public static unsafe extern void ToString(Float64Vec* self, DiplomatWriteable* w);
 
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Float64Vec_destroy", ExactSpelling = true)]
     public static unsafe extern void Destroy(Float64Vec* self);

--- a/feature_tests/js/api/Float64Vec.d.ts
+++ b/feature_tests/js/api/Float64Vec.d.ts
@@ -9,9 +9,37 @@ export class Float64Vec {
 
   /**
    */
+  static new_bool(v: Uint8Array): Float64Vec;
+
+  /**
+   */
+  static new_i16(v: Int16Array): Float64Vec;
+
+  /**
+   */
+  static new_u16(v: Uint16Array): Float64Vec;
+
+  /**
+   */
+  static new_isize(v: Int32Array): Float64Vec;
+
+  /**
+   */
+  static new_usize(v: Uint32Array): Float64Vec;
+
+  /**
+   */
+  static new_f64_be_bytes(v: Uint8Array): Float64Vec;
+
+  /**
+   */
   fill_slice(v: Float64Array): void;
 
   /**
    */
   set_value(new_slice: Float64Array): void;
+
+  /**
+   */
+  to_string(): string;
 }

--- a/feature_tests/js/api/Float64Vec.mjs
+++ b/feature_tests/js/api/Float64Vec.mjs
@@ -22,6 +22,48 @@ export class Float64Vec {
     return diplomat_out;
   }
 
+  static new_bool(arg_v) {
+    const buf_arg_v = diplomatRuntime.DiplomatBuf.slice(wasm, arg_v, "bool");
+    const diplomat_out = new Float64Vec(wasm.Float64Vec_new_bool(buf_arg_v.ptr, buf_arg_v.size), true, []);
+    buf_arg_v.free();
+    return diplomat_out;
+  }
+
+  static new_i16(arg_v) {
+    const buf_arg_v = diplomatRuntime.DiplomatBuf.slice(wasm, arg_v, "i16");
+    const diplomat_out = new Float64Vec(wasm.Float64Vec_new_i16(buf_arg_v.ptr, buf_arg_v.size), true, []);
+    buf_arg_v.free();
+    return diplomat_out;
+  }
+
+  static new_u16(arg_v) {
+    const buf_arg_v = diplomatRuntime.DiplomatBuf.slice(wasm, arg_v, "u16");
+    const diplomat_out = new Float64Vec(wasm.Float64Vec_new_u16(buf_arg_v.ptr, buf_arg_v.size), true, []);
+    buf_arg_v.free();
+    return diplomat_out;
+  }
+
+  static new_isize(arg_v) {
+    const buf_arg_v = diplomatRuntime.DiplomatBuf.slice(wasm, arg_v, "isize");
+    const diplomat_out = new Float64Vec(wasm.Float64Vec_new_isize(buf_arg_v.ptr, buf_arg_v.size), true, []);
+    buf_arg_v.free();
+    return diplomat_out;
+  }
+
+  static new_usize(arg_v) {
+    const buf_arg_v = diplomatRuntime.DiplomatBuf.slice(wasm, arg_v, "usize");
+    const diplomat_out = new Float64Vec(wasm.Float64Vec_new_usize(buf_arg_v.ptr, buf_arg_v.size), true, []);
+    buf_arg_v.free();
+    return diplomat_out;
+  }
+
+  static new_f64_be_bytes(arg_v) {
+    const buf_arg_v = diplomatRuntime.DiplomatBuf.slice(wasm, arg_v, "u8");
+    const diplomat_out = new Float64Vec(wasm.Float64Vec_new_f64_be_bytes(buf_arg_v.ptr, buf_arg_v.size), true, []);
+    buf_arg_v.free();
+    return diplomat_out;
+  }
+
   fill_slice(arg_v) {
     const buf_arg_v = diplomatRuntime.DiplomatBuf.slice(wasm, arg_v, "f64");
     wasm.Float64Vec_fill_slice(this.underlying, buf_arg_v.ptr, buf_arg_v.size);
@@ -32,5 +74,11 @@ export class Float64Vec {
     const buf_arg_new_slice = diplomatRuntime.DiplomatBuf.slice(wasm, arg_new_slice, "f64");
     wasm.Float64Vec_set_value(this.underlying, buf_arg_new_slice.ptr, buf_arg_new_slice.size);
     buf_arg_new_slice.free();
+  }
+
+  to_string() {
+    return diplomatRuntime.withWriteable(wasm, (writeable) => {
+      return wasm.Float64Vec_to_string(this.underlying, writeable);
+    });
   }
 }

--- a/feature_tests/js/docs/source/slices_ffi.rst
+++ b/feature_tests/js/docs/source/slices_ffi.rst
@@ -5,9 +5,23 @@
 
     .. js:function:: new(v)
 
+    .. js:function:: new_bool(v)
+
+    .. js:function:: new_i16(v)
+
+    .. js:function:: new_u16(v)
+
+    .. js:function:: new_isize(v)
+
+    .. js:function:: new_usize(v)
+
+    .. js:function:: new_f64_be_bytes(v)
+
     .. js:method:: fill_slice(v)
 
     .. js:method:: set_value(new_slice)
+
+    .. js:method:: to_string()
 
 .. js:class:: MyString
 

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -33,12 +33,44 @@ mod ffi {
             Box::new(Self(v.to_vec()))
         }
 
+        pub fn new_bool(v: &[bool]) -> Box<Float64Vec> {
+            Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
+        }
+
+        pub fn new_i16(v: &[i16]) -> Box<Float64Vec> {
+            Box::new(Self(v.iter().map(|&x| x as f64).collect()))
+        }
+
+        pub fn new_u16(v: &[u16]) -> Box<Float64Vec> {
+            Box::new(Self(v.iter().map(|&x| x as f64).collect()))
+        }
+
+        pub fn new_isize(v: &[isize]) -> Box<Float64Vec> {
+            Box::new(Self(v.iter().map(|&x| x as f64).collect()))
+        }
+
+        pub fn new_usize(v: &[usize]) -> Box<Float64Vec> {
+            Box::new(Self(v.iter().map(|&x| x as f64).collect()))
+        }
+
+        pub fn new_f64_be_bytes(v: &[DiplomatByte]) -> Box<Float64Vec> {
+            Box::new(Self(
+                v.chunks_exact(8)
+                    .map(|b| f64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
+                    .collect(),
+            ))
+        }
+
         pub fn fill_slice(&self, v: &mut [f64]) {
             v.copy_from_slice(&self.0)
         }
 
         pub fn set_value(&mut self, new_slice: &[f64]) {
             self.0 = new_slice.to_vec();
+        }
+
+        pub fn to_string(&self, w: &mut DiplomatWriteable) {
+            write!(w, "{:?}", self.0).unwrap();
         }
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -24,6 +24,8 @@ pub type DiplomatStr = [u8];
 pub type DiplomatStr16 = [u16];
 
 /// Like [`u8`], but interpreted explicitly as a raw byte as opposed to a numerical value.
+/// This matters for languages like JavaScript or Dart, where there's only a single numeric
+/// type, but special types for byte buffers.
 pub type DiplomatByte = u8;
 
 /// Allocates a buffer of a given size in Rust's memory.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,11 +14,17 @@ pub use writeable::DiplomatWriteable;
 mod result;
 pub use result::DiplomatResult;
 
+/// Like [`char`], but unvalidated.
 pub type DiplomatChar = u32;
 
+/// Like [`str`], but unvalidated.
 pub type DiplomatStr = [u8];
 
+/// Like `Wstr`, but unvalidated.
 pub type DiplomatStr16 = [u16];
+
+/// Like [`u8`], but interpreted explicitly as a raw byte as opposed to a numerical value.
+pub type DiplomatByte = u8;
 
 /// Allocates a buffer of a given size in Rust's memory.
 ///

--- a/tool/src/c/types.rs
+++ b/tool/src/c/types.rs
@@ -124,7 +124,7 @@ pub fn name_for_type(typ: &ast::TypeName) -> ast::Ident {
 pub fn c_type_for_prim(prim: &PrimitiveType) -> &'static str {
     match prim {
         PrimitiveType::i8 => "int8_t",
-        PrimitiveType::u8 => "uint8_t",
+        PrimitiveType::u8 | PrimitiveType::byte => "uint8_t",
         PrimitiveType::i16 => "int16_t",
         PrimitiveType::u16 => "uint16_t",
         PrimitiveType::i32 => "int32_t",

--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -147,7 +147,7 @@ impl<'tcx> CFormatter<'tcx> {
             PrimitiveType::Bool => "bool",
             PrimitiveType::Char => "char32_t",
             PrimitiveType::Int(IntType::I8) => "int8_t",
-            PrimitiveType::Int(IntType::U8) => "uint8_t",
+            PrimitiveType::Int(IntType::U8) | PrimitiveType::Byte => "uint8_t",
             PrimitiveType::Int(IntType::I16) => "int16_t",
             PrimitiveType::Int(IntType::U16) => "uint16_t",
             PrimitiveType::Int(IntType::I32) => "int32_t",

--- a/tool/src/dart/formatter.rs
+++ b/tool/src/dart/formatter.rs
@@ -220,7 +220,7 @@ impl<'tcx> DartFormatter<'tcx> {
             match prim {
                 PrimitiveType::Bool => "bool",
                 PrimitiveType::Char => "Rune",
-                PrimitiveType::Int(_) | PrimitiveType::IntSize(_) | PrimitiveType::Byte  => "int",
+                PrimitiveType::Int(_) | PrimitiveType::IntSize(_) | PrimitiveType::Byte => "int",
                 PrimitiveType::Float(_) => "double",
                 PrimitiveType::Int128(_) => panic!("i128 not supported in Dart"),
             }

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -56,6 +56,7 @@ pub fn run<'cx>(
         Some("show int, double, bool, String, Object, override"),
     ));
     directives.insert(formatter.fmt_import("dart:convert", None));
+    directives.insert(formatter.fmt_import("dart:math", None));
     directives.insert(formatter.fmt_import("dart:core", Some("as core")));
     directives.insert(formatter.fmt_import("dart:ffi", Some("as ffi")));
     directives
@@ -662,16 +663,11 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             Type::Slice(hir::Slice::Str(_, hir::StringEncoding::UnvalidatedUtf16)) => {
                 format!("{dart_name}.utf16View").into()
             }
-            Type::Slice(hir::Slice::Primitive(
-                _,
-                hir::PrimitiveType::Int(_) | hir::PrimitiveType::Float(_),
-            )) => dart_name,
-            // usize doesn't have a typed list: https://github.com/dart-lang/sdk/issues/54119
-            Type::Slice(hir::Slice::Primitive(
-                _,
-                hir::PrimitiveType::IntSize(hir::IntSizeType::Usize),
-            )) => format!("_SizeListView({dart_name})").into(),
-            // Other primitive slices are not supported in Dart
+            Type::Slice(hir::Slice::Primitive(_, p)) => format!(
+                "{dart_name}{view}",
+                view = self.formatter.fmt_primitive_list_view(p)
+            )
+            .into(),
             _ => unreachable!("unknown AST/HIR variant"),
         }
     }

--- a/tool/src/dotnet/types.rs
+++ b/tool/src/dotnet/types.rs
@@ -74,7 +74,7 @@ pub fn gen_type_name(
 pub fn type_name_for_prim(prim: &ast::PrimitiveType) -> &str {
     match prim {
         ast::PrimitiveType::i8 => "sbyte",
-        ast::PrimitiveType::u8 => "byte",
+        ast::PrimitiveType::u8 | ast::PrimitiveType::byte => "byte",
         ast::PrimitiveType::i16 => "short",
         ast::PrimitiveType::u16 => "ushort",
         ast::PrimitiveType::i32 => "int",

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -655,7 +655,7 @@ impl From<&ast::PrimitiveType> for JsPrimitive {
     fn from(prim: &ast::PrimitiveType) -> Self {
         match prim {
             ast::PrimitiveType::i8 => JsPrimitive::Number(JsPrimitiveNumber::Int8),
-            ast::PrimitiveType::u8 => JsPrimitive::Number(JsPrimitiveNumber::Uint8),
+            ast::PrimitiveType::u8 | ast::PrimitiveType::byte => JsPrimitive::Number(JsPrimitiveNumber::Uint8),
             ast::PrimitiveType::i16 => JsPrimitive::Number(JsPrimitiveNumber::Int16),
             ast::PrimitiveType::u16 => JsPrimitive::Number(JsPrimitiveNumber::Uint16),
             ast::PrimitiveType::i32 => JsPrimitive::Number(JsPrimitiveNumber::Int32),

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -655,7 +655,9 @@ impl From<&ast::PrimitiveType> for JsPrimitive {
     fn from(prim: &ast::PrimitiveType) -> Self {
         match prim {
             ast::PrimitiveType::i8 => JsPrimitive::Number(JsPrimitiveNumber::Int8),
-            ast::PrimitiveType::u8 | ast::PrimitiveType::byte => JsPrimitive::Number(JsPrimitiveNumber::Uint8),
+            ast::PrimitiveType::u8 | ast::PrimitiveType::byte => {
+                JsPrimitive::Number(JsPrimitiveNumber::Uint8)
+            }
             ast::PrimitiveType::i16 => JsPrimitive::Number(JsPrimitiveNumber::Int16),
             ast::PrimitiveType::u16 => JsPrimitive::Number(JsPrimitiveNumber::Uint16),
             ast::PrimitiveType::i32 => JsPrimitive::Number(JsPrimitiveNumber::Int32),

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -101,7 +101,7 @@ pub fn gen_bindings(
                 "import {{ {} }} from \"./diplomat-runtime\"",
                 Csv(imports.ts_primitives.iter().map(|prim| match prim {
                     ast::PrimitiveType::i8 => "i8",
-                    ast::PrimitiveType::u8 => "u8",
+                    ast::PrimitiveType::u8 | ast::PrimitiveType::byte => "u8",
                     ast::PrimitiveType::i16 => "i16",
                     ast::PrimitiveType::u16 => "u16",
                     ast::PrimitiveType::i32 => "i32",

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -508,7 +508,7 @@ pub fn gen_ts_type<W: fmt::Write>(
         ) => out.write_str("string")?,
         ast::TypeName::PrimitiveSlice(.., prim) => match prim {
             ast::PrimitiveType::i8 => write!(out, "Int8Array")?,
-            ast::PrimitiveType::u8 => write!(out, "Uint8Array")?,
+            ast::PrimitiveType::u8 | ast::PrimitiveType::byte => write!(out, "Uint8Array")?,
             ast::PrimitiveType::i16 => write!(out, "Int16Array")?,
             ast::PrimitiveType::u16 => write!(out, "Uint16Array")?,
             ast::PrimitiveType::i32 => write!(out, "Int32Array")?,

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -117,7 +117,9 @@ pub fn primitive_size_alignment(prim: PrimitiveType) -> Layout {
     match prim {
         ast::PrimitiveType::bool => Layout::new::<bool>(),
         ast::PrimitiveType::char => Layout::new::<char>(),
-        ast::PrimitiveType::i8 | ast::PrimitiveType::u8 | ast::PrimitiveType::byte => Layout::new::<u8>(),
+        ast::PrimitiveType::i8 | ast::PrimitiveType::u8 | ast::PrimitiveType::byte => {
+            Layout::new::<u8>()
+        }
         ast::PrimitiveType::i16 | ast::PrimitiveType::u16 => Layout::new::<u16>(),
         ast::PrimitiveType::i32 | ast::PrimitiveType::u32 => Layout::new::<u32>(),
         ast::PrimitiveType::i64 | ast::PrimitiveType::u64 => Layout::new::<u64>(),

--- a/tool/src/layout.rs
+++ b/tool/src/layout.rs
@@ -117,7 +117,7 @@ pub fn primitive_size_alignment(prim: PrimitiveType) -> Layout {
     match prim {
         ast::PrimitiveType::bool => Layout::new::<bool>(),
         ast::PrimitiveType::char => Layout::new::<char>(),
-        ast::PrimitiveType::i8 | ast::PrimitiveType::u8 => Layout::new::<u8>(),
+        ast::PrimitiveType::i8 | ast::PrimitiveType::u8 | ast::PrimitiveType::byte => Layout::new::<u8>(),
         ast::PrimitiveType::i16 | ast::PrimitiveType::u16 => Layout::new::<u16>(),
         ast::PrimitiveType::i32 | ast::PrimitiveType::u32 => Layout::new::<u32>(),
         ast::PrimitiveType::i64 | ast::PrimitiveType::u64 => Layout::new::<u64>(),

--- a/tool/templates/dart/init.dart
+++ b/tool/templates/dart/init.dart
@@ -13,21 +13,12 @@
 ///
 /// A [String] can be constructed from a [Rune] using [String.fromCharCode]. 
 typedef Rune = int;
-/// A list of [Rune]s.
-typedef RuneList = Uint32List;
 
 late final ffi.Pointer<T> Function<T extends ffi.NativeType>(String) _capi;
 void init(String path) => _capi = ffi.DynamicLibrary.open(path).lookup;
 
 // ignore: unused_element
 final _callocFree = core.Finalizer(ffi2.calloc.free);
-
-extension _UtfViews on String {
-  // ignore: unused_element
-  _Utf8View get utf8View => _Utf8View(this);
-  // ignore: unused_element
-  _Utf16View get utf16View => _Utf16View(this);
-}
 
 /// An unspecified error value
 // ignore: unused_element
@@ -39,6 +30,57 @@ class VoidError {
   int get hashCode => 1;
 }
 
+extension _View on ByteBuffer {
+  // ignore: unused_element
+  ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setRange(0, length, asUint8List());
+  }
+
+  int get length => lengthInBytes;
+}
+
+extension _UtfViews on String {
+  // ignore: unused_element
+  _Utf8View get utf8View => _Utf8View(this);
+  // ignore: unused_element
+  _Utf16View get utf16View => _Utf16View(this);
+}
+
+extension _NativeBoolViews on core.List<bool> {
+  // ignore: unused_element
+  _BoolListView get boolView => _BoolListView(this);
+}
+
+extension _NativeIntViews on core.List<int> {
+  // ignore: unused_element
+  _Int8ListView get int8View => _Int8ListView(this);
+  // ignore: unused_element
+  _Int16ListView get int16View => _Int16ListView(this);
+  // ignore: unused_element
+  _Int32ListView get int32View => _Int32ListView(this);
+  // ignore: unused_element
+  _Int64ListView get int64View => _Int64ListView(this);
+  // ignore: unused_element
+  _IsizeListView get isizeView => _IsizeListView(this);
+  // ignore: unused_element
+  _Uint8ListView get uint8View => _Uint8ListView(this);
+  // ignore: unused_element
+  _Uint16ListView get uint16View => _Uint16ListView(this);
+  // ignore: unused_element
+  _Uint32ListView get uint32View => _Uint32ListView(this);
+  // ignore: unused_element
+  _Uint64ListView get uint64View => _Uint64ListView(this);
+  // ignore: unused_element
+  _UsizeListView get usizeView => _UsizeListView(this);
+}
+
+extension _NativeFloatViews on core.List<double> {
+  // ignore: unused_element
+  _Float32ListView get float32View => _Float32ListView(this);
+  // ignore: unused_element
+  _Float64ListView get float64View => _Float64ListView(this);
+}
+
 // ignore: unused_element
 class _Utf8View {
   final Uint8List _codeUnits;
@@ -48,7 +90,7 @@ class _Utf8View {
 
   ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
     // Copies
-    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, _codeUnits);
+    return alloc<ffi.Uint8>(length)..asTypedList(length).setRange(0, length, _codeUnits);
   }
 
   int get length => _codeUnits.length;
@@ -62,21 +104,21 @@ class _Utf16View {
 
   ffi.Pointer<ffi.Uint16> pointer(ffi.Allocator alloc) {
     // Copies
-    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, _codeUnits);
+    return alloc<ffi.Uint16>(length)..asTypedList(length).setRange(0, length, _codeUnits);
   }
 
   int get length => _codeUnits.length;
 }
 
 // ignore: unused_element
-class _SizeListView {
-  final core.List<int> _values;
+class _BoolListView{
+  final core.List<bool> _values;
 
-  _SizeListView(this._values);
+  _BoolListView(this._values);
 
   // Copies
-  ffi.Pointer<ffi.Size> pointer(ffi.Allocator alloc) {
-    final pointer = alloc<ffi.Size>(_values.length);
+  ffi.Pointer<ffi.Bool> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.Bool>(_values.length);
     for (var i = 0; i < _values.length; i++) {
       pointer[i] = _values[i];
     }
@@ -86,72 +128,184 @@ class _SizeListView {
   int get length => _values.length;
 }
 
-extension _Int8ListFfi on Int8List {
+class _Int8ListView {
+  final core.List<int> _values;
+
+  _Int8ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int8> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int8>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int8>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int16ListFfi on Int16List {
+class _Int16ListView {
+  final core.List<int> _values;
+
+  _Int16ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int16> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int16>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int16>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int32ListFfi on Int32List {
+class _Int32ListView {
+  final core.List<int> _values;
+
+  _Int32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int32> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int32>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int32>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Int64ListFfi on Int64List {
+class _Int64ListView {
+  final core.List<int> _values;
+
+  _Int64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Int64> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Int64>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Int64>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint8ListFfi on Uint8List {
+// ignore: unused_element
+class _IsizeListView {
+  final core.List<int> _values;
+
+  _IsizeListView(this._values);
+
+  // Copies
+  ffi.Pointer<ffi.IntPtr> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.IntPtr>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = _values[i];
+    }
+    return pointer;
+  }
+
+  int get length => _values.length;
+}
+
+class _Uint8ListView {
+  final core.List<int> _values;
+
+  _Uint8ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint8> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint8>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint8>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(255, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint16ListFfi on Uint16List {
+class _Uint16ListView {
+  final core.List<int> _values;
+
+  _Uint16ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint16> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint16>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint16>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(65535, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint32ListFfi on Uint32List {
+class _Uint32ListView {
+  final core.List<int> _values;
+
+  _Uint32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint32> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint32>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint32>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = min(4294967295, max(0, _values[i]));
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Uint64ListFfi on Uint64List {
+class _Uint64ListView {
+  final core.List<int> _values;
+
+  _Uint64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Uint64> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Uint64>(length)..asTypedList(length).setAll(0, this);
+    final pointer = alloc<ffi.Uint64>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = max(0, _values[i]);
+    }
+    return pointer;
   }
+
+  int get length => _values.length;
 }
 
-extension _Float32ListFfi on Float32List {
+// ignore: unused_element
+class _UsizeListView {
+  final core.List<int> _values;
+
+  _UsizeListView(this._values);
+
+  // Copies
+  ffi.Pointer<ffi.Size> pointer(ffi.Allocator alloc) {
+    final pointer = alloc<ffi.Size>(_values.length);
+    for (var i = 0; i < _values.length; i++) {
+      pointer[i] = max(0, _values[i]);
+    }
+    return pointer;
+  }
+
+  int get length => _values.length;
+}
+
+class _Float32ListView {
+  final core.List<double> _values;
+
+  _Float32ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Float> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Float>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Float>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }
 
-extension _Float64ListFfi on Float64List {
+class _Float64ListView {
+  final core.List<double> _values;
+
+  _Float64ListView(this._values);
+
   // ignore: unused_element
   ffi.Pointer<ffi.Double> pointer(ffi.Allocator alloc) {
-    return alloc<ffi.Double>(length)..asTypedList(length).setAll(0, this);
+    return alloc<ffi.Double>(length)..asTypedList(length).setRange(0, length, _values);
   }
+
+  int get length => _values.length;
 }


### PR DESCRIPTION
This is an alias for `u8`, but allows generating more idiomatic code in Dart, where we can use `ByteBuffer` instead of `List<int>`.

Fixes #385 