### PR TITLE
Dart: add symbols to resource ids

### DIFF
--- a/example/dart/lib/src/ICU4XDataProvider.g.dart
+++ b/example/dart/lib/src/ICU4XDataProvider.g.dart
@@ -40,17 +40,17 @@ final class ICU4XDataProvider implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XDataProvider_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'ICU4XDataProvider_destroy')
 // ignore: non_constant_identifier_names
 external void _ICU4XDataProvider_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XDataProvider_new_static')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'ICU4XDataProvider_new_static')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _ICU4XDataProvider_new_static();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XDataProvider_returns_result')
 @ffi.Native<_ResultVoidVoid Function()>(isLeaf: true, symbol: 'ICU4XDataProvider_returns_result')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _ICU4XDataProvider_returns_result();

--- a/example/dart/lib/src/ICU4XFixedDecimal.g.dart
+++ b/example/dart/lib/src/ICU4XFixedDecimal.g.dart
@@ -51,22 +51,22 @@ final class ICU4XFixedDecimal implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XFixedDecimal_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'ICU4XFixedDecimal_destroy')
 // ignore: non_constant_identifier_names
 external void _ICU4XFixedDecimal_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XFixedDecimal_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'ICU4XFixedDecimal_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _ICU4XFixedDecimal_new(int v);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XFixedDecimal_multiply_pow10')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'ICU4XFixedDecimal_multiply_pow10')
 // ignore: non_constant_identifier_names
 external void _ICU4XFixedDecimal_multiply_pow10(ffi.Pointer<ffi.Opaque> self, int power);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XFixedDecimal_to_string')
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'ICU4XFixedDecimal_to_string')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _ICU4XFixedDecimal_to_string(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> writeable);

--- a/example/dart/lib/src/ICU4XFixedDecimalFormatter.g.dart
+++ b/example/dart/lib/src/ICU4XFixedDecimalFormatter.g.dart
@@ -50,17 +50,17 @@ final class ICU4XFixedDecimalFormatter implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XFixedDecimalFormatter_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'ICU4XFixedDecimalFormatter_destroy')
 // ignore: non_constant_identifier_names
 external void _ICU4XFixedDecimalFormatter_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XFixedDecimalFormatter_try_new')
 @ffi.Native<_ResultOpaqueVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ICU4XFixedDecimalFormatterOptionsFfi)>(isLeaf: true, symbol: 'ICU4XFixedDecimalFormatter_try_new')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueVoid _ICU4XFixedDecimalFormatter_try_new(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> provider, _ICU4XFixedDecimalFormatterOptionsFfi options);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XFixedDecimalFormatter_format_write')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'ICU4XFixedDecimalFormatter_format_write')
 // ignore: non_constant_identifier_names
 external void _ICU4XFixedDecimalFormatter_format_write(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> value, ffi.Pointer<ffi.Opaque> writeable);

--- a/example/dart/lib/src/ICU4XFixedDecimalFormatterOptions.g.dart
+++ b/example/dart/lib/src/ICU4XFixedDecimalFormatterOptions.g.dart
@@ -60,7 +60,7 @@ final class ICU4XFixedDecimalFormatterOptions {
       ]);
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XFixedDecimalFormatterOptions_default')
 @ffi.Native<_ICU4XFixedDecimalFormatterOptionsFfi Function()>(isLeaf: true, symbol: 'ICU4XFixedDecimalFormatterOptions_default')
 // ignore: non_constant_identifier_names
 external _ICU4XFixedDecimalFormatterOptionsFfi _ICU4XFixedDecimalFormatterOptions_default();

--- a/example/dart/lib/src/ICU4XLocale.g.dart
+++ b/example/dart/lib/src/ICU4XLocale.g.dart
@@ -37,12 +37,12 @@ final class ICU4XLocale implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XLocale_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'ICU4XLocale_destroy')
 // ignore: non_constant_identifier_names
 external void _ICU4XLocale_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ICU4XLocale_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'ICU4XLocale_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _ICU4XLocale_new(ffi.Pointer<ffi.Uint8> nameData, int nameLength);

