### PR TITLE
Implementing `==` and `hashCode` in Dart if required

### DIFF
--- a/feature_tests/dart/lib/src/Comparable.g.dart
+++ b/feature_tests/dart/lib/src/Comparable.g.dart
@@ -30,6 +30,10 @@ final class Comparable implements ffi.Finalizable, core.Comparable<Comparable> {
     final result = _namespace_Comparable_cmp(_ffi, other._ffi);
     return result;
   }
+  @override
+  bool operator ==(Object other) => other is Comparable && compareTo(other) == 0;
+  @override
+  int get hashCode => 42; // Cannot get hash from Rust, so a constant is the only correct impl
 }
 
 @meta.ResourceIdentifier('namespace_Comparable_destroy')

--- a/feature_tests/dart/lib/src/Comparable.g.dart
+++ b/feature_tests/dart/lib/src/Comparable.g.dart
@@ -30,6 +30,7 @@ final class Comparable implements ffi.Finalizable, core.Comparable<Comparable> {
     final result = _namespace_Comparable_cmp(_ffi, other._ffi);
     return result;
   }
+
   @override
   bool operator ==(Object other) => other is Comparable && compareTo(other) == 0;
   @override

--- a/tool/templates/dart/enum.dart.jinja
+++ b/tool/templates/dart/enum.dart.jinja
@@ -26,6 +26,13 @@ enum {{type_name}}
   {%- for m in methods %}
 {% include "method.dart.jinja" %}
   {%-endfor %}
+
+  {%- if special.comparator %}
+  @override
+  bool operator ==(Object other) => other is {{type_name}} && compareTo(other) == 0;
+  @override
+  int get hashCode => 42; // Cannot get hash from Rust, so a constant is the only correct impl
+  {%- endif %}
 }
 
 {%- for m in methods %}

--- a/tool/templates/dart/enum.dart.jinja
+++ b/tool/templates/dart/enum.dart.jinja
@@ -28,6 +28,7 @@ enum {{type_name}}
   {%-endfor %}
 
   {%- if special.comparator %}
+
   @override
   bool operator ==(Object other) => other is {{type_name}} && compareTo(other) == 0;
   @override

--- a/tool/templates/dart/method.dart.jinja
+++ b/tool/templates/dart/method.dart.jinja
@@ -47,4 +47,4 @@
     {{statement.replace('\n', "\n    ")}}
     {%- when None %}
     {%- endmatch %}
-  }{% if m.declaration.starts_with("static final") %}();{% endif %}
+  }

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -45,6 +45,13 @@ final class {{type_name}}
   {%- for m in methods %}
 {% include "method.dart.jinja" %}
   {%- endfor %}
+
+  {%- if special.comparator %}
+  @override
+  bool operator ==(Object other) => other is {{type_name}} && compareTo(other) == 0;
+  @override
+  int get hashCode => 42; // Cannot get hash from Rust, so a constant is the only correct impl
+  {%- endif %}
 }
 
 @meta.ResourceIdentifier('{{destructor}}')

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -47,6 +47,7 @@ final class {{type_name}}
   {%- endfor %}
 
   {%- if special.comparator %}
+
   @override
   bool operator ==(Object other) => other is {{type_name}} && compareTo(other) == 0;
   @override


### PR DESCRIPTION
We need to do this if we're implementing `Comparable`.