### PR TITLE
Move CI to g++-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       run: CXX=clang++-14 cargo make test-cpp
 
     - name: GCC tests for cpp backend
-      run: CXX=g++-13 cargo make test-cpp2
+      run: CXX=g++ cargo make test-cpp2
   test-wasm:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
should fix failures due to uninstalled g++-13. GitHub probably updated their defaults, we pin so that we can notice changes not because we actually care about the version that much.