### PR TITLE
Typedef for result structs

### DIFF
--- a/example/c2/include/ICU4XDataProvider.h
+++ b/example/c2/include/ICU4XDataProvider.h
@@ -17,8 +17,8 @@
 
 ICU4XDataProvider* ICU4XDataProvider_new_static();
 
-struct ICU4XDataProvider_returns_result_result { bool is_ok;};
-struct ICU4XDataProvider_returns_result_result ICU4XDataProvider_returns_result();
+typedef struct ICU4XDataProvider_returns_result_result { bool is_ok;} ICU4XDataProvider_returns_result_result;
+ICU4XDataProvider_returns_result_result ICU4XDataProvider_returns_result();
 
 
 void ICU4XDataProvider_destroy(ICU4XDataProvider* self);

--- a/example/c2/include/ICU4XFixedDecimal.h
+++ b/example/c2/include/ICU4XFixedDecimal.h
@@ -19,8 +19,8 @@ ICU4XFixedDecimal* ICU4XFixedDecimal_new(int32_t v);
 
 void ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
 
-struct ICU4XFixedDecimal_to_string_result { bool is_ok;};
-struct ICU4XFixedDecimal_to_string_result ICU4XFixedDecimal_to_string(const ICU4XFixedDecimal* self, DiplomatWrite* write);
+typedef struct ICU4XFixedDecimal_to_string_result { bool is_ok;} ICU4XFixedDecimal_to_string_result;
+ICU4XFixedDecimal_to_string_result ICU4XFixedDecimal_to_string(const ICU4XFixedDecimal* self, DiplomatWrite* write);
 
 
 void ICU4XFixedDecimal_destroy(ICU4XFixedDecimal* self);

--- a/example/c2/include/ICU4XFixedDecimalFormatter.h
+++ b/example/c2/include/ICU4XFixedDecimalFormatter.h
@@ -19,8 +19,8 @@
 
 
 
-struct ICU4XFixedDecimalFormatter_try_new_result {union {ICU4XFixedDecimalFormatter* ok; }; bool is_ok;};
-struct ICU4XFixedDecimalFormatter_try_new_result ICU4XFixedDecimalFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XFixedDecimalFormatterOptions options);
+typedef struct ICU4XFixedDecimalFormatter_try_new_result {union {ICU4XFixedDecimalFormatter* ok; }; bool is_ok;} ICU4XFixedDecimalFormatter_try_new_result;
+ICU4XFixedDecimalFormatter_try_new_result ICU4XFixedDecimalFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XFixedDecimalFormatterOptions options);
 
 void ICU4XFixedDecimalFormatter_format_write(const ICU4XFixedDecimalFormatter* self, const ICU4XFixedDecimal* value, DiplomatWrite* write);
 