--- a/example/dart/lib/src/lib.g.dart
+++ b/example/dart/lib/src/lib.g.dart
@@ -363,22 +363,22 @@ final class _Writeable {
 }
 
   
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_create')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_writeable_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_writeable_create(int len);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_len')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_writeable_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_get_bytes')
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_writeable_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_writeable_destroy(ffi.Pointer<ffi.Opaque> ptr);

--- a/feature_tests/dart/lib/src/AttrOpaque1.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1.g.dart
@@ -52,37 +52,37 @@ final class AttrOpaque1 implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_AttrOpaque1_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_AttrOpaque1_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'namespace_AttrOpaque1_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_AttrOpaque1_new();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_AttrOpaque1_method')
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_method')
 // ignore: non_constant_identifier_names
 external int _namespace_AttrOpaque1_method(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('renamed_on_abi_only')
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'renamed_on_abi_only')
 // ignore: non_constant_identifier_names
 external int _renamed_on_abi_only(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_AttrOpaque1_method_disabledcpp')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_method_disabledcpp')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_method_disabledcpp(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_AttrOpaque1_use_unnamespaced')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_use_unnamespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_use_unnamespaced(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> un);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_AttrOpaque1_use_namespaced')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_use_namespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_use_namespaced(ffi.Pointer<ffi.Opaque> self, int n);

--- a/feature_tests/dart/lib/src/AttrOpaque2.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque2.g.dart
@@ -25,7 +25,7 @@ final class AttrOpaque2 implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_AttrOpaque2_destroy));
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_AttrOpaque2_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_AttrOpaque2_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque2_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/Bar.g.dart
+++ b/feature_tests/dart/lib/src/Bar.g.dart
@@ -36,12 +36,12 @@ final class Bar implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Bar_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Bar_destroy')
 // ignore: non_constant_identifier_names
 external void _Bar_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Bar_foo')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Bar_foo')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Bar_foo(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/Float64Vec.g.dart
+++ b/feature_tests/dart/lib/src/Float64Vec.g.dart
@@ -102,57 +102,57 @@ final class Float64Vec implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Float64Vec_destroy')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Double>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new(ffi.Pointer<ffi.Double> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_new_bool')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Bool>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_new_bool')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_bool(ffi.Pointer<ffi.Bool> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_new_i16')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Int16>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_new_i16')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_i16(ffi.Pointer<ffi.Int16> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_new_u16')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint16>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_new_u16')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_u16(ffi.Pointer<ffi.Uint16> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_new_isize')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.IntPtr>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_new_isize')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_isize(ffi.Pointer<ffi.IntPtr> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_new_usize')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Size>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_new_usize')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_usize(ffi.Pointer<ffi.Size> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_new_f64_be_bytes')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_new_f64_be_bytes')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_f64_be_bytes(ffi.Pointer<ffi.Uint8> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_fill_slice')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Double>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_fill_slice')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_fill_slice(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Double> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_set_value')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Double>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_set_value')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_set_value(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Double> newSliceData, int newSliceLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Float64Vec_to_string')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Float64Vec_to_string')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_to_string(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> writeable);

--- a/feature_tests/dart/lib/src/Foo.g.dart
+++ b/feature_tests/dart/lib/src/Foo.g.dart
@@ -82,37 +82,37 @@ final class Foo implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Foo_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Foo_destroy')
 // ignore: non_constant_identifier_names
 external void _Foo_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Foo_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'Foo_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_new(ffi.Pointer<ffi.Uint8> xData, int xLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Foo_get_bar')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Foo_get_bar')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_get_bar(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Foo_new_static')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'Foo_new_static')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_new_static(ffi.Pointer<ffi.Uint8> xData, int xLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Foo_as_returning')
 @ffi.Native<_BorrowedFieldsReturningFfi Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Foo_as_returning')
 // ignore: non_constant_identifier_names
 external _BorrowedFieldsReturningFfi _Foo_as_returning(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Foo_extract_from_fields')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_BorrowedFieldsFfi)>(isLeaf: true, symbol: 'Foo_extract_from_fields')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_extract_from_fields(_BorrowedFieldsFfi fields);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Foo_extract_from_bounds')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_BorrowedFieldsWithBoundsFfi, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'Foo_extract_from_bounds')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_extract_from_bounds(_BorrowedFieldsWithBoundsFfi bounds, ffi.Pointer<ffi.Uint8> anotherStringData, int anotherStringLength);

