### PR TITLE
Add and track SpecialMethodPresence

### DIFF
--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -1,7 +1,9 @@
 //! Type definitions for structs, output structs, opaque structs, and enums.
 
 use super::lifetimes::LifetimeEnv;
-use super::{Attrs, Everywhere, IdentBuf, Method, OutputOnly, TyPosition, Type};
+use super::{
+    Attrs, Everywhere, IdentBuf, Method, OutputOnly, SpecialMethodPresence, TyPosition, Type,
+};
 use crate::ast::Docs;
 
 #[non_exhaustive]
@@ -32,6 +34,7 @@ pub struct StructDef<P: TyPosition = Everywhere> {
     pub methods: Vec<Method>,
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
+    pub special_method_presence: SpecialMethodPresence,
 }
 
 /// A struct whose contents are opaque across the FFI boundary, and can only
@@ -50,6 +53,7 @@ pub struct OpaqueDef {
     pub methods: Vec<Method>,
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
+    pub special_method_presence: SpecialMethodPresence,
 }
 
 /// The enum type.
@@ -61,6 +65,7 @@ pub struct EnumDef {
     pub variants: Vec<EnumVariant>,
     pub methods: Vec<Method>,
     pub attrs: Attrs,
+    pub special_method_presence: SpecialMethodPresence,
 }
 
 /// A field on a [`OutStruct`]s.
@@ -93,6 +98,7 @@ impl<P: TyPosition> StructDef<P> {
         methods: Vec<Method>,
         attrs: Attrs,
         lifetimes: LifetimeEnv,
+        special_method_presence: SpecialMethodPresence,
     ) -> Self {
         Self {
             docs,
@@ -101,6 +107,7 @@ impl<P: TyPosition> StructDef<P> {
             methods,
             attrs,
             lifetimes,
+            special_method_presence,
         }
     }
 }
@@ -112,6 +119,7 @@ impl OpaqueDef {
         methods: Vec<Method>,
         attrs: Attrs,
         lifetimes: LifetimeEnv,
+        special_method_presence: SpecialMethodPresence,
     ) -> Self {
         Self {
             docs,
@@ -119,6 +127,7 @@ impl OpaqueDef {
             methods,
             attrs,
             lifetimes,
+            special_method_presence,
         }
     }
 }
@@ -130,6 +139,7 @@ impl EnumDef {
         variants: Vec<EnumVariant>,
         methods: Vec<Method>,
         attrs: Attrs,
+        special_method_presence: SpecialMethodPresence,
     ) -> Self {
         Self {
             docs,
@@ -137,6 +147,7 @@ impl EnumDef {
             variants,
             methods,
             attrs,
+            special_method_presence,
         }
     }
 }

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__comparator.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__comparator.snap
@@ -3,12 +3,19 @@ source: core/src/hir/attrs.rs
 expression: output
 ---
 Lowering error in Struct::comparison_other: Comparator's parameter must be identical to self
+Lowering error in Struct::comparison_correct: Cannot define two comparators on the same type
 Lowering error in Opaque::comparator_static: Comparator must be non-static
 Lowering error in Opaque::comparator_none: Comparator must have single parameter
+Lowering error in Opaque::comparator_none: Cannot define two comparators on the same type
+Lowering error in Opaque::comparator_othertype: Cannot define two comparators on the same type
 Lowering error in Opaque::comparator_othertype: Comparator must be non-static
+Lowering error in Opaque::comparator_badreturn: Cannot define two comparators on the same type
 Lowering error in Opaque::comparator_badreturn: Found comparison method that does not return cmp::Ordering
+Lowering error in Opaque::comparison_correct: Cannot define two comparators on the same type
 Lowering error in Opaque::comparison_unmarked: Found comparison return type in method not marked as #[diplomat::attr(.., comparison)]
 Lowering error in Opaque::ordering_wrong: Found cmp::Ordering in parameter or struct field, it is only allowed in return types
+Lowering error in Opaque::comparison_mut: Cannot define two comparators on the same type
 Lowering error in Opaque::comparison_mut: comparators must accept immutable parameters
+Lowering error in Opaque::comparison_opt: Cannot define two comparators on the same type
 Lowering error in Opaque::comparison_opt: comparators must accept non-optional parameters
 

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -130,6 +130,9 @@ TypeContext {
                 ],
                 num_lifetimes: 1,
             },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