--- a/example/cpp2/include/ICU4XDataProvider.hpp
+++ b/example/cpp2/include/ICU4XDataProvider.hpp
@@ -17,8 +17,8 @@ namespace capi {
     
     ICU4XDataProvider* ICU4XDataProvider_new_static();
     
-    struct ICU4XDataProvider_returns_result_result { bool is_ok;};
-    struct ICU4XDataProvider_returns_result_result ICU4XDataProvider_returns_result();
+    typedef struct ICU4XDataProvider_returns_result_result { bool is_ok;} ICU4XDataProvider_returns_result_result;
+    ICU4XDataProvider_returns_result_result ICU4XDataProvider_returns_result();
     
     
     void ICU4XDataProvider_destroy(ICU4XDataProvider* self);

--- a/example/cpp2/include/ICU4XFixedDecimal.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimal.hpp
@@ -19,8 +19,8 @@ namespace capi {
     
     void ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
     
-    struct ICU4XFixedDecimal_to_string_result { bool is_ok;};
-    struct ICU4XFixedDecimal_to_string_result ICU4XFixedDecimal_to_string(const ICU4XFixedDecimal* self, DiplomatWrite* write);
+    typedef struct ICU4XFixedDecimal_to_string_result { bool is_ok;} ICU4XFixedDecimal_to_string_result;
+    ICU4XFixedDecimal_to_string_result ICU4XFixedDecimal_to_string(const ICU4XFixedDecimal* self, DiplomatWrite* write);
     
     
     void ICU4XFixedDecimal_destroy(ICU4XFixedDecimal* self);

--- a/example/cpp2/include/ICU4XFixedDecimalFormatter.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatter.hpp
@@ -19,8 +19,8 @@
 namespace capi {
     extern "C" {
     
-    struct ICU4XFixedDecimalFormatter_try_new_result {union {ICU4XFixedDecimalFormatter* ok; }; bool is_ok;};
-    struct ICU4XFixedDecimalFormatter_try_new_result ICU4XFixedDecimalFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XFixedDecimalFormatterOptions options);
+    typedef struct ICU4XFixedDecimalFormatter_try_new_result {union {ICU4XFixedDecimalFormatter* ok; }; bool is_ok;} ICU4XFixedDecimalFormatter_try_new_result;
+    ICU4XFixedDecimalFormatter_try_new_result ICU4XFixedDecimalFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XFixedDecimalFormatterOptions options);
     
     void ICU4XFixedDecimalFormatter_format_write(const ICU4XFixedDecimalFormatter* self, const ICU4XFixedDecimal* value, DiplomatWrite* write);
     

--- a/feature_tests/c2/include/Float64Vec.h
+++ b/feature_tests/c2/include/Float64Vec.h
@@ -41,8 +41,8 @@ void Float64Vec_to_string(const Float64Vec* self, DiplomatWrite* write);
 
 DiplomatF64View Float64Vec_borrow(const Float64Vec* self);
 
-struct Float64Vec_get_result {union {double ok; }; bool is_ok;};
-struct Float64Vec_get_result Float64Vec_get(const Float64Vec* self, size_t i);
+typedef struct Float64Vec_get_result {union {double ok; }; bool is_ok;} Float64Vec_get_result;
+Float64Vec_get_result Float64Vec_get(const Float64Vec* self, size_t i);
 
 
 void Float64Vec_destroy(Float64Vec* self);

--- a/feature_tests/c2/include/MyStruct.h
+++ b/feature_tests/c2/include/MyStruct.h
@@ -19,8 +19,8 @@ MyStruct MyStruct_new();
 
 uint8_t MyStruct_into_a(MyStruct self);
 
-struct MyStruct_returns_zst_result_result { bool is_ok;};
-struct MyStruct_returns_zst_result_result MyStruct_returns_zst_result();
+typedef struct MyStruct_returns_zst_result_result { bool is_ok;} MyStruct_returns_zst_result_result;
+MyStruct_returns_zst_result_result MyStruct_returns_zst_result();
 
 
 

--- a/feature_tests/c2/include/OptionOpaque.h
+++ b/feature_tests/c2/include/OptionOpaque.h
@@ -20,20 +20,20 @@ OptionOpaque* OptionOpaque_new(int32_t i);
 
 OptionOpaque* OptionOpaque_new_none();
 
-struct OptionOpaque_returns_result {union {OptionStruct ok; }; bool is_ok;};
-struct OptionOpaque_returns_result OptionOpaque_returns();
+typedef struct OptionOpaque_returns_result {union {OptionStruct ok; }; bool is_ok;} OptionOpaque_returns_result;
+OptionOpaque_returns_result OptionOpaque_returns();
 
-struct OptionOpaque_option_isize_result {union {intptr_t ok; }; bool is_ok;};
-struct OptionOpaque_option_isize_result OptionOpaque_option_isize(const OptionOpaque* self);
+typedef struct OptionOpaque_option_isize_result {union {intptr_t ok; }; bool is_ok;} OptionOpaque_option_isize_result;
+OptionOpaque_option_isize_result OptionOpaque_option_isize(const OptionOpaque* self);
 
-struct OptionOpaque_option_usize_result {union {size_t ok; }; bool is_ok;};
-struct OptionOpaque_option_usize_result OptionOpaque_option_usize(const OptionOpaque* self);
+typedef struct OptionOpaque_option_usize_result {union {size_t ok; }; bool is_ok;} OptionOpaque_option_usize_result;
+OptionOpaque_option_usize_result OptionOpaque_option_usize(const OptionOpaque* self);
 
-struct OptionOpaque_option_i32_result {union {int32_t ok; }; bool is_ok;};
-struct OptionOpaque_option_i32_result OptionOpaque_option_i32(const OptionOpaque* self);
+typedef struct OptionOpaque_option_i32_result {union {int32_t ok; }; bool is_ok;} OptionOpaque_option_i32_result;
+OptionOpaque_option_i32_result OptionOpaque_option_i32(const OptionOpaque* self);
 
-struct OptionOpaque_option_u32_result {union {uint32_t ok; }; bool is_ok;};
-struct OptionOpaque_option_u32_result OptionOpaque_option_u32(const OptionOpaque* self);
+typedef struct OptionOpaque_option_u32_result {union {uint32_t ok; }; bool is_ok;} OptionOpaque_option_u32_result;
+OptionOpaque_option_u32_result OptionOpaque_option_u32(const OptionOpaque* self);
 
 OptionStruct OptionOpaque_new_struct();
 

--- a/feature_tests/c2/include/OptionString.h
+++ b/feature_tests/c2/include/OptionString.h
@@ -17,11 +17,11 @@
 
 OptionString* OptionString_new(const char* diplomat_str_data, size_t diplomat_str_len);
 
-struct OptionString_write_result { bool is_ok;};
-struct OptionString_write_result OptionString_write(const OptionString* self, DiplomatWrite* write);
+typedef struct OptionString_write_result { bool is_ok;} OptionString_write_result;
+OptionString_write_result OptionString_write(const OptionString* self, DiplomatWrite* write);
 
-struct OptionString_borrow_result {union {DiplomatStringView ok; }; bool is_ok;};
-struct OptionString_borrow_result OptionString_borrow(const OptionString* self);
+typedef struct OptionString_borrow_result {union {DiplomatStringView ok; }; bool is_ok;} OptionString_borrow_result;
+OptionString_borrow_result OptionString_borrow(const OptionString* self);
 
 
 void OptionString_destroy(OptionString* self);

--- a/feature_tests/c2/include/ResultOpaque.h
+++ b/feature_tests/c2/include/ResultOpaque.h
@@ -17,29 +17,29 @@
 
 
 
-struct ResultOpaque_new_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;};
-struct ResultOpaque_new_result ResultOpaque_new(int32_t i);
+typedef struct ResultOpaque_new_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_result;
+ResultOpaque_new_result ResultOpaque_new(int32_t i);
 
-struct ResultOpaque_new_failing_foo_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;};
-struct ResultOpaque_new_failing_foo_result ResultOpaque_new_failing_foo();
+typedef struct ResultOpaque_new_failing_foo_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_failing_foo_result;
+ResultOpaque_new_failing_foo_result ResultOpaque_new_failing_foo();
 