--- a/feature_tests/dart/lib/src/MyEnum.g.dart
+++ b/feature_tests/dart/lib/src/MyEnum.g.dart
@@ -41,7 +41,7 @@ enum MyEnum {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('MyEnum_into_value')
 @ffi.Native<ffi.Int8 Function(ffi.Int32)>(isLeaf: true, symbol: 'MyEnum_into_value')
 // ignore: non_constant_identifier_names
 external int _MyEnum_into_value(int self);

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -54,27 +54,27 @@ final class MyString implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('MyString_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'MyString_destroy')
 // ignore: non_constant_identifier_names
 external void _MyString_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('MyString_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'MyString_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new(ffi.Pointer<ffi.Uint8> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('MyString_new_unsafe')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'MyString_new_unsafe')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new_unsafe(ffi.Pointer<ffi.Uint8> vData, int vLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('MyString_set_str')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'MyString_set_str')
 // ignore: non_constant_identifier_names
 external void _MyString_set_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Uint8> newStrData, int newStrLength);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('MyString_get_str')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_get_str')
 // ignore: non_constant_identifier_names
 external void _MyString_get_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> writeable);

--- a/feature_tests/dart/lib/src/MyStruct.g.dart
+++ b/feature_tests/dart/lib/src/MyStruct.g.dart
@@ -117,12 +117,12 @@ final class MyStruct {
       ]);
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('MyStruct_new')
 @ffi.Native<_MyStructFfi Function()>(isLeaf: true, symbol: 'MyStruct_new')
 // ignore: non_constant_identifier_names
 external _MyStructFfi _MyStruct_new();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('MyStruct_into_a')
 @ffi.Native<ffi.Uint8 Function(_MyStructFfi)>(isLeaf: true, symbol: 'MyStruct_into_a')
 // ignore: non_constant_identifier_names
 external int _MyStruct_into_a(_MyStructFfi self);

--- a/feature_tests/dart/lib/src/One.g.dart
+++ b/feature_tests/dart/lib/src/One.g.dart
@@ -103,62 +103,62 @@ final class One implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'One_destroy')
 // ignore: non_constant_identifier_names
 external void _One_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_transitivity')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_transitivity')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_transitivity(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_cycle')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_cycle')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_cycle(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_many_dependents')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_many_dependents')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_many_dependents(ffi.Pointer<ffi.Opaque> a, ffi.Pointer<ffi.Opaque> b, ffi.Pointer<ffi.Opaque> c, ffi.Pointer<ffi.Opaque> d, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_return_outlives_param')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_return_outlives_param')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_return_outlives_param(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_diamond_top')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_top')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_top(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_diamond_left')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_left')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_left(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_diamond_right')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_right')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_right(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_diamond_bottom')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_bottom')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_bottom(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_diamond_and_nested_types')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_and_nested_types')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_and_nested_types(ffi.Pointer<ffi.Opaque> a, ffi.Pointer<ffi.Opaque> b, ffi.Pointer<ffi.Opaque> c, ffi.Pointer<ffi.Opaque> d, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_implicit_bounds')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_implicit_bounds')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_implicit_bounds(ffi.Pointer<ffi.Opaque> explicitHold, ffi.Pointer<ffi.Opaque> implicitHold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('One_implicit_bounds_deep')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_implicit_bounds_deep')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_implicit_bounds_deep(ffi.Pointer<ffi.Opaque> explicit, ffi.Pointer<ffi.Opaque> implicit1, ffi.Pointer<ffi.Opaque> implicit2, ffi.Pointer<ffi.Opaque> nohold);

--- a/feature_tests/dart/lib/src/Opaque.g.dart
+++ b/feature_tests/dart/lib/src/Opaque.g.dart
@@ -51,27 +51,27 @@ final class Opaque implements ffi.Finalizable {
   }();
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Opaque_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Opaque_destroy')
 // ignore: non_constant_identifier_names
 external void _Opaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Opaque_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'Opaque_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Opaque_new();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Opaque_assert_struct')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _MyStructFfi)>(isLeaf: true, symbol: 'Opaque_assert_struct')
 // ignore: non_constant_identifier_names
 external void _Opaque_assert_struct(ffi.Pointer<ffi.Opaque> self, _MyStructFfi s);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Opaque_returns_usize')
 @ffi.Native<ffi.Size Function()>(isLeaf: true, symbol: 'Opaque_returns_usize')
 // ignore: non_constant_identifier_names
 external int _Opaque_returns_usize();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Opaque_returns_imported')
 @ffi.Native<_ImportedStructFfi Function()>(isLeaf: true, symbol: 'Opaque_returns_imported')
 // ignore: non_constant_identifier_names
 external _ImportedStructFfi _Opaque_returns_imported();

