### PR TITLE
Add diplomat::c_rename

### DIFF
--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -266,11 +266,11 @@ impl RenameAttr {
             Meta::NameValue(ref nv) => {
                 // Support a shortcut `c_rename = "..."`
                 let Expr::Lit(ref lit) = nv.value else {
-                        return Err(C_RENAME_ERROR.into());
-                    };
+                    return Err(C_RENAME_ERROR.into());
+                };
                 let Lit::Str(ref lit) = lit.lit else {
-                        return Err(C_RENAME_ERROR.into());
-                    };
+                    return Err(C_RENAME_ERROR.into());
+                };
                 Ok(RenameAttr::from_pattern(&lit.value()))
             }
             // The full syntax to which we'll add more things in the future, `c_rename("")`

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -81,7 +81,7 @@ fn syn_attr_to_ast_attr(attrs: &[Attribute]) -> impl Iterator<Item = Attr> + '_ 
                     .expect("Failed to parse malformed diplomat::attr"),
             ))
         } else if a.path() == &crename_attr {
-            Some(Attr::CRename(RenameAttr::from_syn(&a).unwrap()))
+            Some(Attr::CRename(RenameAttr::from_syn(a).unwrap()))
         } else if a.path() == &skipast {
             Some(Attr::SkipIfUnsupported)
         } else {
@@ -262,7 +262,7 @@ impl RenameAttr {
         static C_RENAME_ERROR: &str = "#[diplomat::c_rename] must be given a string value";
 
         match a.meta {
-            Meta::Path(..) => return Err(C_RENAME_ERROR.into()),
+            Meta::Path(..) => Err(C_RENAME_ERROR.into()),
             Meta::NameValue(ref nv) => {
                 // Support a shortcut `c_rename = "..."`
                 let Expr::Lit(ref lit) = nv.value else {

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -97,12 +97,23 @@ impl Serialize for Attrs {
     {
         // 1 is the number of fields in the struct.
         let mut state = serializer.serialize_struct("Attrs", 1)?;
-        let cfg: Vec<_> = self
-            .cfg
-            .iter()
-            .map(|a| quote::quote!(#a).to_string())
-            .collect();
-        state.serialize_field("cfg", &cfg)?;
+        if !self.cfg.is_empty() {
+            let cfg: Vec<_> = self
+                .cfg
+                .iter()
+                .map(|a| quote::quote!(#a).to_string())
+                .collect();
+            state.serialize_field("cfg", &cfg)?;
+        }
+        if !self.attrs.is_empty() {
+            state.serialize_field("attrs", &self.attrs)?;
+        }
+        if self.skip_if_unsupported {
+            state.serialize_field("skip_if_unsupported", &self.skip_if_unsupported)?;
+        }
+        if !self.c_rename.is_empty() {
+            state.serialize_field("c_rename", &self.c_rename)?;
+        }
         state.end()
     }
 }
@@ -223,6 +234,11 @@ impl RenameAttr {
         } else {
             name.into()
         }
+    }
+
+    /// Whether this rename is empty and will perform no changes
+    fn is_empty(&self) -> bool {
+        self.pattern.is_none()
     }
 
     fn extend(&mut self, parent: &Self) {

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -49,10 +49,14 @@ impl Method {
         impl_generics: Option<&syn::Generics>,
         impl_attrs: &Attrs,
     ) -> Method {
+        let mut attrs: Attrs = (&*m.attrs).into();
+        attrs.merge_parent_attrs(impl_attrs);
+
         let self_ident = self_path_type.path.elements.last().unwrap();
         let method_ident = &m.sig.ident;
+        let concat_method_ident = format!("{self_ident}_{method_ident}");
         let extern_ident = syn::Ident::new(
-            format!("{self_ident}_{method_ident}").as_str(),
+            &attrs.c_rename.apply(&concat_method_ident),
             m.sig.ident.span(),
         );
 
@@ -90,9 +94,6 @@ impl Method {
             &all_params[..],
             return_ty.as_ref(),
         );
-
-        let mut attrs: Attrs = (&*m.attrs).into();
-        attrs.merge_parent_attrs(impl_attrs);
 
         Method {
             name: Ident::from(method_ident),

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename-2.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr
+---
+pattern:
+  replacement: foobar_
+  insertion_index: 7
+

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename-2.snap.new
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename-2.snap.new
@@ -1,9 +1,0 @@
----
-source: core/src/ast/attrs.rs
-expression: attr
-
----
-pattern:
-  replacement: foobar_
-  insertion_index: 7
-

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename-2.snap.new
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename-2.snap.new
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr
+
+---
+pattern:
+  replacement: foobar_
+  insertion_index: 7
+

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr
+---
+pattern:
+  replacement: foobar_
+  insertion_index: 7
+

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename.snap.new
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename.snap.new
@@ -1,9 +1,0 @@
----
-source: core/src/ast/attrs.rs
-expression: attr
-
----
-pattern:
-  replacement: foobar_
-  insertion_index: 7
-

--- a/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename.snap.new
+++ b/core/src/ast/snapshots/diplomat_core__ast__attrs__tests__rename.snap.new
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/attrs.rs
+expression: attr
+
+---
+pattern:
+  replacement: foobar_
+  insertion_index: 7
+

--- a/core/src/ast/snapshots/diplomat_core__ast__enums__tests__enum_with_discr.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__enums__tests__enum_with_discr.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/enums.rs
-expression: "Enum::from(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Enum)] enum\n                DiscriminantedEnum { Abc = - 1, Def = 0, Ghi = 1, Jkl = 2, }\n            })"
+expression: "Enum::new(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Enum)] enum\n                DiscriminantedEnum { Abc = - 1, Def = 0, Ghi = 1, Jkl = 2, }\n            }, &Default::default())"
 ---
 name: DiscriminantedEnum
 docs:
@@ -16,23 +16,22 @@ variants:
     - -1
     - - ""
       - []
-    - cfg: []
+    - {}
   - - Def
     - 0
     - - ""
       - []
-    - cfg: []
+    - {}
   - - Ghi
     - 1
     - - ""
       - []
-    - cfg: []
+    - {}
   - - Jkl
     - 2
     - - ""
       - []
-    - cfg: []
+    - {}
 methods: []
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__enums__tests__simple_enum.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__enums__tests__simple_enum.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/enums.rs
-expression: "Enum::from(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Enum)] enum MyLocalEnum\n                {\n                    Abc, /// Some more docs.\n                    Def\n                }\n            })"
+expression: "Enum::new(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Enum)] enum MyLocalEnum\n                {\n                    Abc, /// Some more docs.\n                    Def\n                }\n            }, &Default::default())"
 ---
 name: MyLocalEnum
 docs:
@@ -16,13 +16,12 @@ variants:
     - 0
     - - ""
       - []
-    - cfg: []
+    - {}
   - - Def
     - 1
     - - Some more docs.
       - []
-    - cfg: []
+    - {}
 methods: []
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -36,6 +36,5 @@ params:
 return_type:
   Primitive: u64
 lifetime_env: {}
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -29,6 +29,5 @@ params:
         lifetimes: []
 return_type: ~
 lifetime_env: {}
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
@@ -28,6 +28,5 @@ params:
 return_type:
   Primitive: u64
 lifetime_env: {}
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
@@ -27,6 +27,5 @@ params:
         lifetimes: []
 return_type: ~
 lifetime_env: {}
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
@@ -20,9 +20,13 @@ modules:
           attrs:
             cfg: []
     sub_modules: []
+    attrs:
+      cfg: []
   other:
     name: other
     imports: []
     declared_types: {}
     sub_modules: []
+    attrs:
+      cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__import_in_non_diplomat_not_analyzed.snap
@@ -17,16 +17,13 @@ modules:
           fields: []
           methods: []
           output_only: false
-          attrs:
-            cfg: []
+          attrs: {}
     sub_modules: []
-    attrs:
-      cfg: []
+    attrs: {}
   other:
     name: other
     imports: []
     declared_types: {}
     sub_modules: []
-    attrs:
-      cfg: []
+    attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
@@ -23,12 +23,9 @@ declared_types:
           params: []
           return_type: ~
           lifetime_env: {}
-          attrs:
-            cfg: []
+          attrs: {}
       output_only: false
-      attrs:
-        cfg: []
+      attrs: {}
 sub_modules: []
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
@@ -29,4 +29,6 @@ declared_types:
       attrs:
         cfg: []
 sub_modules: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -44,8 +44,7 @@ declared_types:
                   - NonOpaqueStruct
               lifetimes: []
           lifetime_env: {}
-          attrs:
-            cfg: []
+          attrs: {}
         - name: set_a
           docs:
             - ""
@@ -66,11 +65,9 @@ declared_types:
                 Primitive: i32
           return_type: ~
           lifetime_env: {}
-          attrs:
-            cfg: []
+          attrs: {}
       output_only: false
-      attrs:
-        cfg: []
+      attrs: {}
   OpaqueStruct:
     Opaque:
       name: OpaqueStruct
@@ -94,8 +91,7 @@ declared_types:
                     - OpaqueStruct
                 lifetimes: []
           lifetime_env: {}
-          attrs:
-            cfg: []
+          attrs: {}
         - name: get_string
           docs:
             - ""
@@ -118,12 +114,9 @@ declared_types:
                   - String
               lifetimes: []
           lifetime_env: {}
-          attrs:
-            cfg: []
+          attrs: {}
       mutability: Immutable
-      attrs:
-        cfg: []
+      attrs: {}
 sub_modules: []
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -124,4 +124,6 @@ declared_types:
       attrs:
         cfg: []
 sub_modules: []
+attrs:
+  cfg: []
 

--- a/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__structs__tests__simple_struct.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/structs.rs
-expression: "Struct::new(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Struct)] struct\n                MyLocalStruct { a : i32, b : Box < MyLocalStruct > }\n            }, true)"
+expression: "Struct::new(&syn::parse_quote! {\n                /// Some docs.\n                #[diplomat :: rust_link(foo :: Bar, Struct)] struct\n                MyLocalStruct { a : i32, b : Box < MyLocalStruct > }\n            }, true, &Default::default())"
 ---
 name: MyLocalStruct
 docs:
@@ -28,6 +28,5 @@ fields:
       - []
 methods: []
 output_only: true
-attrs:
-  cfg: []
+attrs: {}
 

--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -18,7 +18,7 @@ pub struct Struct {
 
 impl Struct {
     /// Extract a [`Struct`] metadata value from an AST node.
-    pub fn new(strct: &syn::ItemStruct, output_only: bool) -> Self {
+    pub fn new(strct: &syn::ItemStruct, output_only: bool, parent_attrs: &Attrs) -> Self {
         let self_path_type = PathType::extract_self_type(strct);
         let fields: Vec<_> = strct
             .fields
@@ -38,7 +38,8 @@ impl Struct {
             .collect();
 
         let lifetimes = LifetimeEnv::from_struct_item(strct, &fields[..]);
-
+        let mut attrs: Attrs = (&*strct.attrs).into();
+        attrs.merge_parent_attrs(parent_attrs);
         Struct {
             name: (&strct.ident).into(),
             docs: Docs::from_attrs(&strct.attrs),
@@ -46,7 +47,7 @@ impl Struct {
             fields,
             methods: vec![],
             output_only,
-            attrs: (&*strct.attrs).into(),
+            attrs,
         }
     }
 }
@@ -67,14 +68,16 @@ pub struct OpaqueStruct {
 
 impl OpaqueStruct {
     /// Extract a [`OpaqueStruct`] metadata value from an AST node.
-    pub fn new(strct: &syn::ItemStruct, mutability: Mutability) -> Self {
+    pub fn new(strct: &syn::ItemStruct, mutability: Mutability, parent_attrs: &Attrs) -> Self {
+        let mut attrs: Attrs = (&*strct.attrs).into();
+        attrs.merge_parent_attrs(parent_attrs);
         OpaqueStruct {
             name: Ident::from(&strct.ident),
             docs: Docs::from_attrs(&strct.attrs),
             lifetimes: LifetimeEnv::from_struct_item(strct, &[]),
             methods: vec![],
             mutability,
-            attrs: (&*strct.attrs).into(),
+            attrs,
         }
     }
 }
@@ -102,7 +105,8 @@ mod tests {
                         b: Box<MyLocalStruct>
                     }
                 },
-                true
+                true,
+                &Default::default()
             ));
         });
     }

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -118,7 +118,7 @@ impl Attrs {
 pub struct BackendAttrSupport {
     pub disabling: bool,
     pub renaming: bool,
-    // more to be added: rename, namespace, etc
+    // more to be added: namespace, etc
 }
 
 /// Defined by backends when validating attributes

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -7,11 +7,14 @@ use crate::hir::LoweringError;
 use quote::ToTokens;
 use syn::{LitStr, Meta};
 
+pub use crate::ast::attrs::RenameAttr;
+
 #[non_exhaustive]
 #[derive(Clone, Default, Debug)]
 pub struct Attrs {
     pub disable: bool,
     pub rename: Option<String>,
+    pub c_rename: RenameAttr,
     // more to be added: rename, namespace, etc
 }
 
@@ -35,6 +38,10 @@ impl Attrs {
         errors: &mut Vec<LoweringError>,
     ) -> Self {
         let mut this = Attrs::default();
+
+        // Backends must support this since it applies to the macro/C code.
+        this.c_rename = ast.c_rename.clone();
+
         let support = validator.attrs_supported();
         for attr in &ast.attrs {
             if validator.satisfies_cfg(&attr.cfg) {

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -37,10 +37,11 @@ impl Attrs {
         context: AttributeContext,
         errors: &mut Vec<LoweringError>,
     ) -> Self {
-        let mut this = Attrs::default();
-
-        // Backends must support this since it applies to the macro/C code.
-        this.c_rename = ast.c_rename.clone();
+        let mut this = Attrs {
+            // Backends must support this since it applies to the macro/C code.
+            c_rename: ast.c_rename.clone(),
+            ..Default::default()
+        };
 
         let support = validator.attrs_supported();
         for attr in &ast.attrs {

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -93,12 +93,18 @@ TypeContext {
                     attrs: Attrs {
                         disable: false,
                         rename: None,
+                        c_rename: RenameAttr {
+                            pattern: None,
+                        },
                     },
                 },
             ],
             attrs: Attrs {
                 disable: false,
                 rename: None,
+                c_rename: RenameAttr {
+                    pattern: None,
+                },
             },
             lifetimes: LifetimeEnv {
                 nodes: [
@@ -201,12 +207,18 @@ TypeContext {
                     attrs: Attrs {
                         disable: false,
                         rename: None,
+                        c_rename: RenameAttr {
+                            pattern: None,
+                        },
                     },
                 },
             ],
             attrs: Attrs {
                 disable: false,
                 rename: None,
+                c_rename: RenameAttr {
+                    pattern: None,
+                },
             },
             lifetimes: LifetimeEnv {
                 nodes: [
@@ -231,6 +243,9 @@ TypeContext {
             attrs: Attrs {
                 disable: false,
                 rename: None,
+                c_rename: RenameAttr {
+                    pattern: None,
+                },
             },
             lifetimes: LifetimeEnv {
                 nodes: [

--- a/example/cpp/Makefile
+++ b/example/cpp/Makefile
@@ -4,7 +4,7 @@
 ALL_HEADERS := $(wildcard *.h) $(wildcard *.hpp) $(wildcard tests/*.hpp)
 ALL_RUST := $(wildcard ../src/*.rs)
 
-CXX=g++-10
+CXX=g++-13
 
 FORCE:
 

--- a/feature_tests/c/include/AttrOpaque1.h
+++ b/feature_tests/c/include/AttrOpaque1.h
@@ -19,11 +19,11 @@ namespace capi {
 extern "C" {
 #endif
 
-uint8_t AttrOpaque1_method(const AttrOpaque1* self);
+uint8_t namespace_AttrOpaque1_method(const AttrOpaque1* self);
 
-uint8_t AttrOpaque1_crenamed(const AttrOpaque1* self);
+uint8_t renamed_in_c_only(const AttrOpaque1* self);
 
-void AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
+void namespace_AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
 void AttrOpaque1_destroy(AttrOpaque1* self);
 
 #ifdef __cplusplus

--- a/feature_tests/c/include/AttrOpaque1.h
+++ b/feature_tests/c/include/AttrOpaque1.h
@@ -19,6 +19,8 @@ namespace capi {
 extern "C" {
 #endif
 
+AttrOpaque1* namespace_AttrOpaque1_new();
+
 uint8_t namespace_AttrOpaque1_method(const AttrOpaque1* self);
 
 uint8_t renamed_in_c_only(const AttrOpaque1* self);

--- a/feature_tests/c/include/AttrOpaque1.h
+++ b/feature_tests/c/include/AttrOpaque1.h
@@ -19,7 +19,9 @@ namespace capi {
 extern "C" {
 #endif
 
-void AttrOpaque1_method(const AttrOpaque1* self);
+uint8_t AttrOpaque1_method(const AttrOpaque1* self);
+
+uint8_t AttrOpaque1_crenamed(const AttrOpaque1* self);
 
 void AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
 void AttrOpaque1_destroy(AttrOpaque1* self);

--- a/feature_tests/c2/include/AttrOpaque1.h
+++ b/feature_tests/c2/include/AttrOpaque1.h
@@ -15,7 +15,9 @@ extern "C" {
 #endif // __cplusplus
 
 
-void AttrOpaque1_method(const AttrOpaque1* self);
+uint8_t AttrOpaque1_method(const AttrOpaque1* self);
+
+uint8_t AttrOpaque1_crenamed(const AttrOpaque1* self);
 
 void AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
 

--- a/feature_tests/c2/include/AttrOpaque1.h
+++ b/feature_tests/c2/include/AttrOpaque1.h
@@ -15,6 +15,8 @@ extern "C" {
 #endif // __cplusplus
 
 
+AttrOpaque1* namespace_AttrOpaque1_new();
+
 uint8_t namespace_AttrOpaque1_method(const AttrOpaque1* self);
 
 uint8_t renamed_in_c_only(const AttrOpaque1* self);

--- a/feature_tests/c2/include/AttrOpaque1.h
+++ b/feature_tests/c2/include/AttrOpaque1.h
@@ -15,11 +15,11 @@ extern "C" {
 #endif // __cplusplus
 
 
-uint8_t AttrOpaque1_method(const AttrOpaque1* self);
+uint8_t namespace_AttrOpaque1_method(const AttrOpaque1* self);
 
-uint8_t AttrOpaque1_crenamed(const AttrOpaque1* self);
+uint8_t renamed_in_c_only(const AttrOpaque1* self);
 
-void AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
+void namespace_AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
 
 void AttrOpaque1_destroy(AttrOpaque1* self);
 

--- a/feature_tests/cpp/Makefile
+++ b/feature_tests/cpp/Makefile
@@ -22,7 +22,12 @@ $(ALL_HEADERS):
 ./tests/option.out: ../../target/debug/libdiplomat_feature_tests.a $(ALL_HEADERS) ./tests/option.cpp
 	$(CXX) -std=c++17 ./tests/option.cpp ../../target/debug/libdiplomat_feature_tests.a -ldl -lpthread -lm -g -o ./tests/option.out
 
-test: ./tests/structs.out ./tests/result.out ./tests/option.out
+./tests/attrs.out: ../../target/debug/libdiplomat_feature_tests.a $(ALL_HEADERS) ./tests/attrs.cpp
+	$(CXX) -std=c++17 ./tests/attrs.cpp ../../target/debug/libdiplomat_feature_tests.a -ldl -lpthread -lm -g -o ./tests/attrs.out
+
+
+test: ./tests/structs.out ./tests/result.out ./tests/option.out ./tests/attrs.out
 	./tests/structs.out
 	./tests/result.out
 	./tests/option.out
+	./tests/attrs.out

--- a/feature_tests/cpp/Makefile
+++ b/feature_tests/cpp/Makefile
@@ -4,7 +4,7 @@
 ALL_HEADERS := $(wildcard *.h) $(wildcard *.hpp) $(wildcard tests/*.hpp)
 ALL_RUST := $(wildcard ../src/*.rs)
 
-CXX=g++-10
+CXX=g++-13
 
 FORCE:
 

--- a/feature_tests/cpp/docs/source/attrs_ffi.rst
+++ b/feature_tests/cpp/docs/source/attrs_ffi.rst
@@ -11,7 +11,10 @@
 
 .. cpp:class:: AttrOpaque1
 
-    .. cpp:function:: void method() const
+    .. cpp:function:: uint8_t method() const
+
+
+    .. cpp:function:: uint8_t crenamed() const
 
 
     .. cpp:function:: void method_disabledcpp() const

--- a/feature_tests/cpp/docs/source/attrs_ffi.rst
+++ b/feature_tests/cpp/docs/source/attrs_ffi.rst
@@ -11,6 +11,9 @@
 
 .. cpp:class:: AttrOpaque1
 
+    .. cpp:function:: static AttrOpaque1 new_()
+
+
     .. cpp:function:: uint8_t method() const
 
 

--- a/feature_tests/cpp/include/AttrOpaque1.h
+++ b/feature_tests/cpp/include/AttrOpaque1.h
@@ -19,11 +19,11 @@ namespace capi {
 extern "C" {
 #endif
 
-uint8_t AttrOpaque1_method(const AttrOpaque1* self);
+uint8_t namespace_AttrOpaque1_method(const AttrOpaque1* self);
 
-uint8_t AttrOpaque1_crenamed(const AttrOpaque1* self);
+uint8_t renamed_in_c_only(const AttrOpaque1* self);
 
-void AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
+void namespace_AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
 void AttrOpaque1_destroy(AttrOpaque1* self);
 
 #ifdef __cplusplus

--- a/feature_tests/cpp/include/AttrOpaque1.h
+++ b/feature_tests/cpp/include/AttrOpaque1.h
@@ -19,6 +19,8 @@ namespace capi {
 extern "C" {
 #endif
 
+AttrOpaque1* namespace_AttrOpaque1_new();
+
 uint8_t namespace_AttrOpaque1_method(const AttrOpaque1* self);
 
 uint8_t renamed_in_c_only(const AttrOpaque1* self);

--- a/feature_tests/cpp/include/AttrOpaque1.h
+++ b/feature_tests/cpp/include/AttrOpaque1.h
@@ -19,7 +19,9 @@ namespace capi {
 extern "C" {
 #endif
 
-void AttrOpaque1_method(const AttrOpaque1* self);
+uint8_t AttrOpaque1_method(const AttrOpaque1* self);
+
+uint8_t AttrOpaque1_crenamed(const AttrOpaque1* self);
 
 void AttrOpaque1_method_disabledcpp(const AttrOpaque1* self);
 void AttrOpaque1_destroy(AttrOpaque1* self);

--- a/feature_tests/cpp/include/AttrOpaque1.hpp
+++ b/feature_tests/cpp/include/AttrOpaque1.hpp
@@ -37,12 +37,12 @@ class AttrOpaque1 {
 
 
 inline uint8_t AttrOpaque1::method() const {
-  return capi::AttrOpaque1_method(this->inner.get());
+  return capi::namespace_AttrOpaque1_method(this->inner.get());
 }
 inline uint8_t AttrOpaque1::crenamed() const {
-  return capi::AttrOpaque1_crenamed(this->inner.get());
+  return capi::renamed_in_c_only(this->inner.get());
 }
 inline void AttrOpaque1::method_disabledcpp() const {
-  capi::AttrOpaque1_method_disabledcpp(this->inner.get());
+  capi::namespace_AttrOpaque1_method_disabledcpp(this->inner.get());
 }
 #endif

--- a/feature_tests/cpp/include/AttrOpaque1.hpp
+++ b/feature_tests/cpp/include/AttrOpaque1.hpp
@@ -22,7 +22,8 @@ struct AttrOpaque1Deleter {
 };
 class AttrOpaque1 {
  public:
-  void method() const;
+  uint8_t method() const;
+  uint8_t crenamed() const;
   void method_disabledcpp() const;
   inline const capi::AttrOpaque1* AsFFI() const { return this->inner.get(); }
   inline capi::AttrOpaque1* AsFFIMut() { return this->inner.get(); }
@@ -35,8 +36,11 @@ class AttrOpaque1 {
 };
 
 
-inline void AttrOpaque1::method() const {
-  capi::AttrOpaque1_method(this->inner.get());
+inline uint8_t AttrOpaque1::method() const {
+  return capi::AttrOpaque1_method(this->inner.get());
+}
+inline uint8_t AttrOpaque1::crenamed() const {
+  return capi::AttrOpaque1_crenamed(this->inner.get());
 }
 inline void AttrOpaque1::method_disabledcpp() const {
   capi::AttrOpaque1_method_disabledcpp(this->inner.get());

--- a/feature_tests/cpp/include/AttrOpaque1.hpp
+++ b/feature_tests/cpp/include/AttrOpaque1.hpp
@@ -11,6 +11,7 @@
 
 #include "AttrOpaque1.h"
 
+class AttrOpaque1;
 
 /**
  * A destruction policy for using AttrOpaque1 with std::unique_ptr.
@@ -22,6 +23,7 @@ struct AttrOpaque1Deleter {
 };
 class AttrOpaque1 {
  public:
+  static AttrOpaque1 new_();
   uint8_t method() const;
   uint8_t crenamed() const;
   void method_disabledcpp() const;
@@ -36,6 +38,9 @@ class AttrOpaque1 {
 };
 
 
+inline AttrOpaque1 AttrOpaque1::new_() {
+  return AttrOpaque1(capi::namespace_AttrOpaque1_new());
+}
 inline uint8_t AttrOpaque1::method() const {
   return capi::namespace_AttrOpaque1_method(this->inner.get());
 }

--- a/feature_tests/cpp/tests/attrs.cpp
+++ b/feature_tests/cpp/tests/attrs.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include "../include/AttrOpaque1.hpp"
+#include "assert.hpp"
+
+int main(int argc, char *argv[]) {
+    AttrOpaque1 o = AttrOpaque1::new_();
+    // the cpp2 renames don't apply. However, these must link correctly!!
+    simple_assert_eq("method should call", o.method(), 77);
+    simple_assert_eq("method should call", o.crenamed(), 123);
+
+    // These C names should also resolve
+    void* renamed = (void*)capi::renamed_in_c_only;
+    std::cout<<"Renamed function at "<<renamed<<std::endl;
+    renamed = (void*)capi::namespace_AttrOpaque1_method;
+    std::cout<<"Renamed function at "<<renamed<<std::endl;
+}

--- a/feature_tests/cpp2/Makefile
+++ b/feature_tests/cpp2/Makefile
@@ -22,7 +22,11 @@ $(ALL_HEADERS):
 ./tests/option.out: ../../target/debug/libdiplomat_feature_tests.a $(ALL_HEADERS) ./tests/option.cpp
 	$(CXX) -std=c++17 ./tests/option.cpp ../../target/debug/libdiplomat_feature_tests.a -ldl -lpthread -lm -g -o ./tests/option.out
 
-test: ./tests/structs.out ./tests/result.out ./tests/option.out
+./tests/attrs.out: ../../target/debug/libdiplomat_feature_tests.a $(ALL_HEADERS) ./tests/attrs.cpp
+	$(CXX) -std=c++17 ./tests/attrs.cpp ../../target/debug/libdiplomat_feature_tests.a -ldl -lpthread -lm -g -o ./tests/attrs.out
+
+test: ./tests/structs.out ./tests/result.out ./tests/option.out ./tests/attrs.out
 	./tests/structs.out
 	./tests/result.out
 	./tests/option.out
+	./tests/attrs.out

--- a/feature_tests/cpp2/include/AttrOpaque1.d.h
+++ b/feature_tests/cpp2/include/AttrOpaque1.d.h
@@ -1,0 +1,24 @@
+#ifndef AttrOpaque1_D_H
+#define AttrOpaque1_D_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#ifdef __cplusplus
+namespace capi {
+extern "C" {
+#endif // __cplusplus
+
+
+typedef struct AttrOpaque1 AttrOpaque1;
+
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace capi
+#endif // __cplusplus
+
+#endif // AttrOpaque1_D_H

--- a/feature_tests/cpp2/include/AttrOpaque1.h
+++ b/feature_tests/cpp2/include/AttrOpaque1.h
@@ -1,0 +1,32 @@
+#ifndef AttrOpaque1_H
+#define AttrOpaque1_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+#include "AttrOpaque1.d.h"
+
+#ifdef __cplusplus
+namespace capi {
+extern "C" {
+#endif // __cplusplus
+
+
+AttrOpaque1* namespace_AttrOpaque1_new();
+
+uint8_t namespace_AttrOpaque1_method(const AttrOpaque1* self);
+
+uint8_t renamed_in_c_only(const AttrOpaque1* self);
+
+void AttrOpaque1_destroy(AttrOpaque1* self);
+
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace capi
+#endif // __cplusplus
+
+#endif // AttrOpaque1_H

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
@@ -20,10 +20,10 @@ public:
 
   inline uint8_t crenamed() const;
 
-  inline const capi::AttrOpaque1Renamed* AsFFI() const;
-  inline capi::AttrOpaque1Renamed* AsFFI();
-  inline static const AttrOpaque1Renamed* FromFFI(const capi::AttrOpaque1Renamed* ptr);
-  inline static AttrOpaque1Renamed* FromFFI(capi::AttrOpaque1Renamed* ptr);
+  inline const capi::AttrOpaque1* AsFFI() const;
+  inline capi::AttrOpaque1* AsFFI();
+  inline static const AttrOpaque1Renamed* FromFFI(const capi::AttrOpaque1* ptr);
+  inline static AttrOpaque1Renamed* FromFFI(capi::AttrOpaque1* ptr);
   inline static void operator delete(void* ptr);
 private:
   AttrOpaque1Renamed() = delete;

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
@@ -14,6 +14,8 @@
 class AttrOpaque1Renamed {
 public:
 
+  inline static std::unique_ptr<AttrOpaque1Renamed> new_();
+
   inline uint8_t method_renamed() const;
 
   inline uint8_t crenamed() const;

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
@@ -14,7 +14,9 @@
 class AttrOpaque1Renamed {
 public:
 
-  inline void method_renamed() const;
+  inline uint8_t method_renamed() const;
+
+  inline uint8_t crenamed() const;
 
   inline const capi::AttrOpaque1Renamed* AsFFI() const;
   inline capi::AttrOpaque1Renamed* AsFFI();

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
@@ -14,12 +14,12 @@
 
 
 inline uint8_t AttrOpaque1Renamed::method_renamed() const {
-  auto result = capi::AttrOpaque1_method(this->AsFFI());
+  auto result = capi::namespace_AttrOpaque1_method(this->AsFFI());
   return result;
 }
 
 inline uint8_t AttrOpaque1Renamed::crenamed() const {
-  auto result = capi::AttrOpaque1_crenamed(this->AsFFI());
+  auto result = capi::renamed_in_c_only(this->AsFFI());
   return result;
 }
 

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
@@ -28,24 +28,24 @@ inline uint8_t AttrOpaque1Renamed::crenamed() const {
   return result;
 }
 
-inline const capi::AttrOpaque1Renamed* AttrOpaque1Renamed::AsFFI() const {
-  return reinterpret_cast<const capi::AttrOpaque1Renamed*>(this);
+inline const capi::AttrOpaque1* AttrOpaque1Renamed::AsFFI() const {
+  return reinterpret_cast<const capi::AttrOpaque1*>(this);
 }
 
-inline capi::AttrOpaque1Renamed* AttrOpaque1Renamed::AsFFI() {
-  return reinterpret_cast<capi::AttrOpaque1Renamed*>(this);
+inline capi::AttrOpaque1* AttrOpaque1Renamed::AsFFI() {
+  return reinterpret_cast<capi::AttrOpaque1*>(this);
 }
 
-inline const AttrOpaque1Renamed* AttrOpaque1Renamed::FromFFI(const capi::AttrOpaque1Renamed* ptr) {
+inline const AttrOpaque1Renamed* AttrOpaque1Renamed::FromFFI(const capi::AttrOpaque1* ptr) {
   return reinterpret_cast<const AttrOpaque1Renamed*>(ptr);
 }
 
-inline AttrOpaque1Renamed* AttrOpaque1Renamed::FromFFI(capi::AttrOpaque1Renamed* ptr) {
+inline AttrOpaque1Renamed* AttrOpaque1Renamed::FromFFI(capi::AttrOpaque1* ptr) {
   return reinterpret_cast<AttrOpaque1Renamed*>(ptr);
 }
 
 inline void AttrOpaque1Renamed::operator delete(void* ptr) {
-  capi::AttrOpaque1Renamed_destroy(reinterpret_cast<capi::AttrOpaque1Renamed*>(ptr));
+  capi::AttrOpaque1_destroy(reinterpret_cast<capi::AttrOpaque1*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
@@ -13,8 +13,14 @@
 #include "AttrOpaque1.h"
 
 
-inline void AttrOpaque1Renamed::method_renamed() const {
-  capi::AttrOpaque1_method(this->AsFFI());
+inline uint8_t AttrOpaque1Renamed::method_renamed() const {
+  auto result = capi::AttrOpaque1_method(this->AsFFI());
+  return result;
+}
+
+inline uint8_t AttrOpaque1Renamed::crenamed() const {
+  auto result = capi::AttrOpaque1_crenamed(this->AsFFI());
+  return result;
 }
 
 inline const capi::AttrOpaque1Renamed* AttrOpaque1Renamed::AsFFI() const {

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
@@ -13,6 +13,11 @@
 #include "AttrOpaque1.h"
 
 
+inline std::unique_ptr<AttrOpaque1Renamed> AttrOpaque1Renamed::new_() {
+  auto result = capi::namespace_AttrOpaque1_new();
+  return std::unique_ptr<AttrOpaque1Renamed>(AttrOpaque1Renamed::FromFFI(result));
+}
+
 inline uint8_t AttrOpaque1Renamed::method_renamed() const {
   auto result = capi::namespace_AttrOpaque1_method(this->AsFFI());
   return result;

--- a/feature_tests/cpp2/tests/attrs.cpp
+++ b/feature_tests/cpp2/tests/attrs.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+#include "../include/AttrOpaque1Renamed.hpp"
+#include "assert.hpp"
+
+int main(int argc, char *argv[]) {
+    std::unique_ptr<AttrOpaque1Renamed> r = AttrOpaque1Renamed::new_();
+    simple_assert_eq("method should call", r->method_renamed(), 77);
+    simple_assert_eq("method should call", r->crenamed(), 123);
+
+    // These C names should also resolve
+    void* renamed = (void*)capi::renamed_in_c_only;
+    std::cout<<"Renamed function at "<<renamed<<std::endl;
+    renamed = (void*)capi::namespace_AttrOpaque1_method;
+    std::cout<<"Renamed function at "<<renamed<<std::endl;
+}

--- a/feature_tests/dart/lib/src/AttrOpaque1.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1.g.dart
@@ -24,8 +24,14 @@ final class AttrOpaque1 implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_AttrOpaque1_destroy));
 
-  void method() {
-    _AttrOpaque1_method(_underlying);
+  int get method {
+    final result = _AttrOpaque1_method(_underlying);
+    return result;
+  }
+
+  int get crenamed {
+    final result = _AttrOpaque1_crenamed(_underlying);
+    return result;
   }
 
   void methodDisabledcpp() {
@@ -37,9 +43,13 @@ final class AttrOpaque1 implements ffi.Finalizable {
 // ignore: non_constant_identifier_names
 external void _AttrOpaque1_destroy(ffi.Pointer<ffi.Void> self);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'AttrOpaque1_method')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'AttrOpaque1_method')
 // ignore: non_constant_identifier_names
-external void _AttrOpaque1_method(ffi.Pointer<ffi.Opaque> self);
+external int _AttrOpaque1_method(ffi.Pointer<ffi.Opaque> self);
+
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'AttrOpaque1_crenamed')
+// ignore: non_constant_identifier_names
+external int _AttrOpaque1_crenamed(ffi.Pointer<ffi.Opaque> self);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'AttrOpaque1_method_disabledcpp')
 // ignore: non_constant_identifier_names

--- a/feature_tests/dart/lib/src/AttrOpaque1.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1.g.dart
@@ -24,6 +24,11 @@ final class AttrOpaque1 implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_AttrOpaque1_destroy));
 
+  factory AttrOpaque1() {
+    final result = _namespace_AttrOpaque1_new();
+    return AttrOpaque1._(result, true, []);
+  }
+
   int get method {
     final result = _namespace_AttrOpaque1_method(_underlying);
     return result;
@@ -42,6 +47,10 @@ final class AttrOpaque1 implements ffi.Finalizable {
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'AttrOpaque1_destroy')
 // ignore: non_constant_identifier_names
 external void _AttrOpaque1_destroy(ffi.Pointer<ffi.Void> self);
+
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'namespace_AttrOpaque1_new')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _namespace_AttrOpaque1_new();
 
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_method')
 // ignore: non_constant_identifier_names

--- a/feature_tests/dart/lib/src/AttrOpaque1.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1.g.dart
@@ -25,17 +25,17 @@ final class AttrOpaque1 implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_AttrOpaque1_destroy));
 
   int get method {
-    final result = _AttrOpaque1_method(_underlying);
+    final result = _namespace_AttrOpaque1_method(_underlying);
     return result;
   }
 
   int get crenamed {
-    final result = _AttrOpaque1_crenamed(_underlying);
+    final result = _renamed_in_c_only(_underlying);
     return result;
   }
 
   void methodDisabledcpp() {
-    _AttrOpaque1_method_disabledcpp(_underlying);
+    _namespace_AttrOpaque1_method_disabledcpp(_underlying);
   }
 }
 
@@ -43,14 +43,14 @@ final class AttrOpaque1 implements ffi.Finalizable {
 // ignore: non_constant_identifier_names
 external void _AttrOpaque1_destroy(ffi.Pointer<ffi.Void> self);
 
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'AttrOpaque1_method')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_method')
 // ignore: non_constant_identifier_names
-external int _AttrOpaque1_method(ffi.Pointer<ffi.Opaque> self);
+external int _namespace_AttrOpaque1_method(ffi.Pointer<ffi.Opaque> self);
 
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'AttrOpaque1_crenamed')
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'renamed_in_c_only')
 // ignore: non_constant_identifier_names
-external int _AttrOpaque1_crenamed(ffi.Pointer<ffi.Opaque> self);
+external int _renamed_in_c_only(ffi.Pointer<ffi.Opaque> self);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'AttrOpaque1_method_disabledcpp')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_method_disabledcpp')
 // ignore: non_constant_identifier_names
-external void _AttrOpaque1_method_disabledcpp(ffi.Pointer<ffi.Opaque> self);
+external void _namespace_AttrOpaque1_method_disabledcpp(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dotnet/Lib/Generated/AttrOpaque1.cs
+++ b/feature_tests/dotnet/Lib/Generated/AttrOpaque1.cs
@@ -29,7 +29,7 @@ public partial class AttrOpaque1: IDisposable
         _inner = handle;
     }
 
-    public void Method()
+    public byte Method()
     {
         unsafe
         {
@@ -37,7 +37,21 @@ public partial class AttrOpaque1: IDisposable
             {
                 throw new ObjectDisposedException("AttrOpaque1");
             }
-            Raw.AttrOpaque1.Method(_inner);
+            byte retVal = Raw.AttrOpaque1.Method(_inner);
+            return retVal;
+        }
+    }
+
+    public byte Crenamed()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("AttrOpaque1");
+            }
+            byte retVal = Raw.AttrOpaque1.Crenamed(_inner);
+            return retVal;
         }
     }
 

--- a/feature_tests/dotnet/Lib/Generated/AttrOpaque1.cs
+++ b/feature_tests/dotnet/Lib/Generated/AttrOpaque1.cs
@@ -29,6 +29,18 @@ public partial class AttrOpaque1: IDisposable
         _inner = handle;
     }
 
+    /// <returns>
+    /// A <c>AttrOpaque1</c> allocated on Rust side.
+    /// </returns>
+    public static AttrOpaque1 New()
+    {
+        unsafe
+        {
+            Raw.AttrOpaque1* retVal = Raw.AttrOpaque1.New();
+            return new AttrOpaque1(retVal);
+        }
+    }
+
     public byte Method()
     {
         unsafe

--- a/feature_tests/dotnet/Lib/Generated/RawAttrOpaque1.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawAttrOpaque1.cs
@@ -16,14 +16,14 @@ public partial struct AttrOpaque1
 {
     private const string NativeLib = "diplomat_feature_tests";
 
-    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "AttrOpaque1_method", ExactSpelling = true)]
-    public static unsafe extern byte Method(AttrOpaque1* self);
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespace_AttrOpaque1_method", ExactSpelling = true)]
+    public static unsafe extern byte NamespaceMethod(AttrOpaque1* self);
 
-    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "AttrOpaque1_crenamed", ExactSpelling = true)]
-    public static unsafe extern byte Crenamed(AttrOpaque1* self);
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "renamed_in_c_only", ExactSpelling = true)]
+    public static unsafe extern byte RenamedInCOnly(AttrOpaque1* self);
 
-    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "AttrOpaque1_method_disabledcpp", ExactSpelling = true)]
-    public static unsafe extern void MethodDisabledcpp(AttrOpaque1* self);
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespace_AttrOpaque1_method_disabledcpp", ExactSpelling = true)]
+    public static unsafe extern void NamespaceMethodDisabledcpp(AttrOpaque1* self);
 
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "AttrOpaque1_destroy", ExactSpelling = true)]
     public static unsafe extern void Destroy(AttrOpaque1* self);

--- a/feature_tests/dotnet/Lib/Generated/RawAttrOpaque1.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawAttrOpaque1.cs
@@ -17,7 +17,10 @@ public partial struct AttrOpaque1
     private const string NativeLib = "diplomat_feature_tests";
 
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "AttrOpaque1_method", ExactSpelling = true)]
-    public static unsafe extern void Method(AttrOpaque1* self);
+    public static unsafe extern byte Method(AttrOpaque1* self);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "AttrOpaque1_crenamed", ExactSpelling = true)]
+    public static unsafe extern byte Crenamed(AttrOpaque1* self);
 
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "AttrOpaque1_method_disabledcpp", ExactSpelling = true)]
     public static unsafe extern void MethodDisabledcpp(AttrOpaque1* self);

--- a/feature_tests/dotnet/Lib/Generated/RawAttrOpaque1.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawAttrOpaque1.cs
@@ -16,6 +16,9 @@ public partial struct AttrOpaque1
 {
     private const string NativeLib = "diplomat_feature_tests";
 
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespace_AttrOpaque1_new", ExactSpelling = true)]
+    public static unsafe extern AttrOpaque1* NamespaceNew();
+
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespace_AttrOpaque1_method", ExactSpelling = true)]
     public static unsafe extern byte NamespaceMethod(AttrOpaque1* self);
 

--- a/feature_tests/js/api/AttrOpaque1.d.ts
+++ b/feature_tests/js/api/AttrOpaque1.d.ts
@@ -1,3 +1,4 @@
+import { u8 } from "./diplomat-runtime"
 
 /**
  */
@@ -5,7 +6,11 @@ export class AttrOpaque1 {
 
   /**
    */
-  method(): void;
+  method(): u8;
+
+  /**
+   */
+  crenamed(): u8;
 
   /**
    */

--- a/feature_tests/js/api/AttrOpaque1.d.ts
+++ b/feature_tests/js/api/AttrOpaque1.d.ts
@@ -6,6 +6,10 @@ export class AttrOpaque1 {
 
   /**
    */
+  static new(): AttrOpaque1;
+
+  /**
+   */
   method(): u8;
 
   /**

--- a/feature_tests/js/api/AttrOpaque1.mjs
+++ b/feature_tests/js/api/AttrOpaque1.mjs
@@ -16,7 +16,11 @@ export class AttrOpaque1 {
   }
 
   method() {
-    wasm.AttrOpaque1_method(this.underlying);
+    return wasm.AttrOpaque1_method(this.underlying);
+  }
+
+  crenamed() {
+    return wasm.AttrOpaque1_crenamed(this.underlying);
   }
 
   method_disabledcpp() {

--- a/feature_tests/js/api/AttrOpaque1.mjs
+++ b/feature_tests/js/api/AttrOpaque1.mjs
@@ -16,14 +16,14 @@ export class AttrOpaque1 {
   }
 
   method() {
-    return wasm.AttrOpaque1_method(this.underlying);
+    return wasm.namespace_AttrOpaque1_method(this.underlying);
   }
 
   crenamed() {
-    return wasm.AttrOpaque1_crenamed(this.underlying);
+    return wasm.renamed_in_c_only(this.underlying);
   }
 
   method_disabledcpp() {
-    wasm.AttrOpaque1_method_disabledcpp(this.underlying);
+    wasm.namespace_AttrOpaque1_method_disabledcpp(this.underlying);
   }
 }

--- a/feature_tests/js/api/AttrOpaque1.mjs
+++ b/feature_tests/js/api/AttrOpaque1.mjs
@@ -15,6 +15,10 @@ export class AttrOpaque1 {
     }
   }
 
+  static new() {
+    return new AttrOpaque1(wasm.namespace_AttrOpaque1_new(), true, []);
+  }
+
   method() {
     return wasm.namespace_AttrOpaque1_method(this.underlying);
   }

--- a/feature_tests/js/docs/source/attrs_ffi.rst
+++ b/feature_tests/js/docs/source/attrs_ffi.rst
@@ -5,6 +5,8 @@
 
 .. js:class:: AttrOpaque1
 
+    .. js:function:: new()
+
     .. js:method:: method()
 
     .. js:method:: crenamed()

--- a/feature_tests/js/docs/source/attrs_ffi.rst
+++ b/feature_tests/js/docs/source/attrs_ffi.rst
@@ -7,6 +7,8 @@
 
     .. js:method:: method()
 
+    .. js:method:: crenamed()
+
     .. js:method:: method_disabledcpp()
 
 .. js:class:: AttrOpaque2

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -1,4 +1,5 @@
 #[diplomat::bridge]
+#[diplomat::c_rename = "namespace_{0}"]
 pub mod ffi {
     #[diplomat::opaque]
     #[diplomat::attr(cpp2, rename = "AttrOpaque1Renamed")]
@@ -6,8 +7,13 @@ pub mod ffi {
 
     impl AttrOpaque1 {
         #[diplomat::attr(cpp2, rename = "method_renamed")]
-        pub fn method(&self) {
-            println!("method");
+        pub fn method(&self) -> u8 {
+            77
+        }
+
+        #[diplomat::c_rename("renamed_in_c_only")]
+        pub fn crenamed(&self) -> u8 {
+            123
         }
 
         #[diplomat::attr(cpp2, disable)]

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -6,6 +6,10 @@ pub mod ffi {
     pub struct AttrOpaque1;
 
     impl AttrOpaque1 {
+        pub fn new() -> Box<AttrOpaque1> {
+            Box::new(AttrOpaque1)
+        }
+
         #[diplomat::attr(cpp2, rename = "method_renamed")]
         pub fn method(&self) -> u8 {
             77

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -277,6 +277,7 @@ impl AttributeInfo {
                         || seg == "out"
                         || seg == "attr"
                         || seg == "skip_if_unsupported"
+                        || seg == "c_rename"
                     {
                         // diplomat-tool reads these, not diplomat::bridge.
                         // throw them away so rustc doesn't complain about unknown attributes
@@ -303,8 +304,10 @@ impl AttributeInfo {
     }
 }
 
-fn gen_bridge(input: ItemMod) -> ItemMod {
+fn gen_bridge(mut input: ItemMod) -> ItemMod {
     let module = ast::Module::from_syn(&input, true);
+    // Clean out any diplomat attributes so Rust doesn't get mad
+    let _attrs = AttributeInfo::extract(&mut input.attrs);
     let (brace, mut new_contents) = input.content.unwrap();
 
     new_contents.push(parse2(quote! { use diplomat_runtime::*; }).unwrap());

--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -78,7 +78,8 @@ impl<'tcx> CFormatter<'tcx> {
     pub fn fmt_method_name(&self, ty: TypeId, method: &hir::Method) -> String {
         let ty_name = self.fmt_type_name(ty);
         let method_name = method.name.as_str();
-        format!("{ty_name}_{method_name}")
+        let put_together = format!("{ty_name}_{method_name}");
+        method.attrs.c_rename.apply(&put_together).into()
     }
 
     pub fn fmt_ptr<'a>(&self, ident: &'a str, mutability: hir::Mutability) -> Cow<'a, str> {

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -31,8 +31,8 @@ impl<'tcx> super::CContext<'tcx> {
         }
         for method in ty.methods() {
             if method.attrs.disable {
-                // Skip type if disabled
-                return;
+                // Skip method if disabled
+                continue;
             }
             let _guard = self.errors.set_context_method(
                 self.formatter.fmt_type_name_diagnostics(id),

--- a/tool/src/common/mod.rs
+++ b/tool/src/common/mod.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 /// This type abstracts over files being written to.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FileMap {
     // The context types exist as a way to avoid passing around a billion different
     // parameters. However, passing them around as &mut self restricts the amount of

--- a/tool/src/cpp2/formatter.rs
+++ b/tool/src/cpp2/formatter.rs
@@ -80,8 +80,8 @@ impl<'tcx> Cpp2Formatter<'tcx> {
         ident.into()
     }
 
-    pub fn fmt_c_name<'a>(&self, ident: &'a str) -> Cow<'a, str> {
-        format!("capi::{ident}").into()
+    pub fn fmt_c_type_name<'a>(&self, id: TypeId) -> Cow<'a, str> {
+        format!("capi::{}", self.c.fmt_type_name(id)).into()
     }
 
     pub fn fmt_c_ptr<'a>(&self, ident: &'a str, mutability: hir::Mutability) -> Cow<'a, str> {

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -118,7 +118,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
     /// cannot be added to it.
     pub fn gen_enum_def(&mut self, ty: &'tcx hir::EnumDef, id: TypeId) {
         let type_name = self.cx.formatter.fmt_type_name(id);
-        let ctype = self.cx.formatter.fmt_c_name(&type_name);
+        let ctype = self.cx.formatter.fmt_c_type_name(id);
 
         let methods = ty
             .methods
@@ -173,7 +173,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
 
     pub fn gen_opaque_def(&mut self, ty: &'tcx hir::OpaqueDef, id: TypeId) {
         let type_name = self.cx.formatter.fmt_type_name(id);
-        let ctype = self.cx.formatter.fmt_c_name(&type_name);
+        let ctype = self.cx.formatter.fmt_c_type_name(id);
 
         let methods = ty
             .methods
@@ -228,7 +228,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
 
     pub fn gen_struct_def<P: TyPosition>(&mut self, def: &'tcx hir::StructDef<P>, id: TypeId) {
         let type_name = self.cx.formatter.fmt_type_name(id);
-        let ctype = self.cx.formatter.fmt_c_name(&type_name);
+        let ctype = self.cx.formatter.fmt_c_type_name(id);
 
         let field_decls = def
             .fields


### PR DESCRIPTION
This allows you to rename *methods* in C, by applying patterns. The support is quite extensible: in the long run I would like to support things like `namespace_{type}_{method}` as well (right now you have no control over the way the type gets concatenated to the method, you can just apply a pattern to it or replace it entirely).

The RenameAttr stuff will also get reused in the regular tool backend rename attributes, and we can add things like `camel_case` (or in the case of Dart, `no_camel_case`).

Todo (potential followup):
 - Error when the attribute is explicitly applied to types
 - Maybe test Dart