### PR TITLE
Make `DiplomatWriteable` infallible

### DIFF
--- a/example/c/include/diplomat_runtime.h
+++ b/example/c/include/diplomat_runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/example/c/include/diplomat_runtime.h
+++ b/example/c/include/diplomat_runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/example/c2/include/diplomat_runtime.h
+++ b/example/c2/include/diplomat_runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/example/c2/include/diplomat_runtime.h
+++ b/example/c2/include/diplomat_runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/example/cpp/include/diplomat_runtime.h
+++ b/example/cpp/include/diplomat_runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/example/cpp/include/diplomat_runtime.h
+++ b/example/cpp/include/diplomat_runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -37,7 +37,7 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // to be written to past their len; you resize *first*
   w.cap = string.length();
   // Will never become true, as Grow is infallible.
-  w.is_err = false;
+  w.grow_failed = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -36,6 +36,8 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // Same as length, since C++ strings are not supposed
   // to be written to past their len; you resize *first*
   w.cap = string.length();
+  // Will never become true, as Grow is infallible.
+  w.is_err = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/example/cpp2/include/diplomat_runtime.h
+++ b/example/cpp2/include/diplomat_runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/example/cpp2/include/diplomat_runtime.h
+++ b/example/cpp2/include/diplomat_runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/example/cpp2/include/diplomat_runtime.hpp
+++ b/example/cpp2/include/diplomat_runtime.hpp
@@ -37,7 +37,7 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // to be written to past their len; you resize *first*
   w.cap = string.length();
   // Will never become true, as Grow is infallible.
-  w.is_err = false;
+  w.grow_failed = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/example/cpp2/include/diplomat_runtime.hpp
+++ b/example/cpp2/include/diplomat_runtime.hpp
@@ -36,6 +36,8 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // Same as length, since C++ strings are not supposed
   // to be written to past their len; you resize *first*
   w.cap = string.length();
+  // Will never become true, as Grow is infallible.
+  w.is_err = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/example/dart/lib/src/lib.g.dart
+++ b/example/dart/lib/src/lib.g.dart
@@ -500,9 +500,15 @@ final class _Writeable {
   _Writeable() : _ffi = _diplomat_buffer_writeable_create(0);
   
   String finalize() {
-    final string = Utf8Decoder().convert(_diplomat_buffer_writeable_get_bytes(_ffi).asTypedList(_diplomat_buffer_writeable_len(_ffi)));
-    _diplomat_buffer_writeable_destroy(_ffi);
-    return string;
+    try {
+      final buf = _diplomat_buffer_writeable_get_bytes(_ffi);
+      if (buf == ffi.Pointer.fromAddress(0)) {
+        throw core.OutOfMemoryError();
+      }
+      return Utf8Decoder().convert(buf.asTypedList(_diplomat_buffer_writeable_len(_ffi)));
+    } finally {
+      _diplomat_buffer_writeable_destroy(_ffi);
+    }
   }
 }
 

