### PR TITLE
Fix initialization in immutable structs in Dart

### DIFF
--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -49,7 +49,7 @@ final class OptionOpaque implements ffi.Finalizable {
   }
 
   static bool optionOpaqueArgument(OptionOpaque? arg) {
-    final result = _OptionOpaque_option_opaque_argument(arg == null ? ffi.Pointer.fromAddress(0) : arg._underlying);
+    final result = _OptionOpaque_option_opaque_argument(arg?._underlying ?? ffi.Pointer.fromAddress(0));
     return result;
   }
 }

--- a/feature_tests/dart/lib/src/OptionStruct.g.dart
+++ b/feature_tests/dart/lib/src/OptionStruct.g.dart
@@ -35,6 +35,10 @@ final class OptionStruct {
   // ignore: unused_element
   _OptionStructFfi _pointer(ffi.Allocator temp) {
     final pointer = temp<_OptionStructFfi>();
+    pointer.ref.a = a?._underlying ?? ffi.Pointer.fromAddress(0);
+    pointer.ref.b = b?._underlying ?? ffi.Pointer.fromAddress(0);
+    pointer.ref.c = c;
+    pointer.ref.d = d?._underlying ?? ffi.Pointer.fromAddress(0);
     return pointer.ref;
   }
 

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -226,9 +226,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
                     &ty.lifetimes,
                 );
 
-                let dart_to_c = if !mutable {
-                    vec![]
-                } else if let hir::Type::Slice(..) = &field.ty {
+                let dart_to_c = if let hir::Type::Slice(..) = &field.ty {
                     let view_expr = self.gen_dart_to_c_for_type(&field.ty, name.clone());
                     vec![
                         format!("final {name}View = {view_expr};"),
@@ -799,7 +797,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
         match *ty {
             Type::Primitive(..) => dart_name.clone(),
             Type::Opaque(ref op) if op.is_optional() => format!(
-                "{dart_name} == null ? ffi.Pointer.fromAddress(0) : {dart_name}._underlying"
+                // Note: {dart_name} == null ? 0 : {dart_name}.underlying
+                // will not work for struct fields since Dart can't guarantee the
+                // null check will be unchanged between the two accesses.
+                "{dart_name}?._underlying ?? ffi.Pointer.fromAddress(0)"
             )
             .into(),
             Type::Enum(ref e) if is_contiguous_enum(e.resolve(self.tcx)) => {


### PR DESCRIPTION
This was an oversight from https://github.com/rust-diplomat/diplomat/pull/408: previously when we lazy-loaded structs, converting a struct back to FFI could be a no-op if the struct wasn't mutable.

However in the new eager-converted structs, structs always need to be converted back.