### PR TITLE
Make C2TyGenContext public

### DIFF
--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -108,14 +108,14 @@ struct MethodTemplate<'a> {
 /// The context used for generating a particular type
 ///
 /// Also used by C++ generation code
-pub(crate) struct TyGenContext<'cx, 'tcx> {
-    pub(crate) tcx: &'tcx TypeContext,
-    pub(crate) formatter: &'cx CFormatter<'tcx>,
-    pub(crate) errors: &'cx ErrorStore<'tcx, String>,
-    pub(crate) is_for_cpp: bool,
-    pub(crate) id: TypeId,
-    pub(crate) decl_header_path: String,
-    pub(crate) impl_header_path: String,
+pub struct TyGenContext<'cx, 'tcx> {
+    pub tcx: &'tcx TypeContext,
+    pub formatter: &'cx CFormatter<'tcx>,
+    pub errors: &'cx ErrorStore<'tcx, String>,
+    pub is_for_cpp: bool,
+    pub id: TypeId,
+    pub decl_header_path: String,
+    pub impl_header_path: String,
 }
 
 impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {


### PR DESCRIPTION
Otherwise this fails to compile on Rust 1.70 (ICU4X MSRV)


```
error[E0446]: crate-private type `c2::ty::TyGenContext<'ccx, 'tcx>` in public interface
   --> /home/runner/.cargo/git/checkouts/diplomat-6c8ebb579fc79396/656fd0a/tool/src/cpp2/ty.rs:126:5
    |
126 |     pub c: C2TyGenContext<'ccx, 'tcx>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type
    |
   ::: /home/runner/.cargo/git/checkouts/diplomat-6c8ebb579fc79396/656fd0a/tool/src/c2/ty.rs:111:1
    |
111 | pub(crate) struct TyGenContext<'cx, 'tcx> {
    | ----------------------------------------- `c2::ty::TyGenContext<'ccx, 'tcx>` declared as crate-private
```