--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -62,42 +62,42 @@ final class OptionOpaque implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaque_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'OptionOpaque_destroy')
 // ignore: non_constant_identifier_names
 external void _OptionOpaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaque_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'OptionOpaque_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OptionOpaque_new(int i);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaque_new_none')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'OptionOpaque_new_none')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OptionOpaque_new_none();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaque_returns')
 @ffi.Native<_ResultOptionStructFfiVoid Function()>(isLeaf: true, symbol: 'OptionOpaque_returns')
 // ignore: non_constant_identifier_names
 external _ResultOptionStructFfiVoid _OptionOpaque_returns();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaque_new_struct')
 @ffi.Native<_OptionStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_new_struct')
 // ignore: non_constant_identifier_names
 external _OptionStructFfi _OptionOpaque_new_struct();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaque_new_struct_nones')
 @ffi.Native<_OptionStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_new_struct_nones')
 // ignore: non_constant_identifier_names
 external _OptionStructFfi _OptionOpaque_new_struct_nones();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaque_assert_integer')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'OptionOpaque_assert_integer')
 // ignore: non_constant_identifier_names
 external void _OptionOpaque_assert_integer(ffi.Pointer<ffi.Opaque> self, int i);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaque_option_opaque_argument')
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_opaque_argument')
 // ignore: non_constant_identifier_names
 external bool _OptionOpaque_option_opaque_argument(ffi.Pointer<ffi.Opaque> arg);

--- a/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
@@ -29,12 +29,12 @@ final class OptionOpaqueChar implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaqueChar_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'OptionOpaqueChar_destroy')
 // ignore: non_constant_identifier_names
 external void _OptionOpaqueChar_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('OptionOpaqueChar_assert_char')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'OptionOpaqueChar_assert_char')
 // ignore: non_constant_identifier_names
 external void _OptionOpaqueChar_assert_char(ffi.Pointer<ffi.Opaque> self, Rune ch);

--- a/feature_tests/dart/lib/src/RefList.g.dart
+++ b/feature_tests/dart/lib/src/RefList.g.dart
@@ -33,12 +33,12 @@ final class RefList implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('RefList_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'RefList_destroy')
 // ignore: non_constant_identifier_names
 external void _RefList_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('RefList_node')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'RefList_node')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _RefList_node(ffi.Pointer<ffi.Opaque> data);