-struct ResultOpaque_new_failing_bar_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;};
-struct ResultOpaque_new_failing_bar_result ResultOpaque_new_failing_bar();
+typedef struct ResultOpaque_new_failing_bar_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_failing_bar_result;
+ResultOpaque_new_failing_bar_result ResultOpaque_new_failing_bar();
 
-struct ResultOpaque_new_failing_unit_result {union {ResultOpaque* ok; }; bool is_ok;};
-struct ResultOpaque_new_failing_unit_result ResultOpaque_new_failing_unit();
+typedef struct ResultOpaque_new_failing_unit_result {union {ResultOpaque* ok; }; bool is_ok;} ResultOpaque_new_failing_unit_result;
+ResultOpaque_new_failing_unit_result ResultOpaque_new_failing_unit();
 
-struct ResultOpaque_new_failing_struct_result {union {ResultOpaque* ok; ErrorStruct err;}; bool is_ok;};
-struct ResultOpaque_new_failing_struct_result ResultOpaque_new_failing_struct(int32_t i);
+typedef struct ResultOpaque_new_failing_struct_result {union {ResultOpaque* ok; ErrorStruct err;}; bool is_ok;} ResultOpaque_new_failing_struct_result;
+ResultOpaque_new_failing_struct_result ResultOpaque_new_failing_struct(int32_t i);
 
