### PR TITLE
Fix and Test JS UTF-16 code

### DIFF
--- a/example/js/lib/api/diplomat-runtime.mjs
+++ b/example/js/lib/api/diplomat-runtime.mjs
@@ -96,8 +96,8 @@ export class DiplomatBuf {
     const byteLength = string.length * 2;
     const ptr = wasm.diplomat_alloc(byteLength, 2);
 
-    const destination = new Uint16Array(wasm.memory.buffer, ptr, byteLength);
-    for (var i; i < string.length; i++) {
+    const destination = new Uint16Array(wasm.memory.buffer, ptr, string.length);
+    for (let i = 0; i < string.length; i++) {
       destination[i] = string.charCodeAt(i);
     }
 

--- a/feature_tests/c/include/Opaque.h
+++ b/feature_tests/c/include/Opaque.h
@@ -23,6 +23,12 @@ extern "C" {
 
 Opaque* Opaque_new();
 
+Opaque* Opaque_try_from_utf8(const char* input_data, size_t input_len);
+
+Opaque* Opaque_from_str(const char* input_data, size_t input_len);
+
+void Opaque_get_debug_str(const Opaque* self, DiplomatWrite* write);
+
 void Opaque_assert_struct(const Opaque* self, MyStruct s);
 
 size_t Opaque_returns_usize();

--- a/feature_tests/c/include/Utf16Wrap.h
+++ b/feature_tests/c/include/Utf16Wrap.h
@@ -19,6 +19,10 @@ namespace capi {
 extern "C" {
 #endif
 
+Utf16Wrap* Utf16Wrap_from_utf16(const char16_t* input_data, size_t input_len);
+
+void Utf16Wrap_get_debug_str(const Utf16Wrap* self, DiplomatWrite* write);
+
 DiplomatU16View Utf16Wrap_borrow_cont(const Utf16Wrap* self);
 
 DiplomatU16View Utf16Wrap_owned(const Utf16Wrap* self);

--- a/feature_tests/c2/include/Opaque.h
+++ b/feature_tests/c2/include/Opaque.h
@@ -19,6 +19,12 @@
 
 Opaque* Opaque_new();
 
+Opaque* Opaque_try_from_utf8(const char* input_data, size_t input_len);
+
+Opaque* Opaque_from_str(const char* input_data, size_t input_len);
+
+void Opaque_get_debug_str(const Opaque* self, DiplomatWrite* write);
+
 void Opaque_assert_struct(const Opaque* self, MyStruct s);
 
 size_t Opaque_returns_usize();

--- a/feature_tests/c2/include/Utf16Wrap.h
+++ b/feature_tests/c2/include/Utf16Wrap.h
@@ -15,6 +15,10 @@
 
 
 
+Utf16Wrap* Utf16Wrap_from_utf16(const char16_t* input_data, size_t input_len);
+
+void Utf16Wrap_get_debug_str(const Utf16Wrap* self, DiplomatWrite* write);
+
 DiplomatString16View Utf16Wrap_borrow_cont(const Utf16Wrap* self);
 
 DiplomatString16View Utf16Wrap_owned(const Utf16Wrap* self);

--- a/feature_tests/cpp/docs/source/structs_ffi.rst
+++ b/feature_tests/cpp/docs/source/structs_ffi.rst
@@ -58,6 +58,21 @@
     .. cpp:function:: static Opaque new_()
 
 
+    .. cpp:function:: static std::optional<Opaque> try_from_utf8(const std::string_view input)
+
+
+    .. cpp:function:: static Opaque from_str(const std::string_view input)
+
+        Warning: Passing ill-formed UTF-8 is undefined behavior (and may be memory-unsafe).
+
+
+
+    .. cpp:function:: template<typename W> void get_debug_str_to_write(W& write) const
+
+
+    .. cpp:function:: std::string get_debug_str() const
+
+
     .. cpp:function:: void assert_struct(MyStruct s) const
 
         See the `Rust documentation for something <https://docs.rs/Something/latest/struct.Something.html#method.something>`__ for more information.
@@ -96,6 +111,16 @@
 
 
 .. cpp:class:: Utf16Wrap
+
+    .. cpp:function:: static Utf16Wrap from_utf16(const std::u16string_view input)
+
+
+
+    .. cpp:function:: template<typename W> void get_debug_str_to_write(W& write) const
+
+
+    .. cpp:function:: std::string get_debug_str() const
+
 
     .. cpp:function:: const std::u16string_view borrow_cont() const
 

--- a/feature_tests/cpp/include/Opaque.h
+++ b/feature_tests/cpp/include/Opaque.h
@@ -23,6 +23,12 @@ extern "C" {
 
 Opaque* Opaque_new();
 
+Opaque* Opaque_try_from_utf8(const char* input_data, size_t input_len);
+
+Opaque* Opaque_from_str(const char* input_data, size_t input_len);
+
+void Opaque_get_debug_str(const Opaque* self, DiplomatWrite* write);
+
 void Opaque_assert_struct(const Opaque* self, MyStruct s);
 
 size_t Opaque_returns_usize();

--- a/feature_tests/cpp/include/Utf16Wrap.h
+++ b/feature_tests/cpp/include/Utf16Wrap.h
@@ -19,6 +19,10 @@ namespace capi {
 extern "C" {
 #endif
 
+Utf16Wrap* Utf16Wrap_from_utf16(const char16_t* input_data, size_t input_len);
+
+void Utf16Wrap_get_debug_str(const Utf16Wrap* self, DiplomatWrite* write);
+
 DiplomatU16View Utf16Wrap_borrow_cont(const Utf16Wrap* self);
 
 DiplomatU16View Utf16Wrap_owned(const Utf16Wrap* self);

--- a/feature_tests/cpp2/include/Opaque.d.hpp
+++ b/feature_tests/cpp2/include/Opaque.d.hpp
@@ -21,6 +21,12 @@ public:
 
   inline static std::unique_ptr<Opaque> new_();
 
+  inline static std::unique_ptr<Opaque> try_from_utf8(std::string_view input);
+
+  inline static diplomat::result<std::unique_ptr<Opaque>, diplomat::Utf8Error> from_str(std::string_view input);
+
+  inline std::string get_debug_str() const;
+
   inline void assert_struct(MyStruct s) const;
 
   inline static size_t returns_usize();

--- a/feature_tests/cpp2/include/Opaque.h
+++ b/feature_tests/cpp2/include/Opaque.h
@@ -19,6 +19,12 @@ extern "C" {
 
 Opaque* Opaque_new();
 
+Opaque* Opaque_try_from_utf8(const char* input_data, size_t input_len);
+
+Opaque* Opaque_from_str(const char* input_data, size_t input_len);
+
+void Opaque_get_debug_str(const Opaque* self, DiplomatWrite* write);
+
 void Opaque_assert_struct(const Opaque* self, MyStruct s);
 
 size_t Opaque_returns_usize();

--- a/feature_tests/cpp2/include/Opaque.hpp
+++ b/feature_tests/cpp2/include/Opaque.hpp
@@ -20,6 +20,29 @@ inline std::unique_ptr<Opaque> Opaque::new_() {
   return std::unique_ptr<Opaque>(Opaque::FromFFI(result));
 }
 
+inline std::unique_ptr<Opaque> Opaque::try_from_utf8(std::string_view input) {
+  auto result = capi::Opaque_try_from_utf8(input.data(),
+    input.size());
+  return std::unique_ptr<Opaque>(Opaque::FromFFI(result));
+}
+
+inline diplomat::result<std::unique_ptr<Opaque>, diplomat::Utf8Error> Opaque::from_str(std::string_view input) {
+  if (!capi::diplomat_is_str(input.data(), input.size())) {
+    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
+  }
+  auto result = capi::Opaque_from_str(input.data(),
+    input.size());
+  return diplomat::Ok<std::unique_ptr<Opaque>>(std::move(std::unique_ptr<Opaque>(Opaque::FromFFI(result))));
+}
+
+inline std::string Opaque::get_debug_str() const {
+  std::string output;
+  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  capi::Opaque_get_debug_str(this->AsFFI(),
+    &write);
+  return output;
+}
+
 inline void Opaque::assert_struct(MyStruct s) const {
   capi::Opaque_assert_struct(this->AsFFI(),
     s.AsFFI());

--- a/feature_tests/cpp2/include/Utf16Wrap.d.hpp
+++ b/feature_tests/cpp2/include/Utf16Wrap.d.hpp
@@ -14,6 +14,10 @@
 class Utf16Wrap {
 public:
 
+  inline static std::unique_ptr<Utf16Wrap> from_utf16(std::u16string_view input);
+
+  inline std::string get_debug_str() const;
+
   inline std::u16string_view borrow_cont() const;
 
   inline std::u16string_view owned() const;

--- a/feature_tests/cpp2/include/Utf16Wrap.h
+++ b/feature_tests/cpp2/include/Utf16Wrap.h
@@ -15,6 +15,10 @@ namespace capi {
 
 extern "C" {
 
+Utf16Wrap* Utf16Wrap_from_utf16(const char16_t* input_data, size_t input_len);
+
+void Utf16Wrap_get_debug_str(const Utf16Wrap* self, DiplomatWrite* write);
+
 DiplomatString16View Utf16Wrap_borrow_cont(const Utf16Wrap* self);
 
 DiplomatString16View Utf16Wrap_owned(const Utf16Wrap* self);

--- a/feature_tests/cpp2/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp2/include/Utf16Wrap.hpp
@@ -13,6 +13,20 @@
 #include "Utf16Wrap.h"
 
 
+inline std::unique_ptr<Utf16Wrap> Utf16Wrap::from_utf16(std::u16string_view input) {
+  auto result = capi::Utf16Wrap_from_utf16(input.data(),
+    input.size());
+  return std::unique_ptr<Utf16Wrap>(Utf16Wrap::FromFFI(result));
+}
+
+inline std::string Utf16Wrap::get_debug_str() const {
+  std::string output;
+  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  capi::Utf16Wrap_get_debug_str(this->AsFFI(),
+    &write);
+  return output;
+}
+
 inline std::u16string_view Utf16Wrap::borrow_cont() const {
   auto result = capi::Utf16Wrap_borrow_cont(this->AsFFI());
   return std::u16string_view(result.data, result.len);

--- a/feature_tests/dart/lib/src/Opaque.g.dart
+++ b/feature_tests/dart/lib/src/Opaque.g.dart
@@ -26,7 +26,7 @@ final class Opaque implements ffi.Finalizable {
     return Opaque._fromFfi(result, []);
   }
 
-  factory Opaque(String input) {
+  static Opaque? tryFromUtf8(String input) {
     final temp = ffi2.Arena();
     final inputView = input.utf8View;
     final result = _Opaque_try_from_utf8(inputView.allocIn(temp), inputView.length);
@@ -34,7 +34,7 @@ final class Opaque implements ffi.Finalizable {
     return result.address == 0 ? null : Opaque._fromFfi(result, []);
   }
 
-  factory Opaque(String input) {
+  static Opaque fromStr(String input) {
     final temp = ffi2.Arena();
     final inputView = input.utf8View;
     final result = _Opaque_from_str(inputView.allocIn(temp), inputView.length);

--- a/feature_tests/dart/lib/src/Opaque.g.dart
+++ b/feature_tests/dart/lib/src/Opaque.g.dart
@@ -26,6 +26,28 @@ final class Opaque implements ffi.Finalizable {
     return Opaque._fromFfi(result, []);
   }
 
+  factory Opaque(String input) {
+    final temp = ffi2.Arena();
+    final inputView = input.utf8View;
+    final result = _Opaque_try_from_utf8(inputView.allocIn(temp), inputView.length);
+    temp.releaseAll();
+    return result.address == 0 ? null : Opaque._fromFfi(result, []);
+  }
+
+  factory Opaque(String input) {
+    final temp = ffi2.Arena();
+    final inputView = input.utf8View;
+    final result = _Opaque_from_str(inputView.allocIn(temp), inputView.length);
+    temp.releaseAll();
+    return Opaque._fromFfi(result, []);
+  }
+
+  String getDebugStr() {
+    final write = _Write();
+    _Opaque_get_debug_str(_ffi, write._ffi);
+    return write.finalize();
+  }
+
   /// See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.
   ///
   /// See the [Rust documentation for `something_else`](https://docs.rs/Something/latest/struct.Something.html#method.something_else) for more information.
@@ -62,6 +84,21 @@ external void _Opaque_destroy(ffi.Pointer<ffi.Void> self);
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'Opaque_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Opaque_new();
+
+@meta.ResourceIdentifier('Opaque_try_from_utf8')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'Opaque_try_from_utf8')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _Opaque_try_from_utf8(ffi.Pointer<ffi.Uint8> inputData, int inputLength);
+
+@meta.ResourceIdentifier('Opaque_from_str')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true, symbol: 'Opaque_from_str')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _Opaque_from_str(ffi.Pointer<ffi.Uint8> inputData, int inputLength);
+
+@meta.ResourceIdentifier('Opaque_get_debug_str')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Opaque_get_debug_str')
+// ignore: non_constant_identifier_names
+external void _Opaque_get_debug_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
 @meta.ResourceIdentifier('Opaque_assert_struct')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _MyStructFfi)>(isLeaf: true, symbol: 'Opaque_assert_struct')

--- a/feature_tests/dart/lib/src/Utf16Wrap.g.dart
+++ b/feature_tests/dart/lib/src/Utf16Wrap.g.dart
@@ -21,6 +21,20 @@ final class Utf16Wrap implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Utf16Wrap_destroy));
 
+  factory Utf16Wrap(String input) {
+    final temp = ffi2.Arena();
+    final inputView = input.utf16View;
+    final result = _Utf16Wrap_from_utf16(inputView.allocIn(temp), inputView.length);
+    temp.releaseAll();
+    return Utf16Wrap._fromFfi(result, []);
+  }
+
+  String getDebugStr() {
+    final write = _Write();
+    _Utf16Wrap_get_debug_str(_ffi, write._ffi);
+    return write.finalize();
+  }
+
   String borrowCont() {
     // This lifetime edge depends on lifetimes: 'a
     core.List<Object> aEdges = [this];
@@ -38,6 +52,16 @@ final class Utf16Wrap implements ffi.Finalizable {
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Utf16Wrap_destroy')
 // ignore: non_constant_identifier_names
 external void _Utf16Wrap_destroy(ffi.Pointer<ffi.Void> self);
+
+@meta.ResourceIdentifier('Utf16Wrap_from_utf16')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Uint16>, ffi.Size)>(isLeaf: true, symbol: 'Utf16Wrap_from_utf16')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _Utf16Wrap_from_utf16(ffi.Pointer<ffi.Uint16> inputData, int inputLength);
+
+@meta.ResourceIdentifier('Utf16Wrap_get_debug_str')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Utf16Wrap_get_debug_str')
+// ignore: non_constant_identifier_names
+external void _Utf16Wrap_get_debug_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
 @meta.ResourceIdentifier('Utf16Wrap_borrow_cont')
 @ffi.Native<_SliceUtf16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Utf16Wrap_borrow_cont')

--- a/feature_tests/dotnet/Lib/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Lib/Generated/Opaque.cs
@@ -41,6 +41,72 @@ public partial class Opaque: IDisposable
         }
     }
 
+    /// <returns>
+    /// A <c>Opaque</c> allocated on Rust side.
+    /// </returns>
+    public static Opaque? TryFromUtf8(string input)
+    {
+        unsafe
+        {
+            byte[] inputBuf = DiplomatUtils.StringToUtf8(input);
+            nuint inputBufLength = (nuint)inputBuf.Length;
+            fixed (byte* inputBufPtr = inputBuf)
+            {
+                Raw.Opaque* retVal = Raw.Opaque.TryFromUtf8(inputBufPtr, inputBufLength);
+                if (retVal == null)
+                {
+                    return null;
+                }
+                return new Opaque(retVal);
+            }
+        }
+    }
+
+    /// <returns>
+    /// A <c>Opaque</c> allocated on Rust side.
+    /// </returns>
+    public static Opaque FromStr(string input)
+    {
+        unsafe
+        {
+            byte[] inputBuf = DiplomatUtils.StringToUtf8(input);
+            nuint inputBufLength = (nuint)inputBuf.Length;
+            fixed (byte* inputBufPtr = inputBuf)
+            {
+                Raw.Opaque* retVal = Raw.Opaque.FromStr(inputBufPtr, inputBufLength);
+                return new Opaque(retVal);
+            }
+        }
+    }
+
+    public void GetDebugStr(DiplomatWrite write)
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Opaque");
+            }
+            Raw.Opaque.GetDebugStr(_inner, &write);
+        }
+    }
+
+    public string GetDebugStr()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Opaque");
+            }
+            DiplomatWrite write = new DiplomatWrite();
+            Raw.Opaque.GetDebugStr(_inner, &write);
+            string retVal = write.ToUnicode();
+            write.Dispose();
+            return retVal;
+        }
+    }
+
     /// <summary>
     /// See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.
     /// </summary>

--- a/feature_tests/dotnet/Lib/Generated/RawOpaque.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawOpaque.cs
@@ -19,6 +19,15 @@ public partial struct Opaque
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Opaque_new", ExactSpelling = true)]
     public static unsafe extern Opaque* New();
 
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Opaque_try_from_utf8", ExactSpelling = true)]
+    public static unsafe extern Opaque* TryFromUtf8(byte* input, nuint inputSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Opaque_from_str", ExactSpelling = true)]
+    public static unsafe extern Opaque* FromStr(ushort* input, nuint inputSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Opaque_get_debug_str", ExactSpelling = true)]
+    public static unsafe extern void GetDebugStr(Opaque* self, DiplomatWrite* write);
+
     /// <summary>
     /// See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.
     /// </summary>

--- a/feature_tests/dotnet/Lib/Generated/RawUtf16Wrap.cs
+++ b/feature_tests/dotnet/Lib/Generated/RawUtf16Wrap.cs
@@ -16,6 +16,12 @@ public partial struct Utf16Wrap
 {
     private const string NativeLib = "diplomat_feature_tests";
 
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Utf16Wrap_from_utf16", ExactSpelling = true)]
+    public static unsafe extern Utf16Wrap* FromUtf16(ushort* input, nuint inputSz);
+
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Utf16Wrap_get_debug_str", ExactSpelling = true)]
+    public static unsafe extern void GetDebugStr(Utf16Wrap* self, DiplomatWrite* write);
+
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Utf16Wrap_borrow_cont", ExactSpelling = true)]
     public static unsafe extern ushort[] BorrowCont(Utf16Wrap* self);
 

--- a/feature_tests/dotnet/Lib/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Lib/Generated/Utf16Wrap.cs
@@ -29,6 +29,51 @@ public partial class Utf16Wrap: IDisposable
         _inner = handle;
     }
 
+    /// <returns>
+    /// A <c>Utf16Wrap</c> allocated on Rust side.
+    /// </returns>
+    public static Utf16Wrap FromUtf16(ushort[] input)
+    {
+        unsafe
+        {
+            byte[] inputBuf = DiplomatUtils.StringToUtf8(input);
+            nuint inputBufLength = (nuint)inputBuf.Length;
+            fixed (byte* inputBufPtr = inputBuf)
+            {
+                Raw.Utf16Wrap* retVal = Raw.Utf16Wrap.FromUtf16(inputBufPtr, inputBufLength);
+                return new Utf16Wrap(retVal);
+            }
+        }
+    }
+
+    public void GetDebugStr(DiplomatWrite write)
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Utf16Wrap");
+            }
+            Raw.Utf16Wrap.GetDebugStr(_inner, &write);
+        }
+    }
+
+    public string GetDebugStr()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Utf16Wrap");
+            }
+            DiplomatWrite write = new DiplomatWrite();
+            Raw.Utf16Wrap.GetDebugStr(_inner, &write);
+            string retVal = write.ToUnicode();
+            write.Dispose();
+            return retVal;
+        }
+    }
+
     public ushort[] BorrowCont()
     {
         unsafe

--- a/feature_tests/js/api/Opaque.d.ts
+++ b/feature_tests/js/api/Opaque.d.ts
@@ -11,6 +11,18 @@ export class Opaque {
   static new(): Opaque;
 
   /**
+   */
+  static try_from_utf8(input: string): Opaque | undefined;
+
+  /**
+   */
+  static from_str(input: string): Opaque;
+
+  /**
+   */
+  get_debug_str(): string;
+
+  /**
 
    * See the {@link https://docs.rs/Something/latest/struct.Something.html#method.something Rust documentation for `something`} for more information.
 

--- a/feature_tests/js/api/Opaque.mjs
+++ b/feature_tests/js/api/Opaque.mjs
@@ -22,6 +22,29 @@ export class Opaque {
     return new Opaque(wasm.Opaque_new(), true, []);
   }
 
+  static try_from_utf8(arg_input) {
+    const buf_arg_input = diplomatRuntime.DiplomatBuf.str8(wasm, arg_input);
+    const diplomat_out = (() => {
+      const option_ptr = wasm.Opaque_try_from_utf8(buf_arg_input.ptr, buf_arg_input.size);
+      return (option_ptr == 0) ? undefined : new Opaque(option_ptr, true, []);
+    })();
+    buf_arg_input.free();
+    return diplomat_out;
+  }
+
+  static from_str(arg_input) {
+    const buf_arg_input = diplomatRuntime.DiplomatBuf.str8(wasm, arg_input);
+    const diplomat_out = new Opaque(wasm.Opaque_from_str(buf_arg_input.ptr, buf_arg_input.size), true, []);
+    buf_arg_input.free();
+    return diplomat_out;
+  }
+
+  get_debug_str() {
+    return diplomatRuntime.withDiplomatWrite(wasm, (write) => {
+      return wasm.Opaque_get_debug_str(this.underlying, write);
+    });
+  }
+
   assert_struct(arg_s) {
     const field_a_arg_s = arg_s["a"];
     const field_b_arg_s = arg_s["b"];

--- a/feature_tests/js/api/Utf16Wrap.d.ts
+++ b/feature_tests/js/api/Utf16Wrap.d.ts
@@ -5,6 +5,14 @@ export class Utf16Wrap {
 
   /**
    */
+  static from_utf16(input: string): Utf16Wrap;
+
+  /**
+   */
+  get_debug_str(): string;
+
+  /**
+   */
   borrow_cont(): string;
 
   /**

--- a/feature_tests/js/api/Utf16Wrap.mjs
+++ b/feature_tests/js/api/Utf16Wrap.mjs
@@ -15,6 +15,19 @@ export class Utf16Wrap {
     }
   }
 
+  static from_utf16(arg_input) {
+    const buf_arg_input = diplomatRuntime.DiplomatBuf.str16(wasm, arg_input);
+    const diplomat_out = new Utf16Wrap(wasm.Utf16Wrap_from_utf16(buf_arg_input.ptr, buf_arg_input.size), true, []);
+    buf_arg_input.free();
+    return diplomat_out;
+  }
+
+  get_debug_str() {
+    return diplomatRuntime.withDiplomatWrite(wasm, (write) => {
+      return wasm.Utf16Wrap_get_debug_str(this.underlying, write);
+    });
+  }
+
   borrow_cont() {
     return (() => {
       const diplomat_receive_buffer = wasm.diplomat_alloc(8, 4);

--- a/feature_tests/js/api/diplomat-runtime.mjs
+++ b/feature_tests/js/api/diplomat-runtime.mjs
@@ -96,8 +96,8 @@ export class DiplomatBuf {
     const byteLength = string.length * 2;
     const ptr = wasm.diplomat_alloc(byteLength, 2);
 
-    const destination = new Uint16Array(wasm.memory.buffer, ptr, byteLength);
-    for (var i; i < string.length; i++) {
+    const destination = new Uint16Array(wasm.memory.buffer, ptr, string.length);
+    for (let i = 0; i < string.length; i++) {
       destination[i] = string.charCodeAt(i);
     }
 

--- a/feature_tests/js/docs/source/structs_ffi.rst
+++ b/feature_tests/js/docs/source/structs_ffi.rst
@@ -33,6 +33,12 @@
 
     .. js:function:: new()
 
+    .. js:function:: try_from_utf8(input)
+
+    .. js:function:: from_str(input)
+
+    .. js:method:: get_debug_str()
+
     .. js:method:: assert_struct(s)
 
         See the `Rust documentation for something <https://docs.rs/Something/latest/struct.Something.html#method.something>`__ for more information.
@@ -61,6 +67,10 @@
     .. js:method:: wrapper()
 
 .. js:class:: Utf16Wrap
+
+    .. js:function:: from_utf16(input)
+
+    .. js:method:: get_debug_str()
 
     .. js:method:: borrow_cont()
 

--- a/feature_tests/js/package.json
+++ b/feature_tests/js/package.json
@@ -19,6 +19,7 @@
       "esm"
     ],
     "nodeArguments": [
+      "--experimental-wasm-bigint"
     ]
   },
   "scripts": {

--- a/feature_tests/js/package.json
+++ b/feature_tests/js/package.json
@@ -19,7 +19,6 @@
       "esm"
     ],
     "nodeArguments": [
-      "--experimental-wasm-bigint"
     ]
   },
   "scripts": {

--- a/feature_tests/js/test/struct-ts.mjs
+++ b/feature_tests/js/test/struct-ts.mjs
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { MyEnum, MyStruct } from "diplomat-wasm-feature-tests";
+import { MyEnum, MyStruct, Opaque, Utf16Wrap } from "diplomat-wasm-feature-tests";
 
 test("Verify invariants of struct", t => {
     const s = MyStruct.new();
@@ -10,4 +10,14 @@ test("Verify invariants of struct", t => {
     t.is(s["e"], 5991);
     t.is(s["f"], "餐");
     t.is(s["g"], MyEnum.B);
+});
+
+test("Check string conversions", t => {
+    let input = "Hello 🗺";
+    let str_wrap = Opaque.try_from_utf8(input);
+    let utf8_wrap = Opaque.try_from_utf8(input);
+    let utf16_wrap = Utf16Wrap.from_utf16(input);
+    t.is(str_wrap.get_debug_str(), '"Hello 🗺"');
+    t.is(utf8_wrap.get_debug_str(), '"Hello 🗺"');
+    t.is(utf16_wrap.get_debug_str(), '[72, 101, 108, 108, 111, 32, 55357, 56826]');
 });

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -52,7 +52,7 @@ pub mod ffi {
         }
 
         pub fn try_from_utf8(input: &DiplomatStr) -> Option<Box<Self>> {
-            let s = std::str::from_utf8(input.into()).ok()?;
+            let s = std::str::from_utf8(input).ok()?;
             Some(Box::new(Self(s.into())))
         }
 

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -51,13 +51,11 @@ pub mod ffi {
             Box::new(Opaque("".into()))
         }
 
-        #[diplomat::attr(supports = constructors, constructor)]
         pub fn try_from_utf8(input: &DiplomatStr) -> Option<Box<Self>> {
             let s = std::str::from_utf8(input.into()).ok()?;
             Some(Box::new(Self(s.into())))
         }
 
-        #[diplomat::attr(supports = constructors, constructor)]
         pub fn from_str(input: &str) -> Box<Self> {
             Box::new(Self(input.into()))
         }

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -4,8 +4,8 @@ pub mod ffi {
     use diplomat_runtime::DiplomatStr16;
 
     use crate::imports::ffi::ImportedStruct;
-    use std::sync::Mutex;
     use std::fmt::Write;
+    use std::sync::Mutex;
 
     #[diplomat::opaque]
     #[diplomat::transparent_convert]

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -5,6 +5,7 @@ pub mod ffi {
 
     use crate::imports::ffi::ImportedStruct;
     use std::sync::Mutex;
+    use std::fmt::Write;
 
     #[diplomat::opaque]
     #[diplomat::transparent_convert]
@@ -48,6 +49,21 @@ pub mod ffi {
         #[diplomat::attr(supports = constructors, constructor)]
         pub fn new() -> Box<Opaque> {
             Box::new(Opaque("".into()))
+        }
+
+        #[diplomat::attr(supports = constructors, constructor)]
+        pub fn try_from_utf8(input: &DiplomatStr) -> Option<Box<Self>> {
+            let s = std::str::from_utf8(input.into()).ok()?;
+            Some(Box::new(Self(s.into())))
+        }
+
+        #[diplomat::attr(supports = constructors, constructor)]
+        pub fn from_str(input: &str) -> Box<Self> {
+            Box::new(Self(input.into()))
+        }
+
+        pub fn get_debug_str(&self, write: &mut DiplomatWrite) {
+            let _infallible = write!(write, "{:?}", &self.0);
         }
 
         #[diplomat::rust_link(Something::something, FnInStruct)]
@@ -123,12 +139,19 @@ pub mod ffi {
     }
 
     impl Utf16Wrap {
+        #[diplomat::attr(supports = constructors, constructor)]
+        pub fn from_utf16(input: &DiplomatStr16) -> Box<Self> {
+            Box::new(Self(input.into()))
+        }
+
+        pub fn get_debug_str(&self, write: &mut DiplomatWrite) {
+            let _infallible = write!(write, "{:?}", &self.0);
+        }
+
         pub fn borrow_cont<'a>(&'a self) -> &'a DiplomatStr16 {
             &self.0
         }
-    }
 
-    impl Utf16Wrap {
         pub fn owned<'a>(&'a self) -> Box<DiplomatStr16> {
             self.0.clone().into()
         }

--- a/tool/src/js/runtime.mjs
+++ b/tool/src/js/runtime.mjs
@@ -96,8 +96,8 @@ export class DiplomatBuf {
     const byteLength = string.length * 2;
     const ptr = wasm.diplomat_alloc(byteLength, 2);
 
-    const destination = new Uint16Array(wasm.memory.buffer, ptr, byteLength);
-    for (var i; i < string.length; i++) {
+    const destination = new Uint16Array(wasm.memory.buffer, ptr, string.length);
+    for (let i = 0; i < string.length; i++) {
       destination[i] = string.charCodeAt(i);
     }
 


### PR DESCRIPTION
This code must have never been run before by anyone, because it simply didn't work. This impacts `segment_utf16` and any other functions that take utf16. I added a test.