### PR TITLE
Improve CPP2 enum ergonomics, fix some HIR code

### DIFF
--- a/example/c/include/diplomat_runtime.h
+++ b/example/c/include/diplomat_runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/example/c2/include/diplomat_runtime.h
+++ b/example/c2/include/diplomat_runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/example/cpp/include/diplomat_runtime.h
+++ b/example/cpp/include/diplomat_runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
@@ -12,8 +12,6 @@
 
 
 class ICU4XFixedDecimalGroupingStrategy {
-  capi::ICU4XFixedDecimalGroupingStrategy value;
-
 public:
   enum Value {
     Auto,
@@ -22,11 +20,17 @@ public:
     Min2,
   };
 
-  inline ICU4XFixedDecimalGroupingStrategy(ICU4XFixedDecimalGroupingStrategy::Value cpp_value);
-  inline ICU4XFixedDecimalGroupingStrategy(capi::ICU4XFixedDecimalGroupingStrategy c_enum) : value(c_enum) {};
+  ICU4XFixedDecimalGroupingStrategy() = default;
+  // Implicit conversions between enum and ::Value
+  constexpr ICU4XFixedDecimalGroupingStrategy(Value v) : value(v) {}
+  constexpr operator Value() const { return value; }
+  // Prevent usage as boolean value
+  explicit operator bool() const = delete;
 
   inline capi::ICU4XFixedDecimalGroupingStrategy AsFFI() const;
   inline static ICU4XFixedDecimalGroupingStrategy FromFFI(capi::ICU4XFixedDecimalGroupingStrategy c_enum);
+private:
+    Value value;
 };
 
 

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
@@ -14,10 +14,10 @@
 class ICU4XFixedDecimalGroupingStrategy {
 public:
   enum Value {
-    Auto,
-    Never,
-    Always,
-    Min2,
+    Auto = 0,
+    Never = 1,
+    Always = 2,
+    Min2 = 3,
   };
 
   ICU4XFixedDecimalGroupingStrategy() = default;

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.hpp
@@ -14,30 +14,16 @@
 
 
 inline capi::ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::AsFFI() const {
-  switch (value) {
-    case Auto:
-      return capi::ICU4XFixedDecimalGroupingStrategy_Auto;
-    case Never:
-      return capi::ICU4XFixedDecimalGroupingStrategy_Never;
-    case Always:
-      return capi::ICU4XFixedDecimalGroupingStrategy_Always;
-    case Min2:
-      return capi::ICU4XFixedDecimalGroupingStrategy_Min2;
-    default:
-      abort();
-  }
+  return static_cast<capi::ICU4XFixedDecimalGroupingStrategy>(value);
 }
 
 inline ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::FromFFI(capi::ICU4XFixedDecimalGroupingStrategy c_enum) {
-    switch (c_enum) {
+  switch (c_enum) {
     case capi::ICU4XFixedDecimalGroupingStrategy_Auto:
-      return ICU4XFixedDecimalGroupingStrategy::Value::Auto;
     case capi::ICU4XFixedDecimalGroupingStrategy_Never:
-      return ICU4XFixedDecimalGroupingStrategy::Value::Never;
     case capi::ICU4XFixedDecimalGroupingStrategy_Always:
-      return ICU4XFixedDecimalGroupingStrategy::Value::Always;
     case capi::ICU4XFixedDecimalGroupingStrategy_Min2:
-      return ICU4XFixedDecimalGroupingStrategy::Value::Min2;
+      return static_cast<ICU4XFixedDecimalGroupingStrategy::Value>(c_enum);
     default:
       abort();
   }

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.hpp
@@ -13,31 +13,33 @@
 #include "ICU4XFixedDecimalGroupingStrategy.h"
 
 
-inline ICU4XFixedDecimalGroupingStrategy::ICU4XFixedDecimalGroupingStrategy(ICU4XFixedDecimalGroupingStrategy::Value cpp_value) {
-  switch (cpp_value) {
+inline capi::ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::AsFFI() const {
+  switch (value) {
     case Auto:
-      value = capi::ICU4XFixedDecimalGroupingStrategy_Auto;
-      break;
+      return capi::ICU4XFixedDecimalGroupingStrategy_Auto;
     case Never:
-      value = capi::ICU4XFixedDecimalGroupingStrategy_Never;
-      break;
+      return capi::ICU4XFixedDecimalGroupingStrategy_Never;
     case Always:
-      value = capi::ICU4XFixedDecimalGroupingStrategy_Always;
-      break;
+      return capi::ICU4XFixedDecimalGroupingStrategy_Always;
     case Min2:
-      value = capi::ICU4XFixedDecimalGroupingStrategy_Min2;
-      break;
+      return capi::ICU4XFixedDecimalGroupingStrategy_Min2;
     default:
       abort();
   }
 }
 
-inline capi::ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::AsFFI() const {
-  return value;
-}
-
 inline ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::FromFFI(capi::ICU4XFixedDecimalGroupingStrategy c_enum) {
-  return ICU4XFixedDecimalGroupingStrategy(c_enum);
+    switch (c_enum) {
+    case capi::ICU4XFixedDecimalGroupingStrategy_Auto:
+      return ICU4XFixedDecimalGroupingStrategy::Value::Auto;
+    case capi::ICU4XFixedDecimalGroupingStrategy_Never:
+      return ICU4XFixedDecimalGroupingStrategy::Value::Never;
+    case capi::ICU4XFixedDecimalGroupingStrategy_Always:
+      return ICU4XFixedDecimalGroupingStrategy::Value::Always;
+    case capi::ICU4XFixedDecimalGroupingStrategy_Min2:
+      return ICU4XFixedDecimalGroupingStrategy::Value::Min2;
+    default:
+      abort();
+  }
 }
-
 #endif // ICU4XFixedDecimalGroupingStrategy_HPP

--- a/example/cpp2/include/diplomat_runtime.h
+++ b/example/cpp2/include/diplomat_runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/feature_tests/c/include/diplomat_runtime.h
+++ b/feature_tests/c/include/diplomat_runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/feature_tests/c2/include/BorrowedFields.d.h
+++ b/feature_tests/c2/include/BorrowedFields.d.h
@@ -14,9 +14,9 @@ extern "C" {
 
 
 typedef struct BorrowedFields {
-  struct { const char16_t* data; size_t len; } a;
-  struct { const char* data; size_t len; } b;
-  struct { const char* data; size_t len; } c;
+  DiplomatString16View a;
+  DiplomatStringView b;
+  DiplomatStringView c;
 } BorrowedFields;
 
 

--- a/feature_tests/c2/include/BorrowedFieldsReturning.d.h
+++ b/feature_tests/c2/include/BorrowedFieldsReturning.d.h
@@ -14,7 +14,7 @@ extern "C" {
 
 
 typedef struct BorrowedFieldsReturning {
-  struct { const char* data; size_t len; } bytes;
+  DiplomatStringView bytes;
 } BorrowedFieldsReturning;
 
 

--- a/feature_tests/c2/include/BorrowedFieldsWithBounds.d.h
+++ b/feature_tests/c2/include/BorrowedFieldsWithBounds.d.h
@@ -14,9 +14,9 @@ extern "C" {
 
 
 typedef struct BorrowedFieldsWithBounds {
-  struct { const char16_t* data; size_t len; } field_a;
-  struct { const char* data; size_t len; } field_b;
-  struct { const char* data; size_t len; } field_c;
+  DiplomatString16View field_a;
+  DiplomatStringView field_b;
+  DiplomatStringView field_c;
 } BorrowedFieldsWithBounds;
 
 

--- a/feature_tests/c2/include/Float64Vec.h
+++ b/feature_tests/c2/include/Float64Vec.h
@@ -30,9 +30,9 @@ Float64Vec* Float64Vec_new_usize(const size_t* v_data, size_t v_len);
 
 Float64Vec* Float64Vec_new_f64_be_bytes(const uint8_t* v_data, size_t v_len);
 
-struct { const double* data; size_t len; } Float64Vec_as_boxed_slice(const Float64Vec* self);
+DiplomatF64View Float64Vec_as_boxed_slice(const Float64Vec* self);
 
-struct { const double* data; size_t len; } Float64Vec_as_slice(const Float64Vec* self);
+DiplomatF64View Float64Vec_as_slice(const Float64Vec* self);
 
 void Float64Vec_fill_slice(const Float64Vec* self, double* v_data, size_t v_len);
 
@@ -40,7 +40,7 @@ void Float64Vec_set_value(Float64Vec* self, const double* new_slice_data, size_t
 
 void Float64Vec_to_string(const Float64Vec* self, DiplomatWrite* write);
 
-struct { const double* data; size_t len; } Float64Vec_borrow(const Float64Vec* self);
+DiplomatF64View Float64Vec_borrow(const Float64Vec* self);
 
 diplomat_result_double_void Float64Vec_get(const Float64Vec* self, size_t i);
 

--- a/feature_tests/c2/include/MyString.h
+++ b/feature_tests/c2/include/MyString.h
@@ -21,13 +21,13 @@ MyString* MyString_new_unsafe(const char* v_data, size_t v_len);
 
 MyString* MyString_new_owned(const char* v_data, size_t v_len);
 
-MyString* MyString_new_from_first(DiplomatStrs8View* v_data, size_t v_len);
+MyString* MyString_new_from_first(DiplomatStringsView* v_data, size_t v_len);
 
 void MyString_set_str(MyString* self, const char* new_str_data, size_t new_str_len);
 
 void MyString_get_str(const MyString* self, DiplomatWrite* write);
 
-struct { const char* data; size_t len; } MyString_get_boxed_str(const MyString* self);
+DiplomatStringView MyString_get_boxed_str(const MyString* self);
 
 void MyString_destroy(MyString* self);
 

--- a/feature_tests/c2/include/OpaqueMutexedString.h
+++ b/feature_tests/c2/include/OpaqueMutexedString.h
@@ -29,7 +29,7 @@ const OpaqueMutexedString* OpaqueMutexedString_borrow_self_or_other(const Opaque
 
 size_t OpaqueMutexedString_get_len_and_add(const OpaqueMutexedString* self, size_t other);
 
-struct { const char* data; size_t len; } OpaqueMutexedString_dummy_str(const OpaqueMutexedString* self);
+DiplomatStringView OpaqueMutexedString_dummy_str(const OpaqueMutexedString* self);
 
 Utf16Wrap* OpaqueMutexedString_wrapper(const OpaqueMutexedString* self);
 

--- a/feature_tests/c2/include/Utf16Wrap.h
+++ b/feature_tests/c2/include/Utf16Wrap.h
@@ -15,9 +15,9 @@ extern "C" {
 #endif // __cplusplus
 
 
-struct { const char16_t* data; size_t len; } Utf16Wrap_borrow_cont(const Utf16Wrap* self);
+DiplomatString16View Utf16Wrap_borrow_cont(const Utf16Wrap* self);
 
-struct { const char16_t* data; size_t len; } Utf16Wrap_owned(const Utf16Wrap* self);
+DiplomatString16View Utf16Wrap_owned(const Utf16Wrap* self);
 
 void Utf16Wrap_destroy(Utf16Wrap* self);
 

--- a/feature_tests/c2/include/diplomat_runtime.h
+++ b/feature_tests/c2/include/diplomat_runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/feature_tests/cpp/include/BorrowedFields.hpp
+++ b/feature_tests/cpp/include/BorrowedFields.hpp
@@ -33,7 +33,7 @@ struct BorrowedFields {
 
 inline BorrowedFields BorrowedFields::from_bar_and_strings(const Bar& bar, const std::u16string_view dstr16, const std::string_view utf8_str) {
   capi::BorrowedFields diplomat_raw_struct_out_value = capi::BorrowedFields_from_bar_and_strings(bar.AsFFI(), dstr16.data(), dstr16.size(), utf8_str.data(), utf8_str.size());
-  capi::DiplomatU16StringView diplomat_slice_raw_out_value_a = diplomat_raw_struct_out_value.a;
+  capi::DiplomatString16View diplomat_slice_raw_out_value_a = diplomat_raw_struct_out_value.a;
   diplomat::span<const char16_t> slice(diplomat_slice_raw_out_value_a.data, diplomat_slice_raw_out_value_a.len);
   capi::DiplomatStringView diplomat_str_raw_out_value_b = diplomat_raw_struct_out_value.b;
   std::string_view str(diplomat_str_raw_out_value_b.data, diplomat_str_raw_out_value_b.len);

--- a/feature_tests/cpp/include/BorrowedFieldsWithBounds.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsWithBounds.hpp
@@ -33,7 +33,7 @@ struct BorrowedFieldsWithBounds {
 
 inline BorrowedFieldsWithBounds BorrowedFieldsWithBounds::from_foo_and_strings(const Foo& foo, const std::u16string_view dstr16_x, const std::string_view utf8_str_z) {
   capi::BorrowedFieldsWithBounds diplomat_raw_struct_out_value = capi::BorrowedFieldsWithBounds_from_foo_and_strings(foo.AsFFI(), dstr16_x.data(), dstr16_x.size(), utf8_str_z.data(), utf8_str_z.size());
-  capi::DiplomatU16StringView diplomat_slice_raw_out_value_field_a = diplomat_raw_struct_out_value.field_a;
+  capi::DiplomatString16View diplomat_slice_raw_out_value_field_a = diplomat_raw_struct_out_value.field_a;
   diplomat::span<const char16_t> slice(diplomat_slice_raw_out_value_field_a.data, diplomat_slice_raw_out_value_field_a.len);
   capi::DiplomatStringView diplomat_str_raw_out_value_field_b = diplomat_raw_struct_out_value.field_b;
   std::string_view str(diplomat_str_raw_out_value_field_b.data, diplomat_str_raw_out_value_field_b.len);

--- a/feature_tests/cpp/include/NestedBorrowedFields.hpp
+++ b/feature_tests/cpp/include/NestedBorrowedFields.hpp
@@ -38,21 +38,21 @@ struct NestedBorrowedFields {
 inline NestedBorrowedFields NestedBorrowedFields::from_bar_and_foo_and_strings(const Bar& bar, const Foo& foo, const std::u16string_view dstr16_x, const std::u16string_view dstr16_z, const std::string_view utf8_str_y, const std::string_view utf8_str_z) {
   capi::NestedBorrowedFields diplomat_raw_struct_out_value = capi::NestedBorrowedFields_from_bar_and_foo_and_strings(bar.AsFFI(), foo.AsFFI(), dstr16_x.data(), dstr16_x.size(), dstr16_z.data(), dstr16_z.size(), utf8_str_y.data(), utf8_str_y.size(), utf8_str_z.data(), utf8_str_z.size());
   capi::BorrowedFields diplomat_raw_struct_out_value_fields = diplomat_raw_struct_out_value.fields;
-  capi::DiplomatU16StringView diplomat_slice_raw_out_value_fields_a = diplomat_raw_struct_out_value_fields.a;
+  capi::DiplomatString16View diplomat_slice_raw_out_value_fields_a = diplomat_raw_struct_out_value_fields.a;
   diplomat::span<const char16_t> slice(diplomat_slice_raw_out_value_fields_a.data, diplomat_slice_raw_out_value_fields_a.len);
   capi::DiplomatStringView diplomat_str_raw_out_value_fields_b = diplomat_raw_struct_out_value_fields.b;
   std::string_view str(diplomat_str_raw_out_value_fields_b.data, diplomat_str_raw_out_value_fields_b.len);
   capi::DiplomatStringView diplomat_str_raw_out_value_fields_c = diplomat_raw_struct_out_value_fields.c;
   std::string_view str(diplomat_str_raw_out_value_fields_c.data, diplomat_str_raw_out_value_fields_c.len);
   capi::BorrowedFieldsWithBounds diplomat_raw_struct_out_value_bounds = diplomat_raw_struct_out_value.bounds;
-  capi::DiplomatU16StringView diplomat_slice_raw_out_value_bounds_field_a = diplomat_raw_struct_out_value_bounds.field_a;
+  capi::DiplomatString16View diplomat_slice_raw_out_value_bounds_field_a = diplomat_raw_struct_out_value_bounds.field_a;
   diplomat::span<const char16_t> slice(diplomat_slice_raw_out_value_bounds_field_a.data, diplomat_slice_raw_out_value_bounds_field_a.len);
   capi::DiplomatStringView diplomat_str_raw_out_value_bounds_field_b = diplomat_raw_struct_out_value_bounds.field_b;
   std::string_view str(diplomat_str_raw_out_value_bounds_field_b.data, diplomat_str_raw_out_value_bounds_field_b.len);
   capi::DiplomatStringView diplomat_str_raw_out_value_bounds_field_c = diplomat_raw_struct_out_value_bounds.field_c;
   std::string_view str(diplomat_str_raw_out_value_bounds_field_c.data, diplomat_str_raw_out_value_bounds_field_c.len);
   capi::BorrowedFieldsWithBounds diplomat_raw_struct_out_value_bounds2 = diplomat_raw_struct_out_value.bounds2;
-  capi::DiplomatU16StringView diplomat_slice_raw_out_value_bounds2_field_a = diplomat_raw_struct_out_value_bounds2.field_a;
+  capi::DiplomatString16View diplomat_slice_raw_out_value_bounds2_field_a = diplomat_raw_struct_out_value_bounds2.field_a;
   diplomat::span<const char16_t> slice(diplomat_slice_raw_out_value_bounds2_field_a.data, diplomat_slice_raw_out_value_bounds2_field_a.len);
   capi::DiplomatStringView diplomat_str_raw_out_value_bounds2_field_b = diplomat_raw_struct_out_value_bounds2.field_b;
   std::string_view str(diplomat_str_raw_out_value_bounds2_field_b.data, diplomat_str_raw_out_value_bounds2_field_b.len);

--- a/feature_tests/cpp/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.hpp
@@ -40,12 +40,12 @@ class Utf16Wrap {
 
 
 inline const std::u16string_view Utf16Wrap::borrow_cont() const {
-  capi::DiplomatU16StringView diplomat_slice_raw_out_value = capi::Utf16Wrap_borrow_cont(this->inner.get());
+  capi::DiplomatString16View diplomat_slice_raw_out_value = capi::Utf16Wrap_borrow_cont(this->inner.get());
   diplomat::span<const char16_t> slice(diplomat_slice_raw_out_value.data, diplomat_slice_raw_out_value.len);
   return slice;
 }
 inline const std::u16string_view Utf16Wrap::owned() const {
-  capi::DiplomatU16StringView diplomat_slice_raw_out_value = capi::Utf16Wrap_owned(this->inner.get());
+  capi::DiplomatString16View diplomat_slice_raw_out_value = capi::Utf16Wrap_owned(this->inner.get());
   diplomat::span<const char16_t> slice(diplomat_slice_raw_out_value.data, diplomat_slice_raw_out_value.len);
   return slice;
 }

--- a/feature_tests/cpp/include/diplomat_runtime.h
+++ b/feature_tests/cpp/include/diplomat_runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/feature_tests/cpp2/include/BorrowedFields.d.h
+++ b/feature_tests/cpp2/include/BorrowedFields.d.h
@@ -14,9 +14,9 @@ extern "C" {
 
 
 typedef struct BorrowedFields {
-  struct { const char16_t* data; size_t len; } a;
-  struct { const char* data; size_t len; } b;
-  struct { const char* data; size_t len; } c;
+  DiplomatString16View a;
+  DiplomatStringView b;
+  DiplomatStringView c;
 } BorrowedFields;
 
 

--- a/feature_tests/cpp2/include/BorrowedFields.hpp
+++ b/feature_tests/cpp2/include/BorrowedFields.hpp
@@ -15,34 +15,31 @@
 
 
 inline diplomat::result<BorrowedFields, diplomat::Utf8Error> BorrowedFields::from_bar_and_strings(const Bar& bar, std::u16string_view dstr16, std::string_view utf8_str) {
-  if (!capi::diplomat_is_str(utf8_str.data(), utf8_str.size()) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error)
+  if (!capi::diplomat_is_str(utf8_str.data(), utf8_str.size())) {
+    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
   }
   auto result = capi::BorrowedFields_from_bar_and_strings(bar.AsFFI(),
     dstr16.data(),
     dstr16.size(),
     utf8_str.data(),
     utf8_str.size());
-  return diplomat::Ok<BorrowedFields>(BorrowedFields::FromFFI(result));
+  return diplomat::Ok<BorrowedFields>(std::move(BorrowedFields::FromFFI(result)));
 }
 
 
 inline capi::BorrowedFields BorrowedFields::AsFFI() const {
   return capi::BorrowedFields {
-    .a_data = a.data(),
-    .a_size = a.size(),
-    .b_data = b.data(),
-    .b_size = b.size(),
-    .c_data = c.data(),
-    .c_size = c.size(),
+    .a = { .data = a.data(), .len = a.size() },
+    .b = { .data = b.data(), .len = b.size() },
+    .c = { .data = c.data(), .len = c.size() },
   };
 }
 
 inline BorrowedFields BorrowedFields::FromFFI(capi::BorrowedFields c_struct) {
   return BorrowedFields {
-    .a = std::u16string_view(c_struct.a_data, c_struct.a_size),
-    .b = std::string_view(c_struct.b_data, c_struct.b_size),
-    .c = std::string_view(c_struct.c_data, c_struct.c_size),
+    .a = std::u16string_view(c_struct.a.data, c_struct.a.len),
+    .b = std::string_view(c_struct.b.data, c_struct.b.len),
+    .c = std::string_view(c_struct.c.data, c_struct.c.len),
   };
 }
 

--- a/feature_tests/cpp2/include/BorrowedFieldsReturning.d.h
+++ b/feature_tests/cpp2/include/BorrowedFieldsReturning.d.h
@@ -14,7 +14,7 @@ extern "C" {
 
 
 typedef struct BorrowedFieldsReturning {
-  struct { const char* data; size_t len; } bytes;
+  DiplomatStringView bytes;
 } BorrowedFieldsReturning;
 
 

--- a/feature_tests/cpp2/include/BorrowedFieldsReturning.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsReturning.hpp
@@ -16,14 +16,13 @@
 
 inline capi::BorrowedFieldsReturning BorrowedFieldsReturning::AsFFI() const {
   return capi::BorrowedFieldsReturning {
-    .bytes_data = bytes.data(),
-    .bytes_size = bytes.size(),
+    .bytes = { .data = bytes.data(), .len = bytes.size() },
   };
 }
 
 inline BorrowedFieldsReturning BorrowedFieldsReturning::FromFFI(capi::BorrowedFieldsReturning c_struct) {
   return BorrowedFieldsReturning {
-    .bytes = std::string_view(c_struct.bytes_data, c_struct.bytes_size),
+    .bytes = std::string_view(c_struct.bytes.data, c_struct.bytes.len),
   };
 }
 

--- a/feature_tests/cpp2/include/BorrowedFieldsWithBounds.d.h
+++ b/feature_tests/cpp2/include/BorrowedFieldsWithBounds.d.h
@@ -14,9 +14,9 @@ extern "C" {
 
 
 typedef struct BorrowedFieldsWithBounds {
-  struct { const char16_t* data; size_t len; } field_a;
-  struct { const char* data; size_t len; } field_b;
-  struct { const char* data; size_t len; } field_c;
+  DiplomatString16View field_a;
+  DiplomatStringView field_b;
+  DiplomatStringView field_c;
 } BorrowedFieldsWithBounds;
 
 

--- a/feature_tests/cpp2/include/BorrowedFieldsWithBounds.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsWithBounds.hpp
@@ -15,34 +15,31 @@
 
 
 inline diplomat::result<BorrowedFieldsWithBounds, diplomat::Utf8Error> BorrowedFieldsWithBounds::from_foo_and_strings(const Foo& foo, std::u16string_view dstr16_x, std::string_view utf8_str_z) {
-  if (!capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size()) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error)
+  if (!capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size())) {
+    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
   }
   auto result = capi::BorrowedFieldsWithBounds_from_foo_and_strings(foo.AsFFI(),
     dstr16_x.data(),
     dstr16_x.size(),
     utf8_str_z.data(),
     utf8_str_z.size());
-  return diplomat::Ok<BorrowedFieldsWithBounds>(BorrowedFieldsWithBounds::FromFFI(result));
+  return diplomat::Ok<BorrowedFieldsWithBounds>(std::move(BorrowedFieldsWithBounds::FromFFI(result)));
 }
 
 
 inline capi::BorrowedFieldsWithBounds BorrowedFieldsWithBounds::AsFFI() const {
   return capi::BorrowedFieldsWithBounds {
-    .field_a_data = field_a.data(),
-    .field_a_size = field_a.size(),
-    .field_b_data = field_b.data(),
-    .field_b_size = field_b.size(),
-    .field_c_data = field_c.data(),
-    .field_c_size = field_c.size(),
+    .field_a = { .data = field_a.data(), .len = field_a.size() },
+    .field_b = { .data = field_b.data(), .len = field_b.size() },
+    .field_c = { .data = field_c.data(), .len = field_c.size() },
   };
 }
 
 inline BorrowedFieldsWithBounds BorrowedFieldsWithBounds::FromFFI(capi::BorrowedFieldsWithBounds c_struct) {
   return BorrowedFieldsWithBounds {
-    .field_a = std::u16string_view(c_struct.field_a_data, c_struct.field_a_size),
-    .field_b = std::string_view(c_struct.field_b_data, c_struct.field_b_size),
-    .field_c = std::string_view(c_struct.field_c_data, c_struct.field_c_size),
+    .field_a = std::u16string_view(c_struct.field_a.data, c_struct.field_a.len),
+    .field_b = std::string_view(c_struct.field_b.data, c_struct.field_b.len),
+    .field_c = std::string_view(c_struct.field_c.data, c_struct.field_c.len),
   };
 }
 

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
@@ -15,9 +15,9 @@ namespace ns {
 class CPPRenamedAttrEnum {
 public:
   enum Value {
-    A,
-    B,
-    CPPRenamed,
+    A = 0,
+    B = 1,
+    CPPRenamed = 2,
   };
 
   CPPRenamedAttrEnum() = default;

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
@@ -13,8 +13,6 @@
 
 namespace ns {
 class CPPRenamedAttrEnum {
-  capi::AttrEnum value;
-
 public:
   enum Value {
     A,
@@ -22,11 +20,17 @@ public:
     CPPRenamed,
   };
 
-  inline CPPRenamedAttrEnum(ns::CPPRenamedAttrEnum::Value cpp_value);
-  inline CPPRenamedAttrEnum(capi::AttrEnum c_enum) : value(c_enum) {};
+  CPPRenamedAttrEnum() = default;
+  // Implicit conversions between enum and ::Value
+  constexpr CPPRenamedAttrEnum(Value v) : value(v) {}
+  constexpr operator Value() const { return value; }
+  // Prevent usage as boolean value
+  explicit operator bool() const = delete;
 
   inline capi::AttrEnum AsFFI() const;
   inline static ns::CPPRenamedAttrEnum FromFFI(capi::AttrEnum c_enum);
+private:
+    Value value;
 };
 
 }

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.hpp
@@ -14,26 +14,15 @@
 
 
 inline capi::AttrEnum ns::CPPRenamedAttrEnum::AsFFI() const {
-  switch (value) {
-    case A:
-      return capi::AttrEnum_A;
-    case B:
-      return capi::AttrEnum_B;
-    case CPPRenamed:
-      return capi::AttrEnum_C;
-    default:
-      abort();
-  }
+  return static_cast<capi::AttrEnum>(value);
 }
 
 inline ns::CPPRenamedAttrEnum ns::CPPRenamedAttrEnum::FromFFI(capi::AttrEnum c_enum) {
-    switch (c_enum) {
+  switch (c_enum) {
     case capi::AttrEnum_A:
-      return ns::CPPRenamedAttrEnum::Value::A;
     case capi::AttrEnum_B:
-      return ns::CPPRenamedAttrEnum::Value::B;
     case capi::AttrEnum_C:
-      return ns::CPPRenamedAttrEnum::Value::CPPRenamed;
+      return static_cast<ns::CPPRenamedAttrEnum::Value>(c_enum);
     default:
       abort();
   }

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.hpp
@@ -13,28 +13,29 @@
 #include "AttrEnum.h"
 
 
-inline ns::CPPRenamedAttrEnum::CPPRenamedAttrEnum(ns::CPPRenamedAttrEnum::Value cpp_value) {
-  switch (cpp_value) {
+inline capi::AttrEnum ns::CPPRenamedAttrEnum::AsFFI() const {
+  switch (value) {
     case A:
-      value = capi::AttrEnum_A;
-      break;
+      return capi::AttrEnum_A;
     case B:
-      value = capi::AttrEnum_B;
-      break;
+      return capi::AttrEnum_B;
     case CPPRenamed:
-      value = capi::AttrEnum_C;
-      break;
+      return capi::AttrEnum_C;
     default:
       abort();
   }
 }
 
-inline capi::AttrEnum ns::CPPRenamedAttrEnum::AsFFI() const {
-  return value;
-}
-
 inline ns::CPPRenamedAttrEnum ns::CPPRenamedAttrEnum::FromFFI(capi::AttrEnum c_enum) {
-  return ns::CPPRenamedAttrEnum(c_enum);
+    switch (c_enum) {
+    case capi::AttrEnum_A:
+      return ns::CPPRenamedAttrEnum::Value::A;
+    case capi::AttrEnum_B:
+      return ns::CPPRenamedAttrEnum::Value::B;
+    case capi::AttrEnum_C:
+      return ns::CPPRenamedAttrEnum::Value::CPPRenamed;
+    default:
+      abort();
+  }
 }
-
 #endif // CPPRenamedAttrEnum_HPP

--- a/feature_tests/cpp2/include/ContiguousEnum.d.hpp
+++ b/feature_tests/cpp2/include/ContiguousEnum.d.hpp
@@ -14,10 +14,10 @@
 class ContiguousEnum {
 public:
   enum Value {
-    C,
-    D,
-    E,
-    F,
+    C = 0,
+    D = 1,
+    E = 2,
+    F = 3,
   };
 
   ContiguousEnum() = default;

--- a/feature_tests/cpp2/include/ContiguousEnum.d.hpp
+++ b/feature_tests/cpp2/include/ContiguousEnum.d.hpp
@@ -12,8 +12,6 @@
 
 
 class ContiguousEnum {
-  capi::ContiguousEnum value;
-
 public:
   enum Value {
     C,
@@ -22,11 +20,17 @@ public:
     F,
   };
 
-  inline ContiguousEnum(ContiguousEnum::Value cpp_value);
-  inline ContiguousEnum(capi::ContiguousEnum c_enum) : value(c_enum) {};
+  ContiguousEnum() = default;
+  // Implicit conversions between enum and ::Value
+  constexpr ContiguousEnum(Value v) : value(v) {}
+  constexpr operator Value() const { return value; }
+  // Prevent usage as boolean value
+  explicit operator bool() const = delete;
 
   inline capi::ContiguousEnum AsFFI() const;
   inline static ContiguousEnum FromFFI(capi::ContiguousEnum c_enum);
+private:
+    Value value;
 };
 
 

--- a/feature_tests/cpp2/include/ContiguousEnum.hpp
+++ b/feature_tests/cpp2/include/ContiguousEnum.hpp
@@ -13,31 +13,33 @@
 #include "ContiguousEnum.h"
 
 
-inline ContiguousEnum::ContiguousEnum(ContiguousEnum::Value cpp_value) {
-  switch (cpp_value) {
+inline capi::ContiguousEnum ContiguousEnum::AsFFI() const {
+  switch (value) {
     case C:
-      value = capi::ContiguousEnum_C;
-      break;
+      return capi::ContiguousEnum_C;
     case D:
-      value = capi::ContiguousEnum_D;
-      break;
+      return capi::ContiguousEnum_D;
     case E:
-      value = capi::ContiguousEnum_E;
-      break;
+      return capi::ContiguousEnum_E;
     case F:
-      value = capi::ContiguousEnum_F;
-      break;
+      return capi::ContiguousEnum_F;
     default:
       abort();
   }
 }
 
-inline capi::ContiguousEnum ContiguousEnum::AsFFI() const {
-  return value;
-}
-
 inline ContiguousEnum ContiguousEnum::FromFFI(capi::ContiguousEnum c_enum) {
-  return ContiguousEnum(c_enum);
+    switch (c_enum) {
+    case capi::ContiguousEnum_C:
+      return ContiguousEnum::Value::C;
+    case capi::ContiguousEnum_D:
+      return ContiguousEnum::Value::D;
+    case capi::ContiguousEnum_E:
+      return ContiguousEnum::Value::E;
+    case capi::ContiguousEnum_F:
+      return ContiguousEnum::Value::F;
+    default:
+      abort();
+  }
 }
-
 #endif // ContiguousEnum_HPP

--- a/feature_tests/cpp2/include/ContiguousEnum.hpp
+++ b/feature_tests/cpp2/include/ContiguousEnum.hpp
@@ -14,30 +14,16 @@
 
 
 inline capi::ContiguousEnum ContiguousEnum::AsFFI() const {
-  switch (value) {
-    case C:
-      return capi::ContiguousEnum_C;
-    case D:
-      return capi::ContiguousEnum_D;
-    case E:
-      return capi::ContiguousEnum_E;
-    case F:
-      return capi::ContiguousEnum_F;
-    default:
-      abort();
-  }
+  return static_cast<capi::ContiguousEnum>(value);
 }
 
 inline ContiguousEnum ContiguousEnum::FromFFI(capi::ContiguousEnum c_enum) {
-    switch (c_enum) {
+  switch (c_enum) {
     case capi::ContiguousEnum_C:
-      return ContiguousEnum::Value::C;
     case capi::ContiguousEnum_D:
-      return ContiguousEnum::Value::D;
     case capi::ContiguousEnum_E:
-      return ContiguousEnum::Value::E;
     case capi::ContiguousEnum_F:
-      return ContiguousEnum::Value::F;
+      return static_cast<ContiguousEnum::Value>(c_enum);
     default:
       abort();
   }

--- a/feature_tests/cpp2/include/ErrorEnum.d.hpp
+++ b/feature_tests/cpp2/include/ErrorEnum.d.hpp
@@ -14,8 +14,8 @@
 class ErrorEnum {
 public:
   enum Value {
-    Foo,
-    Bar,
+    Foo = 0,
+    Bar = 1,
   };
 
   ErrorEnum() = default;

--- a/feature_tests/cpp2/include/ErrorEnum.d.hpp
+++ b/feature_tests/cpp2/include/ErrorEnum.d.hpp
@@ -12,19 +12,23 @@
 
 
 class ErrorEnum {
-  capi::ErrorEnum value;
-
 public:
   enum Value {
     Foo,
     Bar,
   };
 
-  inline ErrorEnum(ErrorEnum::Value cpp_value);
-  inline ErrorEnum(capi::ErrorEnum c_enum) : value(c_enum) {};
+  ErrorEnum() = default;
+  // Implicit conversions between enum and ::Value
+  constexpr ErrorEnum(Value v) : value(v) {}
+  constexpr operator Value() const { return value; }
+  // Prevent usage as boolean value
+  explicit operator bool() const = delete;
 
   inline capi::ErrorEnum AsFFI() const;
   inline static ErrorEnum FromFFI(capi::ErrorEnum c_enum);
+private:
+    Value value;
 };
 
 

--- a/feature_tests/cpp2/include/ErrorEnum.hpp
+++ b/feature_tests/cpp2/include/ErrorEnum.hpp
@@ -14,22 +14,14 @@
 
 
 inline capi::ErrorEnum ErrorEnum::AsFFI() const {
-  switch (value) {
-    case Foo:
-      return capi::ErrorEnum_Foo;
-    case Bar:
-      return capi::ErrorEnum_Bar;
-    default:
-      abort();
-  }
+  return static_cast<capi::ErrorEnum>(value);
 }
 
 inline ErrorEnum ErrorEnum::FromFFI(capi::ErrorEnum c_enum) {
-    switch (c_enum) {
+  switch (c_enum) {
     case capi::ErrorEnum_Foo:
-      return ErrorEnum::Value::Foo;
     case capi::ErrorEnum_Bar:
-      return ErrorEnum::Value::Bar;
+      return static_cast<ErrorEnum::Value>(c_enum);
     default:
       abort();
   }

--- a/feature_tests/cpp2/include/ErrorEnum.hpp
+++ b/feature_tests/cpp2/include/ErrorEnum.hpp
@@ -13,25 +13,25 @@
 #include "ErrorEnum.h"
 
 
-inline ErrorEnum::ErrorEnum(ErrorEnum::Value cpp_value) {
-  switch (cpp_value) {
+inline capi::ErrorEnum ErrorEnum::AsFFI() const {
+  switch (value) {
     case Foo:
-      value = capi::ErrorEnum_Foo;
-      break;
+      return capi::ErrorEnum_Foo;
     case Bar:
-      value = capi::ErrorEnum_Bar;
-      break;
+      return capi::ErrorEnum_Bar;
     default:
       abort();
   }
 }
 
-inline capi::ErrorEnum ErrorEnum::AsFFI() const {
-  return value;
-}
-
 inline ErrorEnum ErrorEnum::FromFFI(capi::ErrorEnum c_enum) {
-  return ErrorEnum(c_enum);
+    switch (c_enum) {
+    case capi::ErrorEnum_Foo:
+      return ErrorEnum::Value::Foo;
+    case capi::ErrorEnum_Bar:
+      return ErrorEnum::Value::Bar;
+    default:
+      abort();
+  }
 }
-
 #endif // ErrorEnum_HPP

--- a/feature_tests/cpp2/include/Float64Vec.h
+++ b/feature_tests/cpp2/include/Float64Vec.h
@@ -30,9 +30,9 @@ Float64Vec* Float64Vec_new_usize(const size_t* v_data, size_t v_len);
 
 Float64Vec* Float64Vec_new_f64_be_bytes(const uint8_t* v_data, size_t v_len);
 
-struct { const double* data; size_t len; } Float64Vec_as_boxed_slice(const Float64Vec* self);
+DiplomatF64View Float64Vec_as_boxed_slice(const Float64Vec* self);
 
-struct { const double* data; size_t len; } Float64Vec_as_slice(const Float64Vec* self);
+DiplomatF64View Float64Vec_as_slice(const Float64Vec* self);
 
 void Float64Vec_fill_slice(const Float64Vec* self, double* v_data, size_t v_len);
 
@@ -40,7 +40,7 @@ void Float64Vec_set_value(Float64Vec* self, const double* new_slice_data, size_t
 
 void Float64Vec_to_string(const Float64Vec* self, DiplomatWrite* write);
 
-struct { const double* data; size_t len; } Float64Vec_borrow(const Float64Vec* self);
+DiplomatF64View Float64Vec_borrow(const Float64Vec* self);
 
 diplomat_result_double_void Float64Vec_get(const Float64Vec* self, size_t i);
 

--- a/feature_tests/cpp2/include/Float64Vec.hpp
+++ b/feature_tests/cpp2/include/Float64Vec.hpp
@@ -57,12 +57,12 @@ inline std::unique_ptr<Float64Vec> Float64Vec::new_f64_be_bytes(diplomat::span<c
 
 inline diplomat::span<double> Float64Vec::as_boxed_slice() const {
   auto result = capi::Float64Vec_as_boxed_slice(this->AsFFI());
-  return diplomat::span<double>(result_data, result_size);
+  return diplomat::span<double>(result.data, result.len);
 }
 
 inline diplomat::span<const double> Float64Vec::as_slice() const {
   auto result = capi::Float64Vec_as_slice(this->AsFFI());
-  return diplomat::span<const double>(result_data, result_size);
+  return diplomat::span<const double>(result.data, result.len);
 }
 
 inline void Float64Vec::fill_slice(diplomat::span<double> v) const {
@@ -87,7 +87,7 @@ inline std::string Float64Vec::to_string() const {
 
 inline diplomat::span<const double> Float64Vec::borrow() const {
   auto result = capi::Float64Vec_borrow(this->AsFFI());
-  return diplomat::span<const double>(result_data, result_size);
+  return diplomat::span<const double>(result.data, result.len);
 }
 
 inline std::optional<double> Float64Vec::get(size_t i) const {

--- a/feature_tests/cpp2/include/MyEnum.d.hpp
+++ b/feature_tests/cpp2/include/MyEnum.d.hpp
@@ -14,12 +14,12 @@
 class MyEnum {
 public:
   enum Value {
-    A,
-    B,
-    C,
-    D,
-    E,
-    F,
+    A = -2,
+    B = -1,
+    C = 0,
+    D = 1,
+    E = 2,
+    F = 3,
   };
 
   MyEnum() = default;

--- a/feature_tests/cpp2/include/MyEnum.d.hpp
+++ b/feature_tests/cpp2/include/MyEnum.d.hpp
@@ -12,8 +12,6 @@
 
 
 class MyEnum {
-  capi::MyEnum value;
-
 public:
   enum Value {
     A,
@@ -24,15 +22,21 @@ public:
     F,
   };
 
+  MyEnum() = default;
+  // Implicit conversions between enum and ::Value
+  constexpr MyEnum(Value v) : value(v) {}
+  constexpr operator Value() const { return value; }
+  // Prevent usage as boolean value
+  explicit operator bool() const = delete;
+
   inline int8_t into_value();
 
   inline static MyEnum get_a();
 
-  inline MyEnum(MyEnum::Value cpp_value);
-  inline MyEnum(capi::MyEnum c_enum) : value(c_enum) {};
-
   inline capi::MyEnum AsFFI() const;
   inline static MyEnum FromFFI(capi::MyEnum c_enum);
+private:
+    Value value;
 };
 
 

--- a/feature_tests/cpp2/include/MyEnum.hpp
+++ b/feature_tests/cpp2/include/MyEnum.hpp
@@ -13,26 +13,39 @@
 #include "MyEnum.h"
 
 
-inline MyEnum::MyEnum(MyEnum::Value cpp_value) {
-  switch (cpp_value) {
+inline capi::MyEnum MyEnum::AsFFI() const {
+  switch (value) {
     case A:
-      value = capi::MyEnum_A;
-      break;
+      return capi::MyEnum_A;
     case B:
-      value = capi::MyEnum_B;
-      break;
+      return capi::MyEnum_B;
     case C:
-      value = capi::MyEnum_C;
-      break;
+      return capi::MyEnum_C;
     case D:
-      value = capi::MyEnum_D;
-      break;
+      return capi::MyEnum_D;
     case E:
-      value = capi::MyEnum_E;
-      break;
+      return capi::MyEnum_E;
     case F:
-      value = capi::MyEnum_F;
-      break;
+      return capi::MyEnum_F;
+    default:
+      abort();
+  }
+}
+
+inline MyEnum MyEnum::FromFFI(capi::MyEnum c_enum) {
+    switch (c_enum) {
+    case capi::MyEnum_A:
+      return MyEnum::Value::A;
+    case capi::MyEnum_B:
+      return MyEnum::Value::B;
+    case capi::MyEnum_C:
+      return MyEnum::Value::C;
+    case capi::MyEnum_D:
+      return MyEnum::Value::D;
+    case capi::MyEnum_E:
+      return MyEnum::Value::E;
+    case capi::MyEnum_F:
+      return MyEnum::Value::F;
     default:
       abort();
   }
@@ -47,13 +60,4 @@ inline MyEnum MyEnum::get_a() {
   auto result = capi::MyEnum_get_a();
   return MyEnum::FromFFI(result);
 }
-
-inline capi::MyEnum MyEnum::AsFFI() const {
-  return value;
-}
-
-inline MyEnum MyEnum::FromFFI(capi::MyEnum c_enum) {
-  return MyEnum(c_enum);
-}
-
 #endif // MyEnum_HPP

--- a/feature_tests/cpp2/include/MyEnum.hpp
+++ b/feature_tests/cpp2/include/MyEnum.hpp
@@ -14,38 +14,18 @@
 
 
 inline capi::MyEnum MyEnum::AsFFI() const {
-  switch (value) {
-    case A:
-      return capi::MyEnum_A;
-    case B:
-      return capi::MyEnum_B;
-    case C:
-      return capi::MyEnum_C;
-    case D:
-      return capi::MyEnum_D;
-    case E:
-      return capi::MyEnum_E;
-    case F:
-      return capi::MyEnum_F;
-    default:
-      abort();
-  }
+  return static_cast<capi::MyEnum>(value);
 }
 
 inline MyEnum MyEnum::FromFFI(capi::MyEnum c_enum) {
-    switch (c_enum) {
+  switch (c_enum) {
     case capi::MyEnum_A:
-      return MyEnum::Value::A;
     case capi::MyEnum_B:
-      return MyEnum::Value::B;
     case capi::MyEnum_C:
-      return MyEnum::Value::C;
     case capi::MyEnum_D:
-      return MyEnum::Value::D;
     case capi::MyEnum_E:
-      return MyEnum::Value::E;
     case capi::MyEnum_F:
-      return MyEnum::Value::F;
+      return static_cast<MyEnum::Value>(c_enum);
     default:
       abort();
   }

--- a/feature_tests/cpp2/include/MyString.h
+++ b/feature_tests/cpp2/include/MyString.h
@@ -21,13 +21,13 @@ MyString* MyString_new_unsafe(const char* v_data, size_t v_len);
 
 MyString* MyString_new_owned(const char* v_data, size_t v_len);
 
-MyString* MyString_new_from_first(DiplomatStrs8View* v_data, size_t v_len);
+MyString* MyString_new_from_first(DiplomatStringsView* v_data, size_t v_len);
 
 void MyString_set_str(MyString* self, const char* new_str_data, size_t new_str_len);
 
 void MyString_get_str(const MyString* self, DiplomatWrite* write);
 
-struct { const char* data; size_t len; } MyString_get_boxed_str(const MyString* self);
+DiplomatStringView MyString_get_boxed_str(const MyString* self);
 
 void MyString_destroy(MyString* self);
 

--- a/feature_tests/cpp2/include/MyString.hpp
+++ b/feature_tests/cpp2/include/MyString.hpp
@@ -20,12 +20,12 @@ inline std::unique_ptr<MyString> MyString::new_(std::string_view v) {
 }
 
 inline diplomat::result<std::unique_ptr<MyString>, diplomat::Utf8Error> MyString::new_unsafe(std::string_view v) {
-  if (!capi::diplomat_is_str(v.data(), v.size()) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error)
+  if (!capi::diplomat_is_str(v.data(), v.size())) {
+    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
   }
   auto result = capi::MyString_new_unsafe(v.data(),
     v.size());
-  return diplomat::Ok<std::unique_ptr<MyString>>(std::unique_ptr<MyString>(MyString::FromFFI(result)));
+  return diplomat::Ok<std::unique_ptr<MyString>>(std::move(std::unique_ptr<MyString>(MyString::FromFFI(result))));
 }
 
 inline std::unique_ptr<MyString> MyString::new_owned(std::string_view v) {
@@ -56,7 +56,7 @@ inline std::string MyString::get_str() const {
 
 inline std::string_view MyString::get_boxed_str() const {
   auto result = capi::MyString_get_boxed_str(this->AsFFI());
-  return std::string_view(result_data, result_size);
+  return std::string_view(result.data, result.len);
 }
 
 inline const capi::MyString* MyString::AsFFI() const {

--- a/feature_tests/cpp2/include/NestedBorrowedFields.hpp
+++ b/feature_tests/cpp2/include/NestedBorrowedFields.hpp
@@ -18,11 +18,11 @@
 
 
 inline diplomat::result<NestedBorrowedFields, diplomat::Utf8Error> NestedBorrowedFields::from_bar_and_foo_and_strings(const Bar& bar, const Foo& foo, std::u16string_view dstr16_x, std::u16string_view dstr16_z, std::string_view utf8_str_y, std::string_view utf8_str_z) {
-  if (!capi::diplomat_is_str(utf8_str_y.data(), utf8_str_y.size()) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error)
+  if (!capi::diplomat_is_str(utf8_str_y.data(), utf8_str_y.size())) {
+    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
   }
-  if (!capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size()) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error)
+  if (!capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size())) {
+    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
   }
   auto result = capi::NestedBorrowedFields_from_bar_and_foo_and_strings(bar.AsFFI(),
     foo.AsFFI(),
@@ -34,7 +34,7 @@ inline diplomat::result<NestedBorrowedFields, diplomat::Utf8Error> NestedBorrowe
     utf8_str_y.size(),
     utf8_str_z.data(),
     utf8_str_z.size());
-  return diplomat::Ok<NestedBorrowedFields>(NestedBorrowedFields::FromFFI(result));
+  return diplomat::Ok<NestedBorrowedFields>(std::move(NestedBorrowedFields::FromFFI(result)));
 }
 
 

--- a/feature_tests/cpp2/include/OpaqueMutexedString.h
+++ b/feature_tests/cpp2/include/OpaqueMutexedString.h
@@ -29,7 +29,7 @@ const OpaqueMutexedString* OpaqueMutexedString_borrow_self_or_other(const Opaque
 
 size_t OpaqueMutexedString_get_len_and_add(const OpaqueMutexedString* self, size_t other);
 
-struct { const char* data; size_t len; } OpaqueMutexedString_dummy_str(const OpaqueMutexedString* self);
+DiplomatStringView OpaqueMutexedString_dummy_str(const OpaqueMutexedString* self);
 
 Utf16Wrap* OpaqueMutexedString_wrapper(const OpaqueMutexedString* self);
 

--- a/feature_tests/cpp2/include/OpaqueMutexedString.hpp
+++ b/feature_tests/cpp2/include/OpaqueMutexedString.hpp
@@ -48,7 +48,7 @@ inline size_t OpaqueMutexedString::get_len_and_add(size_t other) const {
 
 inline std::string_view OpaqueMutexedString::dummy_str() const {
   auto result = capi::OpaqueMutexedString_dummy_str(this->AsFFI());
-  return std::string_view(result_data, result_size);
+  return std::string_view(result.data, result.len);
 }
 
 inline std::unique_ptr<Utf16Wrap> OpaqueMutexedString::wrapper() const {

--- a/feature_tests/cpp2/include/UnimportedEnum.d.hpp
+++ b/feature_tests/cpp2/include/UnimportedEnum.d.hpp
@@ -12,8 +12,6 @@
 
 
 class UnimportedEnum {
-  capi::UnimportedEnum value;
-
 public:
   enum Value {
     A,
@@ -21,11 +19,17 @@ public:
     C,
   };
 
-  inline UnimportedEnum(UnimportedEnum::Value cpp_value);
-  inline UnimportedEnum(capi::UnimportedEnum c_enum) : value(c_enum) {};
+  UnimportedEnum() = default;
+  // Implicit conversions between enum and ::Value
+  constexpr UnimportedEnum(Value v) : value(v) {}
+  constexpr operator Value() const { return value; }
+  // Prevent usage as boolean value
+  explicit operator bool() const = delete;
 
   inline capi::UnimportedEnum AsFFI() const;
   inline static UnimportedEnum FromFFI(capi::UnimportedEnum c_enum);
+private:
+    Value value;
 };
 
 

--- a/feature_tests/cpp2/include/UnimportedEnum.d.hpp
+++ b/feature_tests/cpp2/include/UnimportedEnum.d.hpp
@@ -14,9 +14,9 @@
 class UnimportedEnum {
 public:
   enum Value {
-    A,
-    B,
-    C,
+    A = 0,
+    B = 1,
+    C = 2,
   };
 
   UnimportedEnum() = default;

--- a/feature_tests/cpp2/include/UnimportedEnum.hpp
+++ b/feature_tests/cpp2/include/UnimportedEnum.hpp
@@ -14,26 +14,15 @@
 
 
 inline capi::UnimportedEnum UnimportedEnum::AsFFI() const {
-  switch (value) {
-    case A:
-      return capi::UnimportedEnum_A;
-    case B:
-      return capi::UnimportedEnum_B;
-    case C:
-      return capi::UnimportedEnum_C;
-    default:
-      abort();
-  }
+  return static_cast<capi::UnimportedEnum>(value);
 }
 
 inline UnimportedEnum UnimportedEnum::FromFFI(capi::UnimportedEnum c_enum) {
-    switch (c_enum) {
+  switch (c_enum) {
     case capi::UnimportedEnum_A:
-      return UnimportedEnum::Value::A;
     case capi::UnimportedEnum_B:
-      return UnimportedEnum::Value::B;
     case capi::UnimportedEnum_C:
-      return UnimportedEnum::Value::C;
+      return static_cast<UnimportedEnum::Value>(c_enum);
     default:
       abort();
   }

--- a/feature_tests/cpp2/include/UnimportedEnum.hpp
+++ b/feature_tests/cpp2/include/UnimportedEnum.hpp
@@ -13,28 +13,29 @@
 #include "UnimportedEnum.h"
 
 
-inline UnimportedEnum::UnimportedEnum(UnimportedEnum::Value cpp_value) {
-  switch (cpp_value) {
+inline capi::UnimportedEnum UnimportedEnum::AsFFI() const {
+  switch (value) {
     case A:
-      value = capi::UnimportedEnum_A;
-      break;
+      return capi::UnimportedEnum_A;
     case B:
-      value = capi::UnimportedEnum_B;
-      break;
+      return capi::UnimportedEnum_B;
     case C:
-      value = capi::UnimportedEnum_C;
-      break;
+      return capi::UnimportedEnum_C;
     default:
       abort();
   }
 }
 
-inline capi::UnimportedEnum UnimportedEnum::AsFFI() const {
-  return value;
-}
-
 inline UnimportedEnum UnimportedEnum::FromFFI(capi::UnimportedEnum c_enum) {
-  return UnimportedEnum(c_enum);
+    switch (c_enum) {
+    case capi::UnimportedEnum_A:
+      return UnimportedEnum::Value::A;
+    case capi::UnimportedEnum_B:
+      return UnimportedEnum::Value::B;
+    case capi::UnimportedEnum_C:
+      return UnimportedEnum::Value::C;
+    default:
+      abort();
+  }
 }
-
 #endif // UnimportedEnum_HPP

--- a/feature_tests/cpp2/include/Utf16Wrap.h
+++ b/feature_tests/cpp2/include/Utf16Wrap.h
@@ -15,9 +15,9 @@ extern "C" {
 #endif // __cplusplus
 
 
-struct { const char16_t* data; size_t len; } Utf16Wrap_borrow_cont(const Utf16Wrap* self);
+DiplomatString16View Utf16Wrap_borrow_cont(const Utf16Wrap* self);
 
-struct { const char16_t* data; size_t len; } Utf16Wrap_owned(const Utf16Wrap* self);
+DiplomatString16View Utf16Wrap_owned(const Utf16Wrap* self);
 
 void Utf16Wrap_destroy(Utf16Wrap* self);
 

--- a/feature_tests/cpp2/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp2/include/Utf16Wrap.hpp
@@ -15,12 +15,12 @@
 
 inline std::u16string_view Utf16Wrap::borrow_cont() const {
   auto result = capi::Utf16Wrap_borrow_cont(this->AsFFI());
-  return std::u16string_view(result_data, result_size);
+  return std::u16string_view(result.data, result.len);
 }
 
 inline std::u16string_view Utf16Wrap::owned() const {
   auto result = capi::Utf16Wrap_owned(this->AsFFI());
-  return std::u16string_view(result_data, result_size);
+  return std::u16string_view(result.data, result.len);
 }
 
 inline const capi::Utf16Wrap* Utf16Wrap::AsFFI() const {

--- a/feature_tests/cpp2/include/diplomat_runtime.h
+++ b/feature_tests/cpp2/include/diplomat_runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/tool/src/c/runtime.h
+++ b/tool/src/c/runtime.h
@@ -41,7 +41,7 @@ char* diplomat_buffer_write_get_bytes(DiplomatWrite* t);
 size_t diplomat_buffer_write_len(DiplomatWrite* t);
 void diplomat_buffer_write_destroy(DiplomatWrite* t);
 
-bool diplomat_is_str(char* buf, size_t len);
+bool diplomat_is_str(const char* buf, size_t len);
 
 #define MAKE_SLICES(name, c_ty) \
     typedef struct Diplomat##name##View { \
@@ -68,7 +68,9 @@ MAKE_SLICES(F64, double)
 MAKE_SLICES(Bool, bool)
 MAKE_SLICES(Char, char32_t)
 MAKE_SLICES(String, char)
-MAKE_SLICES(U16String, char16_t)
+MAKE_SLICES(String16, char16_t)
+MAKE_SLICES(Strings, DiplomatStringView)
+MAKE_SLICES(Strings16, DiplomatString16View)
 
 
 #ifdef __cplusplus

--- a/tool/src/cpp/conversions.rs
+++ b/tool/src/cpp/conversions.rs
@@ -271,7 +271,7 @@ pub fn gen_rust_to_cpp<W: Write>(
         }
         ast::TypeName::StrReference(_, ast::StringEncoding::UnvalidatedUtf16) => {
             let raw_value_id = format!("diplomat_slice_raw_{path}");
-            writeln!(out, "capi::DiplomatU16StringView {raw_value_id} = {cpp};").unwrap();
+            writeln!(out, "capi::DiplomatString16View {raw_value_id} = {cpp};").unwrap();
 
             let span = &library_config.span.expr;
             writeln!(

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -161,7 +161,6 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             type_name: &'a str,
             ctype: &'a str,
             methods: &'a [MethodInfo<'a>],
-            type_name_unnamespaced: &'a str,
         }
 
         ImplTemplate {
@@ -170,7 +169,6 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             type_name: &type_name,
             ctype: &ctype,
             methods: methods.as_slice(),
-            type_name_unnamespaced: &type_name_unnamespaced,
         }
         .render_into(self.impl_header)
         .unwrap();

--- a/tool/templates/cpp2/enum_decl.h.jinja
+++ b/tool/templates/cpp2/enum_decl.h.jinja
@@ -2,25 +2,29 @@
 namespace {{ns}} {
 {%endif-%}
 class {{type_name_unnamespaced}} {
-	{{ctype}} value;
-
 public:
 	enum Value {
-{%- for enum_variant in ty.variants %}
+		{%- for enum_variant in ty.variants %}
 		{{fmt.fmt_enum_variant(enum_variant)}},
-{%- endfor %}
+		{%- endfor %}
 	};
 
-{%- for m in methods %}
+	{{type_name_unnamespaced}}() = default;
+	// Implicit conversions between enum and ::Value
+	constexpr {{type_name_unnamespaced}}(Value v) : value(v) {}
+	constexpr operator Value() const { return value; }
+	// Prevent usage as boolean value
+	explicit operator bool() const = delete; 
+
+	{%- for m in methods %}
 
 	{% include "method_decl.h.jinja" %}
-{%- endfor %}
-
-	inline {{type_name_unnamespaced}}({{type_name}}::Value cpp_value);
-	inline {{type_name_unnamespaced}}({{ctype}} c_enum) : value(c_enum) {};
+	{%- endfor %}
 
 	inline {{ctype}} AsFFI() const;
 	inline static {{type_name}} FromFFI({{ctype}} c_enum);
+private:
+    Value value;
 };
 
 {% if namespace.is_some() -%}

--- a/tool/templates/cpp2/enum_decl.h.jinja
+++ b/tool/templates/cpp2/enum_decl.h.jinja
@@ -5,7 +5,7 @@ class {{type_name_unnamespaced}} {
 public:
 	enum Value {
 		{%- for enum_variant in ty.variants %}
-		{{fmt.fmt_enum_variant(enum_variant)}},
+		{{fmt.fmt_enum_variant(enum_variant)}} = {{ enum_variant.discriminant }},
 		{%- endfor %}
 	};
 

--- a/tool/templates/cpp2/enum_impl.h.jinja
+++ b/tool/templates/cpp2/enum_impl.h.jinja
@@ -1,26 +1,26 @@
-inline {{type_name}}::{{type_name_unnamespaced}}({{type_name}}::Value cpp_value) {
-	switch (cpp_value) {
+inline {{ctype}} {{type_name}}::AsFFI() const {
+	switch (value) {
 {%- for enum_variant in ty.variants %}
 		case {{fmt.fmt_enum_variant(enum_variant)}}:
-			value = {{fmt.fmt_c_enum_variant(ctype, enum_variant)}};
-			break;
+			return {{fmt.fmt_c_enum_variant(ctype, enum_variant)}};
 {%- endfor %}
 		default:
 			abort();
 	}
 }
 
+inline {{type_name}} {{type_name}}::FromFFI({{ctype}} c_enum) {
+		switch (c_enum) {
+{%- for enum_variant in ty.variants %}
+		case {{fmt.fmt_c_enum_variant(ctype, enum_variant)}}:
+			return {{type_name}}::Value::{{fmt.fmt_enum_variant(enum_variant)}};
+{%- endfor %}
+		default:
+			abort();
+	}
+}
 
 {%- for m in methods %}
 
 {% include "method_impl.h.jinja" %}
 {%- endfor %}
-
-inline {{ctype}} {{type_name}}::AsFFI() const {
-	return value;
-}
-
-inline {{type_name}} {{type_name}}::FromFFI({{ctype}} c_enum) {
-	return {{type_name}}(c_enum);
-}
-

--- a/tool/templates/cpp2/enum_impl.h.jinja
+++ b/tool/templates/cpp2/enum_impl.h.jinja
@@ -1,20 +1,13 @@
 inline {{ctype}} {{type_name}}::AsFFI() const {
-	switch (value) {
-{%- for enum_variant in ty.variants %}
-		case {{fmt.fmt_enum_variant(enum_variant)}}:
-			return {{fmt.fmt_c_enum_variant(ctype, enum_variant)}};
-{%- endfor %}
-		default:
-			abort();
-	}
+	return static_cast<{{ctype}}>(value);
 }
 
 inline {{type_name}} {{type_name}}::FromFFI({{ctype}} c_enum) {
-		switch (c_enum) {
+	switch (c_enum) {
 {%- for enum_variant in ty.variants %}
 		case {{fmt.fmt_c_enum_variant(ctype, enum_variant)}}:
-			return {{type_name}}::Value::{{fmt.fmt_enum_variant(enum_variant)}};
 {%- endfor %}
+			return static_cast<{{type_name}}::Value>(c_enum);
 		default:
 			abort();
 	}


### PR DESCRIPTION
Using the structure proposed in https://stackoverflow.com/a/53284026, where the enum implicitly converts to its `::Value` and back, enabling things like `switch`, comparisons, and construction through `Foo::Value::Bar`.