-struct ResultOpaque_new_in_err_result {union { ResultOpaque* err;}; bool is_ok;};
-struct ResultOpaque_new_in_err_result ResultOpaque_new_in_err(int32_t i);
+typedef struct ResultOpaque_new_in_err_result {union { ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_err_result;
+ResultOpaque_new_in_err_result ResultOpaque_new_in_err(int32_t i);
 
-struct ResultOpaque_new_int_result {union {int32_t ok; }; bool is_ok;};
-struct ResultOpaque_new_int_result ResultOpaque_new_int(int32_t i);
+typedef struct ResultOpaque_new_int_result {union {int32_t ok; }; bool is_ok;} ResultOpaque_new_int_result;
+ResultOpaque_new_int_result ResultOpaque_new_int(int32_t i);
 
-struct ResultOpaque_new_in_enum_err_result {union {ErrorEnum ok; ResultOpaque* err;}; bool is_ok;};
-struct ResultOpaque_new_in_enum_err_result ResultOpaque_new_in_enum_err(int32_t i);
+typedef struct ResultOpaque_new_in_enum_err_result {union {ErrorEnum ok; ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_enum_err_result;
+ResultOpaque_new_in_enum_err_result ResultOpaque_new_in_enum_err(int32_t i);
 
 void ResultOpaque_assert_integer(const ResultOpaque* self, int32_t i);
 

--- a/feature_tests/cpp2/include/Float64Vec.hpp
+++ b/feature_tests/cpp2/include/Float64Vec.hpp
@@ -41,8 +41,8 @@ namespace capi {
     
     DiplomatF64View Float64Vec_borrow(const Float64Vec* self);
     
-    struct Float64Vec_get_result {union {double ok; }; bool is_ok;};
-    struct Float64Vec_get_result Float64Vec_get(const Float64Vec* self, size_t i);
+    typedef struct Float64Vec_get_result {union {double ok; }; bool is_ok;} Float64Vec_get_result;
+    Float64Vec_get_result Float64Vec_get(const Float64Vec* self, size_t i);
     
     
     void Float64Vec_destroy(Float64Vec* self);

--- a/feature_tests/cpp2/include/MyStruct.hpp
+++ b/feature_tests/cpp2/include/MyStruct.hpp
@@ -21,8 +21,8 @@ namespace capi {
     
     uint8_t MyStruct_into_a(MyStruct self);
     
-    struct MyStruct_returns_zst_result_result { bool is_ok;};
-    struct MyStruct_returns_zst_result_result MyStruct_returns_zst_result();
+    typedef struct MyStruct_returns_zst_result_result { bool is_ok;} MyStruct_returns_zst_result_result;
+    MyStruct_returns_zst_result_result MyStruct_returns_zst_result();
     
     
     } // extern "C"

--- a/feature_tests/cpp2/include/OptionOpaque.hpp
+++ b/feature_tests/cpp2/include/OptionOpaque.hpp
@@ -20,20 +20,20 @@ namespace capi {
     
     OptionOpaque* OptionOpaque_new_none();
     
-    struct OptionOpaque_returns_result {union {OptionStruct ok; }; bool is_ok;};
-    struct OptionOpaque_returns_result OptionOpaque_returns();
+    typedef struct OptionOpaque_returns_result {union {OptionStruct ok; }; bool is_ok;} OptionOpaque_returns_result;
+    OptionOpaque_returns_result OptionOpaque_returns();
     
-    struct OptionOpaque_option_isize_result {union {intptr_t ok; }; bool is_ok;};
-    struct OptionOpaque_option_isize_result OptionOpaque_option_isize(const OptionOpaque* self);
+    typedef struct OptionOpaque_option_isize_result {union {intptr_t ok; }; bool is_ok;} OptionOpaque_option_isize_result;
+    OptionOpaque_option_isize_result OptionOpaque_option_isize(const OptionOpaque* self);
     
-    struct OptionOpaque_option_usize_result {union {size_t ok; }; bool is_ok;};
-    struct OptionOpaque_option_usize_result OptionOpaque_option_usize(const OptionOpaque* self);
+    typedef struct OptionOpaque_option_usize_result {union {size_t ok; }; bool is_ok;} OptionOpaque_option_usize_result;
+    OptionOpaque_option_usize_result OptionOpaque_option_usize(const OptionOpaque* self);
     
-    struct OptionOpaque_option_i32_result {union {int32_t ok; }; bool is_ok;};
-    struct OptionOpaque_option_i32_result OptionOpaque_option_i32(const OptionOpaque* self);
+    typedef struct OptionOpaque_option_i32_result {union {int32_t ok; }; bool is_ok;} OptionOpaque_option_i32_result;
+    OptionOpaque_option_i32_result OptionOpaque_option_i32(const OptionOpaque* self);
     
-    struct OptionOpaque_option_u32_result {union {uint32_t ok; }; bool is_ok;};
-    struct OptionOpaque_option_u32_result OptionOpaque_option_u32(const OptionOpaque* self);
+    typedef struct OptionOpaque_option_u32_result {union {uint32_t ok; }; bool is_ok;} OptionOpaque_option_u32_result;
+    OptionOpaque_option_u32_result OptionOpaque_option_u32(const OptionOpaque* self);
     
     OptionStruct OptionOpaque_new_struct();
     

--- a/feature_tests/cpp2/include/OptionString.hpp
+++ b/feature_tests/cpp2/include/OptionString.hpp
@@ -17,11 +17,11 @@ namespace capi {
     
     OptionString* OptionString_new(const char* diplomat_str_data, size_t diplomat_str_len);
     
-    struct OptionString_write_result { bool is_ok;};
-    struct OptionString_write_result OptionString_write(const OptionString* self, DiplomatWrite* write);
+    typedef struct OptionString_write_result { bool is_ok;} OptionString_write_result;
+    OptionString_write_result OptionString_write(const OptionString* self, DiplomatWrite* write);
     
-    struct OptionString_borrow_result {union {DiplomatStringView ok; }; bool is_ok;};
-    struct OptionString_borrow_result OptionString_borrow(const OptionString* self);
+    typedef struct OptionString_borrow_result {union {DiplomatStringView ok; }; bool is_ok;} OptionString_borrow_result;
+    OptionString_borrow_result OptionString_borrow(const OptionString* self);
     
     
     void OptionString_destroy(OptionString* self);

--- a/feature_tests/cpp2/include/ResultOpaque.hpp
+++ b/feature_tests/cpp2/include/ResultOpaque.hpp
@@ -17,29 +17,29 @@
 namespace capi {
     extern "C" {
     
-    struct ResultOpaque_new_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;};
-    struct ResultOpaque_new_result ResultOpaque_new(int32_t i);
+    typedef struct ResultOpaque_new_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_result;
+    ResultOpaque_new_result ResultOpaque_new(int32_t i);
     
-    struct ResultOpaque_new_failing_foo_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;};
-    struct ResultOpaque_new_failing_foo_result ResultOpaque_new_failing_foo();
+    typedef struct ResultOpaque_new_failing_foo_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_failing_foo_result;
+    ResultOpaque_new_failing_foo_result ResultOpaque_new_failing_foo();
     
-    struct ResultOpaque_new_failing_bar_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;};
-    struct ResultOpaque_new_failing_bar_result ResultOpaque_new_failing_bar();
+    typedef struct ResultOpaque_new_failing_bar_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_failing_bar_result;
+    ResultOpaque_new_failing_bar_result ResultOpaque_new_failing_bar();
     
-    struct ResultOpaque_new_failing_unit_result {union {ResultOpaque* ok; }; bool is_ok;};
-    struct ResultOpaque_new_failing_unit_result ResultOpaque_new_failing_unit();
+    typedef struct ResultOpaque_new_failing_unit_result {union {ResultOpaque* ok; }; bool is_ok;} ResultOpaque_new_failing_unit_result;
+    ResultOpaque_new_failing_unit_result ResultOpaque_new_failing_unit();
     
-    struct ResultOpaque_new_failing_struct_result {union {ResultOpaque* ok; ErrorStruct err;}; bool is_ok;};
-    struct ResultOpaque_new_failing_struct_result ResultOpaque_new_failing_struct(int32_t i);
+    typedef struct ResultOpaque_new_failing_struct_result {union {ResultOpaque* ok; ErrorStruct err;}; bool is_ok;} ResultOpaque_new_failing_struct_result;
+    ResultOpaque_new_failing_struct_result ResultOpaque_new_failing_struct(int32_t i);
     
-    struct ResultOpaque_new_in_err_result {union { ResultOpaque* err;}; bool is_ok;};
-    struct ResultOpaque_new_in_err_result ResultOpaque_new_in_err(int32_t i);
+    typedef struct ResultOpaque_new_in_err_result {union { ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_err_result;
+    ResultOpaque_new_in_err_result ResultOpaque_new_in_err(int32_t i);
     
-    struct ResultOpaque_new_int_result {union {int32_t ok; }; bool is_ok;};
-    struct ResultOpaque_new_int_result ResultOpaque_new_int(int32_t i);
+    typedef struct ResultOpaque_new_int_result {union {int32_t ok; }; bool is_ok;} ResultOpaque_new_int_result;
+    ResultOpaque_new_int_result ResultOpaque_new_int(int32_t i);
     
-    struct ResultOpaque_new_in_enum_err_result {union {ErrorEnum ok; ResultOpaque* err;}; bool is_ok;};
-    struct ResultOpaque_new_in_enum_err_result ResultOpaque_new_in_enum_err(int32_t i);
+    typedef struct ResultOpaque_new_in_enum_err_result {union {ErrorEnum ok; ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_enum_err_result;
+    ResultOpaque_new_in_enum_err_result ResultOpaque_new_in_enum_err(int32_t i);
     
     void ResultOpaque_assert_integer(const ResultOpaque* self, int32_t i);
     

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -323,7 +323,7 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
 
         // We can't use an anonymous struct here: C++ doesn't like producing those in return types
         // Instead we name it something unique per-function. This is a bit ugly but works just fine.
-        format!("struct {fn_name}_result {{{union_def} bool is_ok;}};\nstruct {fn_name}_result")
+        format!("typedef struct {fn_name}_result {{{union_def} bool is_ok;}} {fn_name}_result;\n{fn_name}_result")
     }
 
     /// Generates a list of decls for a given type, returned as (type, name)

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -121,11 +121,11 @@ struct MethodInfo<'a> {
 }
 
 /// Context for generating a particular type's header
-pub struct TyGenContext<'ccx, 'tcx, 'header> {
-    pub cx: &'ccx Cpp2Context<'tcx>,
-    pub c: C2TyGenContext<'ccx, 'tcx>,
-    pub impl_header: &'header mut Header,
-    pub decl_header: &'header mut Header,
+pub(crate) struct TyGenContext<'ccx, 'tcx, 'header> {
+    pub(crate) cx: &'ccx Cpp2Context<'tcx>,
+    pub(crate) c: C2TyGenContext<'ccx, 'tcx>,
+    pub(crate) impl_header: &'header mut Header,
+    pub(crate) decl_header: &'header mut Header,
 }
 
 impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
@@ -135,7 +135,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
     /// C enum type. This enables us to add methods to the enum and generally make the enum
     /// behave more like an upgraded C++ type. We don't use `enum class` because methods
     /// cannot be added to it.
-    pub fn gen_enum_def(&mut self, ty: &'tcx hir::EnumDef, id: TypeId) {
+    pub(crate) fn gen_enum_def(&mut self, ty: &'tcx hir::EnumDef, id: TypeId) {
         let type_name = self.cx.formatter.fmt_type_name(id);
         let type_name_unnamespaced = self.cx.formatter.fmt_type_name_unnamespaced(id);
         let ctype = self.cx.formatter.fmt_c_type_name(id);
@@ -197,7 +197,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
         .unwrap();
     }
 
-    pub fn gen_opaque_def(&mut self, ty: &'tcx hir::OpaqueDef, id: TypeId) {
+    pub(crate) fn gen_opaque_def(&mut self, ty: &'tcx hir::OpaqueDef, id: TypeId) {
         let type_name = self.cx.formatter.fmt_type_name(id);
         let type_name_unnamespaced = self.cx.formatter.fmt_type_name_unnamespaced(id);
         let ctype = self.cx.formatter.fmt_c_type_name(id);
@@ -262,7 +262,11 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
         .unwrap();
     }
 
-    pub fn gen_struct_def<P: TyPosition>(&mut self, def: &'tcx hir::StructDef<P>, id: TypeId) {
+    pub(crate) fn gen_struct_def<P: TyPosition>(
+        &mut self,
+        def: &'tcx hir::StructDef<P>,
+        id: TypeId,
+    ) {
         let type_name = self.cx.formatter.fmt_type_name(id);
         let type_name_unnamespaced = self.cx.formatter.fmt_type_name_unnamespaced(id);
         let ctype = self.cx.formatter.fmt_c_type_name(id);


### PR DESCRIPTION
Otherwise they always have to be referred to by `struct Foo_result`