### PR TITLE
Refactor C2 backend to produce Header objects

### DIFF
--- a/example/c2/include/ICU4XFixedDecimalFormatter.h
+++ b/example/c2/include/ICU4XFixedDecimalFormatter.h
@@ -8,13 +8,9 @@
 #include "diplomat_runtime.h"
 
 #include "ICU4XDataProvider.d.h"
-#include "ICU4XDataProvider.h"
 #include "ICU4XFixedDecimal.d.h"
-#include "ICU4XFixedDecimal.h"
 #include "ICU4XFixedDecimalFormatterOptions.d.h"
-#include "ICU4XFixedDecimalFormatterOptions.h"
 #include "ICU4XLocale.d.h"
-#include "ICU4XLocale.h"
 
 #include "ICU4XFixedDecimalFormatter.d.h"
 

--- a/example/c2/main.c
+++ b/example/c2/main.c
@@ -1,7 +1,11 @@
 #include <stdio.h>
 #include <assert.h>
 
+#include "include/ICU4XLocale.h"
+#include "include/ICU4XDataProvider.h"
+#include "include/ICU4XFixedDecimal.h"
 #include "include/ICU4XFixedDecimalFormatter.h"
+#include "include/ICU4XFixedDecimalFormatterOptions.h"
 
 void print_decimal(ICU4XFixedDecimal* fd) {
     char output[40];

--- a/example/cpp2/include/ICU4XFixedDecimalFormatter.h
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatter.h
@@ -8,13 +8,9 @@
 #include "diplomat_runtime.h"
 
 #include "ICU4XDataProvider.d.h"
-#include "ICU4XDataProvider.h"
 #include "ICU4XFixedDecimal.d.h"
-#include "ICU4XFixedDecimal.h"
 #include "ICU4XFixedDecimalFormatterOptions.d.h"
-#include "ICU4XFixedDecimalFormatterOptions.h"
 #include "ICU4XLocale.d.h"
-#include "ICU4XLocale.h"
 
 #include "ICU4XFixedDecimalFormatter.d.h"
 

--- a/feature_tests/c2/include/AttrOpaque1.h
+++ b/feature_tests/c2/include/AttrOpaque1.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "AttrEnum.d.h"
-#include "AttrEnum.h"
 #include "Unnamespaced.d.h"
-#include "Unnamespaced.h"
 
 #include "AttrOpaque1.d.h"
 

--- a/feature_tests/c2/include/Bar.h
+++ b/feature_tests/c2/include/Bar.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Foo.d.h"
-#include "Foo.h"
 
 #include "Bar.d.h"
 

--- a/feature_tests/c2/include/BorrowedFields.h
+++ b/feature_tests/c2/include/BorrowedFields.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Bar.d.h"
-#include "Bar.h"
 
 #include "BorrowedFields.d.h"
 

--- a/feature_tests/c2/include/BorrowedFieldsWithBounds.h
+++ b/feature_tests/c2/include/BorrowedFieldsWithBounds.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Foo.d.h"
-#include "Foo.h"
 
 #include "BorrowedFieldsWithBounds.d.h"
 

--- a/feature_tests/c2/include/Foo.h
+++ b/feature_tests/c2/include/Foo.h
@@ -8,13 +8,9 @@
 #include "diplomat_runtime.h"
 
 #include "Bar.d.h"
-#include "Bar.h"
 #include "BorrowedFields.d.h"
-#include "BorrowedFields.h"
 #include "BorrowedFieldsReturning.d.h"
-#include "BorrowedFieldsReturning.h"
 #include "BorrowedFieldsWithBounds.d.h"
-#include "BorrowedFieldsWithBounds.h"
 
 #include "Foo.d.h"
 

--- a/feature_tests/c2/include/NestedBorrowedFields.h
+++ b/feature_tests/c2/include/NestedBorrowedFields.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "Bar.d.h"
-#include "Bar.h"
 #include "Foo.d.h"
-#include "Foo.h"
 
 #include "NestedBorrowedFields.d.h"
 

--- a/feature_tests/c2/include/One.h
+++ b/feature_tests/c2/include/One.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Two.d.h"
-#include "Two.h"
 
 #include "One.d.h"
 

--- a/feature_tests/c2/include/Opaque.h
+++ b/feature_tests/c2/include/Opaque.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "ImportedStruct.d.h"
-#include "ImportedStruct.h"
 #include "MyStruct.d.h"
-#include "MyStruct.h"
 
 #include "Opaque.d.h"
 

--- a/feature_tests/c2/include/OpaqueMutexedString.h
+++ b/feature_tests/c2/include/OpaqueMutexedString.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Utf16Wrap.d.h"
-#include "Utf16Wrap.h"
 
 #include "OpaqueMutexedString.d.h"
 

--- a/feature_tests/c2/include/OptionOpaque.h
+++ b/feature_tests/c2/include/OptionOpaque.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "OptionStruct.d.h"
-#include "OptionStruct.h"
 
 #include "OptionOpaque.d.h"
 

--- a/feature_tests/c2/include/RefList.h
+++ b/feature_tests/c2/include/RefList.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "RefListParameter.d.h"
-#include "RefListParameter.h"
 
 #include "RefList.d.h"
 

--- a/feature_tests/c2/include/ResultOpaque.h
+++ b/feature_tests/c2/include/ResultOpaque.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "ErrorEnum.d.h"
-#include "ErrorEnum.h"
 #include "ErrorStruct.d.h"
-#include "ErrorStruct.h"
 
 #include "ResultOpaque.d.h"
 

--- a/feature_tests/c2/include/Unnamespaced.h
+++ b/feature_tests/c2/include/Unnamespaced.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "AttrEnum.d.h"
-#include "AttrEnum.h"
 #include "AttrOpaque1.d.h"
-#include "AttrOpaque1.h"
 
 #include "Unnamespaced.d.h"
 

--- a/feature_tests/cpp2/include/AttrOpaque1.h
+++ b/feature_tests/cpp2/include/AttrOpaque1.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "AttrEnum.d.h"
-#include "AttrEnum.h"
 #include "Unnamespaced.d.h"
-#include "Unnamespaced.h"
 
 #include "AttrOpaque1.d.h"
 

--- a/feature_tests/cpp2/include/Bar.h
+++ b/feature_tests/cpp2/include/Bar.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Foo.d.h"
-#include "Foo.h"
 
 #include "Bar.d.h"
 

--- a/feature_tests/cpp2/include/BorrowedFields.h
+++ b/feature_tests/cpp2/include/BorrowedFields.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Bar.d.h"
-#include "Bar.h"
 
 #include "BorrowedFields.d.h"
 

--- a/feature_tests/cpp2/include/BorrowedFieldsWithBounds.h
+++ b/feature_tests/cpp2/include/BorrowedFieldsWithBounds.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Foo.d.h"
-#include "Foo.h"
 
 #include "BorrowedFieldsWithBounds.d.h"
 

--- a/feature_tests/cpp2/include/Foo.h
+++ b/feature_tests/cpp2/include/Foo.h
@@ -8,13 +8,9 @@
 #include "diplomat_runtime.h"
 
 #include "Bar.d.h"
-#include "Bar.h"
 #include "BorrowedFields.d.h"
-#include "BorrowedFields.h"
 #include "BorrowedFieldsReturning.d.h"
-#include "BorrowedFieldsReturning.h"
 #include "BorrowedFieldsWithBounds.d.h"
-#include "BorrowedFieldsWithBounds.h"
 
 #include "Foo.d.h"
 

--- a/feature_tests/cpp2/include/NestedBorrowedFields.h
+++ b/feature_tests/cpp2/include/NestedBorrowedFields.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "Bar.d.h"
-#include "Bar.h"
 #include "Foo.d.h"
-#include "Foo.h"
 
 #include "NestedBorrowedFields.d.h"
 

--- a/feature_tests/cpp2/include/One.h
+++ b/feature_tests/cpp2/include/One.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Two.d.h"
-#include "Two.h"
 
 #include "One.d.h"
 

--- a/feature_tests/cpp2/include/Opaque.h
+++ b/feature_tests/cpp2/include/Opaque.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "ImportedStruct.d.h"
-#include "ImportedStruct.h"
 #include "MyStruct.d.h"
-#include "MyStruct.h"
 
 #include "Opaque.d.h"
 

--- a/feature_tests/cpp2/include/OpaqueMutexedString.h
+++ b/feature_tests/cpp2/include/OpaqueMutexedString.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "Utf16Wrap.d.h"
-#include "Utf16Wrap.h"
 
 #include "OpaqueMutexedString.d.h"
 

--- a/feature_tests/cpp2/include/OptionOpaque.h
+++ b/feature_tests/cpp2/include/OptionOpaque.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "OptionStruct.d.h"
-#include "OptionStruct.h"
 
 #include "OptionOpaque.d.h"
 

--- a/feature_tests/cpp2/include/RefList.h
+++ b/feature_tests/cpp2/include/RefList.h
@@ -8,7 +8,6 @@
 #include "diplomat_runtime.h"
 
 #include "RefListParameter.d.h"
-#include "RefListParameter.h"
 
 #include "RefList.d.h"
 

--- a/feature_tests/cpp2/include/ResultOpaque.h
+++ b/feature_tests/cpp2/include/ResultOpaque.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "ErrorEnum.d.h"
-#include "ErrorEnum.h"
 #include "ErrorStruct.d.h"
-#include "ErrorStruct.h"
 
 #include "ResultOpaque.d.h"
 

--- a/feature_tests/cpp2/include/Unnamespaced.h
+++ b/feature_tests/cpp2/include/Unnamespaced.h
@@ -8,9 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "AttrEnum.d.h"
-#include "AttrEnum.h"
 #include "AttrOpaque1.d.h"
-#include "AttrOpaque1.h"
 
 #include "Unnamespaced.d.h"
 

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -175,8 +175,8 @@ impl<'tcx> super::CContext<'tcx> {
         // a header will get its own includes. Instead of
         // trying to avoid pushing them, it's cleaner to just pull them out
         // once done
-        impl_header.includes.remove(&*impl_header_path);
-        impl_header.includes.remove(&*decl_header_path);
+        impl_header.includes.remove(impl_header_path);
+        impl_header.includes.remove(decl_header_path);
 
         impl_header
     }


### PR DESCRIPTION
This way they can be directly consumed by cpp2 instead of doing a cpp2-c2 folder. This is part of the plan for #427