### PR TITLE
Use Clap 4.2

### DIFF
--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -21,7 +21,7 @@ syn-inline-mod = "0.6.0"
 quote = "1.0"
 indenter = "0.3.3"
 pulldown-cmark = "0.8.0"
-clap = { features = ["color", "derive", "std", "suggestions"], version = "4.5.3" }
+clap = { features = ["color", "derive", "std", "suggestions"], version = "4.2" }
 colored = "2.0"
 serde = { features = ["derive"], version = "1.0.130" }
 toml = "0.5.8"


### PR DESCRIPTION
If we don't need the features in 4.5, we should use 4.2 which is what we have in ICU4X. 4.5 is not compatible with MSRV