### PR TITLE
Make lifetimes no longer generic over Kind

### DIFF
--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -31,7 +31,7 @@ pub struct StructDef<P: TyPosition = Everywhere> {
     pub fields: Vec<StructField<P>>,
     pub methods: Vec<Method>,
     pub attrs: Attrs,
-    pub lifetimes: LifetimeEnv<lifetimes::Type>,
+    pub lifetimes: LifetimeEnv,
 }
 
 /// A struct whose contents are opaque across the FFI boundary, and can only
@@ -49,7 +49,7 @@ pub struct OpaqueDef {
     pub name: IdentBuf,
     pub methods: Vec<Method>,
     pub attrs: Attrs,
-    pub lifetimes: LifetimeEnv<lifetimes::Type>,
+    pub lifetimes: LifetimeEnv,
 }
 
 /// The enum type.
@@ -92,7 +92,7 @@ impl<P: TyPosition> StructDef<P> {
         fields: Vec<StructField<P>>,
         methods: Vec<Method>,
         attrs: Attrs,
-        lifetimes: LifetimeEnv<lifetimes::Type>,
+        lifetimes: LifetimeEnv,
     ) -> Self {
         Self {
             docs,
@@ -111,7 +111,7 @@ impl OpaqueDef {
         name: IdentBuf,
         methods: Vec<Method>,
         attrs: Attrs,
-        lifetimes: LifetimeEnv<lifetimes::Type>,
+        lifetimes: LifetimeEnv,
     ) -> Self {
         Self {
             docs,

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -1,6 +1,6 @@
 //! Type definitions for structs, output structs, opaque structs, and enums.
 
-use super::lifetimes::{self, LifetimeEnv};
+use super::lifetimes::LifetimeEnv;
 use super::{Attrs, Everywhere, IdentBuf, Method, OutputOnly, TyPosition, Type};
 use crate::ast::Docs;
 

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -96,7 +96,7 @@
 //!
 //! [Nomicon]: https://doc.rust-lang.org/nomicon/lifetime-elision.html
 
-use super::lifetimes::{self, BoundedLifetime, Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
+use super::lifetimes::{BoundedLifetime, Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
 use super::LoweringContext;
 use crate::ast;
 use smallvec::SmallVec;

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -171,7 +171,7 @@ impl ElisionSource {
 pub(super) struct BaseLifetimeLowerer<'ast> {
     lifetime_env: &'ast ast::LifetimeEnv,
     self_lifetimes: Option<TypeLifetimes>,
-    nodes: SmallVec<[BoundedLifetime<lifetimes::Method>; super::lifetimes::INLINE_NUM_LIFETIMES]>,
+    nodes: SmallVec<[BoundedLifetime; super::lifetimes::INLINE_NUM_LIFETIMES]>,
     num_lifetimes: usize,
 }
 
@@ -345,7 +345,7 @@ impl<'ast> LifetimeLowerer for ParamLifetimeLowerer<'ast> {
 
 impl<'ast> ReturnLifetimeLowerer<'ast> {
     /// Finalize the lifetimes in the method, returning the resulting [`LifetimeEnv`].
-    pub fn finish(self) -> LifetimeEnv<lifetimes::Method> {
+    pub fn finish(self) -> LifetimeEnv {
         LifetimeEnv::new(self.base.nodes, self.base.num_lifetimes)
     }
 }

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -96,14 +96,12 @@
 //!
 //! [Nomicon]: https://doc.rust-lang.org/nomicon/lifetime-elision.html
 
-use super::lifetimes::{
-    self, BoundedLifetime, LifetimeEnv, MaybeStatic, MethodLifetime, TypeLifetime, TypeLifetimes,
-};
+use super::lifetimes::{self, BoundedLifetime, Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
 use super::LoweringContext;
 use crate::ast;
 use smallvec::SmallVec;
 
-/// Lower [`ast::Lifetime`]s to [`TypeLifetime`]s.
+/// Lower [`ast::Lifetime`]s to [`Lifetime`]s.
 ///
 /// This helper traits allows the [`lower_type`] and [`lower_out_type`] methods
 /// to abstractly lower lifetimes without concern for what sort of tracking
@@ -111,12 +109,12 @@ use smallvec::SmallVec;
 /// when visiting lifetimes in the input.
 pub trait LifetimeLowerer {
     /// Lowers an [`ast::Lifetime`].
-    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> MaybeStatic<TypeLifetime>;
+    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> MaybeStatic<Lifetime>;
 
     /// Lowers a slice of [`ast::Lifetime`]s by calling
     /// [`LifetimeLowerer::lower_lifetime`] repeatedly.
-    fn lower_lifetimes(&mut self, lifetimes: &[ast::Lifetime]) -> TypeLifetimes {
-        TypeLifetimes::from_fn(lifetimes, |lifetime| self.lower_lifetime(lifetime))
+    fn lower_lifetimes(&mut self, lifetimes: &[ast::Lifetime]) -> Lifetimes {
+        Lifetimes::from_fn(lifetimes, |lifetime| self.lower_lifetime(lifetime))
     }
 
     /// Lowers a slice of [`ast::Lifetime`], where the strategy may vary depending
@@ -129,7 +127,7 @@ pub trait LifetimeLowerer {
     /// Additionally, elision inferences knows to not search inside the generics
     /// of `Self` types for candidate lifetimes to correspond to elided lifetimes
     /// in the output.
-    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> TypeLifetimes;
+    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> Lifetimes;
 }
 
 /// A state machine for tracking which lifetime in a function's parameters
@@ -139,16 +137,16 @@ enum ElisionSource {
     /// No borrows in the input, no elision.
     NoBorrows,
     /// `&self` or `&mut self`, elision allowed.
-    SelfParam(MaybeStatic<TypeLifetime>),
+    SelfParam(MaybeStatic<Lifetime>),
     /// One param contains a borrow, elision allowed.
-    OneParam(MaybeStatic<TypeLifetime>),
+    OneParam(MaybeStatic<Lifetime>),
     /// Multiple borrows and no self borrow, no elision.
     MultipleBorrows,
 }
 
 impl ElisionSource {
     /// Potentially transition to a new state.
-    fn visit_lifetime(&mut self, lifetime: MaybeStatic<TypeLifetime>) {
+    fn visit_lifetime(&mut self, lifetime: MaybeStatic<Lifetime>) {
         match self {
             ElisionSource::NoBorrows => *self = ElisionSource::OneParam(lifetime),
             ElisionSource::SelfParam(_) => {
@@ -170,7 +168,7 @@ impl ElisionSource {
 /// lifetimes, and caching lifetimes of `Self`.
 pub(super) struct BaseLifetimeLowerer<'ast> {
     lifetime_env: &'ast ast::LifetimeEnv,
-    self_lifetimes: Option<TypeLifetimes>,
+    self_lifetimes: Option<Lifetimes>,
     nodes: SmallVec<[BoundedLifetime; super::lifetimes::INLINE_NUM_LIFETIMES]>,
     num_lifetimes: usize,
 }
@@ -211,21 +209,21 @@ pub(super) struct ReturnLifetimeLowerer<'ast> {
 }
 
 impl<'ast> BaseLifetimeLowerer<'ast> {
-    /// Returns a [`TypeLifetime`] representing a new anonymous lifetime, and
+    /// Returns a [`Lifetime`] representing a new anonymous lifetime, and
     /// pushes it to the nodes vector.
-    fn new_elided(&mut self) -> TypeLifetime {
+    fn new_elided(&mut self) -> Lifetime {
         let index = self.num_lifetimes;
         self.num_lifetimes += 1;
-        TypeLifetime::new(index)
+        Lifetime::new(index)
     }
 
     /// Lowers a single [`ast::Lifetime`]. If the lifetime is elided, then a fresh
     /// [`ImplicitLifetime`] is generated.
-    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> MaybeStatic<TypeLifetime> {
+    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> MaybeStatic<Lifetime> {
         match lifetime {
             ast::Lifetime::Static => MaybeStatic::Static,
             ast::Lifetime::Named(named) => {
-                MaybeStatic::NonStatic(TypeLifetime::from_ast(named, self.lifetime_env))
+                MaybeStatic::NonStatic(Lifetime::from_ast(named, self.lifetime_env))
             }
             ast::Lifetime::Anonymous => MaybeStatic::NonStatic(self.new_elided()),
         }
@@ -233,11 +231,11 @@ impl<'ast> BaseLifetimeLowerer<'ast> {
 
     /// Retrieves the cached  `Self` lifetimes, or caches newly generated
     /// lifetimes and returns those.
-    fn self_lifetimes_or_new(&mut self, ast_lifetimes: &[ast::Lifetime]) -> TypeLifetimes {
+    fn self_lifetimes_or_new(&mut self, ast_lifetimes: &[ast::Lifetime]) -> Lifetimes {
         if let Some(lifetimes) = &self.self_lifetimes {
             lifetimes.clone()
         } else {
-            let lifetimes = TypeLifetimes::from_fn(ast_lifetimes, |lt| self.lower_lifetime(lt));
+            let lifetimes = Lifetimes::from_fn(ast_lifetimes, |lt| self.lower_lifetime(lt));
             self.self_lifetimes = Some(lifetimes.clone());
             lifetimes
         }
@@ -255,16 +253,8 @@ impl<'ast> SelfParamLifetimeLowerer<'ast> {
                 (Some(lifetime), Some(hir_nodes)) => {
                     hir_nodes.push(BoundedLifetime::new(
                         lifetime,
-                        ast_node
-                            .longer
-                            .iter()
-                            .map(|i| MethodLifetime::new(*i))
-                            .collect(),
-                        ast_node
-                            .shorter
-                            .iter()
-                            .map(|i| MethodLifetime::new(*i))
-                            .collect(),
+                        ast_node.longer.iter().map(|i| Lifetime::new(*i)).collect(),
+                        ast_node.shorter.iter().map(|i| Lifetime::new(*i)).collect(),
                     ));
                 }
                 _ => hir_nodes = None,
@@ -292,7 +282,7 @@ impl<'ast> SelfParamLifetimeLowerer<'ast> {
     pub fn lower_self_ref(
         mut self,
         lifetime: &ast::Lifetime,
-    ) -> (MaybeStatic<TypeLifetime>, ParamLifetimeLowerer<'ast>) {
+    ) -> (MaybeStatic<Lifetime>, ParamLifetimeLowerer<'ast>) {
         let self_lifetime = self.base.lower_lifetime(lifetime);
 
         (
@@ -328,13 +318,13 @@ impl<'ast> ParamLifetimeLowerer<'ast> {
 }
 
 impl<'ast> LifetimeLowerer for ParamLifetimeLowerer<'ast> {
-    fn lower_lifetime(&mut self, borrow: &ast::Lifetime) -> MaybeStatic<TypeLifetime> {
+    fn lower_lifetime(&mut self, borrow: &ast::Lifetime) -> MaybeStatic<Lifetime> {
         let lifetime = self.base.lower_lifetime(borrow);
         self.elision_source.visit_lifetime(lifetime);
         lifetime
     }
 
-    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> TypeLifetimes {
+    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> Lifetimes {
         if is_self {
             self.base.self_lifetimes_or_new(lifetimes)
         } else {
@@ -351,11 +341,11 @@ impl<'ast> ReturnLifetimeLowerer<'ast> {
 }
 
 impl<'ast> LifetimeLowerer for ReturnLifetimeLowerer<'ast> {
-    fn lower_lifetime(&mut self, borrow: &ast::Lifetime) -> MaybeStatic<TypeLifetime> {
+    fn lower_lifetime(&mut self, borrow: &ast::Lifetime) -> MaybeStatic<Lifetime> {
         match borrow {
             ast::Lifetime::Static => MaybeStatic::Static,
             ast::Lifetime::Named(named) => {
-                MaybeStatic::NonStatic(TypeLifetime::from_ast(named, self.base.lifetime_env))
+                MaybeStatic::NonStatic(Lifetime::from_ast(named, self.base.lifetime_env))
             }
             ast::Lifetime::Anonymous => match self.elision_source {
                 ElisionSource::SelfParam(lifetime) | ElisionSource::OneParam(lifetime) => lifetime,
@@ -369,7 +359,7 @@ impl<'ast> LifetimeLowerer for ReturnLifetimeLowerer<'ast> {
         }
     }
 
-    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> TypeLifetimes {
+    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], is_self: bool) -> Lifetimes {
         if is_self {
             self.base.self_lifetimes_or_new(lifetimes)
         } else {
@@ -379,19 +369,17 @@ impl<'ast> LifetimeLowerer for ReturnLifetimeLowerer<'ast> {
 }
 
 impl LifetimeLowerer for &ast::LifetimeEnv {
-    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> MaybeStatic<TypeLifetime> {
+    fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> MaybeStatic<Lifetime> {
         match lifetime {
             ast::Lifetime::Static => MaybeStatic::Static,
-            ast::Lifetime::Named(named) => {
-                MaybeStatic::NonStatic(TypeLifetime::from_ast(named, self))
-            }
+            ast::Lifetime::Named(named) => MaybeStatic::NonStatic(Lifetime::from_ast(named, self)),
             ast::Lifetime::Anonymous => {
                 panic!("anonymous lifetime inside struct, this shouldn't pass rustc's checks")
             }
         }
     }
 
-    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], _: bool) -> TypeLifetimes {
+    fn lower_generics(&mut self, lifetimes: &[ast::Lifetime], _: bool) -> Lifetimes {
         self.lower_lifetimes(lifetimes)
     }
 }

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -225,18 +225,6 @@ impl<T> MaybeStatic<T> {
     }
 }
 
-/// The [`LifetimeKind`] of [`Lifetimes`]
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(clippy::exhaustive_structs)] // marker type
-pub struct Type;
-
-pub type Method = Type;
-
-/// Abstraction over where lifetimes can occur
-pub trait LifetimeKind: Copy + Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord {}
-
-impl LifetimeKind for Type {}
-
 /// A lifetime that exists as part of a type or method signature.
 ///
 /// This index only makes sense in the context of a surrounding type or method; since

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -19,7 +19,7 @@ pub(crate) const INLINE_NUM_LIFETIMES: usize = 4;
 // Not fully sure how that will look like yet, but the ideas of what this will do
 // is basically the same.
 #[derive(Debug)]
-pub struct LifetimeEnv<Kind> {
+pub struct LifetimeEnv<Kind = Type> {
     /// List of named lifetimes in scope of the method, and their bounds
     nodes: SmallVec<[BoundedLifetime<Kind>; INLINE_NUM_LIFETIMES]>,
 
@@ -123,7 +123,7 @@ impl<Kind: LifetimeKind> LifetimeEnv<Kind> {
 /// Invariant: for a BoundedLifetime found inside a LifetimeEnv, all short/long connections
 /// should be bidirectional.
 #[derive(Debug)]
-pub(super) struct BoundedLifetime<Kind> {
+pub(super) struct BoundedLifetime<Kind = Type> {
     pub(super) ident: IdentBuf,
     /// Lifetimes longer than this (not transitive)
     ///
@@ -230,16 +230,13 @@ impl<T> MaybeStatic<T> {
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::exhaustive_structs)] // marker type
 pub struct Type;
-/// The [`LifetimeKind`] of [`MethodLifetimes`]
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(clippy::exhaustive_structs)] // marker type
-pub struct Method;
+
+pub type Method = Type;
 
 /// Abstraction over where lifetimes can occur
 pub trait LifetimeKind: Copy + Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord {}
 
 impl LifetimeKind for Type {}
-impl LifetimeKind for Method {}
 
 /// A lifetime that exists as part of a type or method signature (determined by
 /// Kind parameter, which will be one of [`LifetimeKind`]).
@@ -247,7 +244,7 @@ impl LifetimeKind for Method {}
 /// This index only makes sense in the context of a surrounding type or method; since
 /// this is essentially an index into that type/method's lifetime list.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Lifetime<Kind>(usize, PhantomData<Kind>);
+pub struct Lifetime<Kind = Type>(usize, PhantomData<Kind>);
 
 impl<Kind> Debug for Lifetime<Kind> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -285,11 +282,11 @@ pub type TypeLifetimes = Lifetimes<Type>;
 ///
 /// This type is intended to be used as a key into a map to keep track of which
 /// borrowed fields depend on which method lifetimes.
-pub type MethodLifetime = Lifetime<Method>;
+pub type MethodLifetime = TypeLifetime;
 
 /// Map a lifetime in a nested struct to the original lifetime defined
 /// in the method that it refers to.
-pub type MethodLifetimes = Lifetimes<Method>;
+pub type MethodLifetimes = TypeLifetimes;
 
 impl<Kind: LifetimeKind> Lifetime<Kind> {
     pub(super) fn new(index: usize) -> Self {

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1,11 +1,10 @@
-use super::lifetimes::{self, BoundedLifetime, Lifetime, LifetimeEnv, LifetimeKind};
 use super::{
-    AttributeContext, AttributeValidator, Attrs, Borrow, EnumDef, EnumPath, EnumVariant, IdentBuf,
-    LifetimeLowerer, LookupId, MaybeOwn, Method, NonOptional, OpaqueDef, OpaquePath, Optional,
-    OutStructDef, OutStructField, OutStructPath, OutType, Param, ParamLifetimeLowerer, ParamSelf,
-    PrimitiveType, ReturnLifetimeLowerer, ReturnType, ReturnableStructPath,
-    SelfParamLifetimeLowerer, SelfType, Slice, StructDef, StructField, StructPath, SuccessType,
-    Type,
+    AttributeContext, AttributeValidator, Attrs, Borrow, BoundedLifetime, EnumDef, EnumPath,
+    EnumVariant, IdentBuf, Lifetime, LifetimeEnv, LifetimeLowerer, LookupId, MaybeOwn, Method,
+    NonOptional, OpaqueDef, OpaquePath, Optional, OutStructDef, OutStructField, OutStructPath,
+    OutType, Param, ParamLifetimeLowerer, ParamSelf, PrimitiveType, ReturnLifetimeLowerer,
+    ReturnType, ReturnableStructPath, SelfParamLifetimeLowerer, SelfType, Slice, StructDef,
+    StructField, StructPath, SuccessType, Type,
 };
 use crate::ast::attrs::AttrInheritContext;
 use crate::{ast, Env};

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -863,7 +863,7 @@ impl<'ast, 'errors> LoweringContext<'ast, 'errors> {
         takes_writeable: bool,
         mut return_ltl: Option<ReturnLifetimeLowerer<'_>>,
         in_path: &ast::Path,
-    ) -> Option<(ReturnType, LifetimeEnv<lifetimes::Method>)> {
+    ) -> Option<(ReturnType, LifetimeEnv)> {
         let writeable_option = if takes_writeable {
             Some(SuccessType::Writeable)
         } else {
@@ -897,10 +897,10 @@ impl<'ast, 'errors> LoweringContext<'ast, 'errors> {
         .and_then(|return_fallability| Some((return_fallability, return_ltl?.finish())))
     }
 
-    fn lower_named_lifetime<Kind: LifetimeKind>(
+    fn lower_named_lifetime(
         &mut self,
         lifetime: &ast::lifetimes::LifetimeNode,
-    ) -> Option<BoundedLifetime<Kind>> {
+    ) -> Option<BoundedLifetime> {
         Some(BoundedLifetime {
             ident: self.lower_ident(lifetime.lifetime.name(), "lifetime")?,
             longer: lifetime.longer.iter().copied().map(Lifetime::new).collect(),
@@ -917,10 +917,7 @@ impl<'ast, 'errors> LoweringContext<'ast, 'errors> {
     ///
     /// Should not be extended to return LifetimeEnv<Method>, which needs to use the lifetime
     /// lowerers to handle elision.
-    fn lower_type_lifetime_env(
-        &mut self,
-        ast: &ast::LifetimeEnv,
-    ) -> Option<LifetimeEnv<lifetimes::Type>> {
+    fn lower_type_lifetime_env(&mut self, ast: &ast::LifetimeEnv) -> Option<LifetimeEnv> {
         let nodes = ast
             .nodes
             .iter()

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -7,7 +7,7 @@ use smallvec::SmallVec;
 
 use super::{paths, Attrs, Docs, Ident, IdentBuf, OutType, SelfType, Slice, Type, TypeContext};
 
-use super::lifetimes::{self, Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
+use super::lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
 
 /// A method exposed to Diplomat.
 #[derive(Debug)]
@@ -142,7 +142,7 @@ impl ReturnType {
         let mut add_to_set = |ty: &OutType| {
             for lt in ty.lifetimes() {
                 if let MaybeStatic::NonStatic(lt) = lt {
-                    set.insert(lt.cast());
+                    set.insert(lt);
                 }
             }
         };

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -17,7 +17,7 @@ use super::lifetimes::{
 pub struct Method {
     pub docs: Docs,
     pub name: IdentBuf,
-    pub lifetime_env: LifetimeEnv<lifetimes::Method>,
+    pub lifetime_env: LifetimeEnv,
 
     pub param_self: Option<ParamSelf>,
     pub params: Vec<Param>,

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -13,7 +13,7 @@ mod elision;
 //
 // Two is that this module contains types named Type and Method which will conflict with others.
 pub mod lifetimes;
-pub use lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
+pub use lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic, LifetimeKind};
 mod lowering;
 mod methods;
 mod paths;

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -13,6 +13,7 @@ mod elision;
 //
 // Two is that this module contains types named Type and Method which will conflict with others.
 pub mod lifetimes;
+pub use lifetimes::{LifetimeEnv, Lifetime, Lifetimes, MaybeStatic};
 mod lowering;
 mod methods;
 mod paths;

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -13,7 +13,7 @@ mod elision;
 //
 // Two is that this module contains types named Type and Method which will conflict with others.
 pub mod lifetimes;
-pub use lifetimes::{LifetimeEnv, Lifetime, Lifetimes, MaybeStatic};
+pub use lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
 mod lowering;
 mod methods;
 mod paths;

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -5,15 +5,7 @@
 mod attrs;
 mod defs;
 mod elision;
-// We don't reexport this for two reasons.
-//
-// One is that these are somewhat more niche types and we don't want to clutter the main module too
-// much. You only need these if you're dealing with lifetimes, which not all backends may wish to
-// do.
-//
-// Two is that this module contains types named Type and Method which will conflict with others.
-pub mod lifetimes;
-pub use lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic, LifetimeKind};
+mod lifetimes;
 mod lowering;
 mod methods;
 mod paths;
@@ -24,6 +16,7 @@ mod types;
 pub use attrs::*;
 pub use defs::*;
 pub(super) use elision::*;
+pub use lifetimes::*;
 pub(super) use lowering::*;
 pub use methods::*;
 pub use paths::*;

--- a/core/src/hir/paths.rs
+++ b/core/src/hir/paths.rs
@@ -1,4 +1,4 @@
-use super::lifetimes::{LinkedLifetimes, TypeLifetimes};
+use super::lifetimes::{Lifetimes, LinkedLifetimes};
 use super::{
     Borrow, EnumDef, EnumId, Everywhere, OpaqueDef, OpaqueId, OpaqueOwner, OutStructDef,
     OutputOnly, ReturnableStructDef, StructDef, TyPosition, TypeContext,
@@ -19,7 +19,7 @@ pub type OutStructPath = StructPath<OutputOnly>;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct StructPath<P: TyPosition = Everywhere> {
-    pub lifetimes: TypeLifetimes,
+    pub lifetimes: Lifetimes,
     pub tcx_id: P::StructId,
 }
 
@@ -40,7 +40,7 @@ pub struct StructPath<P: TyPosition = Everywhere> {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct OpaquePath<Opt, Owner> {
-    pub lifetimes: TypeLifetimes,
+    pub lifetimes: Lifetimes,
     pub optional: Opt,
     pub owner: Owner,
     pub tcx_id: OpaqueId,
@@ -118,7 +118,7 @@ impl ReturnableStructPath {
         }
     }
 
-    pub(crate) fn lifetimes(&self) -> &TypeLifetimes {
+    pub(crate) fn lifetimes(&self) -> &Lifetimes {
         match self {
             Self::Struct(p) => &p.lifetimes,
             Self::OutStruct(p) => &p.lifetimes,
@@ -137,7 +137,7 @@ impl ReturnableStructPath {
 
 impl<P: TyPosition> StructPath<P> {
     /// Returns a new [`EnumPath`].
-    pub(super) fn new(lifetimes: TypeLifetimes, tcx_id: P::StructId) -> Self {
+    pub(super) fn new(lifetimes: Lifetimes, tcx_id: P::StructId) -> Self {
         Self { lifetimes, tcx_id }
     }
 }
@@ -173,12 +173,7 @@ impl OutStructPath {
 
 impl<Opt, Owner> OpaquePath<Opt, Owner> {
     /// Returns a new [`EnumPath`].
-    pub(super) fn new(
-        lifetimes: TypeLifetimes,
-        optional: Opt,
-        owner: Owner,
-        tcx_id: OpaqueId,
-    ) -> Self {
+    pub(super) fn new(lifetimes: Lifetimes, optional: Opt, owner: Owner, tcx_id: OpaqueId) -> Self {
         Self {
             lifetimes,
             optional,

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
@@ -8,12 +8,16 @@ expression: lt_to_borrowing_fields
         "_s",
     ],
     NonStatic(
-        diplomat_core::hir::lifetimes::Lifetime(0),
+        Lifetime(
+            0,
+        ),
     ): [
         "this.p_data",
     ],
     NonStatic(
-        diplomat_core::hir::lifetimes::Lifetime(1),
+        Lifetime(
+            1,
+        ),
     ): [
         "this.q_data",
         "this.inner.more_data",

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__borrowing_fields.snap
@@ -8,12 +8,12 @@ expression: lt_to_borrowing_fields
         "_s",
     ],
     NonStatic(
-        diplomat_core::hir::lifetimes::MethodLifetime(0),
+        diplomat_core::hir::lifetimes::Lifetime(0),
     ): [
         "this.p_data",
     ],
     NonStatic(
-        diplomat_core::hir::lifetimes::MethodLifetime(1),
+        diplomat_core::hir::lifetimes::Lifetime(1),
     ): [
         "this.q_data",
         "this.inner.more_data",

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -22,7 +22,9 @@ TypeContext {
                             lifetimes: Lifetimes {
                                 indices: [
                                     NonStatic(
-                                        diplomat_core::hir::lifetimes::Lifetime(0),
+                                        Lifetime(
+                                            0,
+                                        ),
                                     ),
                                 ],
                             },
@@ -61,7 +63,9 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        diplomat_core::hir::lifetimes::Lifetime(0),
+                                        Lifetime(
+                                            0,
+                                        ),
                                     ),
                                     UnvalidatedUtf8,
                                 ),
@@ -77,7 +81,9 @@ TypeContext {
                                             lifetimes: Lifetimes {
                                                 indices: [
                                                     NonStatic(
-                                                        diplomat_core::hir::lifetimes::Lifetime(0),
+                                                        Lifetime(
+                                                            0,
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -141,7 +147,9 @@ TypeContext {
                     ty: Slice(
                         Str(
                             NonStatic(
-                                diplomat_core::hir::lifetimes::Lifetime(0),
+                                Lifetime(
+                                    0,
+                                ),
                             ),
                             UnvalidatedUtf8,
                         ),
@@ -172,7 +180,9 @@ TypeContext {
                                     lifetimes: Lifetimes {
                                         indices: [
                                             NonStatic(
-                                                diplomat_core::hir::lifetimes::Lifetime(0),
+                                                Lifetime(
+                                                    0,
+                                                ),
                                             ),
                                         ],
                                     },
@@ -189,7 +199,9 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        diplomat_core::hir::lifetimes::Lifetime(1),
+                                        Lifetime(
+                                            1,
+                                        ),
                                     ),
                                     UnvalidatedUtf8,
                                 ),
@@ -202,7 +214,9 @@ TypeContext {
                                 Slice(
                                     Str(
                                         NonStatic(
-                                            diplomat_core::hir::lifetimes::Lifetime(1),
+                                            Lifetime(
+                                                1,
+                                            ),
                                         ),
                                         UnvalidatedUtf8,
                                     ),

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -22,7 +22,7 @@ TypeContext {
                             lifetimes: Lifetimes {
                                 indices: [
                                     NonStatic(
-                                        diplomat_core::hir::lifetimes::TypeLifetime(0),
+                                        diplomat_core::hir::lifetimes::Lifetime(0),
                                     ),
                                 ],
                             },
@@ -61,7 +61,7 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        diplomat_core::hir::lifetimes::TypeLifetime(0),
+                                        diplomat_core::hir::lifetimes::Lifetime(0),
                                     ),
                                     UnvalidatedUtf8,
                                 ),
@@ -77,7 +77,7 @@ TypeContext {
                                             lifetimes: Lifetimes {
                                                 indices: [
                                                     NonStatic(
-                                                        diplomat_core::hir::lifetimes::TypeLifetime(0),
+                                                        diplomat_core::hir::lifetimes::Lifetime(0),
                                                     ),
                                                 ],
                                             },
@@ -141,7 +141,7 @@ TypeContext {
                     ty: Slice(
                         Str(
                             NonStatic(
-                                diplomat_core::hir::lifetimes::TypeLifetime(0),
+                                diplomat_core::hir::lifetimes::Lifetime(0),
                             ),
                             UnvalidatedUtf8,
                         ),
@@ -172,7 +172,7 @@ TypeContext {
                                     lifetimes: Lifetimes {
                                         indices: [
                                             NonStatic(
-                                                diplomat_core::hir::lifetimes::TypeLifetime(0),
+                                                diplomat_core::hir::lifetimes::Lifetime(0),
                                             ),
                                         ],
                                     },
@@ -189,7 +189,7 @@ TypeContext {
                             ty: Slice(
                                 Str(
                                     NonStatic(
-                                        diplomat_core::hir::lifetimes::TypeLifetime(1),
+                                        diplomat_core::hir::lifetimes::Lifetime(1),
                                     ),
                                     UnvalidatedUtf8,
                                 ),
@@ -202,7 +202,7 @@ TypeContext {
                                 Slice(
                                     Str(
                                         NonStatic(
-                                            diplomat_core::hir::lifetimes::TypeLifetime(1),
+                                            diplomat_core::hir::lifetimes::Lifetime(1),
                                         ),
                                         UnvalidatedUtf8,
                                     ),

--- a/core/src/hir/ty_position.rs
+++ b/core/src/hir/ty_position.rs
@@ -1,4 +1,4 @@
-use super::lifetimes::{MaybeStatic, TypeLifetime, TypeLifetimes};
+use super::lifetimes::{Lifetime, Lifetimes, MaybeStatic};
 use super::{
     Borrow, MaybeOwn, Mutability, OutStructId, ReturnableStructPath, StructId, StructPath, TypeId,
 };
@@ -134,12 +134,12 @@ impl TyPosition for OutputOnly {
 }
 
 pub trait StructPathLike {
-    fn lifetimes(&self) -> &TypeLifetimes;
+    fn lifetimes(&self) -> &Lifetimes;
     fn id(&self) -> TypeId;
 }
 
 impl StructPathLike for StructPath {
-    fn lifetimes(&self) -> &TypeLifetimes {
+    fn lifetimes(&self) -> &Lifetimes {
         &self.lifetimes
     }
     fn id(&self) -> TypeId {
@@ -148,7 +148,7 @@ impl StructPathLike for StructPath {
 }
 
 impl StructPathLike for ReturnableStructPath {
-    fn lifetimes(&self) -> &TypeLifetimes {
+    fn lifetimes(&self) -> &Lifetimes {
         self.lifetimes()
     }
     fn id(&self) -> TypeId {
@@ -171,7 +171,7 @@ pub trait OpaqueOwner {
     fn is_owned(&self) -> bool;
 
     /// Return the lifetime of the borrow, if any.
-    fn lifetime(&self) -> Option<MaybeStatic<TypeLifetime>>;
+    fn lifetime(&self) -> Option<MaybeStatic<Lifetime>>;
 }
 
 impl OpaqueOwner for MaybeOwn {
@@ -189,7 +189,7 @@ impl OpaqueOwner for MaybeOwn {
         }
     }
 
-    fn lifetime(&self) -> Option<MaybeStatic<TypeLifetime>> {
+    fn lifetime(&self) -> Option<MaybeStatic<Lifetime>> {
         match self {
             MaybeOwn::Own => None,
             MaybeOwn::Borrow(b) => b.lifetime(),
@@ -206,7 +206,7 @@ impl OpaqueOwner for Borrow {
         false
     }
 
-    fn lifetime(&self) -> Option<MaybeStatic<TypeLifetime>> {
+    fn lifetime(&self) -> Option<MaybeStatic<Lifetime>> {
         Some(self.lifetime)
     }
 }

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -1,6 +1,6 @@
 //! Types that can be exposed in Diplomat APIs.
 
-use super::lifetimes::{MaybeStatic, TypeLifetime};
+use super::lifetimes::{Lifetime, MaybeStatic};
 use super::{
     EnumPath, Everywhere, NonOptional, OpaqueOwner, OpaquePath, Optional, OutputOnly,
     PrimitiveType, StructPath, StructPathLike, TyPosition, TypeContext,
@@ -37,7 +37,7 @@ pub enum SelfType {
 #[non_exhaustive]
 pub enum Slice {
     /// A string slice, e.g. `&DiplomatStr`.
-    Str(MaybeStatic<TypeLifetime>, StringEncoding),
+    Str(MaybeStatic<Lifetime>, StringEncoding),
 
     /// A primitive slice, e.g. `&mut [u8]`.
     Primitive(Borrow, PrimitiveType),
@@ -54,7 +54,7 @@ pub enum Slice {
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub struct Borrow {
-    pub lifetime: MaybeStatic<TypeLifetime>,
+    pub lifetime: MaybeStatic<Lifetime>,
     pub mutability: Mutability,
 }
 
@@ -77,7 +77,7 @@ impl Type {
 
 impl<P: TyPosition> Type<P> {
     /// Get all lifetimes "contained" in this type
-    pub fn lifetimes(&self) -> impl Iterator<Item = MaybeStatic<TypeLifetime>> + '_ {
+    pub fn lifetimes(&self) -> impl Iterator<Item = MaybeStatic<Lifetime>> + '_ {
         match self {
             Type::Opaque(opaque) => Either::Right(
                 opaque
@@ -109,9 +109,9 @@ impl SelfType {
 }
 
 impl Slice {
-    /// Returns the [`TypeLifetime`] contained in either the `Str` or `Primitive`
+    /// Returns the [`Lifetime`] contained in either the `Str` or `Primitive`
     /// variant.
-    pub fn lifetime(&self) -> &MaybeStatic<TypeLifetime> {
+    pub fn lifetime(&self) -> &MaybeStatic<Lifetime> {
         match self {
             Slice::Str(lifetime, ..) => lifetime,
             Slice::Primitive(reference, ..) => &reference.lifetime,
@@ -120,7 +120,7 @@ impl Slice {
 }
 
 impl Borrow {
-    pub(super) fn new(lifetime: MaybeStatic<TypeLifetime>, mutability: Mutability) -> Self {
+    pub(super) fn new(lifetime: MaybeStatic<Lifetime>, mutability: Mutability) -> Self {
         Self {
             lifetime,
             mutability,

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -1,13 +1,10 @@
 use crate::common::{ErrorStore, FileMap};
 use askama::Template;
 use diplomat_core::ast::DocsUrlGenerator;
-use diplomat_core::hir::lifetimes::{
-    self, Lifetime, LifetimeEnv, LifetimeKind, Lifetimes, MaybeStatic,
-};
 use diplomat_core::hir::TypeContext;
 use diplomat_core::hir::{
     self, OpaqueOwner, ReturnType, SelfType, StructPathLike, SuccessType, TyPosition, Type,
-    TypeDef, TypeId,
+    TypeDef, TypeId, Lifetime, LifetimeEnv, LifetimeKind, Lifetimes, MaybeStatic,
 };
 use formatter::DartFormatter;
 use std::borrow::Cow;

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -383,10 +383,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
                     // the type lifetimes array
                     for (def_lt, use_lt) in def_lifetimes.zip(use_lifetimes) {
                         if let MaybeStatic::NonStatic(use_lt) = use_lt {
-                            if method_lifetime
-                                .all_longer_lifetimes
-                                .contains(&use_lt.cast())
-                            {
+                            if method_lifetime.all_longer_lifetimes.contains(&use_lt) {
                                 let edge = format!(
                                     "...{param_name}._fields_for_lifetime_{}()",
                                     def.lifetimes.fmt_lifetime(def_lt)
@@ -402,7 +399,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
                 for method_lifetime in method_lifetimes_map.values_mut() {
                     for lt in ty.lifetimes() {
                         if let MaybeStatic::NonStatic(lt) = lt {
-                            if method_lifetime.all_longer_lifetimes.contains(&lt.cast()) {
+                            if method_lifetime.all_longer_lifetimes.contains(&lt) {
                                 let edge = if let hir::Type::Slice(..) = ty {
                                     // Slices make a temporary view type that needs to be attached
                                     // XXXManishearth: this is the wrong variable. We need to grab on to the arena
@@ -824,7 +821,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
     ///
     /// FIXME(Manishearth): this may need to belong in  fmt.rs
     fn gen_single_edge(&self, lifetime: Lifetime, lifetime_env: &LifetimeEnv) -> Cow<'static, str> {
-        format!("edge_{}", lifetime_env.fmt_lifetime(lifetime.cast())).into()
+        format!("edge_{}", lifetime_env.fmt_lifetime(lifetime)).into()
     }
 
     /// Make a list of edge arrays, one for every lifetime in a Lifetimes

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -3,8 +3,8 @@ use askama::Template;
 use diplomat_core::ast::DocsUrlGenerator;
 use diplomat_core::hir::TypeContext;
 use diplomat_core::hir::{
-    self, OpaqueOwner, ReturnType, SelfType, StructPathLike, SuccessType, TyPosition, Type,
-    TypeDef, TypeId, Lifetime, LifetimeEnv, LifetimeKind, Lifetimes, MaybeStatic,
+    self, Lifetime, LifetimeEnv, Lifetimes, MaybeStatic, OpaqueOwner, ReturnType, SelfType,
+    StructPathLike, SuccessType, TyPosition, Type, TypeDef, TypeId,
 };
 use formatter::DartFormatter;
 use std::borrow::Cow;

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -178,7 +178,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             methods: &'a [MethodInfo<'a>],
             docs: String,
             destructor: String,
-            lifetimes: &'a LifetimeEnv<lifetimes::Type>,
+            lifetimes: &'a LifetimeEnv,
         }
 
         ImplTemplate {
@@ -306,7 +306,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             fields: Vec<FieldInfo<'a, P>>,
             methods: Vec<MethodInfo<'a>>,
             docs: String,
-            lifetimes: &'a LifetimeEnv<lifetimes::Type>,
+            lifetimes: &'a LifetimeEnv,
         }
 
         ImplTemplate {
@@ -827,10 +827,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
     /// Generate the name of a single lifetime edge array
     ///
     /// FIXME(Manishearth): this may need to belong in  fmt.rs
-    fn gen_single_edge<Kind: LifetimeKind>(
+    fn gen_single_edge(
         &self,
         lifetime: TypeLifetime,
-        lifetime_env: &LifetimeEnv<Kind>,
+        lifetime_env: &LifetimeEnv,
     ) -> Cow<'static, str> {
         format!("edge_{}", lifetime_env.fmt_lifetime(lifetime.cast())).into()
     }
@@ -838,10 +838,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
     /// Make a list of edge arrays, one for every lifetime in a TypeLifetimes
     ///
     /// Will generate with a leading `, `, so will look something like `, edge_a, edge_b, ...`
-    fn gen_lifetimes_edge_list<Kind: LifetimeKind>(
+    fn gen_lifetimes_edge_list(
         &self,
         lifetimes: &TypeLifetimes,
-        lifetime_env: &LifetimeEnv<Kind>,
+        lifetime_env: &LifetimeEnv,
     ) -> String {
         let mut ret = String::new();
         for lt in lifetimes.lifetimes() {
@@ -861,11 +861,11 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
     }
 
     /// Generates a Dart expression for a type.
-    fn gen_c_to_dart_for_type<P: TyPosition, Kind: LifetimeKind>(
+    fn gen_c_to_dart_for_type<P: TyPosition>(
         &mut self,
         ty: &Type<P>,
         var_name: Cow<'cx, str>,
-        lifetime_env: &LifetimeEnv<Kind>,
+        lifetime_env: &LifetimeEnv,
     ) -> Cow<'cx, str> {
         match *ty {
             Type::Primitive(..) => var_name,
@@ -922,10 +922,10 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
     }
 
     /// Generates a Dart expressions for a return type.
-    fn gen_c_to_dart_for_return_type<Kind: LifetimeKind>(
+    fn gen_c_to_dart_for_return_type(
         &mut self,
         result_ty: &ReturnType,
-        lifetime_env: &LifetimeEnv<Kind>,
+        lifetime_env: &LifetimeEnv,
     ) -> Option<Cow<'cx, str>> {
         match *result_ty {
             ReturnType::Infallible(None) => None,
@@ -1101,7 +1101,7 @@ struct MethodInfo<'a> {
     /// writeable, if present, is saved to a variable named `writeable`.
     return_expression: Option<Cow<'a, str>>,
 
-    lifetimes: &'a LifetimeEnv<lifetimes::Method>,
+    lifetimes: &'a LifetimeEnv,
     /// Maps each (used in the output) method lifetime to a list of parameters
     /// it borrows from. The parameter list may contain the parameter name,
     /// an internal slice View that was temporarily constructed, or
@@ -1135,10 +1135,7 @@ fn iterator_to_btreeset<T: Ord>(i: impl Iterator<Item = T>) -> BTreeSet<T> {
 }
 
 /// Turn a set of lifetimes into a nice comma separated list
-fn display_lifetime_list<K: LifetimeKind>(
-    env: &LifetimeEnv<K>,
-    set: &BTreeSet<Lifetime<K>>,
-) -> String {
+fn display_lifetime_list(env: &LifetimeEnv, set: &BTreeSet<Lifetime>) -> String {
     if set.len() <= 1 {
         String::new()
     } else {


### PR DESCRIPTION
This kind of distinction *is* useful, but it can't just be Type vs Method since Types can be found in method and struct signatures. Doing that woudl mean adding a second parameter to `Type<P>` and I don't think it's useful enough to justify that.