### PR TITLE
Make lifetimes code a bit more generic

### DIFF
--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -97,7 +97,7 @@
 //! [Nomicon]: https://doc.rust-lang.org/nomicon/lifetime-elision.html
 
 use super::{
-    Lifetime, LifetimeEnv, LoweringContext, MaybeStatic, MethodLifetime, TypeLifetime,
+    BoundedLifetime, LifetimeEnv, LoweringContext, MaybeStatic, MethodLifetime, TypeLifetime,
     TypeLifetimes,
 };
 use crate::ast;
@@ -171,7 +171,7 @@ impl ElisionSource {
 pub(super) struct BaseLifetimeLowerer<'ast> {
     lifetime_env: &'ast ast::LifetimeEnv,
     self_lifetimes: Option<TypeLifetimes>,
-    nodes: SmallVec<[Lifetime; 4]>,
+    nodes: SmallVec<[BoundedLifetime; super::lifetimes::INLINE_NUM_LIFETIMES]>,
     num_lifetimes: usize,
 }
 
@@ -253,7 +253,7 @@ impl<'ast> SelfParamLifetimeLowerer<'ast> {
             let lifetime = ctx.lower_ident(ast_node.lifetime.name(), "named lifetime");
             match (lifetime, &mut hir_nodes) {
                 (Some(lifetime), Some(hir_nodes)) => {
-                    hir_nodes.push(Lifetime::new(
+                    hir_nodes.push(BoundedLifetime::new(
                         lifetime,
                         ast_node
                             .longer

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -96,10 +96,10 @@
 //!
 //! [Nomicon]: https://doc.rust-lang.org/nomicon/lifetime-elision.html
 
-use super::{
-    BoundedLifetime, LifetimeEnv, LoweringContext, MaybeStatic, MethodLifetime, TypeLifetime,
-    TypeLifetimes,
+use super::lifetimes::{
+    BoundedLifetime, LifetimeEnv, MaybeStatic, MethodLifetime, TypeLifetime, TypeLifetimes,
 };
+use super::LoweringContext;
 use crate::ast;
 use smallvec::SmallVec;
 

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -97,7 +97,7 @@
 //! [Nomicon]: https://doc.rust-lang.org/nomicon/lifetime-elision.html
 
 use super::lifetimes::{
-    BoundedLifetime, LifetimeEnv, MaybeStatic, MethodLifetime, TypeLifetime, TypeLifetimes,
+    self, BoundedLifetime, LifetimeEnv, MaybeStatic, MethodLifetime, TypeLifetime, TypeLifetimes,
 };
 use super::LoweringContext;
 use crate::ast;
@@ -171,7 +171,7 @@ impl ElisionSource {
 pub(super) struct BaseLifetimeLowerer<'ast> {
     lifetime_env: &'ast ast::LifetimeEnv,
     self_lifetimes: Option<TypeLifetimes>,
-    nodes: SmallVec<[BoundedLifetime; super::lifetimes::INLINE_NUM_LIFETIMES]>,
+    nodes: SmallVec<[BoundedLifetime<lifetimes::Method>; super::lifetimes::INLINE_NUM_LIFETIMES]>,
     num_lifetimes: usize,
 }
 
@@ -345,7 +345,7 @@ impl<'ast> LifetimeLowerer for ParamLifetimeLowerer<'ast> {
 
 impl<'ast> ReturnLifetimeLowerer<'ast> {
     /// Finalize the lifetimes in the method, returning the resulting [`LifetimeEnv`].
-    pub fn finish(self) -> LifetimeEnv {
+    pub fn finish(self) -> LifetimeEnv<lifetimes::Method> {
         LifetimeEnv::new(self.base.nodes, self.base.num_lifetimes)
     }
 }

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -7,16 +7,15 @@ use smallvec::{smallvec, SmallVec};
 
 /// Convenience const representing the number of lifetimes a [`LifetimeEnv`]
 /// can hold inline before needing to dynamically allocate.
-const INLINE_NUM_LIFETIMES: usize = 4;
+pub(crate) const INLINE_NUM_LIFETIMES: usize = 4;
 
 // TODO(Quinn): This type is going to mainly be recycled from `ast::LifetimeEnv`.
 // Not fully sure how that will look like yet, but the ideas of what this will do
 // is basically the same.
 #[derive(Debug)]
 pub struct LifetimeEnv {
-    /// List of named lifetimes in scope of the method, in the form of an
-    /// adjacency matrix.
-    nodes: SmallVec<[Lifetime; INLINE_NUM_LIFETIMES]>,
+    /// List of named lifetimes in scope of the method, and their bounds
+    nodes: SmallVec<[BoundedLifetime; INLINE_NUM_LIFETIMES]>,
 
     /// The number of named _and_ anonymous lifetimes in the method.
     /// We store the sum since it represents the upper bound on what indices
@@ -32,14 +31,14 @@ pub struct LifetimeEnv {
 /// A lifetime in a [`LifetimeEnv`], which keeps track of which lifetimes it's
 /// longer and shorter than.
 #[derive(Debug)]
-pub(super) struct Lifetime {
+pub(super) struct BoundedLifetime {
     ident: IdentBuf,
     longer: SmallVec<[MethodLifetime; 2]>,
     shorter: SmallVec<[MethodLifetime; 2]>,
 }
 
-impl Lifetime {
-    /// Returns a new [`Lifetime`].
+impl BoundedLifetime {
+    /// Returns a new [`BoundedLifetime`].
     pub(super) fn new(
         ident: IdentBuf,
         longer: SmallVec<[MethodLifetime; 2]>,
@@ -167,7 +166,7 @@ pub struct MethodLifetimes {
 impl LifetimeEnv {
     /// Returns a new [`LifetimeEnv`].
     pub(super) fn new(
-        nodes: SmallVec<[Lifetime; INLINE_NUM_LIFETIMES]>,
+        nodes: SmallVec<[BoundedLifetime; INLINE_NUM_LIFETIMES]>,
         num_lifetimes: usize,
     ) -> Self {
         Self {

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -148,8 +148,10 @@ impl LifetimeKind for Type {}
 impl LifetimeKind for Method {}
 
 /// A lifetime that exists as part of a type or method signature (determined by
-/// Kind parameter, which will be one of [`LifetimeKind`])
-/// [`TypeLifetime::as_method_lifetime`] method.
+/// Kind parameter, which will be one of [`LifetimeKind`]).
+///
+/// This index only makes sense in the context of a surrounding type or method; since
+/// this is essentially an index into that type/method's lifetime list.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Lifetime<Kind>(usize, PhantomData<Kind>);
 

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -5,6 +5,8 @@ use super::IdentBuf;
 use crate::ast;
 use core::marker::PhantomData;
 use smallvec::{smallvec, SmallVec};
+use core::fmt::{self, Debug};
+use core::hash::Hash;
 
 /// Convenience const representing the number of lifetimes a [`LifetimeEnv`]
 /// can hold inline before needing to dynamically allocate.
@@ -140,7 +142,7 @@ pub struct Method;
 
 /// Abstraction over where lifetimes can occur
 pub trait LifetimeKind:
-    Copy + Clone + core::fmt::Debug + core::hash::Hash + PartialEq + Eq + PartialOrd + Ord
+    Copy + Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord
 {
 }
 
@@ -152,8 +154,14 @@ impl LifetimeKind for Method {}
 ///
 /// This index only makes sense in the context of a surrounding type or method; since
 /// this is essentially an index into that type/method's lifetime list.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Lifetime<Kind>(usize, PhantomData<Kind>);
+
+impl<Kind> Debug for Lifetime<Kind> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}Lifetime({})", std::any::type_name::<Kind>(), self.0)
+    }
+}
 
 /// A set of lifetimes found on a type name or method signature (determined by
 /// Kind parameter, which will be one of [`LifetimeKind`])

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -135,9 +135,11 @@ impl<T> MaybeStatic<T> {
 
 /// The [`LifetimeKind`] of [`TypeLifetimes`]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::exhaustive_structs)] // marker type
 pub struct Type;
 /// The [`LifetimeKind`] of [`MethodLifetimes`]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::exhaustive_structs)] // marker type
 pub struct Method;
 
 /// Abstraction over where lifetimes can occur

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -3,10 +3,10 @@
 
 use super::IdentBuf;
 use crate::ast;
-use core::marker::PhantomData;
-use smallvec::{smallvec, SmallVec};
 use core::fmt::{self, Debug};
 use core::hash::Hash;
+use core::marker::PhantomData;
+use smallvec::{smallvec, SmallVec};
 
 /// Convenience const representing the number of lifetimes a [`LifetimeEnv`]
 /// can hold inline before needing to dynamically allocate.
@@ -141,10 +141,7 @@ pub struct Type;
 pub struct Method;
 
 /// Abstraction over where lifetimes can occur
-pub trait LifetimeKind:
-    Copy + Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord
-{
-}
+pub trait LifetimeKind: Copy + Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord {}
 
 impl LifetimeKind for Type {}
 impl LifetimeKind for Method {}

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1,10 +1,11 @@
+use super::lifetimes::{self, LifetimeEnv};
 use super::{
-    lifetimes, AttributeContext, AttributeValidator, Borrow, EnumDef, EnumPath, EnumVariant,
-    IdentBuf, LifetimeEnv, LifetimeLowerer, LookupId, MaybeOwn, Method, NonOptional, OpaqueDef,
-    OpaquePath, Optional, OutStructDef, OutStructField, OutStructPath, OutType, Param,
-    ParamLifetimeLowerer, ParamSelf, PrimitiveType, ReturnLifetimeLowerer, ReturnType,
-    ReturnableStructPath, SelfParamLifetimeLowerer, SelfType, Slice, StructDef, StructField,
-    StructPath, SuccessType, Type,
+    AttributeContext, AttributeValidator, Borrow, EnumDef, EnumPath, EnumVariant, IdentBuf,
+    LifetimeLowerer, LookupId, MaybeOwn, Method, NonOptional, OpaqueDef, OpaquePath, Optional,
+    OutStructDef, OutStructField, OutStructPath, OutType, Param, ParamLifetimeLowerer, ParamSelf,
+    PrimitiveType, ReturnLifetimeLowerer, ReturnType, ReturnableStructPath,
+    SelfParamLifetimeLowerer, SelfType, Slice, StructDef, StructField, StructPath, SuccessType,
+    Type,
 };
 use crate::{ast, Env};
 use core::fmt;

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1,10 +1,10 @@
 use super::{
-    AttributeContext, AttributeValidator, Borrow, EnumDef, EnumPath, EnumVariant, IdentBuf,
-    LifetimeEnv, LifetimeLowerer, LookupId, MaybeOwn, Method, NonOptional, OpaqueDef, OpaquePath,
-    Optional, OutStructDef, OutStructField, OutStructPath, OutType, Param, ParamLifetimeLowerer,
-    ParamSelf, PrimitiveType, ReturnLifetimeLowerer, ReturnType, ReturnableStructPath,
-    SelfParamLifetimeLowerer, SelfType, Slice, StructDef, StructField, StructPath, SuccessType,
-    Type,
+    lifetimes, AttributeContext, AttributeValidator, Borrow, EnumDef, EnumPath, EnumVariant,
+    IdentBuf, LifetimeEnv, LifetimeLowerer, LookupId, MaybeOwn, Method, NonOptional, OpaqueDef,
+    OpaquePath, Optional, OutStructDef, OutStructField, OutStructPath, OutType, Param,
+    ParamLifetimeLowerer, ParamSelf, PrimitiveType, ReturnLifetimeLowerer, ReturnType,
+    ReturnableStructPath, SelfParamLifetimeLowerer, SelfType, Slice, StructDef, StructField,
+    StructPath, SuccessType, Type,
 };
 use crate::{ast, Env};
 use core::fmt;
@@ -816,7 +816,7 @@ impl<'ast, 'errors> LoweringContext<'ast, 'errors> {
         takes_writeable: bool,
         mut return_ltl: Option<ReturnLifetimeLowerer<'_>>,
         in_path: &ast::Path,
-    ) -> Option<(ReturnType, LifetimeEnv)> {
+    ) -> Option<(ReturnType, LifetimeEnv<lifetimes::Method>)> {
         let writeable_option = if takes_writeable {
             Some(SuccessType::Writeable)
         } else {

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -7,7 +7,7 @@ use smallvec::SmallVec;
 use super::{paths, Attrs, Docs, Ident, IdentBuf, OutType, SelfType, Slice, Type, TypeContext};
 
 use super::lifetimes::{
-    LifetimeEnv, MaybeStatic, MethodLifetime, MethodLifetimes, TypeLifetime, TypeLifetimes,
+    self, LifetimeEnv, MaybeStatic, MethodLifetime, MethodLifetimes, TypeLifetime, TypeLifetimes,
 };
 
 /// A method exposed to Diplomat.
@@ -16,7 +16,7 @@ use super::lifetimes::{
 pub struct Method {
     pub docs: Docs,
     pub name: IdentBuf,
-    pub lifetime_env: LifetimeEnv,
+    pub lifetime_env: LifetimeEnv<lifetimes::Method>,
 
     pub param_self: Option<ParamSelf>,
     pub params: Vec<Param>,
@@ -169,7 +169,7 @@ impl Method {
 
     /// Returns a fresh [`MethodLifetimes`] corresponding to `self`.
     pub fn method_lifetimes(&self) -> MethodLifetimes {
-        self.lifetime_env.method_lifetimes()
+        self.lifetime_env.lifetimes()
     }
 
     /// Returns a new [`BorrowingFieldVisitor`], which allocates memory to

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -4,9 +4,10 @@ use std::fmt::{self, Write};
 
 use smallvec::SmallVec;
 
-use super::{
-    paths, Attrs, Docs, Ident, IdentBuf, LifetimeEnv, MaybeStatic, MethodLifetime, MethodLifetimes,
-    OutType, SelfType, Slice, Type, TypeContext, TypeLifetime, TypeLifetimes,
+use super::{paths, Attrs, Docs, Ident, IdentBuf, OutType, SelfType, Slice, Type, TypeContext};
+
+use super::lifetimes::{
+    LifetimeEnv, MaybeStatic, MethodLifetime, MethodLifetimes, TypeLifetime, TypeLifetimes,
 };
 
 /// A method exposed to Diplomat.

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -5,7 +5,7 @@
 mod attrs;
 mod defs;
 mod elision;
-mod lifetimes;
+pub mod lifetimes;
 mod lowering;
 mod methods;
 mod paths;
@@ -16,7 +16,9 @@ mod types;
 pub use attrs::*;
 pub use defs::*;
 pub(super) use elision::*;
-pub use lifetimes::*;
+pub use lifetimes::{
+    LifetimeEnv, MaybeStatic, MethodLifetime, MethodLifetimes, TypeLifetime, TypeLifetimes,
+};
 pub(super) use lowering::*;
 pub use methods::*;
 pub use paths::*;

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -5,6 +5,13 @@
 mod attrs;
 mod defs;
 mod elision;
+// We don't reexport this for two reasons.
+// 
+// One is that these are somewhat more niche types and we don't want to clutter the main module too
+// much. You only need these if you're dealing with lifetimes, which not all backends may wish to
+// do.
+//
+// Two is that this module contains types named Type and Method which will conflict with others.
 pub mod lifetimes;
 mod lowering;
 mod methods;
@@ -16,9 +23,6 @@ mod types;
 pub use attrs::*;
 pub use defs::*;
 pub(super) use elision::*;
-pub use lifetimes::{
-    LifetimeEnv, MaybeStatic, MethodLifetime, MethodLifetimes, TypeLifetime, TypeLifetimes,
-};
 pub(super) use lowering::*;
 pub use methods::*;
 pub use paths::*;

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -6,7 +6,7 @@ mod attrs;
 mod defs;
 mod elision;
 // We don't reexport this for two reasons.
-// 
+//
 // One is that these are somewhat more niche types and we don't want to clutter the main module too
 // much. You only need these if you're dealing with lifetimes, which not all backends may wish to
 // do.

--- a/core/src/hir/paths.rs
+++ b/core/src/hir/paths.rs
@@ -1,6 +1,7 @@
+use super::lifetimes::TypeLifetimes;
 use super::{
     Borrow, EnumDef, EnumId, Everywhere, OpaqueDef, OpaqueId, OpaqueOwner, OutStructDef,
-    OutputOnly, ReturnableStructDef, StructDef, TyPosition, TypeContext, TypeLifetimes,
+    OutputOnly, ReturnableStructDef, StructDef, TyPosition, TypeContext,
 };
 
 /// Path to a struct that may appear as an output.

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
@@ -8,18 +8,12 @@ expression: lt_to_borrowing_fields
         "_s",
     ],
     NonStatic(
-        Lifetime(
-            0,
-            PhantomData<diplomat_core::hir::lifetimes::Method>,
-        ),
+        diplomat_core::hir::lifetimes::MethodLifetime(0),
     ): [
         "this.p_data",
     ],
     NonStatic(
-        Lifetime(
-            1,
-            PhantomData<diplomat_core::hir::lifetimes::Method>,
-        ),
+        diplomat_core::hir::lifetimes::MethodLifetime(1),
     ): [
         "this.q_data",
         "this.inner.more_data",

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/hir/elision.rs
-expression: map
+expression: lt_to_borrowing_fields
 ---
 {
     Static: [
@@ -8,15 +8,17 @@ expression: map
         "_s",
     ],
     NonStatic(
-        MethodLifetime(
+        Lifetime(
             0,
+            PhantomData<diplomat_core::hir::lifetimes::Method>,
         ),
     ): [
         "this.p_data",
     ],
     NonStatic(
-        MethodLifetime(
+        Lifetime(
             1,
+            PhantomData<diplomat_core::hir::lifetimes::Method>,
         ),
     ): [
         "this.q_data",

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -19,11 +19,12 @@ TypeContext {
                     name: "inner",
                     ty: Opaque(
                         OpaquePath {
-                            lifetimes: TypeLifetimes {
+                            lifetimes: Lifetimes {
                                 indices: [
                                     NonStatic(
-                                        TypeLifetime(
+                                        Lifetime(
                                             0,
+                                            PhantomData<diplomat_core::hir::lifetimes::Type>,
                                         ),
                                     ),
                                 ],
@@ -48,7 +49,7 @@ TypeContext {
                     name: "new",
                     lifetime_env: LifetimeEnv {
                         nodes: [
-                            Lifetime {
+                            BoundedLifetime {
                                 ident: "a",
                                 longer: [],
                                 shorter: [],
@@ -63,8 +64,9 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        TypeLifetime(
+                                        Lifetime(
                                             0,
+                                            PhantomData<diplomat_core::hir::lifetimes::Type>,
                                         ),
                                     ),
                                     UnvalidatedUtf8,
@@ -78,11 +80,12 @@ TypeContext {
                                 Struct(
                                     OutStruct(
                                         StructPath {
-                                            lifetimes: TypeLifetimes {
+                                            lifetimes: Lifetimes {
                                                 indices: [
                                                     NonStatic(
-                                                        TypeLifetime(
+                                                        Lifetime(
                                                             0,
+                                                            PhantomData<diplomat_core::hir::lifetimes::Type>,
                                                         ),
                                                     ),
                                                 ],
@@ -125,8 +128,9 @@ TypeContext {
                     ty: Slice(
                         Str(
                             NonStatic(
-                                TypeLifetime(
+                                Lifetime(
                                     0,
+                                    PhantomData<diplomat_core::hir::lifetimes::Type>,
                                 ),
                             ),
                             UnvalidatedUtf8,
@@ -143,7 +147,7 @@ TypeContext {
                     name: "rustc_elision",
                     lifetime_env: LifetimeEnv {
                         nodes: [
-                            Lifetime {
+                            BoundedLifetime {
                                 ident: "a",
                                 longer: [],
                                 shorter: [],
@@ -155,11 +159,12 @@ TypeContext {
                         ParamSelf {
                             ty: Struct(
                                 StructPath {
-                                    lifetimes: TypeLifetimes {
+                                    lifetimes: Lifetimes {
                                         indices: [
                                             NonStatic(
-                                                TypeLifetime(
+                                                Lifetime(
                                                     0,
+                                                    PhantomData<diplomat_core::hir::lifetimes::Type>,
                                                 ),
                                             ),
                                         ],
@@ -177,8 +182,9 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        TypeLifetime(
+                                        Lifetime(
                                             1,
+                                            PhantomData<diplomat_core::hir::lifetimes::Type>,
                                         ),
                                     ),
                                     UnvalidatedUtf8,
@@ -192,8 +198,9 @@ TypeContext {
                                 Slice(
                                     Str(
                                         NonStatic(
-                                            TypeLifetime(
+                                            Lifetime(
                                                 1,
+                                                PhantomData<diplomat_core::hir::lifetimes::Type>,
                                             ),
                                         ),
                                         UnvalidatedUtf8,

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -22,10 +22,7 @@ TypeContext {
                             lifetimes: Lifetimes {
                                 indices: [
                                     NonStatic(
-                                        Lifetime(
-                                            0,
-                                            PhantomData<diplomat_core::hir::lifetimes::Type>,
-                                        ),
+                                        diplomat_core::hir::lifetimes::TypeLifetime(0),
                                     ),
                                 ],
                             },
@@ -64,10 +61,7 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        Lifetime(
-                                            0,
-                                            PhantomData<diplomat_core::hir::lifetimes::Type>,
-                                        ),
+                                        diplomat_core::hir::lifetimes::TypeLifetime(0),
                                     ),
                                     UnvalidatedUtf8,
                                 ),
@@ -83,10 +77,7 @@ TypeContext {
                                             lifetimes: Lifetimes {
                                                 indices: [
                                                     NonStatic(
-                                                        Lifetime(
-                                                            0,
-                                                            PhantomData<diplomat_core::hir::lifetimes::Type>,
-                                                        ),
+                                                        diplomat_core::hir::lifetimes::TypeLifetime(0),
                                                     ),
                                                 ],
                                             },
@@ -128,10 +119,7 @@ TypeContext {
                     ty: Slice(
                         Str(
                             NonStatic(
-                                Lifetime(
-                                    0,
-                                    PhantomData<diplomat_core::hir::lifetimes::Type>,
-                                ),
+                                diplomat_core::hir::lifetimes::TypeLifetime(0),
                             ),
                             UnvalidatedUtf8,
                         ),
@@ -162,10 +150,7 @@ TypeContext {
                                     lifetimes: Lifetimes {
                                         indices: [
                                             NonStatic(
-                                                Lifetime(
-                                                    0,
-                                                    PhantomData<diplomat_core::hir::lifetimes::Type>,
-                                                ),
+                                                diplomat_core::hir::lifetimes::TypeLifetime(0),
                                             ),
                                         ],
                                     },
@@ -182,10 +167,7 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        Lifetime(
-                                            1,
-                                            PhantomData<diplomat_core::hir::lifetimes::Type>,
-                                        ),
+                                        diplomat_core::hir::lifetimes::TypeLifetime(1),
                                     ),
                                     UnvalidatedUtf8,
                                 ),
@@ -198,10 +180,7 @@ TypeContext {
                                 Slice(
                                     Str(
                                         NonStatic(
-                                            Lifetime(
-                                                1,
-                                                PhantomData<diplomat_core::hir::lifetimes::Type>,
-                                            ),
+                                            diplomat_core::hir::lifetimes::TypeLifetime(1),
                                         ),
                                         UnvalidatedUtf8,
                                     ),

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -1,8 +1,9 @@
 //! Types that can be exposed in Diplomat APIs.
 
+use super::lifetimes::{MaybeStatic, TypeLifetime};
 use super::{
-    EnumPath, Everywhere, MaybeStatic, NonOptional, OpaquePath, Optional, OutputOnly,
-    PrimitiveType, StructPath, TyPosition, TypeContext, TypeLifetime,
+    EnumPath, Everywhere, NonOptional, OpaquePath, Optional, OutputOnly, PrimitiveType, StructPath,
+    TyPosition, TypeContext,
 };
 use crate::ast;
 pub use ast::Mutability;


### PR DESCRIPTION
I'll probably need to rewrite some of the lifetime handling so that more is precomputed by the hir. For that I need LifetimeEnv to be useful for both types and methods. It was already mostly there, made it generic.