--- a/feature_tests/dart/lib/src/RefListParameter.g.dart
+++ b/feature_tests/dart/lib/src/RefListParameter.g.dart
@@ -25,7 +25,7 @@ final class RefListParameter implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_RefListParameter_destroy));
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('RefListParameter_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'RefListParameter_destroy')
 // ignore: non_constant_identifier_names
 external void _RefListParameter_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/ResultOpaque.g.dart
+++ b/feature_tests/dart/lib/src/ResultOpaque.g.dart
@@ -111,52 +111,52 @@ final class ResultOpaque implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'ResultOpaque_destroy')
 // ignore: non_constant_identifier_names
 external void _ResultOpaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_new')
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new(int i);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_new_failing_foo')
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_foo')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new_failing_foo();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_new_failing_bar')
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_bar')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new_failing_bar();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_new_failing_unit')
 @ffi.Native<_ResultOpaqueVoid Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_unit')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueVoid _ResultOpaque_new_failing_unit();
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_new_failing_struct')
 @ffi.Native<_ResultOpaqueErrorStructFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_failing_struct')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueErrorStructFfi _ResultOpaque_new_failing_struct(int i);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_new_in_err')
 @ffi.Native<_ResultVoidOpaque Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_in_err')
 // ignore: non_constant_identifier_names
 external _ResultVoidOpaque _ResultOpaque_new_in_err(int i);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_new_int')
 @ffi.Native<_ResultInt32Void Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_int')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _ResultOpaque_new_int(int i);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_new_in_enum_err')
 @ffi.Native<_ResultInt32Opaque Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_in_enum_err')
 // ignore: non_constant_identifier_names
 external _ResultInt32Opaque _ResultOpaque_new_in_enum_err(int i);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('ResultOpaque_assert_integer')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_assert_integer')
 // ignore: non_constant_identifier_names
 external void _ResultOpaque_assert_integer(ffi.Pointer<ffi.Opaque> self, int i);

--- a/feature_tests/dart/lib/src/Two.g.dart
+++ b/feature_tests/dart/lib/src/Two.g.dart
@@ -27,7 +27,7 @@ final class Two implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Two_destroy));
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('Two_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Two_destroy')
 // ignore: non_constant_identifier_names
 external void _Two_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/Unnamespaced.g.dart
+++ b/feature_tests/dart/lib/src/Unnamespaced.g.dart
@@ -34,17 +34,17 @@ final class Unnamespaced implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_Unnamespaced_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_Unnamespaced_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_Unnamespaced_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_Unnamespaced_make')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'namespace_Unnamespaced_make')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_Unnamespaced_make(int e);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('namespace_Unnamespaced_use_namespaced')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_Unnamespaced_use_namespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_Unnamespaced_use_namespaced(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> n);

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -505,22 +505,22 @@ final class _Writeable {
 }
 
   
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_create')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_writeable_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_writeable_create(int len);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_len')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_writeable_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_get_bytes')
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_writeable_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_writeable_destroy(ffi.Pointer<ffi.Opaque> ptr);

--- a/tool/templates/dart/native_method.dart.jinja
+++ b/tool/templates/dart/native_method.dart.jinja
@@ -1,4 +1,4 @@
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('{{ m.c_method_name }}')
 @ffi.Native<{{ m.return_type_ffi }} Function({%- for param in m.param_types_ffi %}
       {%- if !loop.first %}, {% endif -%}
       {{ param }}

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -29,7 +29,7 @@ final class {{type_name}} implements ffi.Finalizable {
   {%- endfor %}
 }
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('{{destructor}}')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: '{{destructor}}')
 // ignore: non_constant_identifier_names
 external void _{{destructor}}(ffi.Pointer<ffi.Void> self);

--- a/tool/templates/dart/writeable.dart
+++ b/tool/templates/dart/writeable.dart
@@ -11,22 +11,22 @@ final class _Writeable {
 }
 
   
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_create')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_writeable_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_writeable_create(int len);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_len')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_writeable_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_get_bytes')
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_writeable_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier()
+@meta.ResourceIdentifier('diplomat_buffer_writeable_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_writeable_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_writeable_destroy(ffi.Pointer<ffi.Opaque> ptr);


### PR DESCRIPTION
The function names are prefixed with `_` for private visibility, so they can't be used directly.

Part of #439 