### PR TITLE
Add namespacing attribute

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -99,17 +99,17 @@ impl Attrs {
                         context,
                         AttributeContext::Method | AttributeContext::EnumVariant
                     ) {
-                        errors.push(LoweringError::Other(format!(
-                            "`namespace` can only be used on types"
-                        )));
+                        errors.push(LoweringError::Other(
+                            "`namespace` can only be used on types".to_string(),
+                        ));
                         continue;
                     }
                     match StandardAttribute::from_meta(&attr.meta) {
                         Ok(StandardAttribute::String(s)) => this.namespace = Some(s),
                         Ok(_) | Err(_) => {
-                            errors.push(LoweringError::Other(format!(
-                                "`namespace` must have a single string parameter"
-                            )));
+                            errors.push(LoweringError::Other(
+                                "`namespace` must have a single string parameter".to_string(),
+                            ));
                             continue;
                         }
                     }

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -92,6 +92,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        namespace: None,
                         rename: RenameAttr {
                             pattern: None,
                         },
@@ -103,6 +104,7 @@ TypeContext {
             ],
             attrs: Attrs {
                 disable: false,
+                namespace: None,
                 rename: RenameAttr {
                     pattern: None,
                 },
@@ -210,6 +212,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        namespace: None,
                         rename: RenameAttr {
                             pattern: None,
                         },
@@ -221,6 +224,7 @@ TypeContext {
             ],
             attrs: Attrs {
                 disable: false,
+                namespace: None,
                 rename: RenameAttr {
                     pattern: None,
                 },
@@ -250,6 +254,7 @@ TypeContext {
             methods: [],
             attrs: Attrs {
                 disable: false,
+                namespace: None,
                 rename: RenameAttr {
                     pattern: None,
                 },


### PR DESCRIPTION
Based on https://github.com/rust-diplomat/diplomat/pull/424, can be reviewed together or independently.

This adds parsing for the namespacing attribute, but does not yet use it in CPP.

Progress on #103