### PR TITLE
Don't include std serde from proc macro

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,7 @@ syn = { version = "2", features = [ "full", "extra-traits" ] }
 quote = "1.0"
 proc-macro2 = "1.0.27"
 lazy_static = "1.4.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 displaydoc = { version = "0.2", optional = true }
 smallvec = "1.9.0"
 strck_ident = { version = "0.1", features = ["rust"] }


### PR DESCRIPTION
I'm going to patch release this.

Note that patch releases _cannot_ be made from master right now.