### PR TITLE
Add `Type::lifetimes` to make getting lifetimes out of `Type` easier

### DIFF
--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -240,6 +240,10 @@ impl<Kind: LifetimeKind> Lifetimes<Kind> {
     pub(super) fn lifetimes(&self) -> impl Iterator<Item = MaybeStatic<Lifetime<Kind>>> + '_ {
         self.indices.iter().copied()
     }
+
+    pub(super) fn as_slice(&self) -> &[MaybeStatic<Lifetime<Kind>>] {
+        self.indices.as_slice()
+    }
 }
 
 impl TypeLifetime {

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -73,6 +73,7 @@ impl Type {
         }
     }
 
+    #[allow(unused)] // wip lifetimes (#406)
     pub(super) fn lifetimes(&self) -> &[MaybeStatic<TypeLifetime>] {
         match self {
             Type::Opaque(opaque) => opaque.lifetimes.as_slice(),

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -72,6 +72,15 @@ impl Type {
             Type::Primitive(_) | Type::Enum(_) => (0, 0),
         }
     }
+
+    pub(super) fn lifetimes(&self) -> &[MaybeStatic<TypeLifetime>] {
+        match self {
+            Type::Opaque(opaque) => opaque.lifetimes.as_slice(),
+            Type::Struct(struct_) => struct_.lifetimes.as_slice(),
+            Type::Slice(slice) => std::slice::from_ref(slice.lifetime()),
+            _ => &[],
+        }
+    }
 }
 
 impl SelfType {


### PR DESCRIPTION
Forgive me because it's been a long time since I've looked at this repo- I don't remember how everything works but I wanted to get back into it.

I was looking at #406 and saw this part:
> There is a way to get an exhaustive Lifetimes for every struct field: basically something like LifetimeEnv<Type>.new_lifetimes_for(&field), producing a list of relevant indices. This list is transitively evaluated.

I thought a good first step for this would be to make getting the lifetimes of a field easy, so I added `Type::lifetimes` which returns a `&[MaybeStatic<TypeLifetime>]`, essentially just consolidating where lifetimes are stored in the `Type` enum. This will allow for a higher-level api to use this and [`SubtypeLifetimeVisitor`](https://docs.rs/diplomat_core/latest/diplomat_core/hir/struct.SubtypeLifetimeVisitor.html) to achieve what I quoted above with something like this:

```rust
let mut lifetimes = vec![];
let mut visitor = SubtypeLifetimeVisitor::new(&struct_.lifetime_env, |lt| lifetimes.push(lt));
for field in &struct_.fields {
    for lifetime in field.ty.lifetimes() { // <-- added this method!
        if let MaybeStatic::NonStatic(lt) = lifetime {
            visitor.visit_subtypes(lt);
        }
    }
}
```

Today this doesn't compile because `MethodLifetime` != `TypeLifetime`, but `SubtypeLifetimeVisitor` would probably be adjusted once each type declaration has their own `LifetimeEnv`.