+            },
         },
     ],
     structs: [
@@ -264,6 +267,9 @@ TypeContext {
                 ],
                 num_lifetimes: 1,
             },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
+            },
         },
     ],
     opaques: [
@@ -294,6 +300,9 @@ TypeContext {
                     },
                 ],
                 num_lifetimes: 1,
+            },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
             },
         },
     ],

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -149,6 +149,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             methods: &'a [MethodInfo<'a>],
             docs: String,
             is_contiguous: bool,
+            def: &'a hir::EnumDef,
         }
 
         ImplTemplate {
@@ -158,6 +159,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             methods: methods.as_slice(),
             docs: self.formatter.fmt_docs(&ty.docs),
             is_contiguous: is_contiguous_enum(ty),
+            def: ty,
         }
         .render()
         .unwrap()
@@ -180,6 +182,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             docs: String,
             destructor: String,
             lifetimes: &'a LifetimeEnv,
+            def: &'a hir::OpaqueDef,
         }
 
         ImplTemplate {
@@ -188,6 +191,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             destructor,
             docs: self.formatter.fmt_docs(&ty.docs),
             lifetimes: &ty.lifetimes,
+            def: ty,
         }
         .render()
         .unwrap()
@@ -338,6 +342,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             methods: Vec<MethodInfo<'a>>,
             docs: String,
             lifetimes: &'a LifetimeEnv,
+            def: &'a hir::StructDef<P>,
         }
 
         ImplTemplate {
@@ -348,6 +353,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             methods,
             docs: self.formatter.fmt_docs(&ty.docs),
             lifetimes: &ty.lifetimes,
+            def: ty,
         }
         .render()
         .unwrap()
@@ -1257,15 +1263,6 @@ fn iter_def_lifetimes_matching_use_lt<'a>(
         .filter(|(_def_lt, use_lts)| use_lts.contains(use_lt))
         .map(|(def_lt, _use_lts)| def_lt)
         .copied()
-}
-
-fn has_comparison_method(methods: &[MethodInfo]) -> bool {
-    methods.iter().any(|m| {
-        matches!(
-            m.method.attrs.special_method,
-            Some(SpecialMethod::Comparison)
-        )
-    })
 }
 
 /// Context about a struct being borrowed when doing dart-to-c conversions

--- a/tool/templates/dart/enum.dart.jinja
+++ b/tool/templates/dart/enum.dart.jinja
@@ -1,7 +1,7 @@
 {% if !docs.is_empty() -%}
 /// {{docs}}
 {% endif -%}
-enum {{type_name}} {%- if self::has_comparison_method(methods) -%} implements core.Comparable<{{type_name}}> {%- endif %} {
+enum {{type_name}} {%- if def.special_method_presence.comparator -%} implements core.Comparable<{{type_name}}> {%- endif %} {
 {%- for enum_variant in ty.variants %}
   {% if !enum_variant.docs.is_empty() -%}
   /// {{fmt.fmt_docs(enum_variant.docs).replace('\n', "\n  ") }}

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -1,7 +1,7 @@
 {% if !docs.is_empty() -%}
 /// {{docs}}
 {% endif -%}
-final class {{type_name}} implements ffi.Finalizable {%- if self::has_comparison_method(methods) -%}, core.Comparable<{{type_name}}> {%- endif %} {
+final class {{type_name}} implements ffi.Finalizable {%- if def.special_method_presence.comparator -%}, core.Comparable<{{type_name}}> {%- endif %} {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
   // These are "used" in the sense that they keep dependencies alive

--- a/tool/templates/dart/struct.dart.jinja
+++ b/tool/templates/dart/struct.dart.jinja
@@ -12,7 +12,7 @@ final class _{{type_name}}Ffi extends ffi.Struct {
 {% if !docs.is_empty() -%}
 /// {{docs}}
 {% endif -%}
-final class {{type_name}} {%- if self::has_comparison_method(methods) -%} implements core.Comparable<{{type_name}}> {%- endif %} {
+final class {{type_name}} {%- if def.special_method_presence.comparator -%} implements core.Comparable<{{type_name}}> {%- endif %} {
 
   {%- for field in fields %}
   {% if !mutable -%} final {% endif -%} {{field.dart_type_name}} {{field.name}};


### PR DESCRIPTION
This is somewhat useful for comparators, but it will be doubly useful for iterators where we'll need to keep track of things like the iterable return value.

Progress on #460