--- a/example/js/lib/api/diplomat-runtime.mjs
+++ b/example/js/lib/api/diplomat-runtime.mjs
@@ -13,6 +13,9 @@ export function withWriteable(wasm, callback) {
   try {
     callback(writeable);
     const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
+    if (outStringPtr == null) {
+      throw FFIError("Out of memory");
+    }
     const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
     return readString8(wasm, outStringPtr, outStringLen);
   } finally {

--- a/feature_tests/c/include/diplomat_runtime.h
+++ b/feature_tests/c/include/diplomat_runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/feature_tests/c/include/diplomat_runtime.h
+++ b/feature_tests/c/include/diplomat_runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/feature_tests/c2/include/diplomat_runtime.h
+++ b/feature_tests/c2/include/diplomat_runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/feature_tests/c2/include/diplomat_runtime.h
+++ b/feature_tests/c2/include/diplomat_runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/feature_tests/cpp/include/diplomat_runtime.h
+++ b/feature_tests/cpp/include/diplomat_runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/feature_tests/cpp/include/diplomat_runtime.h
+++ b/feature_tests/cpp/include/diplomat_runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -37,7 +37,7 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // to be written to past their len; you resize *first*
   w.cap = string.length();
   // Will never become true, as Grow is infallible.
-  w.is_err = false;
+  w.grow_failed = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -36,6 +36,8 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // Same as length, since C++ strings are not supposed
   // to be written to past their len; you resize *first*
   w.cap = string.length();
+  // Will never become true, as Grow is infallible.
+  w.is_err = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/feature_tests/cpp2/include/diplomat_runtime.h
+++ b/feature_tests/cpp2/include/diplomat_runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/feature_tests/cpp2/include/diplomat_runtime.h
+++ b/feature_tests/cpp2/include/diplomat_runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/feature_tests/cpp2/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp2/include/diplomat_runtime.hpp
@@ -37,7 +37,7 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // to be written to past their len; you resize *first*
   w.cap = string.length();
   // Will never become true, as Grow is infallible.
-  w.is_err = false;
+  w.grow_failed = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/feature_tests/cpp2/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp2/include/diplomat_runtime.hpp
@@ -36,6 +36,8 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // Same as length, since C++ strings are not supposed
   // to be written to past their len; you resize *first*
   w.cap = string.length();
+  // Will never become true, as Grow is infallible.
+  w.is_err = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -656,9 +656,15 @@ final class _Writeable {
   _Writeable() : _ffi = _diplomat_buffer_writeable_create(0);
   
   String finalize() {
-    final string = Utf8Decoder().convert(_diplomat_buffer_writeable_get_bytes(_ffi).asTypedList(_diplomat_buffer_writeable_len(_ffi)));
-    _diplomat_buffer_writeable_destroy(_ffi);
-    return string;
+    try {
+      final buf = _diplomat_buffer_writeable_get_bytes(_ffi);
+      if (buf == ffi.Pointer.fromAddress(0)) {
+        throw core.OutOfMemoryError();
+      }
+      return Utf8Decoder().convert(buf.asTypedList(_diplomat_buffer_writeable_len(_ffi)));
+    } finally {
+      _diplomat_buffer_writeable_destroy(_ffi);
+    }
   }
 }
 

--- a/feature_tests/js/api/diplomat-runtime.mjs
+++ b/feature_tests/js/api/diplomat-runtime.mjs
@@ -13,6 +13,9 @@ export function withWriteable(wasm, callback) {
   try {
     callback(writeable);
     const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
+    if (outStringPtr == null) {
+      throw FFIError("Out of memory");
+    }
     const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
     return readString8(wasm, outStringPtr, outStringLen);
   } finally {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
@@ -156,9 +156,7 @@ class Float64Vec internal constructor (
         val writeable = DW.lib.diplomat_buffer_writeable_create(0)
         val returnVal = lib.Float64Vec_to_string(handle, writeable);
     
-        val returnString = DW.writeableToString(writeable)
-        DW.lib.diplomat_buffer_writeable_destroy(writeable)
-        return returnString
+        return DW.writeableToString(writeable)
     }
     fun borrow(): DoubleArray {
         

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -24,10 +24,17 @@ object DW {
     val lib: DiplomatWriteableLib = Native.load("somelib", libClass)
 
     fun writeableToString (writeable: Pointer): String {
-        val pointer = lib.diplomat_buffer_writeable_get_bytes(writeable)
-        val len = lib.diplomat_buffer_writeable_len(writeable)
-        val bytes = pointer.getByteArray(0, len.toInt())
-        return bytes.decodeToString()
+        try {
+            val pointer = lib.diplomat_buffer_writeable_get_bytes(writeable)
+            if (bytes == null) {
+                throw OutOfMemoryError();
+            }
+            val len = lib.diplomat_buffer_writeable_len(writeable)
+            val bytes = pointer.getByteArray(0, len.toInt())
+            return bytes.decodeToString();
+        } finally {
+            lib.diplomat_buffer_writeable_destroy(writeable);
+        }
     }
 }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
@@ -93,9 +93,7 @@ class MyString internal constructor (
         val writeable = DW.lib.diplomat_buffer_writeable_create(0)
         val returnVal = lib.MyString_get_str(handle, writeable);
     
-        val returnString = DW.writeableToString(writeable)
-        DW.lib.diplomat_buffer_writeable_destroy(writeable)
-        return returnString
+        return DW.writeableToString(writeable)
     }
     fun getBoxedStr(): String {
         

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -33,8 +33,7 @@ mod ffi {
 
         #[diplomat::attr(supports = accessors, getter = "str")]
         pub fn get_str(&self, writeable: &mut DiplomatWriteable) {
-            let _ = write!(writeable, "{}", self.0);
-            writeable.flush();
+            let _infallible = write!(writeable, "{}", self.0);
         }
 
         #[diplomat::skip_if_ast]
@@ -113,7 +112,7 @@ mod ffi {
 
         #[diplomat::attr(supports = stringifiers, stringifier)]
         pub fn to_string(&self, w: &mut DiplomatWriteable) {
-            write!(w, "{:?}", self.0).unwrap();
+            let _infallible = write!(w, "{:?}", self.0);
         }
 
         #[allow(clippy::needless_lifetimes)]

--- a/tool/src/c/runtime.h
+++ b/tool/src/c/runtime.h
@@ -29,6 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
+    bool is_err;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/tool/src/c/runtime.h
+++ b/tool/src/c/runtime.h
@@ -29,7 +29,7 @@ typedef struct DiplomatWriteable {
     char* buf;
     size_t len;
     size_t cap;
-    bool is_err;
+    bool grow_failed;
     void (*flush)(struct DiplomatWriteable*);
     bool (*grow)(struct DiplomatWriteable*, size_t);
 } DiplomatWriteable;

--- a/tool/src/cpp/runtime.hpp
+++ b/tool/src/cpp/runtime.hpp
@@ -37,7 +37,7 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // to be written to past their len; you resize *first*
   w.cap = string.length();
   // Will never become true, as Grow is infallible.
-  w.is_err = false;
+  w.grow_failed = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/tool/src/cpp/runtime.hpp
+++ b/tool/src/cpp/runtime.hpp
@@ -36,6 +36,8 @@ inline capi::DiplomatWriteable WriteableFromString(std::string& string) {
   // Same as length, since C++ strings are not supposed
   // to be written to past their len; you resize *first*
   w.cap = string.length();
+  // Will never become true, as Grow is infallible.
+  w.is_err = false;
   w.flush = Flush;
   w.grow = Grow;
   return w;

--- a/tool/src/js/runtime.mjs
+++ b/tool/src/js/runtime.mjs
@@ -13,6 +13,9 @@ export function withWriteable(wasm, callback) {
   try {
     callback(writeable);
     const outStringPtr = wasm.diplomat_buffer_writeable_get_bytes(writeable);
+    if (outStringPtr == null) {
+      throw FFIError("Out of memory");
+    }
     const outStringLen = wasm.diplomat_buffer_writeable_len(writeable);
     return readString8(wasm, outStringPtr, outStringLen);
   } finally {

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -309,10 +309,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             .expect("Failed to render opaque return block")
     }
 
-    const WRITEABLE_RETURN: &'static str = r#"
-val returnString = DW.writeableToString(writeable)
-DW.lib.diplomat_buffer_writeable_destroy(writeable)
-return returnString"#;
+    const WRITEABLE_RETURN: &'static str = "\nreturn DW.writeableToString(writeable)";
 
     fn boxed_slice_return(encoding: &str) -> String {
         format!(

--- a/tool/templates/dart/writeable.dart
+++ b/tool/templates/dart/writeable.dart
@@ -4,9 +4,15 @@ final class _Writeable {
   _Writeable() : _ffi = _diplomat_buffer_writeable_create(0);
   
   String finalize() {
-    final string = Utf8Decoder().convert(_diplomat_buffer_writeable_get_bytes(_ffi).asTypedList(_diplomat_buffer_writeable_len(_ffi)));
-    _diplomat_buffer_writeable_destroy(_ffi);
-    return string;
+    try {
+      final buf = _diplomat_buffer_writeable_get_bytes(_ffi);
+      if (buf == ffi.Pointer.fromAddress(0)) {
+        throw core.OutOfMemoryError();
+      }
+      return Utf8Decoder().convert(buf.asTypedList(_diplomat_buffer_writeable_len(_ffi)));
+    } finally {
+      _diplomat_buffer_writeable_destroy(_ffi);
+    }
   }
 }
 

--- a/tool/templates/kotlin/WriteableReturn.kt.jinja
+++ b/tool/templates/kotlin/WriteableReturn.kt.jinja
@@ -1,6 +1,4 @@
     val writeable = DW.lib.diplomat_buffer_writeable_create(0)
     {{method}}
-    val returnString = DW.writeableToString(writeable)
-    writeable = DW.lib.diplomat_buffer_writeable_destroy(writeable)
-    return returnString
+    return DW.writeableToString(writeable)
 

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -24,10 +24,17 @@ object DW {
     val lib: DiplomatWriteableLib = Native.load("{{lib_name}}", libClass)
 
     fun writeableToString (writeable: Pointer): String {
-        val pointer = lib.diplomat_buffer_writeable_get_bytes(writeable)
-        val len = lib.diplomat_buffer_writeable_len(writeable)
-        val bytes = pointer.getByteArray(0, len.toInt())
-        return bytes.decodeToString()
+        try {
+            val pointer = lib.diplomat_buffer_writeable_get_bytes(writeable)
+            if (bytes == null) {
+                throw OutOfMemoryError();
+            }
+            val len = lib.diplomat_buffer_writeable_len(writeable)
+            val bytes = pointer.getByteArray(0, len.toInt())
+            return bytes.decodeToString();
+        } finally {
+            lib.diplomat_buffer_writeable_destroy(writeable);
+        }
     }
 }
 


### PR DESCRIPTION
Instead, added an `is_err` boolean on the writeable itself. FFI can then check this before converting into their string type, and raise an error if they want (Dart, Kotlin, JS). C++ doesn't need to do this, as its `grow` method is infallible (it throws a `bad_alloc` exception itself). This does mean there is no early exit, but we don't need to be optimal in the presence of an allocation failure.

#475