### PR TITLE
WASM.mjs template fix for Node/Browser detection

### DIFF
--- a/tool/src/js/wasm.mjs
+++ b/tool/src/js/wasm.mjs
@@ -26,7 +26,7 @@ const imports = {
   }
 }
 
-if (typeof fetch === 'undefined') { // Node
+if (typeof process !== 'undefined') { // Node
   const fs = await import("fs");
   const wasmFile = new Uint8Array(fs.readFileSync(cfg['wasm_path']));
   const loadedWasm = await WebAssembly.instantiate(wasmFile, imports);


### PR DESCRIPTION
`fetch === 'undefined'` doesn't work for my setup when running ava in the ICU4X ffi/capi folder. fetch is defined for the Browser as well as Node.JS.

`typeof process` hopefully works better to detect if it's Node.JS instead of Browser modules? But let me know if this breaks anything for anyone else!