### PR TITLE
Add shallow lifetime helpers to HIR

### DIFF
--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -512,7 +512,7 @@ mod tests {
                 .push(DebugBorrowingField(bf));
         });
 
-        struct DebugBorrowingField<'m>(crate::hir::BorrowingField<'m>);
+        struct DebugBorrowingField<'m>(crate::hir::borrowing_field::BorrowingField<'m>);
 
         impl<'m> fmt::Debug for DebugBorrowingField<'m> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/src/hir/lifetimes.rs
+++ b/core/src/hir/lifetimes.rs
@@ -362,17 +362,17 @@ impl<'env> Iterator for LifetimeTransitivityIterator<'env> {
 /// with the lifetimes found at its *def* site (e.g. `struct Foo<'x, 'y>`).
 ///
 /// Construct this by calling `.linked_lifetimes()` on a StructPath or OpaquePath
-pub struct LinkedLifetimes<'tcx> {
+pub struct LinkedLifetimes<'def, 'tcx> {
     env: &'tcx LifetimeEnv,
     self_lt: Option<MaybeStatic<Lifetime>>,
-    lifetimes: &'tcx Lifetimes,
+    lifetimes: &'def Lifetimes,
 }
 
-impl<'tcx> LinkedLifetimes<'tcx> {
+impl<'def, 'tcx> LinkedLifetimes<'def, 'tcx> {
     pub(crate) fn new(
         env: &'tcx LifetimeEnv,
         self_lt: Option<MaybeStatic<Lifetime>>,
-        lifetimes: &'tcx Lifetimes,
+        lifetimes: &'def Lifetimes,
     ) -> Self {
         debug_assert_eq!(
             lifetimes.lifetimes().len(),

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -1,14 +1,15 @@
 //! Methods for types and navigating lifetimes within methods.
 
 use std::collections::BTreeSet;
-use std::fmt::{self, Write};
 use std::ops::Deref;
 
-use smallvec::SmallVec;
-
-use super::{paths, Attrs, Docs, Ident, IdentBuf, OutType, SelfType, Slice, Type, TypeContext};
+use super::{Attrs, Docs, Ident, IdentBuf, OutType, SelfType, Type, TypeContext};
 
 use super::lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
+
+use borrowing_field::BorrowingFieldVisitor;
+
+pub mod borrowing_field;
 
 /// A method exposed to Diplomat.
 #[derive(Debug)]
@@ -55,43 +56,6 @@ pub struct ParamSelf {
 pub struct Param {
     pub name: IdentBuf,
     pub ty: Type,
-}
-
-/// An id for indexing into a [`BorrowingFieldsVisitor`].
-#[derive(Copy, Clone, Debug)]
-struct ParentId(usize);
-
-/// Convenience const representing the number of nested structs a [`BorrowingFieldVisitor`]
-/// can hold inline before needing to dynamically allocate.
-const INLINE_NUM_PARENTS: usize = 4;
-
-/// Convenience const representing the number of borrowed fields a [`BorrowingFieldVisitor`]
-/// can hold inline before needing to dynamically allocate.
-const INLINE_NUM_LEAVES: usize = 8;
-
-/// A tree of lifetimes mapping onto a specific instantiation of a type tree.
-///
-/// Each `BorrowingFieldsVisitor` corresponds to the type of an input of a method.
-pub struct BorrowingFieldVisitor<'m> {
-    parents: SmallVec<[(Option<ParentId>, &'m Ident); INLINE_NUM_PARENTS]>,
-    leaves: SmallVec<[BorrowingFieldVisitorLeaf; INLINE_NUM_LEAVES]>,
-}
-
-/// Non-recursive input-output types that contain lifetimes
-enum BorrowingFieldVisitorLeaf {
-    Opaque(ParentId, MaybeStatic<Lifetime>, Lifetimes),
-    Slice(ParentId, MaybeStatic<Lifetime>),
-}
-
-/// A leaf of a lifetime tree capable of tracking its parents.
-#[derive(Copy, Clone)]
-pub struct BorrowingField<'m> {
-    /// All inner nodes in the tree. When tracing from the root, we jump around
-    /// this slice based on indices, but don't necessarily use all of them.
-    parents: &'m [(Option<ParentId>, &'m Ident)],
-
-    /// The unpacked field that is a leaf on the tree.
-    leaf: &'m BorrowingFieldVisitorLeaf,
 }
 
 impl SuccessType {
@@ -201,6 +165,10 @@ impl Method {
     /// Returns a new [`BorrowingFieldVisitor`], which allocates memory to
     /// efficiently represent all fields (and their paths!) of the inputs that
     /// have a lifetime.
+    ///
+    /// This is useful for backends which wish to "splat out" lifetime edge codegen for methods,
+    /// linking each borrowed input param/field (however deep it may be in a struct) to a borrowed output param/field.
+    ///
     /// ```ignore
     /// # use std::collections::BTreeMap;
     /// let visitor = method.borrowing_field_visitor(&tcx, "this".ck().unwrap());
@@ -215,308 +183,5 @@ impl Method {
         self_name: &'m Ident,
     ) -> BorrowingFieldVisitor<'m> {
         BorrowingFieldVisitor::new(self, tcx, self_name)
-    }
-}
-
-impl ParentId {
-    /// Pushes a new parent to the vec, returning the corresponding [`ParentId`].
-    fn new<'m>(
-        parent: Option<ParentId>,
-        name: &'m Ident,
-        parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
-    ) -> Self {
-        let this = ParentId(parents.len());
-        parents.push((parent, name));
-        this
-    }
-}
-
-impl<'m> BorrowingFieldVisitor<'m> {
-    /// Visits every borrowing field and method lifetime that it uses.
-    ///
-    /// The idea is that you could use this to construct a mapping from
-    /// `Lifetime`s to `BorrowingField`s. We choose to use a visitor
-    /// pattern to avoid having to
-    ///
-    /// This would be convenient in the JavaScript backend where if you're
-    /// returning an `NonOpaque<'a, 'b>` from Rust, you need to pass a
-    /// `[[all input borrowing fields with 'a], [all input borrowing fields with 'b]]`
-    /// array into `NonOpaque`'s constructor.
-    ///
-    /// Alternatively, you could use such a map in the C++ backend by recursing
-    /// down the return type and keeping track of which fields you've recursed
-    /// into so far, and when you hit some lifetime 'a, generate docs saying
-    /// "path.to.current.field must be outlived by {borrowing fields of input that
-    /// contain 'a}".
-    pub fn visit_borrowing_fields<'a, F>(&'a self, mut visit: F)
-    where
-        F: FnMut(MaybeStatic<Lifetime>, BorrowingField<'a>),
-    {
-        for leaf in self.leaves.iter() {
-            let borrowing_field = BorrowingField {
-                parents: self.parents.as_slice(),
-                leaf,
-            };
-
-            match leaf {
-                BorrowingFieldVisitorLeaf::Opaque(_, lt, method_lifetimes) => {
-                    visit(*lt, borrowing_field);
-                    for lt in method_lifetimes.lifetimes() {
-                        visit(lt, borrowing_field);
-                    }
-                }
-                BorrowingFieldVisitorLeaf::Slice(_, lt) => {
-                    visit(*lt, borrowing_field);
-                }
-            }
-        }
-    }
-
-    /// Returns a new `BorrowingFieldsVisitor` containing all the lifetime trees of the arguments
-    /// in only two allocations.
-    fn new(method: &'m Method, tcx: &'m TypeContext, self_name: &'m Ident) -> Self {
-        let (parents, leaves) = method
-            .param_self
-            .as_ref()
-            .map(|param_self| param_self.field_leaf_lifetime_counts(tcx))
-            .into_iter()
-            .chain(
-                method
-                    .params
-                    .iter()
-                    .map(|param| param.ty.field_leaf_lifetime_counts(tcx)),
-            )
-            .reduce(|acc, x| (acc.0 + x.0, acc.1 + x.1))
-            .map(|(num_fields, num_leaves)| {
-                let num_params = method.params.len() + usize::from(method.param_self.is_some());
-                let mut parents = SmallVec::with_capacity(num_fields + num_params);
-                let mut leaves = SmallVec::with_capacity(num_leaves);
-                let method_lifetimes = method.method_lifetimes();
-
-                if let Some(param_self) = method.param_self.as_ref() {
-                    let parent = ParentId::new(None, self_name, &mut parents);
-                    match &param_self.ty {
-                        SelfType::Opaque(ty) => {
-                            Self::visit_opaque(
-                                &ty.lifetimes,
-                                &ty.borrowed().lifetime,
-                                parent,
-                                &method_lifetimes,
-                                &mut leaves,
-                            );
-                        }
-                        SelfType::Struct(ty) => {
-                            Self::visit_struct(
-                                ty,
-                                tcx,
-                                parent,
-                                &method_lifetimes,
-                                &mut parents,
-                                &mut leaves,
-                            );
-                        }
-                        SelfType::Enum(_) => {}
-                    }
-                }
-
-                for param in method.params.iter() {
-                    let parent = ParentId::new(None, param.name.as_ref(), &mut parents);
-                    Self::from_type(
-                        &param.ty,
-                        tcx,
-                        parent,
-                        &method_lifetimes,
-                        &mut parents,
-                        &mut leaves,
-                    );
-                }
-
-                // sanity check that the preallocations were correct
-                debug_assert_eq!(
-                    parents.capacity(),
-                    std::cmp::max(INLINE_NUM_PARENTS, num_fields + num_params)
-                );
-                debug_assert_eq!(
-                    leaves.capacity(),
-                    std::cmp::max(INLINE_NUM_LEAVES, num_leaves)
-                );
-                (parents, leaves)
-            })
-            .unwrap_or_default();
-
-        Self { parents, leaves }
-    }
-
-    /// Returns a new [`BorrowingFieldsVisitor`] corresponding to a type.
-    fn from_type(
-        ty: &'m Type,
-        tcx: &'m TypeContext,
-        parent: ParentId,
-        method_lifetimes: &Lifetimes,
-        parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
-        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
-    ) {
-        match ty {
-            Type::Opaque(path) => {
-                Self::visit_opaque(
-                    &path.lifetimes,
-                    &path.borrowed().lifetime,
-                    parent,
-                    method_lifetimes,
-                    leaves,
-                );
-            }
-            Type::Slice(slice) => {
-                Self::visit_slice(slice, parent, method_lifetimes, leaves);
-            }
-            Type::Struct(path) => {
-                Self::visit_struct(path, tcx, parent, method_lifetimes, parents, leaves);
-            }
-            _ => {}
-        }
-    }
-
-    /// Add an opaque as a leaf during construction of a [`BorrowingFieldsVisitor`].
-    fn visit_opaque(
-        lifetimes: &'m Lifetimes,
-        borrow: &'m MaybeStatic<Lifetime>,
-        parent: ParentId,
-        method_lifetimes: &Lifetimes,
-        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
-    ) {
-        let method_borrow_lifetime =
-            borrow.flat_map_nonstatic(|lt| lt.as_method_lifetime(method_lifetimes));
-        let method_type_lifetimes = lifetimes.as_method_lifetimes(method_lifetimes);
-        leaves.push(BorrowingFieldVisitorLeaf::Opaque(
-            parent,
-            method_borrow_lifetime,
-            method_type_lifetimes,
-        ));
-    }
-
-    /// Add a slice as a leaf during construction of a [`BorrowingFieldsVisitor`].
-    fn visit_slice(
-        slice: &Slice,
-        parent: ParentId,
-        method_lifetimes: &Lifetimes,
-        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
-    ) {
-        let method_lifetime = slice
-            .lifetime()
-            .flat_map_nonstatic(|lt| lt.as_method_lifetime(method_lifetimes));
-        leaves.push(BorrowingFieldVisitorLeaf::Slice(parent, method_lifetime));
-    }
-
-    /// Add a struct as a parent and recurse down leaves during construction of a
-    /// [`BorrowingFieldsVisitor`].
-    fn visit_struct(
-        ty: &paths::StructPath,
-        tcx: &'m TypeContext,
-        parent: ParentId,
-        method_lifetimes: &Lifetimes,
-        parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
-        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
-    ) {
-        let method_type_lifetimes = ty.lifetimes.as_method_lifetimes(method_lifetimes);
-        for field in ty.resolve(tcx).fields.iter() {
-            Self::from_type(
-                &field.ty,
-                tcx,
-                ParentId::new(Some(parent), field.name.as_ref(), parents),
-                &method_type_lifetimes,
-                parents,
-                leaves,
-            );
-        }
-    }
-}
-
-impl<'m> BorrowingField<'m> {
-    /// Visit fields in order.
-    ///
-    /// If `self` represents the field `param.first.second`, then calling [`BorrowingField::trace`]
-    /// will visit the following in order: `"param"`, `"first"`, `"second"`.
-    pub fn backtrace<F>(&self, mut visit: F)
-    where
-        F: FnMut(usize, &'m Ident),
-    {
-        let (parent, ident) = match self.leaf {
-            BorrowingFieldVisitorLeaf::Opaque(id, ..) | BorrowingFieldVisitorLeaf::Slice(id, _) => {
-                self.parents[id.0]
-            }
-        };
-
-        self.backtrace_rec(parent, ident, &mut visit);
-    }
-
-    /// Recursively visits fields in order from root to leaf by building up the
-    /// stack, and then visiting fields as it unwinds.
-    fn backtrace_rec<F>(&self, parent: Option<ParentId>, ident: &'m Ident, visit: &mut F) -> usize
-    where
-        F: FnMut(usize, &'m Ident),
-    {
-        let from_end = if let Some(id) = parent {
-            let (parent, ident) = self.parents[id.0];
-            self.backtrace_rec(parent, ident, visit)
-        } else {
-            0
-        };
-
-        visit(from_end, ident);
-
-        from_end + 1
-    }
-
-    /// Fallibly visits fields in order.
-    ///
-    /// This method is similar to [`BorrowinfField::backtrace`], but short-circuits
-    /// when an `Err` is returned.
-    pub fn try_backtrace<F, E>(&self, mut visit: F) -> Result<(), E>
-    where
-        F: FnMut(usize, &'m Ident) -> Result<(), E>,
-    {
-        let (parent, ident) = match self.leaf {
-            BorrowingFieldVisitorLeaf::Opaque(id, ..) | BorrowingFieldVisitorLeaf::Slice(id, _) => {
-                self.parents[id.0]
-            }
-        };
-
-        self.try_backtrace_rec(parent, ident, &mut visit)?;
-
-        Ok(())
-    }
-
-    /// Recursively visits fields in order from root to leaf by building up the
-    /// stack, and then visiting fields as it unwinds.
-    fn try_backtrace_rec<F, E>(
-        &self,
-        parent: Option<ParentId>,
-        ident: &'m Ident,
-        visit: &mut F,
-    ) -> Result<usize, E>
-    where
-        F: FnMut(usize, &'m Ident) -> Result<(), E>,
-    {
-        let from_end = if let Some(id) = parent {
-            let (parent, ident) = self.parents[id.0];
-            self.try_backtrace_rec(parent, ident, visit)?
-        } else {
-            0
-        };
-
-        visit(from_end, ident)?;
-
-        Ok(from_end + 1)
-    }
-}
-
-impl<'m> fmt::Display for BorrowingField<'m> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.try_backtrace(|i, ident| {
-            if i != 0 {
-                f.write_char('.')?;
-            }
-            f.write_str(ident.as_str())
-        })
     }
 }

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -8,8 +8,10 @@ use super::{Attrs, Docs, Ident, IdentBuf, OutType, SelfType, Type, TypeContext};
 use super::lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
 
 use borrowing_field::BorrowingFieldVisitor;
+use borrowing_param::BorrowingParamVisitor;
 
 pub mod borrowing_field;
+pub mod borrowing_param;
 
 /// A method exposed to Diplomat.
 #[derive(Debug)]
@@ -160,6 +162,18 @@ impl Method {
     /// Returns a fresh [`Lifetimes`] corresponding to `self`.
     pub fn method_lifetimes(&self) -> Lifetimes {
         self.lifetime_env.lifetimes()
+    }
+
+    /// Returns a new [`BorrowingParamVisitor`], which can *shallowly* link output lifetimes
+    /// to the parameters they borrow from.
+    ///
+    /// This is useful for backends which wish to have lifetime codegen for methods only handle the local
+    /// method lifetime, and delegate to generated code on structs for handling the internals of struct lifetimes.
+    pub fn borrowing_param_visitor<'tcx>(
+        &'tcx self,
+        tcx: &'tcx TypeContext,
+    ) -> BorrowingParamVisitor<'tcx> {
+        BorrowingParamVisitor::new(self, tcx)
     }
 
     /// Returns a new [`BorrowingFieldVisitor`], which allocates memory to

--- a/core/src/hir/methods/borrowing_field.rs
+++ b/core/src/hir/methods/borrowing_field.rs
@@ -1,0 +1,354 @@
+//! Tools for traversing all borrows in method parameters and return types, transitively
+//!
+//! This is useful for backends which wish to "splat out" lifetime edge codegen for methods,
+//! linking each borrowed input param/field (however deep it may be in a struct) to a borrowed output param/field.
+
+use std::fmt::{self, Write};
+
+use smallvec::SmallVec;
+
+use crate::hir::{paths, Ident, Method, SelfType, Slice, Type, TypeContext};
+
+use crate::hir::lifetimes::{Lifetime, Lifetimes, MaybeStatic};
+
+/// An id for indexing into a [`BorrowingFieldsVisitor`].
+#[derive(Copy, Clone, Debug)]
+struct ParentId(usize);
+
+impl ParentId {
+    /// Pushes a new parent to the vec, returning the corresponding [`ParentId`].
+    fn new<'m>(
+        parent: Option<ParentId>,
+        name: &'m Ident,
+        parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
+    ) -> Self {
+        let this = ParentId(parents.len());
+        parents.push((parent, name));
+        this
+    }
+}
+
+/// Convenience const representing the number of nested structs a [`BorrowingFieldVisitor`]
+/// can hold inline before needing to dynamically allocate.
+const INLINE_NUM_PARENTS: usize = 4;
+
+/// Convenience const representing the number of borrowed fields a [`BorrowingFieldVisitor`]
+/// can hold inline before needing to dynamically allocate.
+const INLINE_NUM_LEAVES: usize = 8;
+
+/// A tree of lifetimes mapping onto a specific instantiation of a type tree.
+///
+/// Each `BorrowingFieldsVisitor` corresponds to the type of an input of a method.
+///
+/// Obtain from [`Method::borrowing_field_visitor()`].
+pub struct BorrowingFieldVisitor<'m> {
+    parents: SmallVec<[(Option<ParentId>, &'m Ident); INLINE_NUM_PARENTS]>,
+    leaves: SmallVec<[BorrowingFieldVisitorLeaf; INLINE_NUM_LEAVES]>,
+}
+
+/// A leaf of a lifetime tree capable of tracking its parents.
+#[derive(Copy, Clone)]
+pub struct BorrowingField<'m> {
+    /// All inner nodes in the tree. When tracing from the root, we jump around
+    /// this slice based on indices, but don't necessarily use all of them.
+    parents: &'m [(Option<ParentId>, &'m Ident)],
+
+    /// The unpacked field that is a leaf on the tree.
+    leaf: &'m BorrowingFieldVisitorLeaf,
+}
+
+/// Non-recursive input-output types that contain lifetimes
+enum BorrowingFieldVisitorLeaf {
+    Opaque(ParentId, MaybeStatic<Lifetime>, Lifetimes),
+    Slice(ParentId, MaybeStatic<Lifetime>),
+}
+
+impl<'m> BorrowingFieldVisitor<'m> {
+    /// Visits every borrowing field and method lifetime that it uses.
+    ///
+    /// The idea is that you could use this to construct a mapping from
+    /// `Lifetime`s to `BorrowingField`s. We choose to use a visitor
+    /// pattern to avoid having to
+    ///
+    /// This would be convenient in the JavaScript backend where if you're
+    /// returning an `NonOpaque<'a, 'b>` from Rust, you need to pass a
+    /// `[[all input borrowing fields with 'a], [all input borrowing fields with 'b]]`
+    /// array into `NonOpaque`'s constructor.
+    ///
+    /// Alternatively, you could use such a map in the C++ backend by recursing
+    /// down the return type and keeping track of which fields you've recursed
+    /// into so far, and when you hit some lifetime 'a, generate docs saying
+    /// "path.to.current.field must be outlived by {borrowing fields of input that
+    /// contain 'a}".
+    pub fn visit_borrowing_fields<'a, F>(&'a self, mut visit: F)
+    where
+        F: FnMut(MaybeStatic<Lifetime>, BorrowingField<'a>),
+    {
+        for leaf in self.leaves.iter() {
+            let borrowing_field = BorrowingField {
+                parents: self.parents.as_slice(),
+                leaf,
+            };
+
+            match leaf {
+                BorrowingFieldVisitorLeaf::Opaque(_, lt, method_lifetimes) => {
+                    visit(*lt, borrowing_field);
+                    for lt in method_lifetimes.lifetimes() {
+                        visit(lt, borrowing_field);
+                    }
+                }
+                BorrowingFieldVisitorLeaf::Slice(_, lt) => {
+                    visit(*lt, borrowing_field);
+                }
+            }
+        }
+    }
+
+    /// Returns a new `BorrowingFieldsVisitor` containing all the lifetime trees of the arguments
+    /// in only two allocations.
+    pub(crate) fn new(method: &'m Method, tcx: &'m TypeContext, self_name: &'m Ident) -> Self {
+        let (parents, leaves) = method
+            .param_self
+            .as_ref()
+            .map(|param_self| param_self.field_leaf_lifetime_counts(tcx))
+            .into_iter()
+            .chain(
+                method
+                    .params
+                    .iter()
+                    .map(|param| param.ty.field_leaf_lifetime_counts(tcx)),
+            )
+            .reduce(|acc, x| (acc.0 + x.0, acc.1 + x.1))
+            .map(|(num_fields, num_leaves)| {
+                let num_params = method.params.len() + usize::from(method.param_self.is_some());
+                let mut parents = SmallVec::with_capacity(num_fields + num_params);
+                let mut leaves = SmallVec::with_capacity(num_leaves);
+                let method_lifetimes = method.method_lifetimes();
+
+                if let Some(param_self) = method.param_self.as_ref() {
+                    let parent = ParentId::new(None, self_name, &mut parents);
+                    match &param_self.ty {
+                        SelfType::Opaque(ty) => {
+                            Self::visit_opaque(
+                                &ty.lifetimes,
+                                &ty.borrowed().lifetime,
+                                parent,
+                                &method_lifetimes,
+                                &mut leaves,
+                            );
+                        }
+                        SelfType::Struct(ty) => {
+                            Self::visit_struct(
+                                ty,
+                                tcx,
+                                parent,
+                                &method_lifetimes,
+                                &mut parents,
+                                &mut leaves,
+                            );
+                        }
+                        SelfType::Enum(_) => {}
+                    }
+                }
+
+                for param in method.params.iter() {
+                    let parent = ParentId::new(None, param.name.as_ref(), &mut parents);
+                    Self::from_type(
+                        &param.ty,
+                        tcx,
+                        parent,
+                        &method_lifetimes,
+                        &mut parents,
+                        &mut leaves,
+                    );
+                }
+
+                // sanity check that the preallocations were correct
+                debug_assert_eq!(
+                    parents.capacity(),
+                    std::cmp::max(INLINE_NUM_PARENTS, num_fields + num_params)
+                );
+                debug_assert_eq!(
+                    leaves.capacity(),
+                    std::cmp::max(INLINE_NUM_LEAVES, num_leaves)
+                );
+                (parents, leaves)
+            })
+            .unwrap_or_default();
+
+        Self { parents, leaves }
+    }
+
+    /// Returns a new [`BorrowingFieldsVisitor`] corresponding to a type.
+    fn from_type(
+        ty: &'m Type,
+        tcx: &'m TypeContext,
+        parent: ParentId,
+        method_lifetimes: &Lifetimes,
+        parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
+        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
+    ) {
+        match ty {
+            Type::Opaque(path) => {
+                Self::visit_opaque(
+                    &path.lifetimes,
+                    &path.borrowed().lifetime,
+                    parent,
+                    method_lifetimes,
+                    leaves,
+                );
+            }
+            Type::Slice(slice) => {
+                Self::visit_slice(slice, parent, method_lifetimes, leaves);
+            }
+            Type::Struct(path) => {
+                Self::visit_struct(path, tcx, parent, method_lifetimes, parents, leaves);
+            }
+            _ => {}
+        }
+    }
+
+    /// Add an opaque as a leaf during construction of a [`BorrowingFieldsVisitor`].
+    fn visit_opaque(
+        lifetimes: &'m Lifetimes,
+        borrow: &'m MaybeStatic<Lifetime>,
+        parent: ParentId,
+        method_lifetimes: &Lifetimes,
+        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
+    ) {
+        let method_borrow_lifetime =
+            borrow.flat_map_nonstatic(|lt| lt.as_method_lifetime(method_lifetimes));
+        let method_type_lifetimes = lifetimes.as_method_lifetimes(method_lifetimes);
+        leaves.push(BorrowingFieldVisitorLeaf::Opaque(
+            parent,
+            method_borrow_lifetime,
+            method_type_lifetimes,
+        ));
+    }
+
+    /// Add a slice as a leaf during construction of a [`BorrowingFieldsVisitor`].
+    fn visit_slice(
+        slice: &Slice,
+        parent: ParentId,
+        method_lifetimes: &Lifetimes,
+        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
+    ) {
+        let method_lifetime = slice
+            .lifetime()
+            .flat_map_nonstatic(|lt| lt.as_method_lifetime(method_lifetimes));
+        leaves.push(BorrowingFieldVisitorLeaf::Slice(parent, method_lifetime));
+    }
+
+    /// Add a struct as a parent and recurse down leaves during construction of a
+    /// [`BorrowingFieldsVisitor`].
+    fn visit_struct(
+        ty: &paths::StructPath,
+        tcx: &'m TypeContext,
+        parent: ParentId,
+        method_lifetimes: &Lifetimes,
+        parents: &mut SmallVec<[(Option<ParentId>, &'m Ident); 4]>,
+        leaves: &mut SmallVec<[BorrowingFieldVisitorLeaf; 8]>,
+    ) {
+        let method_type_lifetimes = ty.lifetimes.as_method_lifetimes(method_lifetimes);
+        for field in ty.resolve(tcx).fields.iter() {
+            Self::from_type(
+                &field.ty,
+                tcx,
+                ParentId::new(Some(parent), field.name.as_ref(), parents),
+                &method_type_lifetimes,
+                parents,
+                leaves,
+            );
+        }
+    }
+}
+
+impl<'m> BorrowingField<'m> {
+    /// Visit fields in order.
+    ///
+    /// If `self` represents the field `param.first.second`, then calling [`BorrowingField::trace`]
+    /// will visit the following in order: `"param"`, `"first"`, `"second"`.
+    pub fn backtrace<F>(&self, mut visit: F)
+    where
+        F: FnMut(usize, &'m Ident),
+    {
+        let (parent, ident) = match self.leaf {
+            BorrowingFieldVisitorLeaf::Opaque(id, ..) | BorrowingFieldVisitorLeaf::Slice(id, _) => {
+                self.parents[id.0]
+            }
+        };
+
+        self.backtrace_rec(parent, ident, &mut visit);
+    }
+
+    /// Recursively visits fields in order from root to leaf by building up the
+    /// stack, and then visiting fields as it unwinds.
+    fn backtrace_rec<F>(&self, parent: Option<ParentId>, ident: &'m Ident, visit: &mut F) -> usize
+    where
+        F: FnMut(usize, &'m Ident),
+    {
+        let from_end = if let Some(id) = parent {
+            let (parent, ident) = self.parents[id.0];
+            self.backtrace_rec(parent, ident, visit)
+        } else {
+            0
+        };
+
+        visit(from_end, ident);
+
+        from_end + 1
+    }
+
+    /// Fallibly visits fields in order.
+    ///
+    /// This method is similar to [`BorrowinfField::backtrace`], but short-circuits
+    /// when an `Err` is returned.
+    pub fn try_backtrace<F, E>(&self, mut visit: F) -> Result<(), E>
+    where
+        F: FnMut(usize, &'m Ident) -> Result<(), E>,
+    {
+        let (parent, ident) = match self.leaf {
+            BorrowingFieldVisitorLeaf::Opaque(id, ..) | BorrowingFieldVisitorLeaf::Slice(id, _) => {
+                self.parents[id.0]
+            }
+        };
+
+        self.try_backtrace_rec(parent, ident, &mut visit)?;
+
+        Ok(())
+    }
+
+    /// Recursively visits fields in order from root to leaf by building up the
+    /// stack, and then visiting fields as it unwinds.
+    fn try_backtrace_rec<F, E>(
+        &self,
+        parent: Option<ParentId>,
+        ident: &'m Ident,
+        visit: &mut F,
+    ) -> Result<usize, E>
+    where
+        F: FnMut(usize, &'m Ident) -> Result<(), E>,
+    {
+        let from_end = if let Some(id) = parent {
+            let (parent, ident) = self.parents[id.0];
+            self.try_backtrace_rec(parent, ident, visit)?
+        } else {
+            0
+        };
+
+        visit(from_end, ident)?;
+
+        Ok(from_end + 1)
+    }
+}
+
+impl<'m> fmt::Display for BorrowingField<'m> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.try_backtrace(|i, ident| {
+            if i != 0 {
+                f.write_char('.')?;
+            }
+            f.write_str(ident.as_str())
+        })
+    }
+}

--- a/core/src/hir/methods/borrowing_param.rs
+++ b/core/src/hir/methods/borrowing_param.rs
@@ -26,11 +26,15 @@ pub struct BorrowingParamVisitor<'tcx> {
 }
 
 /// A single lifetime "edge" from a parameter to a value
+#[non_exhaustive]
+#[derive(Clone, Debug)]
 pub struct LifetimeEdge<'tcx> {
     pub param_name: String,
     pub kind: LifetimeEdgeKind<'tcx>,
 }
 
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug)]
 pub enum LifetimeEdgeKind<'tcx> {
     /// Just an opaque parameter directly being borrowed.
     OpaqueParam,
@@ -43,6 +47,8 @@ pub enum LifetimeEdgeKind<'tcx> {
     StructLifetime(&'tcx LifetimeEnv, Lifetime),
 }
 
+#[non_exhaustive]
+#[derive(Clone, Debug)]
 pub struct BorrowedLifetimeInfo<'tcx> {
     // Initializers for all inputs to the edge array from parameters, except for slices (slices get handled
     // differently)

--- a/core/src/hir/methods/borrowing_param.rs
+++ b/core/src/hir/methods/borrowing_param.rs
@@ -1,0 +1,165 @@
+//! Tools for traversing all borrows in method parameters and return types, shallowly
+//!
+//! This is useful for backends which wish to figure out the borrowing relationships between parameters
+//! and return values,
+//! and then delegate how lifetimes get mapped to fields to the codegen for those types respectively.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::hir::{self, Method, TypeContext};
+
+use crate::hir::lifetimes::{Lifetime, LifetimeEnv, MaybeStatic};
+
+/// A visitor for processing method parameters/returns and understanding their borrowing relationships, shallowly.
+///
+/// This produces a list of lifetime "edges" per lifetime in the output producing a borrow.
+///
+/// Each `BorrowingFieldsVisitor` corresponds to the type of an input of a method.
+///
+/// Obtain from [`Method::borrowing_param_visitor()`].
+pub struct BorrowingParamVisitor<'tcx> {
+    tcx: &'tcx TypeContext,
+    #[allow(unused)] // to be used later
+    method: &'tcx Method,
+    used_method_lifetimes: BTreeSet<Lifetime>,
+    borrow_map: BTreeMap<Lifetime, BorrowedLifetimeInfo<'tcx>>,
+}
+
+/// A single lifetime "edge" from a parameter to a value
+pub struct LifetimeEdge<'tcx> {
+    pub param_name: String,
+    pub kind: LifetimeEdgeKind<'tcx>,
+}
+
+pub enum LifetimeEdgeKind<'tcx> {
+    /// Just an opaque parameter directly being borrowed.
+    OpaqueParam,
+    /// A slice being converted and then borrowed. These often need to be handled differently
+    /// when they are borrowed as the borrow will need to create an edge
+    SliceParam,
+    /// A lifetime parameter of a struct, given the lifetime context and the struct-def lifetime for that struct
+    ///
+    /// Using this, you can generate code that "asks" the struct for the lifetime-relevant field edges
+    StructLifetime(&'tcx LifetimeEnv, Lifetime),
+}
+
+pub struct BorrowedLifetimeInfo<'tcx> {
+    // Initializers for all inputs to the edge array from parameters, except for slices (slices get handled
+    // differently)
+    pub incoming_edges: Vec<LifetimeEdge<'tcx>>,
+    // All lifetimes longer than this. When this lifetime is borrowed from, data corresponding to
+    // the other lifetimes may also be borrowed from.
+    pub all_longer_lifetimes: BTreeSet<Lifetime>,
+}
+
+impl<'tcx> BorrowingParamVisitor<'tcx> {
+    pub(crate) fn new(method: &'tcx Method, tcx: &'tcx TypeContext) -> Self {
+        let used_method_lifetimes = method.output.used_method_lifetimes();
+        let borrow_map = used_method_lifetimes
+            .iter()
+            .map(|lt| {
+                (
+                    *lt,
+                    BorrowedLifetimeInfo {
+                        incoming_edges: Vec::new(),
+                        all_longer_lifetimes: method
+                            .lifetime_env
+                            .all_longer_lifetimes(lt)
+                            .collect(),
+                    },
+                )
+            })
+            .collect();
+        BorrowingParamVisitor {
+            tcx,
+            method,
+            used_method_lifetimes,
+            borrow_map,
+        }
+    }
+
+    /// Get the cached list of used method lifetimes. Same as calling `.used_method_lifetimes()` on `method.output`
+    pub fn used_method_lifetimes(&self) -> &BTreeSet<Lifetime> {
+        &self.used_method_lifetimes
+    }
+
+    /// Get the final borrow map, listing lifetime edges for each output lfietime
+    pub fn borrow_map(self) -> BTreeMap<Lifetime, BorrowedLifetimeInfo<'tcx>> {
+        self.borrow_map
+    }
+
+    /// Processes a parameter, adding it to the borrow_map for any lifetimes it references. Returns true if the lifetime is referenced.
+    ///
+    /// This basically boils down to: For each lifetime that is actually relevant to borrowing in this method, check if that
+    /// lifetime or lifetimes longer than it are used by this parameter. In other words, check if
+    /// it is possible for data in the return type with this lifetime to have been borrowed from this parameter.
+    /// If so, add code that will yield the ownership-relevant parts of this object to incoming_edges for that lifetime.
+    pub fn visit_param(&mut self, ty: &hir::Type, param_name: &str) -> bool {
+        if self.used_method_lifetimes.is_empty() {
+            return false;
+        }
+        let mut edges_pushed = false;
+
+        // Structs have special handling: structs are purely Dart-side, so if you borrow
+        // from a struct, you really are borrowing from the internal fields.
+        if let hir::Type::Struct(s) = ty {
+            let def = s.resolve(self.tcx);
+            for method_lifetime in self.borrow_map.values_mut() {
+                // Note that ty.lifetimes()/s.lifetimes() is lifetimes
+                // in the *use* context, i.e. lifetimes on the Type that reference the
+                // indices of the method's lifetime arrays. Their *order* references
+                // the indices of the underlying struct def. We need to link the two,
+                // since the _fields_for_lifetime_foo() methods are named after
+                // the *def* context lifetime.
+                //
+                // Concretely, if we have struct `Foo<'a, 'b>` and our method
+                // accepts `Foo<'x, 'y>`, we need to output _fields_for_lifetime_a()/b not x/y.
+                let def_lifetimes = def.lifetimes.all_lifetimes();
+                let use_lifetimes = s.lifetimes.lifetimes();
+                assert_eq!(def_lifetimes.len(), use_lifetimes.len(), "lifetimes array found on struct def must match lifetime parameters accepted by struct");
+                // the type lifetimes array
+                for (def_lt, use_lt) in def_lifetimes.zip(use_lifetimes) {
+                    if let MaybeStatic::NonStatic(use_lt) = use_lt {
+                        if method_lifetime.all_longer_lifetimes.contains(&use_lt) {
+                            let edge = LifetimeEdge {
+                                param_name: param_name.into(),
+                                kind: LifetimeEdgeKind::StructLifetime(&def.lifetimes, def_lt),
+                            };
+                            method_lifetime.incoming_edges.push(edge);
+                            edges_pushed = true;
+                            // Do *not* break the inner loop here: even if we found *one* matching lifetime
+                            // in this struct that may not be all of them, there may be some other fields that are borrowed
+                        }
+                    }
+                }
+            }
+        } else {
+            for method_lifetime in self.borrow_map.values_mut() {
+                for lt in ty.lifetimes() {
+                    if let MaybeStatic::NonStatic(lt) = lt {
+                        if method_lifetime.all_longer_lifetimes.contains(&lt) {
+                            let kind = match ty {
+                                hir::Type::Slice(..) => LifetimeEdgeKind::SliceParam,
+                                hir::Type::Opaque(..) => LifetimeEdgeKind::OpaqueParam,
+                                _ => unreachable!("Types other than slices, opaques, and structs cannot have lifetimes")
+                            };
+
+                            let edge = LifetimeEdge {
+                                param_name: param_name.into(),
+                                kind,
+                            };
+
+                            method_lifetime.incoming_edges.push(edge);
+                            edges_pushed = true;
+                            // Break the inner loop: we've already determined this
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // return true if the number of edges changed
+        edges_pushed
+    }
+}

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -7,7 +7,7 @@ mod defs;
 mod elision;
 mod lifetimes;
 mod lowering;
-mod methods;
+pub mod methods;
 mod paths;
 mod primitives;
 mod ty_position;

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -7,7 +7,7 @@ mod defs;
 mod elision;
 mod lifetimes;
 mod lowering;
-pub mod methods;
+mod methods;
 mod paths;
 mod primitives;
 mod ty_position;

--- a/core/src/hir/paths.rs
+++ b/core/src/hir/paths.rs
@@ -127,7 +127,7 @@ impl ReturnableStructPath {
 
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
-    pub fn link_lifetimes<'tcx>(&'tcx self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'tcx> {
+    pub fn link_lifetimes<'def, 'tcx>(&'def self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'def, 'tcx> {
         match self {
             Self::Struct(p) => p.link_lifetimes(tcx),
             Self::OutStruct(p) => p.link_lifetimes(tcx),
@@ -149,7 +149,7 @@ impl StructPath {
 
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
-    pub fn link_lifetimes<'tcx>(&'tcx self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'tcx> {
+    pub fn link_lifetimes<'def, 'tcx>(&'def self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'def, 'tcx> {
         let struc = self.resolve(tcx);
         let env = &struc.lifetimes;
         LinkedLifetimes::new(env, None, &self.lifetimes)
@@ -164,7 +164,7 @@ impl OutStructPath {
 
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
-    pub fn link_lifetimes<'tcx>(&'tcx self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'tcx> {
+    pub fn link_lifetimes<'def, 'tcx>(&'def self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'def, 'tcx> {
         let struc = self.resolve(tcx);
         let env = &struc.lifetimes;
         LinkedLifetimes::new(env, None, &self.lifetimes)
@@ -191,7 +191,7 @@ impl<Opt, Owner> OpaquePath<Opt, Owner> {
 impl<Opt, Owner: OpaqueOwner> OpaquePath<Opt, Owner> {
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
-    pub fn link_lifetimes<'tcx>(&'tcx self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'tcx> {
+    pub fn link_lifetimes<'def, 'tcx>(&'def self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'def, 'tcx> {
         let opaque = self.resolve(tcx);
         let env = &opaque.lifetimes;
         LinkedLifetimes::new(env, self.owner.lifetime(), &self.lifetimes)

--- a/core/src/hir/paths.rs
+++ b/core/src/hir/paths.rs
@@ -127,7 +127,10 @@ impl ReturnableStructPath {
 
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
-    pub fn link_lifetimes<'def, 'tcx>(&'def self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'def, 'tcx> {
+    pub fn link_lifetimes<'def, 'tcx>(
+        &'def self,
+        tcx: &'tcx TypeContext,
+    ) -> LinkedLifetimes<'def, 'tcx> {
         match self {
             Self::Struct(p) => p.link_lifetimes(tcx),
             Self::OutStruct(p) => p.link_lifetimes(tcx),
@@ -149,7 +152,10 @@ impl StructPath {
 
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
-    pub fn link_lifetimes<'def, 'tcx>(&'def self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'def, 'tcx> {
+    pub fn link_lifetimes<'def, 'tcx>(
+        &'def self,
+        tcx: &'tcx TypeContext,
+    ) -> LinkedLifetimes<'def, 'tcx> {
         let struc = self.resolve(tcx);
         let env = &struc.lifetimes;
         LinkedLifetimes::new(env, None, &self.lifetimes)
@@ -164,7 +170,10 @@ impl OutStructPath {
 
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
-    pub fn link_lifetimes<'def, 'tcx>(&'def self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'def, 'tcx> {
+    pub fn link_lifetimes<'def, 'tcx>(
+        &'def self,
+        tcx: &'tcx TypeContext,
+    ) -> LinkedLifetimes<'def, 'tcx> {
         let struc = self.resolve(tcx);
         let env = &struc.lifetimes;
         LinkedLifetimes::new(env, None, &self.lifetimes)
@@ -191,7 +200,10 @@ impl<Opt, Owner> OpaquePath<Opt, Owner> {
 impl<Opt, Owner: OpaqueOwner> OpaquePath<Opt, Owner> {
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
-    pub fn link_lifetimes<'def, 'tcx>(&'def self, tcx: &'tcx TypeContext) -> LinkedLifetimes<'def, 'tcx> {
+    pub fn link_lifetimes<'def, 'tcx>(
+        &'def self,
+        tcx: &'tcx TypeContext,
+    ) -> LinkedLifetimes<'def, 'tcx> {
         let opaque = self.resolve(tcx);
         let env = &opaque.lifetimes;
         LinkedLifetimes::new(env, self.owner.lifetime(), &self.lifetimes)

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -1,9 +1,7 @@
 use crate::common::{ErrorStore, FileMap};
 use askama::Template;
 use diplomat_core::ast::DocsUrlGenerator;
-use diplomat_core::hir::methods::borrowing_param::{
-    BorrowedLifetimeInfo, LifetimeEdge, LifetimeEdgeKind,
-};
+use diplomat_core::hir::borrowing_param::{BorrowedLifetimeInfo, LifetimeEdge, LifetimeEdgeKind};
 use diplomat_core::hir::TypeContext;
 use diplomat_core::hir::{
     self, Lifetime, LifetimeEnv, Lifetimes, MaybeStatic, OpaqueOwner, ReturnType, SelfType,

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -1093,6 +1093,7 @@ fn display_lifetime_edge<'a>(edge: &'a LifetimeEdge) -> Cow<'a, str> {
             def_env.fmt_lifetime(def_lt)
         )
         .into(),
+        _ => unreachable!("Unknown lifetime edge kind {:?}", edge.kind),
     }
 }
 

--- a/tool/templates/dart/method.dart.jinja
+++ b/tool/templates/dart/method.dart.jinja
@@ -20,7 +20,7 @@
     // This lifetime edge depends on lifetimes: {% for longer in lifetime_info.all_longer_lifetimes.iter().copied() -%} {%- if !loop.first %}, {% endif -%} '{{m.lifetimes.fmt_lifetime(longer)}} {%- endfor %}
     core.List<Object> edge_{{m.lifetimes.fmt_lifetime(lifetime)}} = [
       {%- for incoming_edge in lifetime_info.incoming_edges.iter() %}
-      {%- if !loop.first %}, {% endif -%} {{incoming_edge}}
+      {%- if !loop.first %}, {% endif -%} {{self::display_lifetime_edge(incoming_edge)}}
       {%- endfor -%}
     ];
     {%- endif %}


### PR DESCRIPTION
I was planning on doing this work when I do the JS backend, but for dart structs-with-slices I'm already needing to add some abstractions so I figured I'd do it now.

I'll probably continue work on structs on top of this branch. It will primarily involve turning `visit_param`'s return type into an enum.