### PR TITLE
Namespace c-in-c++

### DIFF
--- a/example/cpp2/include/ICU4XDataProvider.d.hpp
+++ b/example/cpp2/include/ICU4XDataProvider.d.hpp
@@ -9,7 +9,13 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace icu4x {
+namespace capi {typedef struct ICU4XDataProvider ICU4XDataProvider; }
+class ICU4XDataProvider;
+}
 
+
+namespace icu4x {
 namespace capi {
     typedef struct ICU4XDataProvider ICU4XDataProvider;
 }
@@ -17,23 +23,23 @@ namespace capi {
 class ICU4XDataProvider {
 public:
 
-  inline static std::unique_ptr<ICU4XDataProvider> new_static();
+  inline static std::unique_ptr<icu4x::ICU4XDataProvider> new_static();
 
   inline static diplomat::result<std::monostate, std::monostate> returns_result();
 
-  inline const ::capi::ICU4XDataProvider* AsFFI() const;
-  inline ::capi::ICU4XDataProvider* AsFFI();
-  inline static const ICU4XDataProvider* FromFFI(const ::capi::ICU4XDataProvider* ptr);
-  inline static ICU4XDataProvider* FromFFI(::capi::ICU4XDataProvider* ptr);
+  inline const icu4x::capi::ICU4XDataProvider* AsFFI() const;
+  inline icu4x::capi::ICU4XDataProvider* AsFFI();
+  inline static const icu4x::ICU4XDataProvider* FromFFI(const icu4x::capi::ICU4XDataProvider* ptr);
+  inline static icu4x::ICU4XDataProvider* FromFFI(icu4x::capi::ICU4XDataProvider* ptr);
   inline static void operator delete(void* ptr);
 private:
   ICU4XDataProvider() = delete;
-  ICU4XDataProvider(const ICU4XDataProvider&) = delete;
-  ICU4XDataProvider(ICU4XDataProvider&&) noexcept = delete;
-  ICU4XDataProvider operator=(const ICU4XDataProvider&) = delete;
-  ICU4XDataProvider operator=(ICU4XDataProvider&&) noexcept = delete;
+  ICU4XDataProvider(const icu4x::ICU4XDataProvider&) = delete;
+  ICU4XDataProvider(icu4x::ICU4XDataProvider&&) noexcept = delete;
+  ICU4XDataProvider operator=(const icu4x::ICU4XDataProvider&) = delete;
+  ICU4XDataProvider operator=(icu4x::ICU4XDataProvider&&) noexcept = delete;
   static void operator delete[](void*, size_t) = delete;
 };
 
-
+}
 #endif // ICU4XDataProvider_D_HPP

--- a/example/cpp2/include/ICU4XDataProvider.d.hpp
+++ b/example/cpp2/include/ICU4XDataProvider.d.hpp
@@ -21,10 +21,10 @@ public:
 
   inline static diplomat::result<std::monostate, std::monostate> returns_result();
 
-  inline const capi::ICU4XDataProvider* AsFFI() const;
-  inline capi::ICU4XDataProvider* AsFFI();
-  inline static const ICU4XDataProvider* FromFFI(const capi::ICU4XDataProvider* ptr);
-  inline static ICU4XDataProvider* FromFFI(capi::ICU4XDataProvider* ptr);
+  inline const ::capi::ICU4XDataProvider* AsFFI() const;
+  inline ::capi::ICU4XDataProvider* AsFFI();
+  inline static const ICU4XDataProvider* FromFFI(const ::capi::ICU4XDataProvider* ptr);
+  inline static ICU4XDataProvider* FromFFI(::capi::ICU4XDataProvider* ptr);
   inline static void operator delete(void* ptr);
 private:
   ICU4XDataProvider() = delete;

--- a/example/cpp2/include/ICU4XDataProvider.hpp
+++ b/example/cpp2/include/ICU4XDataProvider.hpp
@@ -15,7 +15,7 @@
 namespace capi {
     extern "C" {
     
-    ICU4XDataProvider* ICU4XDataProvider_new_static();
+    ::capi::ICU4XDataProvider* ICU4XDataProvider_new_static();
     
     typedef struct ICU4XDataProvider_returns_result_result { bool is_ok;} ICU4XDataProvider_returns_result_result;
     ICU4XDataProvider_returns_result_result ICU4XDataProvider_returns_result();
@@ -25,7 +25,6 @@ namespace capi {
     
     } // extern "C"
 }
-
 inline std::unique_ptr<ICU4XDataProvider> ICU4XDataProvider::new_static() {
   auto result = capi::ICU4XDataProvider_new_static();
   return std::unique_ptr<ICU4XDataProvider>(ICU4XDataProvider::FromFFI(result));
@@ -36,24 +35,24 @@ inline diplomat::result<std::monostate, std::monostate> ICU4XDataProvider::retur
   return result.is_ok ? diplomat::result<std::monostate, std::monostate>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, std::monostate>(diplomat::Err<std::monostate>());
 }
 
-inline const capi::ICU4XDataProvider* ICU4XDataProvider::AsFFI() const {
-  return reinterpret_cast<const capi::ICU4XDataProvider*>(this);
+inline const ::capi::ICU4XDataProvider* ICU4XDataProvider::AsFFI() const {
+  return reinterpret_cast<const ::capi::ICU4XDataProvider*>(this);
 }
 
-inline capi::ICU4XDataProvider* ICU4XDataProvider::AsFFI() {
-  return reinterpret_cast<capi::ICU4XDataProvider*>(this);
+inline ::capi::ICU4XDataProvider* ICU4XDataProvider::AsFFI() {
+  return reinterpret_cast<::capi::ICU4XDataProvider*>(this);
 }
 
-inline const ICU4XDataProvider* ICU4XDataProvider::FromFFI(const capi::ICU4XDataProvider* ptr) {
+inline const ICU4XDataProvider* ICU4XDataProvider::FromFFI(const ::capi::ICU4XDataProvider* ptr) {
   return reinterpret_cast<const ICU4XDataProvider*>(ptr);
 }
 
-inline ICU4XDataProvider* ICU4XDataProvider::FromFFI(capi::ICU4XDataProvider* ptr) {
+inline ICU4XDataProvider* ICU4XDataProvider::FromFFI(::capi::ICU4XDataProvider* ptr) {
   return reinterpret_cast<ICU4XDataProvider*>(ptr);
 }
 
 inline void ICU4XDataProvider::operator delete(void* ptr) {
-  capi::ICU4XDataProvider_destroy(reinterpret_cast<capi::ICU4XDataProvider*>(ptr));
+  capi::ICU4XDataProvider_destroy(reinterpret_cast<::capi::ICU4XDataProvider*>(ptr));
 }
 
 

--- a/example/cpp2/include/ICU4XDataProvider.hpp
+++ b/example/cpp2/include/ICU4XDataProvider.hpp
@@ -12,10 +12,11 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace icu4x {
 namespace capi {
     extern "C" {
     
-    ::capi::ICU4XDataProvider* ICU4XDataProvider_new_static();
+    icu4x::capi::ICU4XDataProvider* ICU4XDataProvider_new_static();
     
     typedef struct ICU4XDataProvider_returns_result_result { bool is_ok;} ICU4XDataProvider_returns_result_result;
     ICU4XDataProvider_returns_result_result ICU4XDataProvider_returns_result();
@@ -25,34 +26,35 @@ namespace capi {
     
     } // extern "C"
 }
-inline std::unique_ptr<ICU4XDataProvider> ICU4XDataProvider::new_static() {
+}
+inline std::unique_ptr<icu4x::ICU4XDataProvider> icu4x::ICU4XDataProvider::new_static() {
   auto result = capi::ICU4XDataProvider_new_static();
-  return std::unique_ptr<ICU4XDataProvider>(ICU4XDataProvider::FromFFI(result));
+  return std::unique_ptr<icu4x::ICU4XDataProvider>(icu4x::ICU4XDataProvider::FromFFI(result));
 }
 
-inline diplomat::result<std::monostate, std::monostate> ICU4XDataProvider::returns_result() {
+inline diplomat::result<std::monostate, std::monostate> icu4x::ICU4XDataProvider::returns_result() {
   auto result = capi::ICU4XDataProvider_returns_result();
   return result.is_ok ? diplomat::result<std::monostate, std::monostate>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, std::monostate>(diplomat::Err<std::monostate>());
 }
 
-inline const ::capi::ICU4XDataProvider* ICU4XDataProvider::AsFFI() const {
-  return reinterpret_cast<const ::capi::ICU4XDataProvider*>(this);
+inline const icu4x::capi::ICU4XDataProvider* icu4x::ICU4XDataProvider::AsFFI() const {
+  return reinterpret_cast<const icu4x::capi::ICU4XDataProvider*>(this);
 }
 
-inline ::capi::ICU4XDataProvider* ICU4XDataProvider::AsFFI() {
-  return reinterpret_cast<::capi::ICU4XDataProvider*>(this);
+inline icu4x::capi::ICU4XDataProvider* icu4x::ICU4XDataProvider::AsFFI() {
+  return reinterpret_cast<icu4x::capi::ICU4XDataProvider*>(this);
 }
 
-inline const ICU4XDataProvider* ICU4XDataProvider::FromFFI(const ::capi::ICU4XDataProvider* ptr) {
-  return reinterpret_cast<const ICU4XDataProvider*>(ptr);
+inline const icu4x::ICU4XDataProvider* icu4x::ICU4XDataProvider::FromFFI(const icu4x::capi::ICU4XDataProvider* ptr) {
+  return reinterpret_cast<const icu4x::ICU4XDataProvider*>(ptr);
 }
 
-inline ICU4XDataProvider* ICU4XDataProvider::FromFFI(::capi::ICU4XDataProvider* ptr) {
-  return reinterpret_cast<ICU4XDataProvider*>(ptr);
+inline icu4x::ICU4XDataProvider* icu4x::ICU4XDataProvider::FromFFI(icu4x::capi::ICU4XDataProvider* ptr) {
+  return reinterpret_cast<icu4x::ICU4XDataProvider*>(ptr);
 }
 
-inline void ICU4XDataProvider::operator delete(void* ptr) {
-  capi::ICU4XDataProvider_destroy(reinterpret_cast<::capi::ICU4XDataProvider*>(ptr));
+inline void icu4x::ICU4XDataProvider::operator delete(void* ptr) {
+  capi::ICU4XDataProvider_destroy(reinterpret_cast<icu4x::capi::ICU4XDataProvider*>(ptr));
 }
 
 

--- a/example/cpp2/include/ICU4XFixedDecimal.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimal.d.hpp
@@ -9,7 +9,13 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace icu4x {
+namespace capi {typedef struct ICU4XFixedDecimal ICU4XFixedDecimal; }
+class ICU4XFixedDecimal;
+}
 
+
+namespace icu4x {
 namespace capi {
     typedef struct ICU4XFixedDecimal ICU4XFixedDecimal;
 }
@@ -17,25 +23,25 @@ namespace capi {
 class ICU4XFixedDecimal {
 public:
 
-  inline static std::unique_ptr<ICU4XFixedDecimal> new_(int32_t v);
+  inline static std::unique_ptr<icu4x::ICU4XFixedDecimal> new_(int32_t v);
 
   inline void multiply_pow10(int16_t power);
 
   inline diplomat::result<std::string, std::monostate> to_string() const;
 
-  inline const ::capi::ICU4XFixedDecimal* AsFFI() const;
-  inline ::capi::ICU4XFixedDecimal* AsFFI();
-  inline static const ICU4XFixedDecimal* FromFFI(const ::capi::ICU4XFixedDecimal* ptr);
-  inline static ICU4XFixedDecimal* FromFFI(::capi::ICU4XFixedDecimal* ptr);
+  inline const icu4x::capi::ICU4XFixedDecimal* AsFFI() const;
+  inline icu4x::capi::ICU4XFixedDecimal* AsFFI();
+  inline static const icu4x::ICU4XFixedDecimal* FromFFI(const icu4x::capi::ICU4XFixedDecimal* ptr);
+  inline static icu4x::ICU4XFixedDecimal* FromFFI(icu4x::capi::ICU4XFixedDecimal* ptr);
   inline static void operator delete(void* ptr);
 private:
   ICU4XFixedDecimal() = delete;
-  ICU4XFixedDecimal(const ICU4XFixedDecimal&) = delete;
-  ICU4XFixedDecimal(ICU4XFixedDecimal&&) noexcept = delete;
-  ICU4XFixedDecimal operator=(const ICU4XFixedDecimal&) = delete;
-  ICU4XFixedDecimal operator=(ICU4XFixedDecimal&&) noexcept = delete;
+  ICU4XFixedDecimal(const icu4x::ICU4XFixedDecimal&) = delete;
+  ICU4XFixedDecimal(icu4x::ICU4XFixedDecimal&&) noexcept = delete;
+  ICU4XFixedDecimal operator=(const icu4x::ICU4XFixedDecimal&) = delete;
+  ICU4XFixedDecimal operator=(icu4x::ICU4XFixedDecimal&&) noexcept = delete;
   static void operator delete[](void*, size_t) = delete;
 };
 
-
+}
 #endif // ICU4XFixedDecimal_D_HPP

--- a/example/cpp2/include/ICU4XFixedDecimal.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimal.d.hpp
@@ -23,10 +23,10 @@ public:
 
   inline diplomat::result<std::string, std::monostate> to_string() const;
 
-  inline const capi::ICU4XFixedDecimal* AsFFI() const;
-  inline capi::ICU4XFixedDecimal* AsFFI();
-  inline static const ICU4XFixedDecimal* FromFFI(const capi::ICU4XFixedDecimal* ptr);
-  inline static ICU4XFixedDecimal* FromFFI(capi::ICU4XFixedDecimal* ptr);
+  inline const ::capi::ICU4XFixedDecimal* AsFFI() const;
+  inline ::capi::ICU4XFixedDecimal* AsFFI();
+  inline static const ICU4XFixedDecimal* FromFFI(const ::capi::ICU4XFixedDecimal* ptr);
+  inline static ICU4XFixedDecimal* FromFFI(::capi::ICU4XFixedDecimal* ptr);
   inline static void operator delete(void* ptr);
 private:
   ICU4XFixedDecimal() = delete;

--- a/example/cpp2/include/ICU4XFixedDecimal.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimal.hpp
@@ -12,57 +12,59 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace icu4x {
 namespace capi {
     extern "C" {
     
-    ::capi::ICU4XFixedDecimal* ICU4XFixedDecimal_new(int32_t v);
+    icu4x::capi::ICU4XFixedDecimal* ICU4XFixedDecimal_new(int32_t v);
     
-    void ICU4XFixedDecimal_multiply_pow10(::capi::ICU4XFixedDecimal* self, int16_t power);
+    void ICU4XFixedDecimal_multiply_pow10(icu4x::capi::ICU4XFixedDecimal* self, int16_t power);
     
     typedef struct ICU4XFixedDecimal_to_string_result { bool is_ok;} ICU4XFixedDecimal_to_string_result;
-    ICU4XFixedDecimal_to_string_result ICU4XFixedDecimal_to_string(const ::capi::ICU4XFixedDecimal* self, DiplomatWrite* write);
+    ICU4XFixedDecimal_to_string_result ICU4XFixedDecimal_to_string(const icu4x::capi::ICU4XFixedDecimal* self, ::capi::DiplomatWrite* write);
     
     
     void ICU4XFixedDecimal_destroy(ICU4XFixedDecimal* self);
     
     } // extern "C"
 }
-inline std::unique_ptr<ICU4XFixedDecimal> ICU4XFixedDecimal::new_(int32_t v) {
+}
+inline std::unique_ptr<icu4x::ICU4XFixedDecimal> icu4x::ICU4XFixedDecimal::new_(int32_t v) {
   auto result = capi::ICU4XFixedDecimal_new(v);
-  return std::unique_ptr<ICU4XFixedDecimal>(ICU4XFixedDecimal::FromFFI(result));
+  return std::unique_ptr<icu4x::ICU4XFixedDecimal>(icu4x::ICU4XFixedDecimal::FromFFI(result));
 }
 
-inline void ICU4XFixedDecimal::multiply_pow10(int16_t power) {
+inline void icu4x::ICU4XFixedDecimal::multiply_pow10(int16_t power) {
   capi::ICU4XFixedDecimal_multiply_pow10(this->AsFFI(),
     power);
 }
 
-inline diplomat::result<std::string, std::monostate> ICU4XFixedDecimal::to_string() const {
+inline diplomat::result<std::string, std::monostate> icu4x::ICU4XFixedDecimal::to_string() const {
   std::string output;
-  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  ::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   auto result = capi::ICU4XFixedDecimal_to_string(this->AsFFI(),
     &write);
   return result.is_ok ? diplomat::result<std::string, std::monostate>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, std::monostate>(diplomat::Err<std::monostate>());
 }
 
-inline const ::capi::ICU4XFixedDecimal* ICU4XFixedDecimal::AsFFI() const {
-  return reinterpret_cast<const ::capi::ICU4XFixedDecimal*>(this);
+inline const icu4x::capi::ICU4XFixedDecimal* icu4x::ICU4XFixedDecimal::AsFFI() const {
+  return reinterpret_cast<const icu4x::capi::ICU4XFixedDecimal*>(this);
 }
 
-inline ::capi::ICU4XFixedDecimal* ICU4XFixedDecimal::AsFFI() {
-  return reinterpret_cast<::capi::ICU4XFixedDecimal*>(this);
+inline icu4x::capi::ICU4XFixedDecimal* icu4x::ICU4XFixedDecimal::AsFFI() {
+  return reinterpret_cast<icu4x::capi::ICU4XFixedDecimal*>(this);
 }
 
-inline const ICU4XFixedDecimal* ICU4XFixedDecimal::FromFFI(const ::capi::ICU4XFixedDecimal* ptr) {
-  return reinterpret_cast<const ICU4XFixedDecimal*>(ptr);
+inline const icu4x::ICU4XFixedDecimal* icu4x::ICU4XFixedDecimal::FromFFI(const icu4x::capi::ICU4XFixedDecimal* ptr) {
+  return reinterpret_cast<const icu4x::ICU4XFixedDecimal*>(ptr);
 }
 
-inline ICU4XFixedDecimal* ICU4XFixedDecimal::FromFFI(::capi::ICU4XFixedDecimal* ptr) {
-  return reinterpret_cast<ICU4XFixedDecimal*>(ptr);
+inline icu4x::ICU4XFixedDecimal* icu4x::ICU4XFixedDecimal::FromFFI(icu4x::capi::ICU4XFixedDecimal* ptr) {
+  return reinterpret_cast<icu4x::ICU4XFixedDecimal*>(ptr);
 }
 
-inline void ICU4XFixedDecimal::operator delete(void* ptr) {
-  capi::ICU4XFixedDecimal_destroy(reinterpret_cast<::capi::ICU4XFixedDecimal*>(ptr));
+inline void icu4x::ICU4XFixedDecimal::operator delete(void* ptr) {
+  capi::ICU4XFixedDecimal_destroy(reinterpret_cast<icu4x::capi::ICU4XFixedDecimal*>(ptr));
 }
 
 

--- a/example/cpp2/include/ICU4XFixedDecimal.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimal.hpp
@@ -15,19 +15,18 @@
 namespace capi {
     extern "C" {
     
-    ICU4XFixedDecimal* ICU4XFixedDecimal_new(int32_t v);
+    ::capi::ICU4XFixedDecimal* ICU4XFixedDecimal_new(int32_t v);
     
-    void ICU4XFixedDecimal_multiply_pow10(ICU4XFixedDecimal* self, int16_t power);
+    void ICU4XFixedDecimal_multiply_pow10(::capi::ICU4XFixedDecimal* self, int16_t power);
     
     typedef struct ICU4XFixedDecimal_to_string_result { bool is_ok;} ICU4XFixedDecimal_to_string_result;
-    ICU4XFixedDecimal_to_string_result ICU4XFixedDecimal_to_string(const ICU4XFixedDecimal* self, DiplomatWrite* write);
+    ICU4XFixedDecimal_to_string_result ICU4XFixedDecimal_to_string(const ::capi::ICU4XFixedDecimal* self, DiplomatWrite* write);
     
     
     void ICU4XFixedDecimal_destroy(ICU4XFixedDecimal* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<ICU4XFixedDecimal> ICU4XFixedDecimal::new_(int32_t v) {
   auto result = capi::ICU4XFixedDecimal_new(v);
   return std::unique_ptr<ICU4XFixedDecimal>(ICU4XFixedDecimal::FromFFI(result));
@@ -46,24 +45,24 @@ inline diplomat::result<std::string, std::monostate> ICU4XFixedDecimal::to_strin
   return result.is_ok ? diplomat::result<std::string, std::monostate>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, std::monostate>(diplomat::Err<std::monostate>());
 }
 
-inline const capi::ICU4XFixedDecimal* ICU4XFixedDecimal::AsFFI() const {
-  return reinterpret_cast<const capi::ICU4XFixedDecimal*>(this);
+inline const ::capi::ICU4XFixedDecimal* ICU4XFixedDecimal::AsFFI() const {
+  return reinterpret_cast<const ::capi::ICU4XFixedDecimal*>(this);
 }
 
-inline capi::ICU4XFixedDecimal* ICU4XFixedDecimal::AsFFI() {
-  return reinterpret_cast<capi::ICU4XFixedDecimal*>(this);
+inline ::capi::ICU4XFixedDecimal* ICU4XFixedDecimal::AsFFI() {
+  return reinterpret_cast<::capi::ICU4XFixedDecimal*>(this);
 }
 
-inline const ICU4XFixedDecimal* ICU4XFixedDecimal::FromFFI(const capi::ICU4XFixedDecimal* ptr) {
+inline const ICU4XFixedDecimal* ICU4XFixedDecimal::FromFFI(const ::capi::ICU4XFixedDecimal* ptr) {
   return reinterpret_cast<const ICU4XFixedDecimal*>(ptr);
 }
 
-inline ICU4XFixedDecimal* ICU4XFixedDecimal::FromFFI(capi::ICU4XFixedDecimal* ptr) {
+inline ICU4XFixedDecimal* ICU4XFixedDecimal::FromFFI(::capi::ICU4XFixedDecimal* ptr) {
   return reinterpret_cast<ICU4XFixedDecimal*>(ptr);
 }
 
 inline void ICU4XFixedDecimal::operator delete(void* ptr) {
-  capi::ICU4XFixedDecimal_destroy(reinterpret_cast<capi::ICU4XFixedDecimal*>(ptr));
+  capi::ICU4XFixedDecimal_destroy(reinterpret_cast<::capi::ICU4XFixedDecimal*>(ptr));
 }
 
 

--- a/example/cpp2/include/ICU4XFixedDecimalFormatter.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatter.d.hpp
@@ -10,8 +10,11 @@
 #include "diplomat_runtime.hpp"
 #include "ICU4XFixedDecimalFormatterOptions.d.hpp"
 
+namespace capi {typedef struct ICU4XDataProvider ICU4XDataProvider; }
 class ICU4XDataProvider;
+namespace capi {typedef struct ICU4XFixedDecimal ICU4XFixedDecimal; }
 class ICU4XFixedDecimal;
+namespace capi {typedef struct ICU4XLocale ICU4XLocale; }
 class ICU4XLocale;
 struct ICU4XFixedDecimalFormatterOptions;
 
@@ -27,10 +30,10 @@ public:
 
   inline std::string format_write(const ICU4XFixedDecimal& value) const;
 
-  inline const capi::ICU4XFixedDecimalFormatter* AsFFI() const;
-  inline capi::ICU4XFixedDecimalFormatter* AsFFI();
-  inline static const ICU4XFixedDecimalFormatter* FromFFI(const capi::ICU4XFixedDecimalFormatter* ptr);
-  inline static ICU4XFixedDecimalFormatter* FromFFI(capi::ICU4XFixedDecimalFormatter* ptr);
+  inline const ::capi::ICU4XFixedDecimalFormatter* AsFFI() const;
+  inline ::capi::ICU4XFixedDecimalFormatter* AsFFI();
+  inline static const ICU4XFixedDecimalFormatter* FromFFI(const ::capi::ICU4XFixedDecimalFormatter* ptr);
+  inline static ICU4XFixedDecimalFormatter* FromFFI(::capi::ICU4XFixedDecimalFormatter* ptr);
   inline static void operator delete(void* ptr);
 private:
   ICU4XFixedDecimalFormatter() = delete;

--- a/example/cpp2/include/ICU4XFixedDecimalFormatter.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatter.d.hpp
@@ -10,15 +10,20 @@
 #include "diplomat_runtime.hpp"
 #include "ICU4XFixedDecimalFormatterOptions.d.hpp"
 
+namespace icu4x {
 namespace capi {typedef struct ICU4XDataProvider ICU4XDataProvider; }
 class ICU4XDataProvider;
 namespace capi {typedef struct ICU4XFixedDecimal ICU4XFixedDecimal; }
 class ICU4XFixedDecimal;
+namespace capi {typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter; }
+class ICU4XFixedDecimalFormatter;
 namespace capi {typedef struct ICU4XLocale ICU4XLocale; }
 class ICU4XLocale;
 struct ICU4XFixedDecimalFormatterOptions;
+}
 
 
+namespace icu4x {
 namespace capi {
     typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter;
 }
@@ -26,23 +31,23 @@ namespace capi {
 class ICU4XFixedDecimalFormatter {
 public:
 
-  inline static diplomat::result<std::unique_ptr<ICU4XFixedDecimalFormatter>, std::monostate> try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XFixedDecimalFormatterOptions options);
+  inline static diplomat::result<std::unique_ptr<icu4x::ICU4XFixedDecimalFormatter>, std::monostate> try_new(const icu4x::ICU4XLocale& locale, const icu4x::ICU4XDataProvider& provider, icu4x::ICU4XFixedDecimalFormatterOptions options);
 
-  inline std::string format_write(const ICU4XFixedDecimal& value) const;
+  inline std::string format_write(const icu4x::ICU4XFixedDecimal& value) const;
 
-  inline const ::capi::ICU4XFixedDecimalFormatter* AsFFI() const;
-  inline ::capi::ICU4XFixedDecimalFormatter* AsFFI();
-  inline static const ICU4XFixedDecimalFormatter* FromFFI(const ::capi::ICU4XFixedDecimalFormatter* ptr);
-  inline static ICU4XFixedDecimalFormatter* FromFFI(::capi::ICU4XFixedDecimalFormatter* ptr);
+  inline const icu4x::capi::ICU4XFixedDecimalFormatter* AsFFI() const;
+  inline icu4x::capi::ICU4XFixedDecimalFormatter* AsFFI();
+  inline static const icu4x::ICU4XFixedDecimalFormatter* FromFFI(const icu4x::capi::ICU4XFixedDecimalFormatter* ptr);
+  inline static icu4x::ICU4XFixedDecimalFormatter* FromFFI(icu4x::capi::ICU4XFixedDecimalFormatter* ptr);
   inline static void operator delete(void* ptr);
 private:
   ICU4XFixedDecimalFormatter() = delete;
-  ICU4XFixedDecimalFormatter(const ICU4XFixedDecimalFormatter&) = delete;
-  ICU4XFixedDecimalFormatter(ICU4XFixedDecimalFormatter&&) noexcept = delete;
-  ICU4XFixedDecimalFormatter operator=(const ICU4XFixedDecimalFormatter&) = delete;
-  ICU4XFixedDecimalFormatter operator=(ICU4XFixedDecimalFormatter&&) noexcept = delete;
+  ICU4XFixedDecimalFormatter(const icu4x::ICU4XFixedDecimalFormatter&) = delete;
+  ICU4XFixedDecimalFormatter(icu4x::ICU4XFixedDecimalFormatter&&) noexcept = delete;
+  ICU4XFixedDecimalFormatter operator=(const icu4x::ICU4XFixedDecimalFormatter&) = delete;
+  ICU4XFixedDecimalFormatter operator=(icu4x::ICU4XFixedDecimalFormatter&&) noexcept = delete;
   static void operator delete[](void*, size_t) = delete;
 };
 
-
+}
 #endif // ICU4XFixedDecimalFormatter_D_HPP

--- a/example/cpp2/include/ICU4XFixedDecimalFormatter.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatter.hpp
@@ -16,53 +16,55 @@
 #include "ICU4XLocale.hpp"
 
 
+namespace icu4x {
 namespace capi {
     extern "C" {
     
-    typedef struct ICU4XFixedDecimalFormatter_try_new_result {union {::capi::ICU4XFixedDecimalFormatter* ok; }; bool is_ok;} ICU4XFixedDecimalFormatter_try_new_result;
-    ICU4XFixedDecimalFormatter_try_new_result ICU4XFixedDecimalFormatter_try_new(const ::capi::ICU4XLocale* locale, const ::capi::ICU4XDataProvider* provider, ::capi::ICU4XFixedDecimalFormatterOptions options);
+    typedef struct ICU4XFixedDecimalFormatter_try_new_result {union {icu4x::capi::ICU4XFixedDecimalFormatter* ok; }; bool is_ok;} ICU4XFixedDecimalFormatter_try_new_result;
+    ICU4XFixedDecimalFormatter_try_new_result ICU4XFixedDecimalFormatter_try_new(const icu4x::capi::ICU4XLocale* locale, const icu4x::capi::ICU4XDataProvider* provider, icu4x::capi::ICU4XFixedDecimalFormatterOptions options);
     
-    void ICU4XFixedDecimalFormatter_format_write(const ::capi::ICU4XFixedDecimalFormatter* self, const ::capi::ICU4XFixedDecimal* value, DiplomatWrite* write);
+    void ICU4XFixedDecimalFormatter_format_write(const icu4x::capi::ICU4XFixedDecimalFormatter* self, const icu4x::capi::ICU4XFixedDecimal* value, ::capi::DiplomatWrite* write);
     
     
     void ICU4XFixedDecimalFormatter_destroy(ICU4XFixedDecimalFormatter* self);
     
     } // extern "C"
 }
-inline diplomat::result<std::unique_ptr<ICU4XFixedDecimalFormatter>, std::monostate> ICU4XFixedDecimalFormatter::try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XFixedDecimalFormatterOptions options) {
+}
+inline diplomat::result<std::unique_ptr<icu4x::ICU4XFixedDecimalFormatter>, std::monostate> icu4x::ICU4XFixedDecimalFormatter::try_new(const icu4x::ICU4XLocale& locale, const icu4x::ICU4XDataProvider& provider, icu4x::ICU4XFixedDecimalFormatterOptions options) {
   auto result = capi::ICU4XFixedDecimalFormatter_try_new(locale.AsFFI(),
     provider.AsFFI(),
     options.AsFFI());
-  return result.is_ok ? diplomat::result<std::unique_ptr<ICU4XFixedDecimalFormatter>, std::monostate>(diplomat::Ok<std::unique_ptr<ICU4XFixedDecimalFormatter>>(std::unique_ptr<ICU4XFixedDecimalFormatter>(ICU4XFixedDecimalFormatter::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<ICU4XFixedDecimalFormatter>, std::monostate>(diplomat::Err<std::monostate>());
+  return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::ICU4XFixedDecimalFormatter>, std::monostate>(diplomat::Ok<std::unique_ptr<icu4x::ICU4XFixedDecimalFormatter>>(std::unique_ptr<icu4x::ICU4XFixedDecimalFormatter>(icu4x::ICU4XFixedDecimalFormatter::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::ICU4XFixedDecimalFormatter>, std::monostate>(diplomat::Err<std::monostate>());
 }
 
-inline std::string ICU4XFixedDecimalFormatter::format_write(const ICU4XFixedDecimal& value) const {
+inline std::string icu4x::ICU4XFixedDecimalFormatter::format_write(const icu4x::ICU4XFixedDecimal& value) const {
   std::string output;
-  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  ::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   capi::ICU4XFixedDecimalFormatter_format_write(this->AsFFI(),
     value.AsFFI(),
     &write);
   return output;
 }
 
-inline const ::capi::ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::AsFFI() const {
-  return reinterpret_cast<const ::capi::ICU4XFixedDecimalFormatter*>(this);
+inline const icu4x::capi::ICU4XFixedDecimalFormatter* icu4x::ICU4XFixedDecimalFormatter::AsFFI() const {
+  return reinterpret_cast<const icu4x::capi::ICU4XFixedDecimalFormatter*>(this);
 }
 
-inline ::capi::ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::AsFFI() {
-  return reinterpret_cast<::capi::ICU4XFixedDecimalFormatter*>(this);
+inline icu4x::capi::ICU4XFixedDecimalFormatter* icu4x::ICU4XFixedDecimalFormatter::AsFFI() {
+  return reinterpret_cast<icu4x::capi::ICU4XFixedDecimalFormatter*>(this);
 }
 
-inline const ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::FromFFI(const ::capi::ICU4XFixedDecimalFormatter* ptr) {
-  return reinterpret_cast<const ICU4XFixedDecimalFormatter*>(ptr);
+inline const icu4x::ICU4XFixedDecimalFormatter* icu4x::ICU4XFixedDecimalFormatter::FromFFI(const icu4x::capi::ICU4XFixedDecimalFormatter* ptr) {
+  return reinterpret_cast<const icu4x::ICU4XFixedDecimalFormatter*>(ptr);
 }
 
-inline ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::FromFFI(::capi::ICU4XFixedDecimalFormatter* ptr) {
-  return reinterpret_cast<ICU4XFixedDecimalFormatter*>(ptr);
+inline icu4x::ICU4XFixedDecimalFormatter* icu4x::ICU4XFixedDecimalFormatter::FromFFI(icu4x::capi::ICU4XFixedDecimalFormatter* ptr) {
+  return reinterpret_cast<icu4x::ICU4XFixedDecimalFormatter*>(ptr);
 }
 
-inline void ICU4XFixedDecimalFormatter::operator delete(void* ptr) {
-  capi::ICU4XFixedDecimalFormatter_destroy(reinterpret_cast<::capi::ICU4XFixedDecimalFormatter*>(ptr));
+inline void icu4x::ICU4XFixedDecimalFormatter::operator delete(void* ptr) {
+  capi::ICU4XFixedDecimalFormatter_destroy(reinterpret_cast<icu4x::capi::ICU4XFixedDecimalFormatter*>(ptr));
 }
 
 

--- a/example/cpp2/include/ICU4XFixedDecimalFormatter.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatter.hpp
@@ -19,17 +19,16 @@
 namespace capi {
     extern "C" {
     
-    typedef struct ICU4XFixedDecimalFormatter_try_new_result {union {ICU4XFixedDecimalFormatter* ok; }; bool is_ok;} ICU4XFixedDecimalFormatter_try_new_result;
-    ICU4XFixedDecimalFormatter_try_new_result ICU4XFixedDecimalFormatter_try_new(const ICU4XLocale* locale, const ICU4XDataProvider* provider, ICU4XFixedDecimalFormatterOptions options);
+    typedef struct ICU4XFixedDecimalFormatter_try_new_result {union {::capi::ICU4XFixedDecimalFormatter* ok; }; bool is_ok;} ICU4XFixedDecimalFormatter_try_new_result;
+    ICU4XFixedDecimalFormatter_try_new_result ICU4XFixedDecimalFormatter_try_new(const ::capi::ICU4XLocale* locale, const ::capi::ICU4XDataProvider* provider, ::capi::ICU4XFixedDecimalFormatterOptions options);
     
-    void ICU4XFixedDecimalFormatter_format_write(const ICU4XFixedDecimalFormatter* self, const ICU4XFixedDecimal* value, DiplomatWrite* write);
+    void ICU4XFixedDecimalFormatter_format_write(const ::capi::ICU4XFixedDecimalFormatter* self, const ::capi::ICU4XFixedDecimal* value, DiplomatWrite* write);
     
     
     void ICU4XFixedDecimalFormatter_destroy(ICU4XFixedDecimalFormatter* self);
     
     } // extern "C"
 }
-
 inline diplomat::result<std::unique_ptr<ICU4XFixedDecimalFormatter>, std::monostate> ICU4XFixedDecimalFormatter::try_new(const ICU4XLocale& locale, const ICU4XDataProvider& provider, ICU4XFixedDecimalFormatterOptions options) {
   auto result = capi::ICU4XFixedDecimalFormatter_try_new(locale.AsFFI(),
     provider.AsFFI(),
@@ -46,24 +45,24 @@ inline std::string ICU4XFixedDecimalFormatter::format_write(const ICU4XFixedDeci
   return output;
 }
 
-inline const capi::ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::AsFFI() const {
-  return reinterpret_cast<const capi::ICU4XFixedDecimalFormatter*>(this);
+inline const ::capi::ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::AsFFI() const {
+  return reinterpret_cast<const ::capi::ICU4XFixedDecimalFormatter*>(this);
 }
 
-inline capi::ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::AsFFI() {
-  return reinterpret_cast<capi::ICU4XFixedDecimalFormatter*>(this);
+inline ::capi::ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::AsFFI() {
+  return reinterpret_cast<::capi::ICU4XFixedDecimalFormatter*>(this);
 }
 
-inline const ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::FromFFI(const capi::ICU4XFixedDecimalFormatter* ptr) {
+inline const ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::FromFFI(const ::capi::ICU4XFixedDecimalFormatter* ptr) {
   return reinterpret_cast<const ICU4XFixedDecimalFormatter*>(ptr);
 }
 
-inline ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::FromFFI(capi::ICU4XFixedDecimalFormatter* ptr) {
+inline ICU4XFixedDecimalFormatter* ICU4XFixedDecimalFormatter::FromFFI(::capi::ICU4XFixedDecimalFormatter* ptr) {
   return reinterpret_cast<ICU4XFixedDecimalFormatter*>(ptr);
 }
 
 inline void ICU4XFixedDecimalFormatter::operator delete(void* ptr) {
-  capi::ICU4XFixedDecimalFormatter_destroy(reinterpret_cast<capi::ICU4XFixedDecimalFormatter*>(ptr));
+  capi::ICU4XFixedDecimalFormatter_destroy(reinterpret_cast<::capi::ICU4XFixedDecimalFormatter*>(ptr));
 }
 
 

--- a/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.d.hpp
@@ -10,25 +10,29 @@
 #include "diplomat_runtime.hpp"
 #include "ICU4XFixedDecimalGroupingStrategy.d.hpp"
 
+namespace icu4x {
+struct ICU4XFixedDecimalFormatterOptions;
 class ICU4XFixedDecimalGroupingStrategy;
+}
 
 
+namespace icu4x {
 namespace capi {
     typedef struct ICU4XFixedDecimalFormatterOptions {
-      ::capi::ICU4XFixedDecimalGroupingStrategy grouping_strategy;
+      icu4x::capi::ICU4XFixedDecimalGroupingStrategy grouping_strategy;
       bool some_other_config;
     } ICU4XFixedDecimalFormatterOptions;
 }
 
 struct ICU4XFixedDecimalFormatterOptions {
-  ICU4XFixedDecimalGroupingStrategy grouping_strategy;
+  icu4x::ICU4XFixedDecimalGroupingStrategy grouping_strategy;
   bool some_other_config;
 
-  inline static ICU4XFixedDecimalFormatterOptions default_();
+  inline static icu4x::ICU4XFixedDecimalFormatterOptions default_();
 
-  inline ::capi::ICU4XFixedDecimalFormatterOptions AsFFI() const;
-  inline static ICU4XFixedDecimalFormatterOptions FromFFI(::capi::ICU4XFixedDecimalFormatterOptions c_struct);
+  inline icu4x::capi::ICU4XFixedDecimalFormatterOptions AsFFI() const;
+  inline static icu4x::ICU4XFixedDecimalFormatterOptions FromFFI(icu4x::capi::ICU4XFixedDecimalFormatterOptions c_struct);
 };
 
-
+}
 #endif // ICU4XFixedDecimalFormatterOptions_D_HPP

--- a/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.d.hpp
@@ -15,7 +15,7 @@ class ICU4XFixedDecimalGroupingStrategy;
 
 namespace capi {
     typedef struct ICU4XFixedDecimalFormatterOptions {
-      ICU4XFixedDecimalGroupingStrategy grouping_strategy;
+      ::capi::ICU4XFixedDecimalGroupingStrategy grouping_strategy;
       bool some_other_config;
     } ICU4XFixedDecimalFormatterOptions;
 }
@@ -26,8 +26,8 @@ struct ICU4XFixedDecimalFormatterOptions {
 
   inline static ICU4XFixedDecimalFormatterOptions default_();
 
-  inline capi::ICU4XFixedDecimalFormatterOptions AsFFI() const;
-  inline static ICU4XFixedDecimalFormatterOptions FromFFI(capi::ICU4XFixedDecimalFormatterOptions c_struct);
+  inline ::capi::ICU4XFixedDecimalFormatterOptions AsFFI() const;
+  inline static ICU4XFixedDecimalFormatterOptions FromFFI(::capi::ICU4XFixedDecimalFormatterOptions c_struct);
 };
 
 

--- a/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.hpp
@@ -13,30 +13,32 @@
 #include "ICU4XFixedDecimalGroupingStrategy.hpp"
 
 
+namespace icu4x {
 namespace capi {
     extern "C" {
     
-    ::capi::ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions_default();
+    icu4x::capi::ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions_default();
     
     
     } // extern "C"
 }
-inline ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions::default_() {
+}
+inline icu4x::ICU4XFixedDecimalFormatterOptions icu4x::ICU4XFixedDecimalFormatterOptions::default_() {
   auto result = capi::ICU4XFixedDecimalFormatterOptions_default();
-  return ICU4XFixedDecimalFormatterOptions::FromFFI(result);
+  return icu4x::ICU4XFixedDecimalFormatterOptions::FromFFI(result);
 }
 
 
-inline ::capi::ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions::AsFFI() const {
-  return ::capi::ICU4XFixedDecimalFormatterOptions {
+inline icu4x::capi::ICU4XFixedDecimalFormatterOptions icu4x::ICU4XFixedDecimalFormatterOptions::AsFFI() const {
+  return icu4x::capi::ICU4XFixedDecimalFormatterOptions {
     .grouping_strategy = grouping_strategy.AsFFI(),
     .some_other_config = some_other_config,
   };
 }
 
-inline ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions::FromFFI(::capi::ICU4XFixedDecimalFormatterOptions c_struct) {
-  return ICU4XFixedDecimalFormatterOptions {
-    .grouping_strategy = ICU4XFixedDecimalGroupingStrategy::FromFFI(c_struct.grouping_strategy),
+inline icu4x::ICU4XFixedDecimalFormatterOptions icu4x::ICU4XFixedDecimalFormatterOptions::FromFFI(icu4x::capi::ICU4XFixedDecimalFormatterOptions c_struct) {
+  return icu4x::ICU4XFixedDecimalFormatterOptions {
+    .grouping_strategy = icu4x::ICU4XFixedDecimalGroupingStrategy::FromFFI(c_struct.grouping_strategy),
     .some_other_config = c_struct.some_other_config,
   };
 }

--- a/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.hpp
@@ -16,26 +16,25 @@
 namespace capi {
     extern "C" {
     
-    ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions_default();
+    ::capi::ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions_default();
     
     
     } // extern "C"
 }
-
 inline ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions::default_() {
   auto result = capi::ICU4XFixedDecimalFormatterOptions_default();
   return ICU4XFixedDecimalFormatterOptions::FromFFI(result);
 }
 
 
-inline capi::ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions::AsFFI() const {
-  return capi::ICU4XFixedDecimalFormatterOptions {
+inline ::capi::ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions::AsFFI() const {
+  return ::capi::ICU4XFixedDecimalFormatterOptions {
     .grouping_strategy = grouping_strategy.AsFFI(),
     .some_other_config = some_other_config,
   };
 }
 
-inline ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions::FromFFI(capi::ICU4XFixedDecimalFormatterOptions c_struct) {
+inline ICU4XFixedDecimalFormatterOptions ICU4XFixedDecimalFormatterOptions::FromFFI(::capi::ICU4XFixedDecimalFormatterOptions c_struct) {
   return ICU4XFixedDecimalFormatterOptions {
     .grouping_strategy = ICU4XFixedDecimalGroupingStrategy::FromFFI(c_struct.grouping_strategy),
     .some_other_config = c_struct.some_other_config,

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
@@ -10,6 +10,7 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace icu4x {
 namespace capi {
     typedef enum ICU4XFixedDecimalGroupingStrategy {
       ICU4XFixedDecimalGroupingStrategy_Auto = 0,
@@ -36,11 +37,11 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline ::capi::ICU4XFixedDecimalGroupingStrategy AsFFI() const;
-  inline static ICU4XFixedDecimalGroupingStrategy FromFFI(::capi::ICU4XFixedDecimalGroupingStrategy c_enum);
+  inline icu4x::capi::ICU4XFixedDecimalGroupingStrategy AsFFI() const;
+  inline static icu4x::ICU4XFixedDecimalGroupingStrategy FromFFI(icu4x::capi::ICU4XFixedDecimalGroupingStrategy c_enum);
 private:
     Value value;
 };
 
-
+}
 #endif // ICU4XFixedDecimalGroupingStrategy_D_HPP

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
@@ -19,6 +19,7 @@ namespace capi {
     } ICU4XFixedDecimalGroupingStrategy;
 }
 
+
 class ICU4XFixedDecimalGroupingStrategy {
 public:
   enum Value {
@@ -35,8 +36,8 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline capi::ICU4XFixedDecimalGroupingStrategy AsFFI() const;
-  inline static ICU4XFixedDecimalGroupingStrategy FromFFI(capi::ICU4XFixedDecimalGroupingStrategy c_enum);
+  inline ::capi::ICU4XFixedDecimalGroupingStrategy AsFFI() const;
+  inline static ICU4XFixedDecimalGroupingStrategy FromFFI(::capi::ICU4XFixedDecimalGroupingStrategy c_enum);
 private:
     Value value;
 };

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.hpp
@@ -18,18 +18,16 @@ namespace capi {
     
     } // extern "C"
 }
-
-
-inline capi::ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::AsFFI() const {
-  return static_cast<capi::ICU4XFixedDecimalGroupingStrategy>(value);
+inline ::capi::ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::AsFFI() const {
+  return static_cast<::capi::ICU4XFixedDecimalGroupingStrategy>(value);
 }
 
-inline ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::FromFFI(capi::ICU4XFixedDecimalGroupingStrategy c_enum) {
+inline ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::FromFFI(::capi::ICU4XFixedDecimalGroupingStrategy c_enum) {
   switch (c_enum) {
-    case capi::ICU4XFixedDecimalGroupingStrategy_Auto:
-    case capi::ICU4XFixedDecimalGroupingStrategy_Never:
-    case capi::ICU4XFixedDecimalGroupingStrategy_Always:
-    case capi::ICU4XFixedDecimalGroupingStrategy_Min2:
+    case ::capi::ICU4XFixedDecimalGroupingStrategy_Auto:
+    case ::capi::ICU4XFixedDecimalGroupingStrategy_Never:
+    case ::capi::ICU4XFixedDecimalGroupingStrategy_Always:
+    case ::capi::ICU4XFixedDecimalGroupingStrategy_Min2:
       return static_cast<ICU4XFixedDecimalGroupingStrategy::Value>(c_enum);
     default:
       abort();

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.hpp
@@ -12,23 +12,25 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace icu4x {
 namespace capi {
     extern "C" {
     
     
     } // extern "C"
 }
-inline ::capi::ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::AsFFI() const {
-  return static_cast<::capi::ICU4XFixedDecimalGroupingStrategy>(value);
+}
+inline icu4x::capi::ICU4XFixedDecimalGroupingStrategy icu4x::ICU4XFixedDecimalGroupingStrategy::AsFFI() const {
+  return static_cast<icu4x::capi::ICU4XFixedDecimalGroupingStrategy>(value);
 }
 
-inline ICU4XFixedDecimalGroupingStrategy ICU4XFixedDecimalGroupingStrategy::FromFFI(::capi::ICU4XFixedDecimalGroupingStrategy c_enum) {
+inline icu4x::ICU4XFixedDecimalGroupingStrategy icu4x::ICU4XFixedDecimalGroupingStrategy::FromFFI(icu4x::capi::ICU4XFixedDecimalGroupingStrategy c_enum) {
   switch (c_enum) {
-    case ::capi::ICU4XFixedDecimalGroupingStrategy_Auto:
-    case ::capi::ICU4XFixedDecimalGroupingStrategy_Never:
-    case ::capi::ICU4XFixedDecimalGroupingStrategy_Always:
-    case ::capi::ICU4XFixedDecimalGroupingStrategy_Min2:
-      return static_cast<ICU4XFixedDecimalGroupingStrategy::Value>(c_enum);
+    case icu4x::capi::ICU4XFixedDecimalGroupingStrategy_Auto:
+    case icu4x::capi::ICU4XFixedDecimalGroupingStrategy_Never:
+    case icu4x::capi::ICU4XFixedDecimalGroupingStrategy_Always:
+    case icu4x::capi::ICU4XFixedDecimalGroupingStrategy_Min2:
+      return static_cast<icu4x::ICU4XFixedDecimalGroupingStrategy::Value>(c_enum);
     default:
       abort();
   }

--- a/example/cpp2/include/ICU4XLocale.d.hpp
+++ b/example/cpp2/include/ICU4XLocale.d.hpp
@@ -9,7 +9,13 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace icu4x {
+namespace capi {typedef struct ICU4XLocale ICU4XLocale; }
+class ICU4XLocale;
+}
 
+
+namespace icu4x {
 namespace capi {
     typedef struct ICU4XLocale ICU4XLocale;
 }
@@ -17,21 +23,21 @@ namespace capi {
 class ICU4XLocale {
 public:
 
-  inline static std::unique_ptr<ICU4XLocale> new_(std::string_view name);
+  inline static std::unique_ptr<icu4x::ICU4XLocale> new_(std::string_view name);
 
-  inline const ::capi::ICU4XLocale* AsFFI() const;
-  inline ::capi::ICU4XLocale* AsFFI();
-  inline static const ICU4XLocale* FromFFI(const ::capi::ICU4XLocale* ptr);
-  inline static ICU4XLocale* FromFFI(::capi::ICU4XLocale* ptr);
+  inline const icu4x::capi::ICU4XLocale* AsFFI() const;
+  inline icu4x::capi::ICU4XLocale* AsFFI();
+  inline static const icu4x::ICU4XLocale* FromFFI(const icu4x::capi::ICU4XLocale* ptr);
+  inline static icu4x::ICU4XLocale* FromFFI(icu4x::capi::ICU4XLocale* ptr);
   inline static void operator delete(void* ptr);
 private:
   ICU4XLocale() = delete;
-  ICU4XLocale(const ICU4XLocale&) = delete;
-  ICU4XLocale(ICU4XLocale&&) noexcept = delete;
-  ICU4XLocale operator=(const ICU4XLocale&) = delete;
-  ICU4XLocale operator=(ICU4XLocale&&) noexcept = delete;
+  ICU4XLocale(const icu4x::ICU4XLocale&) = delete;
+  ICU4XLocale(icu4x::ICU4XLocale&&) noexcept = delete;
+  ICU4XLocale operator=(const icu4x::ICU4XLocale&) = delete;
+  ICU4XLocale operator=(icu4x::ICU4XLocale&&) noexcept = delete;
   static void operator delete[](void*, size_t) = delete;
 };
 
-
+}
 #endif // ICU4XLocale_D_HPP

--- a/example/cpp2/include/ICU4XLocale.d.hpp
+++ b/example/cpp2/include/ICU4XLocale.d.hpp
@@ -19,10 +19,10 @@ public:
 
   inline static std::unique_ptr<ICU4XLocale> new_(std::string_view name);
 
-  inline const capi::ICU4XLocale* AsFFI() const;
-  inline capi::ICU4XLocale* AsFFI();
-  inline static const ICU4XLocale* FromFFI(const capi::ICU4XLocale* ptr);
-  inline static ICU4XLocale* FromFFI(capi::ICU4XLocale* ptr);
+  inline const ::capi::ICU4XLocale* AsFFI() const;
+  inline ::capi::ICU4XLocale* AsFFI();
+  inline static const ICU4XLocale* FromFFI(const ::capi::ICU4XLocale* ptr);
+  inline static ICU4XLocale* FromFFI(::capi::ICU4XLocale* ptr);
   inline static void operator delete(void* ptr);
 private:
   ICU4XLocale() = delete;

--- a/example/cpp2/include/ICU4XLocale.hpp
+++ b/example/cpp2/include/ICU4XLocale.hpp
@@ -12,40 +12,42 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace icu4x {
 namespace capi {
     extern "C" {
     
-    ::capi::ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
+    icu4x::capi::ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
     
     
     void ICU4XLocale_destroy(ICU4XLocale* self);
     
     } // extern "C"
 }
-inline std::unique_ptr<ICU4XLocale> ICU4XLocale::new_(std::string_view name) {
+}
+inline std::unique_ptr<icu4x::ICU4XLocale> icu4x::ICU4XLocale::new_(std::string_view name) {
   auto result = capi::ICU4XLocale_new(name.data(),
     name.size());
-  return std::unique_ptr<ICU4XLocale>(ICU4XLocale::FromFFI(result));
+  return std::unique_ptr<icu4x::ICU4XLocale>(icu4x::ICU4XLocale::FromFFI(result));
 }
 
-inline const ::capi::ICU4XLocale* ICU4XLocale::AsFFI() const {
-  return reinterpret_cast<const ::capi::ICU4XLocale*>(this);
+inline const icu4x::capi::ICU4XLocale* icu4x::ICU4XLocale::AsFFI() const {
+  return reinterpret_cast<const icu4x::capi::ICU4XLocale*>(this);
 }
 
-inline ::capi::ICU4XLocale* ICU4XLocale::AsFFI() {
-  return reinterpret_cast<::capi::ICU4XLocale*>(this);
+inline icu4x::capi::ICU4XLocale* icu4x::ICU4XLocale::AsFFI() {
+  return reinterpret_cast<icu4x::capi::ICU4XLocale*>(this);
 }
 
-inline const ICU4XLocale* ICU4XLocale::FromFFI(const ::capi::ICU4XLocale* ptr) {
-  return reinterpret_cast<const ICU4XLocale*>(ptr);
+inline const icu4x::ICU4XLocale* icu4x::ICU4XLocale::FromFFI(const icu4x::capi::ICU4XLocale* ptr) {
+  return reinterpret_cast<const icu4x::ICU4XLocale*>(ptr);
 }
 
-inline ICU4XLocale* ICU4XLocale::FromFFI(::capi::ICU4XLocale* ptr) {
-  return reinterpret_cast<ICU4XLocale*>(ptr);
+inline icu4x::ICU4XLocale* icu4x::ICU4XLocale::FromFFI(icu4x::capi::ICU4XLocale* ptr) {
+  return reinterpret_cast<icu4x::ICU4XLocale*>(ptr);
 }
 
-inline void ICU4XLocale::operator delete(void* ptr) {
-  capi::ICU4XLocale_destroy(reinterpret_cast<::capi::ICU4XLocale*>(ptr));
+inline void icu4x::ICU4XLocale::operator delete(void* ptr) {
+  capi::ICU4XLocale_destroy(reinterpret_cast<icu4x::capi::ICU4XLocale*>(ptr));
 }
 
 

--- a/example/cpp2/include/ICU4XLocale.hpp
+++ b/example/cpp2/include/ICU4XLocale.hpp
@@ -15,38 +15,37 @@
 namespace capi {
     extern "C" {
     
-    ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
+    ::capi::ICU4XLocale* ICU4XLocale_new(const char* name_data, size_t name_len);
     
     
     void ICU4XLocale_destroy(ICU4XLocale* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<ICU4XLocale> ICU4XLocale::new_(std::string_view name) {
   auto result = capi::ICU4XLocale_new(name.data(),
     name.size());
   return std::unique_ptr<ICU4XLocale>(ICU4XLocale::FromFFI(result));
 }
 
-inline const capi::ICU4XLocale* ICU4XLocale::AsFFI() const {
-  return reinterpret_cast<const capi::ICU4XLocale*>(this);
+inline const ::capi::ICU4XLocale* ICU4XLocale::AsFFI() const {
+  return reinterpret_cast<const ::capi::ICU4XLocale*>(this);
 }
 
-inline capi::ICU4XLocale* ICU4XLocale::AsFFI() {
-  return reinterpret_cast<capi::ICU4XLocale*>(this);
+inline ::capi::ICU4XLocale* ICU4XLocale::AsFFI() {
+  return reinterpret_cast<::capi::ICU4XLocale*>(this);
 }
 
-inline const ICU4XLocale* ICU4XLocale::FromFFI(const capi::ICU4XLocale* ptr) {
+inline const ICU4XLocale* ICU4XLocale::FromFFI(const ::capi::ICU4XLocale* ptr) {
   return reinterpret_cast<const ICU4XLocale*>(ptr);
 }
 
-inline ICU4XLocale* ICU4XLocale::FromFFI(capi::ICU4XLocale* ptr) {
+inline ICU4XLocale* ICU4XLocale::FromFFI(::capi::ICU4XLocale* ptr) {
   return reinterpret_cast<ICU4XLocale*>(ptr);
 }
 
 inline void ICU4XLocale::operator delete(void* ptr) {
-  capi::ICU4XLocale_destroy(reinterpret_cast<capi::ICU4XLocale*>(ptr));
+  capi::ICU4XLocale_destroy(reinterpret_cast<::capi::ICU4XLocale*>(ptr));
 }
 
 

--- a/example/cpp2/tests/fixeddecimal.cpp
+++ b/example/cpp2/tests/fixeddecimal.cpp
@@ -4,7 +4,7 @@
 #include "assert.hpp"
 
 int main(int argc, char *argv[]) {
-    std::unique_ptr<ICU4XFixedDecimal> fd = ICU4XFixedDecimal::new_(123);
+    std::unique_ptr<icu4x::ICU4XFixedDecimal> fd = icu4x::ICU4XFixedDecimal::new_(123);
 
     simple_assert("constructing FixedDecimal", !fd->to_string().is_err());
 
@@ -24,11 +24,11 @@ int main(int argc, char *argv[]) {
 
     // simple_assert_eq("Formatting FixedDecimal to DiplomatWrite", fd_out, "12.3");
 
-    std::unique_ptr<ICU4XLocale> locale = ICU4XLocale::new_("bn");
+    std::unique_ptr<icu4x::ICU4XLocale> locale = icu4x::ICU4XLocale::new_("bn");
 
-    std::unique_ptr<ICU4XDataProvider> data_provider = ICU4XDataProvider::new_static();
+    std::unique_ptr<icu4x::ICU4XDataProvider> data_provider = icu4x::ICU4XDataProvider::new_static();
 
-    auto fdf = ICU4XFixedDecimalFormatter::try_new(*locale, *data_provider, ICU4XFixedDecimalFormatterOptions::default_());
+    auto fdf = icu4x::ICU4XFixedDecimalFormatter::try_new(*locale, *data_provider, icu4x::ICU4XFixedDecimalFormatterOptions::default_());
 
     simple_assert("Formatting FixedDecimal", fdf.is_ok());
 

--- a/example/src/data_provider.rs
+++ b/example/src/data_provider.rs
@@ -1,4 +1,5 @@
 #[diplomat::bridge]
+#[diplomat::attr(supports = namespacing, namespace = "icu4x")]
 pub mod ffi {
     use icu_provider::AnyProvider;
 

--- a/example/src/decimal.rs
+++ b/example/src/decimal.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_unit_err, clippy::should_implement_trait)]
 
 #[diplomat::bridge]
+#[diplomat::attr(supports = namespacing, namespace = "icu4x")]
 pub mod ffi {
     use diplomat_runtime::DiplomatWrite;
     use icu::decimal::{options::GroupingStrategy, FixedDecimalFormatter};

--- a/example/src/fixed_decimal.rs
+++ b/example/src/fixed_decimal.rs
@@ -1,4 +1,5 @@
 #[diplomat::bridge]
+#[diplomat::attr(supports = namespacing, namespace = "icu4x")]
 pub mod ffi {
     use diplomat_runtime::DiplomatWrite;
     use fixed_decimal::FixedDecimal;

--- a/example/src/locale.rs
+++ b/example/src/locale.rs
@@ -1,4 +1,5 @@
 #[diplomat::bridge]
+#[diplomat::attr(supports = namespacing, namespace = "icu4x")]
 pub mod ffi {
     use icu::locid::Locale;
 

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
@@ -21,7 +21,7 @@ class CPPRenamedAttrEnum;
 
 namespace ns {
 namespace capi {
-    typedef struct AttrOpaque1 AttrOpaque1;
+    typedef struct AttrOpaque1Renamed AttrOpaque1Renamed;
 }
 
 class AttrOpaque1Renamed {
@@ -37,10 +37,10 @@ public:
 
   inline void use_namespaced(ns::CPPRenamedAttrEnum _n) const;
 
-  inline const ns::capi::AttrOpaque1* AsFFI() const;
-  inline ns::capi::AttrOpaque1* AsFFI();
-  inline static const ns::AttrOpaque1Renamed* FromFFI(const ns::capi::AttrOpaque1* ptr);
-  inline static ns::AttrOpaque1Renamed* FromFFI(ns::capi::AttrOpaque1* ptr);
+  inline const ns::capi::AttrOpaque1Renamed* AsFFI() const;
+  inline ns::capi::AttrOpaque1Renamed* AsFFI();
+  inline static const ns::AttrOpaque1Renamed* FromFFI(const ns::capi::AttrOpaque1Renamed* ptr);
+  inline static ns::AttrOpaque1Renamed* FromFFI(ns::capi::AttrOpaque1Renamed* ptr);
   inline static void operator delete(void* ptr);
 private:
   AttrOpaque1Renamed() = delete;

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
@@ -10,18 +10,20 @@
 #include "diplomat_runtime.hpp"
 #include "CPPRenamedAttrEnum.d.hpp"
 
+namespace capi {typedef struct Unnamespaced Unnamespaced; }
 class Unnamespaced;
 namespace ns {
+namespace capi {typedef struct AttrOpaque1Renamed AttrOpaque1Renamed; }
 class AttrOpaque1Renamed;
 class CPPRenamedAttrEnum;
 }
 
 
+namespace ns {
 namespace capi {
     typedef struct AttrOpaque1 AttrOpaque1;
 }
 
-namespace ns {
 class AttrOpaque1Renamed {
 public:
 
@@ -35,10 +37,10 @@ public:
 
   inline void use_namespaced(ns::CPPRenamedAttrEnum _n) const;
 
-  inline const capi::AttrOpaque1* AsFFI() const;
-  inline capi::AttrOpaque1* AsFFI();
-  inline static const ns::AttrOpaque1Renamed* FromFFI(const capi::AttrOpaque1* ptr);
-  inline static ns::AttrOpaque1Renamed* FromFFI(capi::AttrOpaque1* ptr);
+  inline const ns::capi::AttrOpaque1* AsFFI() const;
+  inline ns::capi::AttrOpaque1* AsFFI();
+  inline static const ns::AttrOpaque1Renamed* FromFFI(const ns::capi::AttrOpaque1* ptr);
+  inline static ns::AttrOpaque1Renamed* FromFFI(ns::capi::AttrOpaque1* ptr);
   inline static void operator delete(void* ptr);
 private:
   AttrOpaque1Renamed() = delete;

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
@@ -18,18 +18,18 @@ namespace ns {
 namespace capi {
     extern "C" {
     
-    ns::capi::AttrOpaque1* namespace_AttrOpaque1_new();
+    ns::capi::AttrOpaque1Renamed* namespace_AttrOpaque1_new();
     
-    uint8_t namespace_AttrOpaque1_method(const ns::capi::AttrOpaque1* self);
+    uint8_t namespace_AttrOpaque1_method(const ns::capi::AttrOpaque1Renamed* self);
     
-    uint8_t renamed_on_abi_only(const ns::capi::AttrOpaque1* self);
+    uint8_t renamed_on_abi_only(const ns::capi::AttrOpaque1Renamed* self);
     
-    void namespace_AttrOpaque1_use_unnamespaced(const ns::capi::AttrOpaque1* self, const ::capi::Unnamespaced* _un);
+    void namespace_AttrOpaque1_use_unnamespaced(const ns::capi::AttrOpaque1Renamed* self, const ::capi::Unnamespaced* _un);
     
-    void namespace_AttrOpaque1_use_namespaced(const ns::capi::AttrOpaque1* self, ns::capi::AttrEnum _n);
+    void namespace_AttrOpaque1_use_namespaced(const ns::capi::AttrOpaque1Renamed* self, ns::capi::CPPRenamedAttrEnum _n);
     
     
-    void namespace_AttrOpaque1_destroy(AttrOpaque1* self);
+    void namespace_AttrOpaque1_destroy(AttrOpaque1Renamed* self);
     
     } // extern "C"
 }
@@ -59,24 +59,24 @@ inline void ns::AttrOpaque1Renamed::use_namespaced(ns::CPPRenamedAttrEnum _n) co
     _n.AsFFI());
 }
 
-inline const ns::capi::AttrOpaque1* ns::AttrOpaque1Renamed::AsFFI() const {
-  return reinterpret_cast<const ns::capi::AttrOpaque1*>(this);
+inline const ns::capi::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::AsFFI() const {
+  return reinterpret_cast<const ns::capi::AttrOpaque1Renamed*>(this);
 }
 
-inline ns::capi::AttrOpaque1* ns::AttrOpaque1Renamed::AsFFI() {
-  return reinterpret_cast<ns::capi::AttrOpaque1*>(this);
+inline ns::capi::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::AsFFI() {
+  return reinterpret_cast<ns::capi::AttrOpaque1Renamed*>(this);
 }
 
-inline const ns::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::FromFFI(const ns::capi::AttrOpaque1* ptr) {
+inline const ns::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::FromFFI(const ns::capi::AttrOpaque1Renamed* ptr) {
   return reinterpret_cast<const ns::AttrOpaque1Renamed*>(ptr);
 }
 
-inline ns::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::FromFFI(ns::capi::AttrOpaque1* ptr) {
+inline ns::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::FromFFI(ns::capi::AttrOpaque1Renamed* ptr) {
   return reinterpret_cast<ns::AttrOpaque1Renamed*>(ptr);
 }
 
 inline void ns::AttrOpaque1Renamed::operator delete(void* ptr) {
-  capi::namespace_AttrOpaque1_destroy(reinterpret_cast<ns::capi::AttrOpaque1*>(ptr));
+  capi::namespace_AttrOpaque1_destroy(reinterpret_cast<ns::capi::AttrOpaque1Renamed*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.hpp
@@ -14,25 +14,26 @@
 #include "Unnamespaced.hpp"
 
 
+namespace ns {
 namespace capi {
     extern "C" {
     
-    AttrOpaque1* namespace_AttrOpaque1_new();
+    ns::capi::AttrOpaque1* namespace_AttrOpaque1_new();
     
-    uint8_t namespace_AttrOpaque1_method(const AttrOpaque1* self);
+    uint8_t namespace_AttrOpaque1_method(const ns::capi::AttrOpaque1* self);
     
-    uint8_t renamed_on_abi_only(const AttrOpaque1* self);
+    uint8_t renamed_on_abi_only(const ns::capi::AttrOpaque1* self);
     
-    void namespace_AttrOpaque1_use_unnamespaced(const AttrOpaque1* self, const Unnamespaced* _un);
+    void namespace_AttrOpaque1_use_unnamespaced(const ns::capi::AttrOpaque1* self, const ::capi::Unnamespaced* _un);
     
-    void namespace_AttrOpaque1_use_namespaced(const AttrOpaque1* self, AttrEnum _n);
+    void namespace_AttrOpaque1_use_namespaced(const ns::capi::AttrOpaque1* self, ns::capi::AttrEnum _n);
     
     
     void namespace_AttrOpaque1_destroy(AttrOpaque1* self);
     
     } // extern "C"
 }
-
+}
 inline std::unique_ptr<ns::AttrOpaque1Renamed> ns::AttrOpaque1Renamed::totally_not_new() {
   auto result = capi::namespace_AttrOpaque1_new();
   return std::unique_ptr<ns::AttrOpaque1Renamed>(ns::AttrOpaque1Renamed::FromFFI(result));
@@ -58,24 +59,24 @@ inline void ns::AttrOpaque1Renamed::use_namespaced(ns::CPPRenamedAttrEnum _n) co
     _n.AsFFI());
 }
 
-inline const capi::AttrOpaque1* ns::AttrOpaque1Renamed::AsFFI() const {
-  return reinterpret_cast<const capi::AttrOpaque1*>(this);
+inline const ns::capi::AttrOpaque1* ns::AttrOpaque1Renamed::AsFFI() const {
+  return reinterpret_cast<const ns::capi::AttrOpaque1*>(this);
 }
 
-inline capi::AttrOpaque1* ns::AttrOpaque1Renamed::AsFFI() {
-  return reinterpret_cast<capi::AttrOpaque1*>(this);
+inline ns::capi::AttrOpaque1* ns::AttrOpaque1Renamed::AsFFI() {
+  return reinterpret_cast<ns::capi::AttrOpaque1*>(this);
 }
 
-inline const ns::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::FromFFI(const capi::AttrOpaque1* ptr) {
+inline const ns::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::FromFFI(const ns::capi::AttrOpaque1* ptr) {
   return reinterpret_cast<const ns::AttrOpaque1Renamed*>(ptr);
 }
 
-inline ns::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::FromFFI(capi::AttrOpaque1* ptr) {
+inline ns::AttrOpaque1Renamed* ns::AttrOpaque1Renamed::FromFFI(ns::capi::AttrOpaque1* ptr) {
   return reinterpret_cast<ns::AttrOpaque1Renamed*>(ptr);
 }
 
 inline void ns::AttrOpaque1Renamed::operator delete(void* ptr) {
-  capi::namespace_AttrOpaque1_destroy(reinterpret_cast<capi::AttrOpaque1*>(ptr));
+  capi::namespace_AttrOpaque1_destroy(reinterpret_cast<ns::capi::AttrOpaque1*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/Bar.d.hpp
+++ b/feature_tests/cpp2/include/Bar.d.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace capi {typedef struct Foo Foo; }
 class Foo;
 
 
@@ -21,10 +22,10 @@ public:
 
   inline const Foo& foo() const;
 
-  inline const capi::Bar* AsFFI() const;
-  inline capi::Bar* AsFFI();
-  inline static const Bar* FromFFI(const capi::Bar* ptr);
-  inline static Bar* FromFFI(capi::Bar* ptr);
+  inline const ::capi::Bar* AsFFI() const;
+  inline ::capi::Bar* AsFFI();
+  inline static const Bar* FromFFI(const ::capi::Bar* ptr);
+  inline static Bar* FromFFI(::capi::Bar* ptr);
   inline static void operator delete(void* ptr);
 private:
   Bar() = delete;

--- a/feature_tests/cpp2/include/Bar.hpp
+++ b/feature_tests/cpp2/include/Bar.hpp
@@ -16,37 +16,36 @@
 namespace capi {
     extern "C" {
     
-    const Foo* Bar_foo(const Bar* self);
+    const ::capi::Foo* Bar_foo(const ::capi::Bar* self);
     
     
     void Bar_destroy(Bar* self);
     
     } // extern "C"
 }
-
 inline const Foo& Bar::foo() const {
   auto result = capi::Bar_foo(this->AsFFI());
   return *Foo::FromFFI(result);
 }
 
-inline const capi::Bar* Bar::AsFFI() const {
-  return reinterpret_cast<const capi::Bar*>(this);
+inline const ::capi::Bar* Bar::AsFFI() const {
+  return reinterpret_cast<const ::capi::Bar*>(this);
 }
 
-inline capi::Bar* Bar::AsFFI() {
-  return reinterpret_cast<capi::Bar*>(this);
+inline ::capi::Bar* Bar::AsFFI() {
+  return reinterpret_cast<::capi::Bar*>(this);
 }
 
-inline const Bar* Bar::FromFFI(const capi::Bar* ptr) {
+inline const Bar* Bar::FromFFI(const ::capi::Bar* ptr) {
   return reinterpret_cast<const Bar*>(ptr);
 }
 
-inline Bar* Bar::FromFFI(capi::Bar* ptr) {
+inline Bar* Bar::FromFFI(::capi::Bar* ptr) {
   return reinterpret_cast<Bar*>(ptr);
 }
 
 inline void Bar::operator delete(void* ptr) {
-  capi::Bar_destroy(reinterpret_cast<capi::Bar*>(ptr));
+  capi::Bar_destroy(reinterpret_cast<::capi::Bar*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/BorrowedFields.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFields.d.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace capi {typedef struct Bar Bar; }
 class Bar;
 
 
@@ -27,8 +28,8 @@ struct BorrowedFields {
 
   inline static diplomat::result<BorrowedFields, diplomat::Utf8Error> from_bar_and_strings(const Bar& bar, std::u16string_view dstr16, std::string_view utf8_str);
 
-  inline capi::BorrowedFields AsFFI() const;
-  inline static BorrowedFields FromFFI(capi::BorrowedFields c_struct);
+  inline ::capi::BorrowedFields AsFFI() const;
+  inline static BorrowedFields FromFFI(::capi::BorrowedFields c_struct);
 };
 
 

--- a/feature_tests/cpp2/include/BorrowedFields.hpp
+++ b/feature_tests/cpp2/include/BorrowedFields.hpp
@@ -16,12 +16,11 @@
 namespace capi {
     extern "C" {
     
-    BorrowedFields BorrowedFields_from_bar_and_strings(const Bar* bar, const char16_t* dstr16_data, size_t dstr16_len, const char* utf8_str_data, size_t utf8_str_len);
+    ::capi::BorrowedFields BorrowedFields_from_bar_and_strings(const ::capi::Bar* bar, const char16_t* dstr16_data, size_t dstr16_len, const char* utf8_str_data, size_t utf8_str_len);
     
     
     } // extern "C"
 }
-
 inline diplomat::result<BorrowedFields, diplomat::Utf8Error> BorrowedFields::from_bar_and_strings(const Bar& bar, std::u16string_view dstr16, std::string_view utf8_str) {
   if (!capi::diplomat_is_str(utf8_str.data(), utf8_str.size())) {
     return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
@@ -35,15 +34,15 @@ inline diplomat::result<BorrowedFields, diplomat::Utf8Error> BorrowedFields::fro
 }
 
 
-inline capi::BorrowedFields BorrowedFields::AsFFI() const {
-  return capi::BorrowedFields {
+inline ::capi::BorrowedFields BorrowedFields::AsFFI() const {
+  return ::capi::BorrowedFields {
     .a = { .data = a.data(), .len = a.size() },
     .b = { .data = b.data(), .len = b.size() },
     .c = { .data = c.data(), .len = c.size() },
   };
 }
 
-inline BorrowedFields BorrowedFields::FromFFI(capi::BorrowedFields c_struct) {
+inline BorrowedFields BorrowedFields::FromFFI(::capi::BorrowedFields c_struct) {
   return BorrowedFields {
     .a = std::u16string_view(c_struct.a.data, c_struct.a.len),
     .b = std::string_view(c_struct.b.data, c_struct.b.len),

--- a/feature_tests/cpp2/include/BorrowedFieldsReturning.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsReturning.d.hpp
@@ -19,8 +19,8 @@ namespace capi {
 struct BorrowedFieldsReturning {
   std::string_view bytes;
 
-  inline capi::BorrowedFieldsReturning AsFFI() const;
-  inline static BorrowedFieldsReturning FromFFI(capi::BorrowedFieldsReturning c_struct);
+  inline ::capi::BorrowedFieldsReturning AsFFI() const;
+  inline static BorrowedFieldsReturning FromFFI(::capi::BorrowedFieldsReturning c_struct);
 };
 
 

--- a/feature_tests/cpp2/include/BorrowedFieldsReturning.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsReturning.hpp
@@ -19,14 +19,13 @@ namespace capi {
     } // extern "C"
 }
 
-
-inline capi::BorrowedFieldsReturning BorrowedFieldsReturning::AsFFI() const {
-  return capi::BorrowedFieldsReturning {
+inline ::capi::BorrowedFieldsReturning BorrowedFieldsReturning::AsFFI() const {
+  return ::capi::BorrowedFieldsReturning {
     .bytes = { .data = bytes.data(), .len = bytes.size() },
   };
 }
 
-inline BorrowedFieldsReturning BorrowedFieldsReturning::FromFFI(capi::BorrowedFieldsReturning c_struct) {
+inline BorrowedFieldsReturning BorrowedFieldsReturning::FromFFI(::capi::BorrowedFieldsReturning c_struct) {
   return BorrowedFieldsReturning {
     .bytes = std::string_view(c_struct.bytes.data, c_struct.bytes.len),
   };

--- a/feature_tests/cpp2/include/BorrowedFieldsWithBounds.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsWithBounds.d.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace capi {typedef struct Foo Foo; }
 class Foo;
 
 
@@ -27,8 +28,8 @@ struct BorrowedFieldsWithBounds {
 
   inline static diplomat::result<BorrowedFieldsWithBounds, diplomat::Utf8Error> from_foo_and_strings(const Foo& foo, std::u16string_view dstr16_x, std::string_view utf8_str_z);
 
-  inline capi::BorrowedFieldsWithBounds AsFFI() const;
-  inline static BorrowedFieldsWithBounds FromFFI(capi::BorrowedFieldsWithBounds c_struct);
+  inline ::capi::BorrowedFieldsWithBounds AsFFI() const;
+  inline static BorrowedFieldsWithBounds FromFFI(::capi::BorrowedFieldsWithBounds c_struct);
 };
 
 

--- a/feature_tests/cpp2/include/BorrowedFieldsWithBounds.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsWithBounds.hpp
@@ -16,12 +16,11 @@
 namespace capi {
     extern "C" {
     
-    BorrowedFieldsWithBounds BorrowedFieldsWithBounds_from_foo_and_strings(const Foo* foo, const char16_t* dstr16_x_data, size_t dstr16_x_len, const char* utf8_str_z_data, size_t utf8_str_z_len);
+    ::capi::BorrowedFieldsWithBounds BorrowedFieldsWithBounds_from_foo_and_strings(const ::capi::Foo* foo, const char16_t* dstr16_x_data, size_t dstr16_x_len, const char* utf8_str_z_data, size_t utf8_str_z_len);
     
     
     } // extern "C"
 }
-
 inline diplomat::result<BorrowedFieldsWithBounds, diplomat::Utf8Error> BorrowedFieldsWithBounds::from_foo_and_strings(const Foo& foo, std::u16string_view dstr16_x, std::string_view utf8_str_z) {
   if (!capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size())) {
     return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
@@ -35,15 +34,15 @@ inline diplomat::result<BorrowedFieldsWithBounds, diplomat::Utf8Error> BorrowedF
 }
 
 
-inline capi::BorrowedFieldsWithBounds BorrowedFieldsWithBounds::AsFFI() const {
-  return capi::BorrowedFieldsWithBounds {
+inline ::capi::BorrowedFieldsWithBounds BorrowedFieldsWithBounds::AsFFI() const {
+  return ::capi::BorrowedFieldsWithBounds {
     .field_a = { .data = field_a.data(), .len = field_a.size() },
     .field_b = { .data = field_b.data(), .len = field_b.size() },
     .field_c = { .data = field_c.data(), .len = field_c.size() },
   };
 }
 
-inline BorrowedFieldsWithBounds BorrowedFieldsWithBounds::FromFFI(capi::BorrowedFieldsWithBounds c_struct) {
+inline BorrowedFieldsWithBounds BorrowedFieldsWithBounds::FromFFI(::capi::BorrowedFieldsWithBounds c_struct) {
   return BorrowedFieldsWithBounds {
     .field_a = std::u16string_view(c_struct.field_a.data, c_struct.field_a.len),
     .field_b = std::string_view(c_struct.field_b.data, c_struct.field_b.len),

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
@@ -10,6 +10,7 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace ns {
 namespace capi {
     typedef enum AttrEnum {
       AttrEnum_A = 0,
@@ -18,7 +19,7 @@ namespace capi {
     } AttrEnum;
 }
 
-namespace ns {
+
 class CPPRenamedAttrEnum {
 public:
   enum Value {
@@ -34,8 +35,8 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline capi::AttrEnum AsFFI() const;
-  inline static ns::CPPRenamedAttrEnum FromFFI(capi::AttrEnum c_enum);
+  inline ns::capi::AttrEnum AsFFI() const;
+  inline static ns::CPPRenamedAttrEnum FromFFI(ns::capi::AttrEnum c_enum);
 private:
     Value value;
 };

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
@@ -12,11 +12,11 @@
 
 namespace ns {
 namespace capi {
-    typedef enum AttrEnum {
-      AttrEnum_A = 0,
-      AttrEnum_B = 1,
-      AttrEnum_C = 2,
-    } AttrEnum;
+    typedef enum CPPRenamedAttrEnum {
+      CPPRenamedAttrEnum_A = 0,
+      CPPRenamedAttrEnum_B = 1,
+      CPPRenamedAttrEnum_C = 2,
+    } CPPRenamedAttrEnum;
 }
 
 
@@ -35,8 +35,8 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline ns::capi::AttrEnum AsFFI() const;
-  inline static ns::CPPRenamedAttrEnum FromFFI(ns::capi::AttrEnum c_enum);
+  inline ns::capi::CPPRenamedAttrEnum AsFFI() const;
+  inline static ns::CPPRenamedAttrEnum FromFFI(ns::capi::CPPRenamedAttrEnum c_enum);
 private:
     Value value;
 };

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.hpp
@@ -20,15 +20,15 @@ namespace capi {
     } // extern "C"
 }
 }
-inline ns::capi::AttrEnum ns::CPPRenamedAttrEnum::AsFFI() const {
-  return static_cast<ns::capi::AttrEnum>(value);
+inline ns::capi::CPPRenamedAttrEnum ns::CPPRenamedAttrEnum::AsFFI() const {
+  return static_cast<ns::capi::CPPRenamedAttrEnum>(value);
 }
 
-inline ns::CPPRenamedAttrEnum ns::CPPRenamedAttrEnum::FromFFI(ns::capi::AttrEnum c_enum) {
+inline ns::CPPRenamedAttrEnum ns::CPPRenamedAttrEnum::FromFFI(ns::capi::CPPRenamedAttrEnum c_enum) {
   switch (c_enum) {
-    case ns::capi::AttrEnum_A:
-    case ns::capi::AttrEnum_B:
-    case ns::capi::AttrEnum_C:
+    case ns::capi::CPPRenamedAttrEnum_A:
+    case ns::capi::CPPRenamedAttrEnum_B:
+    case ns::capi::CPPRenamedAttrEnum_C:
       return static_cast<ns::CPPRenamedAttrEnum::Value>(c_enum);
     default:
       abort();

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.hpp
@@ -12,23 +12,23 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace ns {
 namespace capi {
     extern "C" {
     
     
     } // extern "C"
 }
-
-
-inline capi::AttrEnum ns::CPPRenamedAttrEnum::AsFFI() const {
-  return static_cast<capi::AttrEnum>(value);
+}
+inline ns::capi::AttrEnum ns::CPPRenamedAttrEnum::AsFFI() const {
+  return static_cast<ns::capi::AttrEnum>(value);
 }
 
-inline ns::CPPRenamedAttrEnum ns::CPPRenamedAttrEnum::FromFFI(capi::AttrEnum c_enum) {
+inline ns::CPPRenamedAttrEnum ns::CPPRenamedAttrEnum::FromFFI(ns::capi::AttrEnum c_enum) {
   switch (c_enum) {
-    case capi::AttrEnum_A:
-    case capi::AttrEnum_B:
-    case capi::AttrEnum_C:
+    case ns::capi::AttrEnum_A:
+    case ns::capi::AttrEnum_B:
+    case ns::capi::AttrEnum_C:
       return static_cast<ns::CPPRenamedAttrEnum::Value>(c_enum);
     default:
       abort();

--- a/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.d.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.d.hpp
@@ -10,18 +10,18 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace ns {
 namespace capi {
     typedef struct AttrOpaque2 AttrOpaque2;
 }
 
-namespace ns {
 class CPPRenamedAttrOpaque2 {
 public:
 
-  inline const capi::AttrOpaque2* AsFFI() const;
-  inline capi::AttrOpaque2* AsFFI();
-  inline static const ns::CPPRenamedAttrOpaque2* FromFFI(const capi::AttrOpaque2* ptr);
-  inline static ns::CPPRenamedAttrOpaque2* FromFFI(capi::AttrOpaque2* ptr);
+  inline const ns::capi::AttrOpaque2* AsFFI() const;
+  inline ns::capi::AttrOpaque2* AsFFI();
+  inline static const ns::CPPRenamedAttrOpaque2* FromFFI(const ns::capi::AttrOpaque2* ptr);
+  inline static ns::CPPRenamedAttrOpaque2* FromFFI(ns::capi::AttrOpaque2* ptr);
   inline static void operator delete(void* ptr);
 private:
   CPPRenamedAttrOpaque2() = delete;

--- a/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.d.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.d.hpp
@@ -12,16 +12,16 @@
 
 namespace ns {
 namespace capi {
-    typedef struct AttrOpaque2 AttrOpaque2;
+    typedef struct CPPRenamedAttrOpaque2 CPPRenamedAttrOpaque2;
 }
 
 class CPPRenamedAttrOpaque2 {
 public:
 
-  inline const ns::capi::AttrOpaque2* AsFFI() const;
-  inline ns::capi::AttrOpaque2* AsFFI();
-  inline static const ns::CPPRenamedAttrOpaque2* FromFFI(const ns::capi::AttrOpaque2* ptr);
-  inline static ns::CPPRenamedAttrOpaque2* FromFFI(ns::capi::AttrOpaque2* ptr);
+  inline const ns::capi::CPPRenamedAttrOpaque2* AsFFI() const;
+  inline ns::capi::CPPRenamedAttrOpaque2* AsFFI();
+  inline static const ns::CPPRenamedAttrOpaque2* FromFFI(const ns::capi::CPPRenamedAttrOpaque2* ptr);
+  inline static ns::CPPRenamedAttrOpaque2* FromFFI(ns::capi::CPPRenamedAttrOpaque2* ptr);
   inline static void operator delete(void* ptr);
 private:
   CPPRenamedAttrOpaque2() = delete;

--- a/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.hpp
@@ -17,29 +17,29 @@ namespace capi {
     extern "C" {
     
     
-    void namespace_AttrOpaque2_destroy(AttrOpaque2* self);
+    void namespace_AttrOpaque2_destroy(CPPRenamedAttrOpaque2* self);
     
     } // extern "C"
 }
 }
-inline const ns::capi::AttrOpaque2* ns::CPPRenamedAttrOpaque2::AsFFI() const {
-  return reinterpret_cast<const ns::capi::AttrOpaque2*>(this);
+inline const ns::capi::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::AsFFI() const {
+  return reinterpret_cast<const ns::capi::CPPRenamedAttrOpaque2*>(this);
 }
 
-inline ns::capi::AttrOpaque2* ns::CPPRenamedAttrOpaque2::AsFFI() {
-  return reinterpret_cast<ns::capi::AttrOpaque2*>(this);
+inline ns::capi::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::AsFFI() {
+  return reinterpret_cast<ns::capi::CPPRenamedAttrOpaque2*>(this);
 }
 
-inline const ns::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::FromFFI(const ns::capi::AttrOpaque2* ptr) {
+inline const ns::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::FromFFI(const ns::capi::CPPRenamedAttrOpaque2* ptr) {
   return reinterpret_cast<const ns::CPPRenamedAttrOpaque2*>(ptr);
 }
 
-inline ns::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::FromFFI(ns::capi::AttrOpaque2* ptr) {
+inline ns::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::FromFFI(ns::capi::CPPRenamedAttrOpaque2* ptr) {
   return reinterpret_cast<ns::CPPRenamedAttrOpaque2*>(ptr);
 }
 
 inline void ns::CPPRenamedAttrOpaque2::operator delete(void* ptr) {
-  capi::namespace_AttrOpaque2_destroy(reinterpret_cast<ns::capi::AttrOpaque2*>(ptr));
+  capi::namespace_AttrOpaque2_destroy(reinterpret_cast<ns::capi::CPPRenamedAttrOpaque2*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.hpp
@@ -12,6 +12,7 @@
 #include "diplomat_runtime.hpp"
 
 
+namespace ns {
 namespace capi {
     extern "C" {
     
@@ -20,25 +21,25 @@ namespace capi {
     
     } // extern "C"
 }
-
-inline const capi::AttrOpaque2* ns::CPPRenamedAttrOpaque2::AsFFI() const {
-  return reinterpret_cast<const capi::AttrOpaque2*>(this);
+}
+inline const ns::capi::AttrOpaque2* ns::CPPRenamedAttrOpaque2::AsFFI() const {
+  return reinterpret_cast<const ns::capi::AttrOpaque2*>(this);
 }
 
-inline capi::AttrOpaque2* ns::CPPRenamedAttrOpaque2::AsFFI() {
-  return reinterpret_cast<capi::AttrOpaque2*>(this);
+inline ns::capi::AttrOpaque2* ns::CPPRenamedAttrOpaque2::AsFFI() {
+  return reinterpret_cast<ns::capi::AttrOpaque2*>(this);
 }
 
-inline const ns::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::FromFFI(const capi::AttrOpaque2* ptr) {
+inline const ns::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::FromFFI(const ns::capi::AttrOpaque2* ptr) {
   return reinterpret_cast<const ns::CPPRenamedAttrOpaque2*>(ptr);
 }
 
-inline ns::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::FromFFI(capi::AttrOpaque2* ptr) {
+inline ns::CPPRenamedAttrOpaque2* ns::CPPRenamedAttrOpaque2::FromFFI(ns::capi::AttrOpaque2* ptr) {
   return reinterpret_cast<ns::CPPRenamedAttrOpaque2*>(ptr);
 }
 
 inline void ns::CPPRenamedAttrOpaque2::operator delete(void* ptr) {
-  capi::namespace_AttrOpaque2_destroy(reinterpret_cast<capi::AttrOpaque2*>(ptr));
+  capi::namespace_AttrOpaque2_destroy(reinterpret_cast<ns::capi::AttrOpaque2*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/ContiguousEnum.d.hpp
+++ b/feature_tests/cpp2/include/ContiguousEnum.d.hpp
@@ -19,6 +19,7 @@ namespace capi {
     } ContiguousEnum;
 }
 
+
 class ContiguousEnum {
 public:
   enum Value {
@@ -35,8 +36,8 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline capi::ContiguousEnum AsFFI() const;
-  inline static ContiguousEnum FromFFI(capi::ContiguousEnum c_enum);
+  inline ::capi::ContiguousEnum AsFFI() const;
+  inline static ContiguousEnum FromFFI(::capi::ContiguousEnum c_enum);
 private:
     Value value;
 };

--- a/feature_tests/cpp2/include/ContiguousEnum.hpp
+++ b/feature_tests/cpp2/include/ContiguousEnum.hpp
@@ -18,18 +18,16 @@ namespace capi {
     
     } // extern "C"
 }
-
-
-inline capi::ContiguousEnum ContiguousEnum::AsFFI() const {
-  return static_cast<capi::ContiguousEnum>(value);
+inline ::capi::ContiguousEnum ContiguousEnum::AsFFI() const {
+  return static_cast<::capi::ContiguousEnum>(value);
 }
 
-inline ContiguousEnum ContiguousEnum::FromFFI(capi::ContiguousEnum c_enum) {
+inline ContiguousEnum ContiguousEnum::FromFFI(::capi::ContiguousEnum c_enum) {
   switch (c_enum) {
-    case capi::ContiguousEnum_C:
-    case capi::ContiguousEnum_D:
-    case capi::ContiguousEnum_E:
-    case capi::ContiguousEnum_F:
+    case ::capi::ContiguousEnum_C:
+    case ::capi::ContiguousEnum_D:
+    case ::capi::ContiguousEnum_E:
+    case ::capi::ContiguousEnum_F:
       return static_cast<ContiguousEnum::Value>(c_enum);
     default:
       abort();

--- a/feature_tests/cpp2/include/ErrorEnum.d.hpp
+++ b/feature_tests/cpp2/include/ErrorEnum.d.hpp
@@ -17,6 +17,7 @@ namespace capi {
     } ErrorEnum;
 }
 
+
 class ErrorEnum {
 public:
   enum Value {
@@ -31,8 +32,8 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline capi::ErrorEnum AsFFI() const;
-  inline static ErrorEnum FromFFI(capi::ErrorEnum c_enum);
+  inline ::capi::ErrorEnum AsFFI() const;
+  inline static ErrorEnum FromFFI(::capi::ErrorEnum c_enum);
 private:
     Value value;
 };

--- a/feature_tests/cpp2/include/ErrorEnum.hpp
+++ b/feature_tests/cpp2/include/ErrorEnum.hpp
@@ -18,16 +18,14 @@ namespace capi {
     
     } // extern "C"
 }
-
-
-inline capi::ErrorEnum ErrorEnum::AsFFI() const {
-  return static_cast<capi::ErrorEnum>(value);
+inline ::capi::ErrorEnum ErrorEnum::AsFFI() const {
+  return static_cast<::capi::ErrorEnum>(value);
 }
 
-inline ErrorEnum ErrorEnum::FromFFI(capi::ErrorEnum c_enum) {
+inline ErrorEnum ErrorEnum::FromFFI(::capi::ErrorEnum c_enum) {
   switch (c_enum) {
-    case capi::ErrorEnum_Foo:
-    case capi::ErrorEnum_Bar:
+    case ::capi::ErrorEnum_Foo:
+    case ::capi::ErrorEnum_Bar:
       return static_cast<ErrorEnum::Value>(c_enum);
     default:
       abort();

--- a/feature_tests/cpp2/include/ErrorStruct.d.hpp
+++ b/feature_tests/cpp2/include/ErrorStruct.d.hpp
@@ -21,8 +21,8 @@ struct ErrorStruct {
   int32_t i;
   int32_t j;
 
-  inline capi::ErrorStruct AsFFI() const;
-  inline static ErrorStruct FromFFI(capi::ErrorStruct c_struct);
+  inline ::capi::ErrorStruct AsFFI() const;
+  inline static ErrorStruct FromFFI(::capi::ErrorStruct c_struct);
 };
 
 

--- a/feature_tests/cpp2/include/ErrorStruct.hpp
+++ b/feature_tests/cpp2/include/ErrorStruct.hpp
@@ -19,15 +19,14 @@ namespace capi {
     } // extern "C"
 }
 
-
-inline capi::ErrorStruct ErrorStruct::AsFFI() const {
-  return capi::ErrorStruct {
+inline ::capi::ErrorStruct ErrorStruct::AsFFI() const {
+  return ::capi::ErrorStruct {
     .i = i,
     .j = j,
   };
 }
 
-inline ErrorStruct ErrorStruct::FromFFI(capi::ErrorStruct c_struct) {
+inline ErrorStruct ErrorStruct::FromFFI(::capi::ErrorStruct c_struct) {
   return ErrorStruct {
     .i = c_struct.i,
     .j = c_struct.j,

--- a/feature_tests/cpp2/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp2/include/Float64Vec.d.hpp
@@ -45,10 +45,10 @@ public:
 
   inline std::optional<double> get(size_t i) const;
 
-  inline const capi::Float64Vec* AsFFI() const;
-  inline capi::Float64Vec* AsFFI();
-  inline static const Float64Vec* FromFFI(const capi::Float64Vec* ptr);
-  inline static Float64Vec* FromFFI(capi::Float64Vec* ptr);
+  inline const ::capi::Float64Vec* AsFFI() const;
+  inline ::capi::Float64Vec* AsFFI();
+  inline static const Float64Vec* FromFFI(const ::capi::Float64Vec* ptr);
+  inline static Float64Vec* FromFFI(::capi::Float64Vec* ptr);
   inline static void operator delete(void* ptr);
 private:
   Float64Vec() = delete;

--- a/feature_tests/cpp2/include/Float64Vec.hpp
+++ b/feature_tests/cpp2/include/Float64Vec.hpp
@@ -15,41 +15,40 @@
 namespace capi {
     extern "C" {
     
-    Float64Vec* Float64Vec_new(const double* v_data, size_t v_len);
+    ::capi::Float64Vec* Float64Vec_new(const double* v_data, size_t v_len);
     
-    Float64Vec* Float64Vec_new_bool(const bool* v_data, size_t v_len);
+    ::capi::Float64Vec* Float64Vec_new_bool(const bool* v_data, size_t v_len);
     
-    Float64Vec* Float64Vec_new_i16(const int16_t* v_data, size_t v_len);
+    ::capi::Float64Vec* Float64Vec_new_i16(const int16_t* v_data, size_t v_len);
     
-    Float64Vec* Float64Vec_new_u16(const uint16_t* v_data, size_t v_len);
+    ::capi::Float64Vec* Float64Vec_new_u16(const uint16_t* v_data, size_t v_len);
     
-    Float64Vec* Float64Vec_new_isize(const intptr_t* v_data, size_t v_len);
+    ::capi::Float64Vec* Float64Vec_new_isize(const intptr_t* v_data, size_t v_len);
     
-    Float64Vec* Float64Vec_new_usize(const size_t* v_data, size_t v_len);
+    ::capi::Float64Vec* Float64Vec_new_usize(const size_t* v_data, size_t v_len);
     
-    Float64Vec* Float64Vec_new_f64_be_bytes(const uint8_t* v_data, size_t v_len);
+    ::capi::Float64Vec* Float64Vec_new_f64_be_bytes(const uint8_t* v_data, size_t v_len);
     
-    DiplomatF64ViewMut Float64Vec_as_boxed_slice(const Float64Vec* self);
+    DiplomatF64ViewMut Float64Vec_as_boxed_slice(const ::capi::Float64Vec* self);
     
-    DiplomatF64View Float64Vec_as_slice(const Float64Vec* self);
+    DiplomatF64View Float64Vec_as_slice(const ::capi::Float64Vec* self);
     
-    void Float64Vec_fill_slice(const Float64Vec* self, double* v_data, size_t v_len);
+    void Float64Vec_fill_slice(const ::capi::Float64Vec* self, double* v_data, size_t v_len);
     
-    void Float64Vec_set_value(Float64Vec* self, const double* new_slice_data, size_t new_slice_len);
+    void Float64Vec_set_value(::capi::Float64Vec* self, const double* new_slice_data, size_t new_slice_len);
     
-    void Float64Vec_to_string(const Float64Vec* self, DiplomatWrite* write);
+    void Float64Vec_to_string(const ::capi::Float64Vec* self, DiplomatWrite* write);
     
-    DiplomatF64View Float64Vec_borrow(const Float64Vec* self);
+    DiplomatF64View Float64Vec_borrow(const ::capi::Float64Vec* self);
     
     typedef struct Float64Vec_get_result {union {double ok; }; bool is_ok;} Float64Vec_get_result;
-    Float64Vec_get_result Float64Vec_get(const Float64Vec* self, size_t i);
+    Float64Vec_get_result Float64Vec_get(const ::capi::Float64Vec* self, size_t i);
     
     
     void Float64Vec_destroy(Float64Vec* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<Float64Vec> Float64Vec::new_(diplomat::span<const double> v) {
   auto result = capi::Float64Vec_new(v.data(),
     v.size());
@@ -133,24 +132,24 @@ inline std::optional<double> Float64Vec::get(size_t i) const {
   return result.is_ok ? std::optional<double>(result.ok) : std::nullopt;
 }
 
-inline const capi::Float64Vec* Float64Vec::AsFFI() const {
-  return reinterpret_cast<const capi::Float64Vec*>(this);
+inline const ::capi::Float64Vec* Float64Vec::AsFFI() const {
+  return reinterpret_cast<const ::capi::Float64Vec*>(this);
 }
 
-inline capi::Float64Vec* Float64Vec::AsFFI() {
-  return reinterpret_cast<capi::Float64Vec*>(this);
+inline ::capi::Float64Vec* Float64Vec::AsFFI() {
+  return reinterpret_cast<::capi::Float64Vec*>(this);
 }
 
-inline const Float64Vec* Float64Vec::FromFFI(const capi::Float64Vec* ptr) {
+inline const Float64Vec* Float64Vec::FromFFI(const ::capi::Float64Vec* ptr) {
   return reinterpret_cast<const Float64Vec*>(ptr);
 }
 
-inline Float64Vec* Float64Vec::FromFFI(capi::Float64Vec* ptr) {
+inline Float64Vec* Float64Vec::FromFFI(::capi::Float64Vec* ptr) {
   return reinterpret_cast<Float64Vec*>(ptr);
 }
 
 inline void Float64Vec::operator delete(void* ptr) {
-  capi::Float64Vec_destroy(reinterpret_cast<capi::Float64Vec*>(ptr));
+  capi::Float64Vec_destroy(reinterpret_cast<::capi::Float64Vec*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/Float64Vec.hpp
+++ b/feature_tests/cpp2/include/Float64Vec.hpp
@@ -37,7 +37,7 @@ namespace capi {
     
     void Float64Vec_set_value(::capi::Float64Vec* self, const double* new_slice_data, size_t new_slice_len);
     
-    void Float64Vec_to_string(const ::capi::Float64Vec* self, DiplomatWrite* write);
+    void Float64Vec_to_string(const ::capi::Float64Vec* self, ::capi::DiplomatWrite* write);
     
     DiplomatF64View Float64Vec_borrow(const ::capi::Float64Vec* self);
     
@@ -115,7 +115,7 @@ inline void Float64Vec::set_value(diplomat::span<const double> new_slice) {
 
 inline std::string Float64Vec::to_string() const {
   std::string output;
-  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  ::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   capi::Float64Vec_to_string(this->AsFFI(),
     &write);
   return output;

--- a/feature_tests/cpp2/include/Foo.d.hpp
+++ b/feature_tests/cpp2/include/Foo.d.hpp
@@ -12,6 +12,7 @@
 #include "BorrowedFieldsReturning.d.hpp"
 #include "BorrowedFieldsWithBounds.d.hpp"
 
+namespace capi {typedef struct Bar Bar; }
 class Bar;
 struct BorrowedFields;
 struct BorrowedFieldsReturning;
@@ -37,10 +38,10 @@ public:
 
   inline static std::unique_ptr<Foo> extract_from_bounds(BorrowedFieldsWithBounds bounds, std::string_view another_string);
 
-  inline const capi::Foo* AsFFI() const;
-  inline capi::Foo* AsFFI();
-  inline static const Foo* FromFFI(const capi::Foo* ptr);
-  inline static Foo* FromFFI(capi::Foo* ptr);
+  inline const ::capi::Foo* AsFFI() const;
+  inline ::capi::Foo* AsFFI();
+  inline static const Foo* FromFFI(const ::capi::Foo* ptr);
+  inline static Foo* FromFFI(::capi::Foo* ptr);
   inline static void operator delete(void* ptr);
 private:
   Foo() = delete;

--- a/feature_tests/cpp2/include/Foo.hpp
+++ b/feature_tests/cpp2/include/Foo.hpp
@@ -19,24 +19,23 @@
 namespace capi {
     extern "C" {
     
-    Foo* Foo_new(const char* x_data, size_t x_len);
+    ::capi::Foo* Foo_new(const char* x_data, size_t x_len);
     
-    Bar* Foo_get_bar(const Foo* self);
+    ::capi::Bar* Foo_get_bar(const ::capi::Foo* self);
     
-    Foo* Foo_new_static(const char* x_data, size_t x_len);
+    ::capi::Foo* Foo_new_static(const char* x_data, size_t x_len);
     
-    BorrowedFieldsReturning Foo_as_returning(const Foo* self);
+    ::capi::BorrowedFieldsReturning Foo_as_returning(const ::capi::Foo* self);
     
-    Foo* Foo_extract_from_fields(BorrowedFields fields);
+    ::capi::Foo* Foo_extract_from_fields(::capi::BorrowedFields fields);
     
-    Foo* Foo_extract_from_bounds(BorrowedFieldsWithBounds bounds, const char* another_string_data, size_t another_string_len);
+    ::capi::Foo* Foo_extract_from_bounds(::capi::BorrowedFieldsWithBounds bounds, const char* another_string_data, size_t another_string_len);
     
     
     void Foo_destroy(Foo* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<Foo> Foo::new_(std::string_view x) {
   auto result = capi::Foo_new(x.data(),
     x.size());
@@ -71,24 +70,24 @@ inline std::unique_ptr<Foo> Foo::extract_from_bounds(BorrowedFieldsWithBounds bo
   return std::unique_ptr<Foo>(Foo::FromFFI(result));
 }
 
-inline const capi::Foo* Foo::AsFFI() const {
-  return reinterpret_cast<const capi::Foo*>(this);
+inline const ::capi::Foo* Foo::AsFFI() const {
+  return reinterpret_cast<const ::capi::Foo*>(this);
 }
 
-inline capi::Foo* Foo::AsFFI() {
-  return reinterpret_cast<capi::Foo*>(this);
+inline ::capi::Foo* Foo::AsFFI() {
+  return reinterpret_cast<::capi::Foo*>(this);
 }
 
-inline const Foo* Foo::FromFFI(const capi::Foo* ptr) {
+inline const Foo* Foo::FromFFI(const ::capi::Foo* ptr) {
   return reinterpret_cast<const Foo*>(ptr);
 }
 
-inline Foo* Foo::FromFFI(capi::Foo* ptr) {
+inline Foo* Foo::FromFFI(::capi::Foo* ptr) {
   return reinterpret_cast<Foo*>(ptr);
 }
 
 inline void Foo::operator delete(void* ptr) {
-  capi::Foo_destroy(reinterpret_cast<capi::Foo*>(ptr));
+  capi::Foo_destroy(reinterpret_cast<::capi::Foo*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/ImportedStruct.d.hpp
+++ b/feature_tests/cpp2/include/ImportedStruct.d.hpp
@@ -15,7 +15,7 @@ class UnimportedEnum;
 
 namespace capi {
     typedef struct ImportedStruct {
-      UnimportedEnum foo;
+      ::capi::UnimportedEnum foo;
       uint8_t count;
     } ImportedStruct;
 }
@@ -24,8 +24,8 @@ struct ImportedStruct {
   UnimportedEnum foo;
   uint8_t count;
 
-  inline capi::ImportedStruct AsFFI() const;
-  inline static ImportedStruct FromFFI(capi::ImportedStruct c_struct);
+  inline ::capi::ImportedStruct AsFFI() const;
+  inline static ImportedStruct FromFFI(::capi::ImportedStruct c_struct);
 };
 
 

--- a/feature_tests/cpp2/include/ImportedStruct.hpp
+++ b/feature_tests/cpp2/include/ImportedStruct.hpp
@@ -20,15 +20,14 @@ namespace capi {
     } // extern "C"
 }
 
-
-inline capi::ImportedStruct ImportedStruct::AsFFI() const {
-  return capi::ImportedStruct {
+inline ::capi::ImportedStruct ImportedStruct::AsFFI() const {
+  return ::capi::ImportedStruct {
     .foo = foo.AsFFI(),
     .count = count,
   };
 }
 
-inline ImportedStruct ImportedStruct::FromFFI(capi::ImportedStruct c_struct) {
+inline ImportedStruct ImportedStruct::FromFFI(::capi::ImportedStruct c_struct) {
   return ImportedStruct {
     .foo = UnimportedEnum::FromFFI(c_struct.foo),
     .count = c_struct.count,

--- a/feature_tests/cpp2/include/MyEnum.d.hpp
+++ b/feature_tests/cpp2/include/MyEnum.d.hpp
@@ -21,6 +21,7 @@ namespace capi {
     } MyEnum;
 }
 
+
 class MyEnum {
 public:
   enum Value {
@@ -43,8 +44,8 @@ public:
 
   inline static MyEnum get_a();
 
-  inline capi::MyEnum AsFFI() const;
-  inline static MyEnum FromFFI(capi::MyEnum c_enum);
+  inline ::capi::MyEnum AsFFI() const;
+  inline static MyEnum FromFFI(::capi::MyEnum c_enum);
 private:
     Value value;
 };

--- a/feature_tests/cpp2/include/MyEnum.hpp
+++ b/feature_tests/cpp2/include/MyEnum.hpp
@@ -15,27 +15,25 @@
 namespace capi {
     extern "C" {
     
-    int8_t MyEnum_into_value(MyEnum self);
+    int8_t MyEnum_into_value(::capi::MyEnum self);
     
-    MyEnum MyEnum_get_a();
+    ::capi::MyEnum MyEnum_get_a();
     
     
     } // extern "C"
 }
-
-
-inline capi::MyEnum MyEnum::AsFFI() const {
-  return static_cast<capi::MyEnum>(value);
+inline ::capi::MyEnum MyEnum::AsFFI() const {
+  return static_cast<::capi::MyEnum>(value);
 }
 
-inline MyEnum MyEnum::FromFFI(capi::MyEnum c_enum) {
+inline MyEnum MyEnum::FromFFI(::capi::MyEnum c_enum) {
   switch (c_enum) {
-    case capi::MyEnum_A:
-    case capi::MyEnum_B:
-    case capi::MyEnum_C:
-    case capi::MyEnum_D:
-    case capi::MyEnum_E:
-    case capi::MyEnum_F:
+    case ::capi::MyEnum_A:
+    case ::capi::MyEnum_B:
+    case ::capi::MyEnum_C:
+    case ::capi::MyEnum_D:
+    case ::capi::MyEnum_E:
+    case ::capi::MyEnum_F:
       return static_cast<MyEnum::Value>(c_enum);
     default:
       abort();

--- a/feature_tests/cpp2/include/MyString.d.hpp
+++ b/feature_tests/cpp2/include/MyString.d.hpp
@@ -29,10 +29,10 @@ public:
 
   inline std::string_view get_boxed_str() const;
 
-  inline const capi::MyString* AsFFI() const;
-  inline capi::MyString* AsFFI();
-  inline static const MyString* FromFFI(const capi::MyString* ptr);
-  inline static MyString* FromFFI(capi::MyString* ptr);
+  inline const ::capi::MyString* AsFFI() const;
+  inline ::capi::MyString* AsFFI();
+  inline static const MyString* FromFFI(const ::capi::MyString* ptr);
+  inline static MyString* FromFFI(::capi::MyString* ptr);
   inline static void operator delete(void* ptr);
 private:
   MyString() = delete;

--- a/feature_tests/cpp2/include/MyString.hpp
+++ b/feature_tests/cpp2/include/MyString.hpp
@@ -23,7 +23,7 @@ namespace capi {
     
     void MyString_set_str(::capi::MyString* self, const char* new_str_data, size_t new_str_len);
     
-    void MyString_get_str(const ::capi::MyString* self, DiplomatWrite* write);
+    void MyString_get_str(const ::capi::MyString* self, ::capi::DiplomatWrite* write);
     
     DiplomatStringView MyString_get_boxed_str(const ::capi::MyString* self);
     
@@ -61,7 +61,7 @@ inline void MyString::set_str(std::string_view new_str) {
 
 inline std::string MyString::get_str() const {
   std::string output;
-  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  ::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   capi::MyString_get_str(this->AsFFI(),
     &write);
   return output;

--- a/feature_tests/cpp2/include/MyString.hpp
+++ b/feature_tests/cpp2/include/MyString.hpp
@@ -15,24 +15,23 @@
 namespace capi {
     extern "C" {
     
-    MyString* MyString_new(const char* v_data, size_t v_len);
+    ::capi::MyString* MyString_new(const char* v_data, size_t v_len);
     
-    MyString* MyString_new_unsafe(const char* v_data, size_t v_len);
+    ::capi::MyString* MyString_new_unsafe(const char* v_data, size_t v_len);
     
-    MyString* MyString_new_owned(const char* v_data, size_t v_len);
+    ::capi::MyString* MyString_new_owned(const char* v_data, size_t v_len);
     
-    void MyString_set_str(MyString* self, const char* new_str_data, size_t new_str_len);
+    void MyString_set_str(::capi::MyString* self, const char* new_str_data, size_t new_str_len);
     
-    void MyString_get_str(const MyString* self, DiplomatWrite* write);
+    void MyString_get_str(const ::capi::MyString* self, DiplomatWrite* write);
     
-    DiplomatStringView MyString_get_boxed_str(const MyString* self);
+    DiplomatStringView MyString_get_boxed_str(const ::capi::MyString* self);
     
     
     void MyString_destroy(MyString* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<MyString> MyString::new_(std::string_view v) {
   auto result = capi::MyString_new(v.data(),
     v.size());
@@ -73,24 +72,24 @@ inline std::string_view MyString::get_boxed_str() const {
   return std::string_view(result.data, result.len);
 }
 
-inline const capi::MyString* MyString::AsFFI() const {
-  return reinterpret_cast<const capi::MyString*>(this);
+inline const ::capi::MyString* MyString::AsFFI() const {
+  return reinterpret_cast<const ::capi::MyString*>(this);
 }
 
-inline capi::MyString* MyString::AsFFI() {
-  return reinterpret_cast<capi::MyString*>(this);
+inline ::capi::MyString* MyString::AsFFI() {
+  return reinterpret_cast<::capi::MyString*>(this);
 }
 
-inline const MyString* MyString::FromFFI(const capi::MyString* ptr) {
+inline const MyString* MyString::FromFFI(const ::capi::MyString* ptr) {
   return reinterpret_cast<const MyString*>(ptr);
 }
 
-inline MyString* MyString::FromFFI(capi::MyString* ptr) {
+inline MyString* MyString::FromFFI(::capi::MyString* ptr) {
   return reinterpret_cast<MyString*>(ptr);
 }
 
 inline void MyString::operator delete(void* ptr) {
-  capi::MyString_destroy(reinterpret_cast<capi::MyString*>(ptr));
+  capi::MyString_destroy(reinterpret_cast<::capi::MyString*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/MyStruct.d.hpp
+++ b/feature_tests/cpp2/include/MyStruct.d.hpp
@@ -23,7 +23,7 @@ namespace capi {
       uint64_t d;
       int32_t e;
       char32_t f;
-      MyEnum g;
+      ::capi::MyEnum g;
     } MyStruct;
 }
 
@@ -42,8 +42,8 @@ struct MyStruct {
 
   inline static diplomat::result<std::monostate, MyZst> returns_zst_result();
 
-  inline capi::MyStruct AsFFI() const;
-  inline static MyStruct FromFFI(capi::MyStruct c_struct);
+  inline ::capi::MyStruct AsFFI() const;
+  inline static MyStruct FromFFI(::capi::MyStruct c_struct);
 };
 
 

--- a/feature_tests/cpp2/include/MyStruct.hpp
+++ b/feature_tests/cpp2/include/MyStruct.hpp
@@ -17,9 +17,9 @@
 namespace capi {
     extern "C" {
     
-    MyStruct MyStruct_new();
+    ::capi::MyStruct MyStruct_new();
     
-    uint8_t MyStruct_into_a(MyStruct self);
+    uint8_t MyStruct_into_a(::capi::MyStruct self);
     
     typedef struct MyStruct_returns_zst_result_result { bool is_ok;} MyStruct_returns_zst_result_result;
     MyStruct_returns_zst_result_result MyStruct_returns_zst_result();
@@ -27,7 +27,6 @@ namespace capi {
     
     } // extern "C"
 }
-
 inline MyStruct MyStruct::new_() {
   auto result = capi::MyStruct_new();
   return MyStruct::FromFFI(result);
@@ -44,8 +43,8 @@ inline diplomat::result<std::monostate, MyZst> MyStruct::returns_zst_result() {
 }
 
 
-inline capi::MyStruct MyStruct::AsFFI() const {
-  return capi::MyStruct {
+inline ::capi::MyStruct MyStruct::AsFFI() const {
+  return ::capi::MyStruct {
     .a = a,
     .b = b,
     .c = c,
@@ -56,7 +55,7 @@ inline capi::MyStruct MyStruct::AsFFI() const {
   };
 }
 
-inline MyStruct MyStruct::FromFFI(capi::MyStruct c_struct) {
+inline MyStruct MyStruct::FromFFI(::capi::MyStruct c_struct) {
   return MyStruct {
     .a = c_struct.a,
     .b = c_struct.b,

--- a/feature_tests/cpp2/include/MyZst.hpp
+++ b/feature_tests/cpp2/include/MyZst.hpp
@@ -21,5 +21,4 @@ namespace capi {
 
 
 
-
 #endif // MyZst_HPP

--- a/feature_tests/cpp2/include/NestedBorrowedFields.d.hpp
+++ b/feature_tests/cpp2/include/NestedBorrowedFields.d.hpp
@@ -11,7 +11,9 @@
 #include "BorrowedFields.d.hpp"
 #include "BorrowedFieldsWithBounds.d.hpp"
 
+namespace capi {typedef struct Bar Bar; }
 class Bar;
+namespace capi {typedef struct Foo Foo; }
 class Foo;
 struct BorrowedFields;
 struct BorrowedFieldsWithBounds;
@@ -19,9 +21,9 @@ struct BorrowedFieldsWithBounds;
 
 namespace capi {
     typedef struct NestedBorrowedFields {
-      BorrowedFields fields;
-      BorrowedFieldsWithBounds bounds;
-      BorrowedFieldsWithBounds bounds2;
+      ::capi::BorrowedFields fields;
+      ::capi::BorrowedFieldsWithBounds bounds;
+      ::capi::BorrowedFieldsWithBounds bounds2;
     } NestedBorrowedFields;
 }
 
@@ -32,8 +34,8 @@ struct NestedBorrowedFields {
 
   inline static diplomat::result<NestedBorrowedFields, diplomat::Utf8Error> from_bar_and_foo_and_strings(const Bar& bar, const Foo& foo, std::u16string_view dstr16_x, std::u16string_view dstr16_z, std::string_view utf8_str_y, std::string_view utf8_str_z);
 
-  inline capi::NestedBorrowedFields AsFFI() const;
-  inline static NestedBorrowedFields FromFFI(capi::NestedBorrowedFields c_struct);
+  inline ::capi::NestedBorrowedFields AsFFI() const;
+  inline static NestedBorrowedFields FromFFI(::capi::NestedBorrowedFields c_struct);
 };
 
 

--- a/feature_tests/cpp2/include/NestedBorrowedFields.hpp
+++ b/feature_tests/cpp2/include/NestedBorrowedFields.hpp
@@ -19,12 +19,11 @@
 namespace capi {
     extern "C" {
     
-    NestedBorrowedFields NestedBorrowedFields_from_bar_and_foo_and_strings(const Bar* bar, const Foo* foo, const char16_t* dstr16_x_data, size_t dstr16_x_len, const char16_t* dstr16_z_data, size_t dstr16_z_len, const char* utf8_str_y_data, size_t utf8_str_y_len, const char* utf8_str_z_data, size_t utf8_str_z_len);
+    ::capi::NestedBorrowedFields NestedBorrowedFields_from_bar_and_foo_and_strings(const ::capi::Bar* bar, const ::capi::Foo* foo, const char16_t* dstr16_x_data, size_t dstr16_x_len, const char16_t* dstr16_z_data, size_t dstr16_z_len, const char* utf8_str_y_data, size_t utf8_str_y_len, const char* utf8_str_z_data, size_t utf8_str_z_len);
     
     
     } // extern "C"
 }
-
 inline diplomat::result<NestedBorrowedFields, diplomat::Utf8Error> NestedBorrowedFields::from_bar_and_foo_and_strings(const Bar& bar, const Foo& foo, std::u16string_view dstr16_x, std::u16string_view dstr16_z, std::string_view utf8_str_y, std::string_view utf8_str_z) {
   if (!capi::diplomat_is_str(utf8_str_y.data(), utf8_str_y.size())) {
     return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
@@ -46,15 +45,15 @@ inline diplomat::result<NestedBorrowedFields, diplomat::Utf8Error> NestedBorrowe
 }
 
 
-inline capi::NestedBorrowedFields NestedBorrowedFields::AsFFI() const {
-  return capi::NestedBorrowedFields {
+inline ::capi::NestedBorrowedFields NestedBorrowedFields::AsFFI() const {
+  return ::capi::NestedBorrowedFields {
     .fields = fields.AsFFI(),
     .bounds = bounds.AsFFI(),
     .bounds2 = bounds2.AsFFI(),
   };
 }
 
-inline NestedBorrowedFields NestedBorrowedFields::FromFFI(capi::NestedBorrowedFields c_struct) {
+inline NestedBorrowedFields NestedBorrowedFields::FromFFI(::capi::NestedBorrowedFields c_struct) {
   return NestedBorrowedFields {
     .fields = BorrowedFields::FromFFI(c_struct.fields),
     .bounds = BorrowedFieldsWithBounds::FromFFI(c_struct.bounds),

--- a/feature_tests/cpp2/include/One.d.hpp
+++ b/feature_tests/cpp2/include/One.d.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace capi {typedef struct Two Two; }
 class Two;
 
 
@@ -41,10 +42,10 @@ public:
 
   inline static std::unique_ptr<One> implicit_bounds_deep(const One& explicit_, const One& implicit_1, const One& implicit_2, const One& nohold);
 
-  inline const capi::One* AsFFI() const;
-  inline capi::One* AsFFI();
-  inline static const One* FromFFI(const capi::One* ptr);
-  inline static One* FromFFI(capi::One* ptr);
+  inline const ::capi::One* AsFFI() const;
+  inline ::capi::One* AsFFI();
+  inline static const One* FromFFI(const ::capi::One* ptr);
+  inline static One* FromFFI(::capi::One* ptr);
   inline static void operator delete(void* ptr);
 private:
   One() = delete;

--- a/feature_tests/cpp2/include/One.hpp
+++ b/feature_tests/cpp2/include/One.hpp
@@ -16,34 +16,33 @@
 namespace capi {
     extern "C" {
     
-    One* One_transitivity(const One* hold, const One* nohold);
+    ::capi::One* One_transitivity(const ::capi::One* hold, const ::capi::One* nohold);
     
-    One* One_cycle(const Two* hold, const One* nohold);
+    ::capi::One* One_cycle(const ::capi::Two* hold, const ::capi::One* nohold);
     
-    One* One_many_dependents(const One* a, const One* b, const Two* c, const Two* d, const Two* nohold);
+    ::capi::One* One_many_dependents(const ::capi::One* a, const ::capi::One* b, const ::capi::Two* c, const ::capi::Two* d, const ::capi::Two* nohold);
     
-    One* One_return_outlives_param(const Two* hold, const One* nohold);
+    ::capi::One* One_return_outlives_param(const ::capi::Two* hold, const ::capi::One* nohold);
     
-    One* One_diamond_top(const One* top, const One* left, const One* right, const One* bottom);
+    ::capi::One* One_diamond_top(const ::capi::One* top, const ::capi::One* left, const ::capi::One* right, const ::capi::One* bottom);
     
-    One* One_diamond_left(const One* top, const One* left, const One* right, const One* bottom);
+    ::capi::One* One_diamond_left(const ::capi::One* top, const ::capi::One* left, const ::capi::One* right, const ::capi::One* bottom);
     
-    One* One_diamond_right(const One* top, const One* left, const One* right, const One* bottom);
+    ::capi::One* One_diamond_right(const ::capi::One* top, const ::capi::One* left, const ::capi::One* right, const ::capi::One* bottom);
     
-    One* One_diamond_bottom(const One* top, const One* left, const One* right, const One* bottom);
+    ::capi::One* One_diamond_bottom(const ::capi::One* top, const ::capi::One* left, const ::capi::One* right, const ::capi::One* bottom);
     
-    One* One_diamond_and_nested_types(const One* a, const One* b, const One* c, const One* d, const One* nohold);
+    ::capi::One* One_diamond_and_nested_types(const ::capi::One* a, const ::capi::One* b, const ::capi::One* c, const ::capi::One* d, const ::capi::One* nohold);
     
-    One* One_implicit_bounds(const One* explicit_hold, const One* implicit_hold, const One* nohold);
+    ::capi::One* One_implicit_bounds(const ::capi::One* explicit_hold, const ::capi::One* implicit_hold, const ::capi::One* nohold);
     
-    One* One_implicit_bounds_deep(const One* explicit_, const One* implicit_1, const One* implicit_2, const One* nohold);
+    ::capi::One* One_implicit_bounds_deep(const ::capi::One* explicit_, const ::capi::One* implicit_1, const ::capi::One* implicit_2, const ::capi::One* nohold);
     
     
     void One_destroy(One* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<One> One::transitivity(const One& hold, const One& nohold) {
   auto result = capi::One_transitivity(hold.AsFFI(),
     nohold.AsFFI());
@@ -127,24 +126,24 @@ inline std::unique_ptr<One> One::implicit_bounds_deep(const One& explicit_, cons
   return std::unique_ptr<One>(One::FromFFI(result));
 }
 
-inline const capi::One* One::AsFFI() const {
-  return reinterpret_cast<const capi::One*>(this);
+inline const ::capi::One* One::AsFFI() const {
+  return reinterpret_cast<const ::capi::One*>(this);
 }
 
-inline capi::One* One::AsFFI() {
-  return reinterpret_cast<capi::One*>(this);
+inline ::capi::One* One::AsFFI() {
+  return reinterpret_cast<::capi::One*>(this);
 }
 
-inline const One* One::FromFFI(const capi::One* ptr) {
+inline const One* One::FromFFI(const ::capi::One* ptr) {
   return reinterpret_cast<const One*>(ptr);
 }
 
-inline One* One::FromFFI(capi::One* ptr) {
+inline One* One::FromFFI(::capi::One* ptr) {
   return reinterpret_cast<One*>(ptr);
 }
 
 inline void One::operator delete(void* ptr) {
-  capi::One_destroy(reinterpret_cast<capi::One*>(ptr));
+  capi::One_destroy(reinterpret_cast<::capi::One*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/Opaque.d.hpp
+++ b/feature_tests/cpp2/include/Opaque.d.hpp
@@ -38,10 +38,10 @@ public:
 
   inline static int8_t cmp();
 
-  inline const capi::Opaque* AsFFI() const;
-  inline capi::Opaque* AsFFI();
-  inline static const Opaque* FromFFI(const capi::Opaque* ptr);
-  inline static Opaque* FromFFI(capi::Opaque* ptr);
+  inline const ::capi::Opaque* AsFFI() const;
+  inline ::capi::Opaque* AsFFI();
+  inline static const Opaque* FromFFI(const ::capi::Opaque* ptr);
+  inline static Opaque* FromFFI(::capi::Opaque* ptr);
   inline static void operator delete(void* ptr);
 private:
   Opaque() = delete;

--- a/feature_tests/cpp2/include/Opaque.hpp
+++ b/feature_tests/cpp2/include/Opaque.hpp
@@ -23,7 +23,7 @@ namespace capi {
     
     ::capi::Opaque* Opaque_from_str(const char* input_data, size_t input_len);
     
-    void Opaque_get_debug_str(const ::capi::Opaque* self, DiplomatWrite* write);
+    void Opaque_get_debug_str(const ::capi::Opaque* self, ::capi::DiplomatWrite* write);
     
     void Opaque_assert_struct(const ::capi::Opaque* self, ::capi::MyStruct s);
     
@@ -60,7 +60,7 @@ inline diplomat::result<std::unique_ptr<Opaque>, diplomat::Utf8Error> Opaque::fr
 
 inline std::string Opaque::get_debug_str() const {
   std::string output;
-  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  ::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   capi::Opaque_get_debug_str(this->AsFFI(),
     &write);
   return output;

--- a/feature_tests/cpp2/include/Opaque.hpp
+++ b/feature_tests/cpp2/include/Opaque.hpp
@@ -17,19 +17,19 @@
 namespace capi {
     extern "C" {
     
-    Opaque* Opaque_new();
+    ::capi::Opaque* Opaque_new();
     
-    Opaque* Opaque_try_from_utf8(const char* input_data, size_t input_len);
+    ::capi::Opaque* Opaque_try_from_utf8(const char* input_data, size_t input_len);
     
-    Opaque* Opaque_from_str(const char* input_data, size_t input_len);
+    ::capi::Opaque* Opaque_from_str(const char* input_data, size_t input_len);
     
-    void Opaque_get_debug_str(const Opaque* self, DiplomatWrite* write);
+    void Opaque_get_debug_str(const ::capi::Opaque* self, DiplomatWrite* write);
     
-    void Opaque_assert_struct(const Opaque* self, MyStruct s);
+    void Opaque_assert_struct(const ::capi::Opaque* self, ::capi::MyStruct s);
     
     size_t Opaque_returns_usize();
     
-    ImportedStruct Opaque_returns_imported();
+    ::capi::ImportedStruct Opaque_returns_imported();
     
     int8_t Opaque_cmp();
     
@@ -38,7 +38,6 @@ namespace capi {
     
     } // extern "C"
 }
-
 inline std::unique_ptr<Opaque> Opaque::new_() {
   auto result = capi::Opaque_new();
   return std::unique_ptr<Opaque>(Opaque::FromFFI(result));
@@ -87,24 +86,24 @@ inline int8_t Opaque::cmp() {
   return result;
 }
 
-inline const capi::Opaque* Opaque::AsFFI() const {
-  return reinterpret_cast<const capi::Opaque*>(this);
+inline const ::capi::Opaque* Opaque::AsFFI() const {
+  return reinterpret_cast<const ::capi::Opaque*>(this);
 }
 
-inline capi::Opaque* Opaque::AsFFI() {
-  return reinterpret_cast<capi::Opaque*>(this);
+inline ::capi::Opaque* Opaque::AsFFI() {
+  return reinterpret_cast<::capi::Opaque*>(this);
 }
 
-inline const Opaque* Opaque::FromFFI(const capi::Opaque* ptr) {
+inline const Opaque* Opaque::FromFFI(const ::capi::Opaque* ptr) {
   return reinterpret_cast<const Opaque*>(ptr);
 }
 
-inline Opaque* Opaque::FromFFI(capi::Opaque* ptr) {
+inline Opaque* Opaque::FromFFI(::capi::Opaque* ptr) {
   return reinterpret_cast<Opaque*>(ptr);
 }
 
 inline void Opaque::operator delete(void* ptr) {
-  capi::Opaque_destroy(reinterpret_cast<capi::Opaque*>(ptr));
+  capi::Opaque_destroy(reinterpret_cast<::capi::Opaque*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/OpaqueMutexedString.d.hpp
+++ b/feature_tests/cpp2/include/OpaqueMutexedString.d.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace capi {typedef struct Utf16Wrap Utf16Wrap; }
 class Utf16Wrap;
 
 
@@ -35,10 +36,10 @@ public:
 
   inline std::unique_ptr<Utf16Wrap> wrapper() const;
 
-  inline const capi::OpaqueMutexedString* AsFFI() const;
-  inline capi::OpaqueMutexedString* AsFFI();
-  inline static const OpaqueMutexedString* FromFFI(const capi::OpaqueMutexedString* ptr);
-  inline static OpaqueMutexedString* FromFFI(capi::OpaqueMutexedString* ptr);
+  inline const ::capi::OpaqueMutexedString* AsFFI() const;
+  inline ::capi::OpaqueMutexedString* AsFFI();
+  inline static const OpaqueMutexedString* FromFFI(const ::capi::OpaqueMutexedString* ptr);
+  inline static OpaqueMutexedString* FromFFI(::capi::OpaqueMutexedString* ptr);
   inline static void operator delete(void* ptr);
 private:
   OpaqueMutexedString() = delete;

--- a/feature_tests/cpp2/include/OpaqueMutexedString.hpp
+++ b/feature_tests/cpp2/include/OpaqueMutexedString.hpp
@@ -16,28 +16,27 @@
 namespace capi {
     extern "C" {
     
-    OpaqueMutexedString* OpaqueMutexedString_from_usize(size_t number);
+    ::capi::OpaqueMutexedString* OpaqueMutexedString_from_usize(size_t number);
     
-    void OpaqueMutexedString_change(const OpaqueMutexedString* self, size_t number);
+    void OpaqueMutexedString_change(const ::capi::OpaqueMutexedString* self, size_t number);
     
-    const OpaqueMutexedString* OpaqueMutexedString_borrow(const OpaqueMutexedString* self);
+    const ::capi::OpaqueMutexedString* OpaqueMutexedString_borrow(const ::capi::OpaqueMutexedString* self);
     
-    const OpaqueMutexedString* OpaqueMutexedString_borrow_other(const OpaqueMutexedString* other);
+    const ::capi::OpaqueMutexedString* OpaqueMutexedString_borrow_other(const ::capi::OpaqueMutexedString* other);
     
-    const OpaqueMutexedString* OpaqueMutexedString_borrow_self_or_other(const OpaqueMutexedString* self, const OpaqueMutexedString* other);
+    const ::capi::OpaqueMutexedString* OpaqueMutexedString_borrow_self_or_other(const ::capi::OpaqueMutexedString* self, const ::capi::OpaqueMutexedString* other);
     
-    size_t OpaqueMutexedString_get_len_and_add(const OpaqueMutexedString* self, size_t other);
+    size_t OpaqueMutexedString_get_len_and_add(const ::capi::OpaqueMutexedString* self, size_t other);
     
-    DiplomatStringView OpaqueMutexedString_dummy_str(const OpaqueMutexedString* self);
+    DiplomatStringView OpaqueMutexedString_dummy_str(const ::capi::OpaqueMutexedString* self);
     
-    Utf16Wrap* OpaqueMutexedString_wrapper(const OpaqueMutexedString* self);
+    ::capi::Utf16Wrap* OpaqueMutexedString_wrapper(const ::capi::OpaqueMutexedString* self);
     
     
     void OpaqueMutexedString_destroy(OpaqueMutexedString* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<OpaqueMutexedString> OpaqueMutexedString::from_usize(size_t number) {
   auto result = capi::OpaqueMutexedString_from_usize(number);
   return std::unique_ptr<OpaqueMutexedString>(OpaqueMutexedString::FromFFI(result));
@@ -80,24 +79,24 @@ inline std::unique_ptr<Utf16Wrap> OpaqueMutexedString::wrapper() const {
   return std::unique_ptr<Utf16Wrap>(Utf16Wrap::FromFFI(result));
 }
 
-inline const capi::OpaqueMutexedString* OpaqueMutexedString::AsFFI() const {
-  return reinterpret_cast<const capi::OpaqueMutexedString*>(this);
+inline const ::capi::OpaqueMutexedString* OpaqueMutexedString::AsFFI() const {
+  return reinterpret_cast<const ::capi::OpaqueMutexedString*>(this);
 }
 
-inline capi::OpaqueMutexedString* OpaqueMutexedString::AsFFI() {
-  return reinterpret_cast<capi::OpaqueMutexedString*>(this);
+inline ::capi::OpaqueMutexedString* OpaqueMutexedString::AsFFI() {
+  return reinterpret_cast<::capi::OpaqueMutexedString*>(this);
 }
 
-inline const OpaqueMutexedString* OpaqueMutexedString::FromFFI(const capi::OpaqueMutexedString* ptr) {
+inline const OpaqueMutexedString* OpaqueMutexedString::FromFFI(const ::capi::OpaqueMutexedString* ptr) {
   return reinterpret_cast<const OpaqueMutexedString*>(ptr);
 }
 
-inline OpaqueMutexedString* OpaqueMutexedString::FromFFI(capi::OpaqueMutexedString* ptr) {
+inline OpaqueMutexedString* OpaqueMutexedString::FromFFI(::capi::OpaqueMutexedString* ptr) {
   return reinterpret_cast<OpaqueMutexedString*>(ptr);
 }
 
 inline void OpaqueMutexedString::operator delete(void* ptr) {
-  capi::OpaqueMutexedString_destroy(reinterpret_cast<capi::OpaqueMutexedString*>(ptr));
+  capi::OpaqueMutexedString_destroy(reinterpret_cast<::capi::OpaqueMutexedString*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp2/include/OptionOpaque.d.hpp
@@ -42,10 +42,10 @@ public:
 
   inline static bool option_opaque_argument(const OptionOpaque* arg);
 
-  inline const capi::OptionOpaque* AsFFI() const;
-  inline capi::OptionOpaque* AsFFI();
-  inline static const OptionOpaque* FromFFI(const capi::OptionOpaque* ptr);
-  inline static OptionOpaque* FromFFI(capi::OptionOpaque* ptr);
+  inline const ::capi::OptionOpaque* AsFFI() const;
+  inline ::capi::OptionOpaque* AsFFI();
+  inline static const OptionOpaque* FromFFI(const ::capi::OptionOpaque* ptr);
+  inline static OptionOpaque* FromFFI(::capi::OptionOpaque* ptr);
   inline static void operator delete(void* ptr);
 private:
   OptionOpaque() = delete;

--- a/feature_tests/cpp2/include/OptionOpaque.hpp
+++ b/feature_tests/cpp2/include/OptionOpaque.hpp
@@ -16,39 +16,38 @@
 namespace capi {
     extern "C" {
     
-    OptionOpaque* OptionOpaque_new(int32_t i);
+    ::capi::OptionOpaque* OptionOpaque_new(int32_t i);
     
-    OptionOpaque* OptionOpaque_new_none();
+    ::capi::OptionOpaque* OptionOpaque_new_none();
     
-    typedef struct OptionOpaque_returns_result {union {OptionStruct ok; }; bool is_ok;} OptionOpaque_returns_result;
+    typedef struct OptionOpaque_returns_result {union {::capi::OptionStruct ok; }; bool is_ok;} OptionOpaque_returns_result;
     OptionOpaque_returns_result OptionOpaque_returns();
     
     typedef struct OptionOpaque_option_isize_result {union {intptr_t ok; }; bool is_ok;} OptionOpaque_option_isize_result;
-    OptionOpaque_option_isize_result OptionOpaque_option_isize(const OptionOpaque* self);
+    OptionOpaque_option_isize_result OptionOpaque_option_isize(const ::capi::OptionOpaque* self);
     
     typedef struct OptionOpaque_option_usize_result {union {size_t ok; }; bool is_ok;} OptionOpaque_option_usize_result;
-    OptionOpaque_option_usize_result OptionOpaque_option_usize(const OptionOpaque* self);
+    OptionOpaque_option_usize_result OptionOpaque_option_usize(const ::capi::OptionOpaque* self);
     
     typedef struct OptionOpaque_option_i32_result {union {int32_t ok; }; bool is_ok;} OptionOpaque_option_i32_result;
-    OptionOpaque_option_i32_result OptionOpaque_option_i32(const OptionOpaque* self);
+    OptionOpaque_option_i32_result OptionOpaque_option_i32(const ::capi::OptionOpaque* self);
     
     typedef struct OptionOpaque_option_u32_result {union {uint32_t ok; }; bool is_ok;} OptionOpaque_option_u32_result;
-    OptionOpaque_option_u32_result OptionOpaque_option_u32(const OptionOpaque* self);
+    OptionOpaque_option_u32_result OptionOpaque_option_u32(const ::capi::OptionOpaque* self);
     
-    OptionStruct OptionOpaque_new_struct();
+    ::capi::OptionStruct OptionOpaque_new_struct();
     
-    OptionStruct OptionOpaque_new_struct_nones();
+    ::capi::OptionStruct OptionOpaque_new_struct_nones();
     
-    void OptionOpaque_assert_integer(const OptionOpaque* self, int32_t i);
+    void OptionOpaque_assert_integer(const ::capi::OptionOpaque* self, int32_t i);
     
-    bool OptionOpaque_option_opaque_argument(const OptionOpaque* arg);
+    bool OptionOpaque_option_opaque_argument(const ::capi::OptionOpaque* arg);
     
     
     void OptionOpaque_destroy(OptionOpaque* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<OptionOpaque> OptionOpaque::new_(int32_t i) {
   auto result = capi::OptionOpaque_new(i);
   return std::unique_ptr<OptionOpaque>(OptionOpaque::FromFFI(result));
@@ -104,24 +103,24 @@ inline bool OptionOpaque::option_opaque_argument(const OptionOpaque* arg) {
   return result;
 }
 
-inline const capi::OptionOpaque* OptionOpaque::AsFFI() const {
-  return reinterpret_cast<const capi::OptionOpaque*>(this);
+inline const ::capi::OptionOpaque* OptionOpaque::AsFFI() const {
+  return reinterpret_cast<const ::capi::OptionOpaque*>(this);
 }
 
-inline capi::OptionOpaque* OptionOpaque::AsFFI() {
-  return reinterpret_cast<capi::OptionOpaque*>(this);
+inline ::capi::OptionOpaque* OptionOpaque::AsFFI() {
+  return reinterpret_cast<::capi::OptionOpaque*>(this);
 }
 
-inline const OptionOpaque* OptionOpaque::FromFFI(const capi::OptionOpaque* ptr) {
+inline const OptionOpaque* OptionOpaque::FromFFI(const ::capi::OptionOpaque* ptr) {
   return reinterpret_cast<const OptionOpaque*>(ptr);
 }
 
-inline OptionOpaque* OptionOpaque::FromFFI(capi::OptionOpaque* ptr) {
+inline OptionOpaque* OptionOpaque::FromFFI(::capi::OptionOpaque* ptr) {
   return reinterpret_cast<OptionOpaque*>(ptr);
 }
 
 inline void OptionOpaque::operator delete(void* ptr) {
-  capi::OptionOpaque_destroy(reinterpret_cast<capi::OptionOpaque*>(ptr));
+  capi::OptionOpaque_destroy(reinterpret_cast<::capi::OptionOpaque*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/OptionOpaqueChar.d.hpp
+++ b/feature_tests/cpp2/include/OptionOpaqueChar.d.hpp
@@ -19,10 +19,10 @@ public:
 
   inline void assert_char(char32_t ch) const;
 
-  inline const capi::OptionOpaqueChar* AsFFI() const;
-  inline capi::OptionOpaqueChar* AsFFI();
-  inline static const OptionOpaqueChar* FromFFI(const capi::OptionOpaqueChar* ptr);
-  inline static OptionOpaqueChar* FromFFI(capi::OptionOpaqueChar* ptr);
+  inline const ::capi::OptionOpaqueChar* AsFFI() const;
+  inline ::capi::OptionOpaqueChar* AsFFI();
+  inline static const OptionOpaqueChar* FromFFI(const ::capi::OptionOpaqueChar* ptr);
+  inline static OptionOpaqueChar* FromFFI(::capi::OptionOpaqueChar* ptr);
   inline static void operator delete(void* ptr);
 private:
   OptionOpaqueChar() = delete;

--- a/feature_tests/cpp2/include/OptionOpaqueChar.hpp
+++ b/feature_tests/cpp2/include/OptionOpaqueChar.hpp
@@ -15,37 +15,36 @@
 namespace capi {
     extern "C" {
     
-    void OptionOpaqueChar_assert_char(const OptionOpaqueChar* self, char32_t ch);
+    void OptionOpaqueChar_assert_char(const ::capi::OptionOpaqueChar* self, char32_t ch);
     
     
     void OptionOpaqueChar_destroy(OptionOpaqueChar* self);
     
     } // extern "C"
 }
-
 inline void OptionOpaqueChar::assert_char(char32_t ch) const {
   capi::OptionOpaqueChar_assert_char(this->AsFFI(),
     ch);
 }
 
-inline const capi::OptionOpaqueChar* OptionOpaqueChar::AsFFI() const {
-  return reinterpret_cast<const capi::OptionOpaqueChar*>(this);
+inline const ::capi::OptionOpaqueChar* OptionOpaqueChar::AsFFI() const {
+  return reinterpret_cast<const ::capi::OptionOpaqueChar*>(this);
 }
 
-inline capi::OptionOpaqueChar* OptionOpaqueChar::AsFFI() {
-  return reinterpret_cast<capi::OptionOpaqueChar*>(this);
+inline ::capi::OptionOpaqueChar* OptionOpaqueChar::AsFFI() {
+  return reinterpret_cast<::capi::OptionOpaqueChar*>(this);
 }
 
-inline const OptionOpaqueChar* OptionOpaqueChar::FromFFI(const capi::OptionOpaqueChar* ptr) {
+inline const OptionOpaqueChar* OptionOpaqueChar::FromFFI(const ::capi::OptionOpaqueChar* ptr) {
   return reinterpret_cast<const OptionOpaqueChar*>(ptr);
 }
 
-inline OptionOpaqueChar* OptionOpaqueChar::FromFFI(capi::OptionOpaqueChar* ptr) {
+inline OptionOpaqueChar* OptionOpaqueChar::FromFFI(::capi::OptionOpaqueChar* ptr) {
   return reinterpret_cast<OptionOpaqueChar*>(ptr);
 }
 
 inline void OptionOpaqueChar::operator delete(void* ptr) {
-  capi::OptionOpaqueChar_destroy(reinterpret_cast<capi::OptionOpaqueChar*>(ptr));
+  capi::OptionOpaqueChar_destroy(reinterpret_cast<::capi::OptionOpaqueChar*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/OptionString.d.hpp
+++ b/feature_tests/cpp2/include/OptionString.d.hpp
@@ -23,10 +23,10 @@ public:
 
   inline std::optional<std::string_view> borrow() const;
 
-  inline const capi::OptionString* AsFFI() const;
-  inline capi::OptionString* AsFFI();
-  inline static const OptionString* FromFFI(const capi::OptionString* ptr);
-  inline static OptionString* FromFFI(capi::OptionString* ptr);
+  inline const ::capi::OptionString* AsFFI() const;
+  inline ::capi::OptionString* AsFFI();
+  inline static const OptionString* FromFFI(const ::capi::OptionString* ptr);
+  inline static OptionString* FromFFI(::capi::OptionString* ptr);
   inline static void operator delete(void* ptr);
 private:
   OptionString() = delete;

--- a/feature_tests/cpp2/include/OptionString.hpp
+++ b/feature_tests/cpp2/include/OptionString.hpp
@@ -18,7 +18,7 @@ namespace capi {
     ::capi::OptionString* OptionString_new(const char* diplomat_str_data, size_t diplomat_str_len);
     
     typedef struct OptionString_write_result { bool is_ok;} OptionString_write_result;
-    OptionString_write_result OptionString_write(const ::capi::OptionString* self, DiplomatWrite* write);
+    OptionString_write_result OptionString_write(const ::capi::OptionString* self, ::capi::DiplomatWrite* write);
     
     typedef struct OptionString_borrow_result {union {DiplomatStringView ok; }; bool is_ok;} OptionString_borrow_result;
     OptionString_borrow_result OptionString_borrow(const ::capi::OptionString* self);
@@ -36,7 +36,7 @@ inline std::unique_ptr<OptionString> OptionString::new_(std::string_view diploma
 
 inline diplomat::result<std::string, std::monostate> OptionString::write() const {
   std::string output;
-  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  ::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   auto result = capi::OptionString_write(this->AsFFI(),
     &write);
   return result.is_ok ? diplomat::result<std::string, std::monostate>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, std::monostate>(diplomat::Err<std::monostate>());

--- a/feature_tests/cpp2/include/OptionString.hpp
+++ b/feature_tests/cpp2/include/OptionString.hpp
@@ -15,20 +15,19 @@
 namespace capi {
     extern "C" {
     
-    OptionString* OptionString_new(const char* diplomat_str_data, size_t diplomat_str_len);
+    ::capi::OptionString* OptionString_new(const char* diplomat_str_data, size_t diplomat_str_len);
     
     typedef struct OptionString_write_result { bool is_ok;} OptionString_write_result;
-    OptionString_write_result OptionString_write(const OptionString* self, DiplomatWrite* write);
+    OptionString_write_result OptionString_write(const ::capi::OptionString* self, DiplomatWrite* write);
     
     typedef struct OptionString_borrow_result {union {DiplomatStringView ok; }; bool is_ok;} OptionString_borrow_result;
-    OptionString_borrow_result OptionString_borrow(const OptionString* self);
+    OptionString_borrow_result OptionString_borrow(const ::capi::OptionString* self);
     
     
     void OptionString_destroy(OptionString* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<OptionString> OptionString::new_(std::string_view diplomat_str) {
   auto result = capi::OptionString_new(diplomat_str.data(),
     diplomat_str.size());
@@ -48,24 +47,24 @@ inline std::optional<std::string_view> OptionString::borrow() const {
   return result.is_ok ? std::optional<std::string_view>(std::string_view(result.ok.data, result.ok.len)) : std::nullopt;
 }
 
-inline const capi::OptionString* OptionString::AsFFI() const {
-  return reinterpret_cast<const capi::OptionString*>(this);
+inline const ::capi::OptionString* OptionString::AsFFI() const {
+  return reinterpret_cast<const ::capi::OptionString*>(this);
 }
 
-inline capi::OptionString* OptionString::AsFFI() {
-  return reinterpret_cast<capi::OptionString*>(this);
+inline ::capi::OptionString* OptionString::AsFFI() {
+  return reinterpret_cast<::capi::OptionString*>(this);
 }
 
-inline const OptionString* OptionString::FromFFI(const capi::OptionString* ptr) {
+inline const OptionString* OptionString::FromFFI(const ::capi::OptionString* ptr) {
   return reinterpret_cast<const OptionString*>(ptr);
 }
 
-inline OptionString* OptionString::FromFFI(capi::OptionString* ptr) {
+inline OptionString* OptionString::FromFFI(::capi::OptionString* ptr) {
   return reinterpret_cast<OptionString*>(ptr);
 }
 
 inline void OptionString::operator delete(void* ptr) {
-  capi::OptionString_destroy(reinterpret_cast<capi::OptionString*>(ptr));
+  capi::OptionString_destroy(reinterpret_cast<::capi::OptionString*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/OptionStruct.d.hpp
+++ b/feature_tests/cpp2/include/OptionStruct.d.hpp
@@ -9,16 +9,18 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace capi {typedef struct OptionOpaque OptionOpaque; }
 class OptionOpaque;
+namespace capi {typedef struct OptionOpaqueChar OptionOpaqueChar; }
 class OptionOpaqueChar;
 
 
 namespace capi {
     typedef struct OptionStruct {
-      OptionOpaque* a;
-      OptionOpaqueChar* b;
+      ::capi::OptionOpaque* a;
+      ::capi::OptionOpaqueChar* b;
       uint32_t c;
-      OptionOpaque* d;
+      ::capi::OptionOpaque* d;
     } OptionStruct;
 }
 
@@ -28,8 +30,8 @@ struct OptionStruct {
   uint32_t c;
   std::unique_ptr<OptionOpaque> d;
 
-  inline capi::OptionStruct AsFFI() const;
-  inline static OptionStruct FromFFI(capi::OptionStruct c_struct);
+  inline ::capi::OptionStruct AsFFI() const;
+  inline static OptionStruct FromFFI(::capi::OptionStruct c_struct);
 };
 
 

--- a/feature_tests/cpp2/include/OptionStruct.hpp
+++ b/feature_tests/cpp2/include/OptionStruct.hpp
@@ -21,9 +21,8 @@ namespace capi {
     } // extern "C"
 }
 
-
-inline capi::OptionStruct OptionStruct::AsFFI() const {
-  return capi::OptionStruct {
+inline ::capi::OptionStruct OptionStruct::AsFFI() const {
+  return ::capi::OptionStruct {
     .a = a ? a->AsFFI() : nullptr,
     .b = b ? b->AsFFI() : nullptr,
     .c = c,
@@ -31,7 +30,7 @@ inline capi::OptionStruct OptionStruct::AsFFI() const {
   };
 }
 
-inline OptionStruct OptionStruct::FromFFI(capi::OptionStruct c_struct) {
+inline OptionStruct OptionStruct::FromFFI(::capi::OptionStruct c_struct) {
   return OptionStruct {
     .a = std::unique_ptr<OptionOpaque>(OptionOpaque::FromFFI(c_struct.a)),
     .b = std::unique_ptr<OptionOpaqueChar>(OptionOpaqueChar::FromFFI(c_struct.b)),

--- a/feature_tests/cpp2/include/RefList.d.hpp
+++ b/feature_tests/cpp2/include/RefList.d.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace capi {typedef struct RefListParameter RefListParameter; }
 class RefListParameter;
 
 
@@ -21,10 +22,10 @@ public:
 
   inline static std::unique_ptr<RefList> node(const RefListParameter& data);
 
-  inline const capi::RefList* AsFFI() const;
-  inline capi::RefList* AsFFI();
-  inline static const RefList* FromFFI(const capi::RefList* ptr);
-  inline static RefList* FromFFI(capi::RefList* ptr);
+  inline const ::capi::RefList* AsFFI() const;
+  inline ::capi::RefList* AsFFI();
+  inline static const RefList* FromFFI(const ::capi::RefList* ptr);
+  inline static RefList* FromFFI(::capi::RefList* ptr);
   inline static void operator delete(void* ptr);
 private:
   RefList() = delete;

--- a/feature_tests/cpp2/include/RefList.hpp
+++ b/feature_tests/cpp2/include/RefList.hpp
@@ -16,37 +16,36 @@
 namespace capi {
     extern "C" {
     
-    RefList* RefList_node(const RefListParameter* data);
+    ::capi::RefList* RefList_node(const ::capi::RefListParameter* data);
     
     
     void RefList_destroy(RefList* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<RefList> RefList::node(const RefListParameter& data) {
   auto result = capi::RefList_node(data.AsFFI());
   return std::unique_ptr<RefList>(RefList::FromFFI(result));
 }
 
-inline const capi::RefList* RefList::AsFFI() const {
-  return reinterpret_cast<const capi::RefList*>(this);
+inline const ::capi::RefList* RefList::AsFFI() const {
+  return reinterpret_cast<const ::capi::RefList*>(this);
 }
 
-inline capi::RefList* RefList::AsFFI() {
-  return reinterpret_cast<capi::RefList*>(this);
+inline ::capi::RefList* RefList::AsFFI() {
+  return reinterpret_cast<::capi::RefList*>(this);
 }
 
-inline const RefList* RefList::FromFFI(const capi::RefList* ptr) {
+inline const RefList* RefList::FromFFI(const ::capi::RefList* ptr) {
   return reinterpret_cast<const RefList*>(ptr);
 }
 
-inline RefList* RefList::FromFFI(capi::RefList* ptr) {
+inline RefList* RefList::FromFFI(::capi::RefList* ptr) {
   return reinterpret_cast<RefList*>(ptr);
 }
 
 inline void RefList::operator delete(void* ptr) {
-  capi::RefList_destroy(reinterpret_cast<capi::RefList*>(ptr));
+  capi::RefList_destroy(reinterpret_cast<::capi::RefList*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/RefListParameter.d.hpp
+++ b/feature_tests/cpp2/include/RefListParameter.d.hpp
@@ -17,10 +17,10 @@ namespace capi {
 class RefListParameter {
 public:
 
-  inline const capi::RefListParameter* AsFFI() const;
-  inline capi::RefListParameter* AsFFI();
-  inline static const RefListParameter* FromFFI(const capi::RefListParameter* ptr);
-  inline static RefListParameter* FromFFI(capi::RefListParameter* ptr);
+  inline const ::capi::RefListParameter* AsFFI() const;
+  inline ::capi::RefListParameter* AsFFI();
+  inline static const RefListParameter* FromFFI(const ::capi::RefListParameter* ptr);
+  inline static RefListParameter* FromFFI(::capi::RefListParameter* ptr);
   inline static void operator delete(void* ptr);
 private:
   RefListParameter() = delete;

--- a/feature_tests/cpp2/include/RefListParameter.hpp
+++ b/feature_tests/cpp2/include/RefListParameter.hpp
@@ -20,25 +20,24 @@ namespace capi {
     
     } // extern "C"
 }
-
-inline const capi::RefListParameter* RefListParameter::AsFFI() const {
-  return reinterpret_cast<const capi::RefListParameter*>(this);
+inline const ::capi::RefListParameter* RefListParameter::AsFFI() const {
+  return reinterpret_cast<const ::capi::RefListParameter*>(this);
 }
 
-inline capi::RefListParameter* RefListParameter::AsFFI() {
-  return reinterpret_cast<capi::RefListParameter*>(this);
+inline ::capi::RefListParameter* RefListParameter::AsFFI() {
+  return reinterpret_cast<::capi::RefListParameter*>(this);
 }
 
-inline const RefListParameter* RefListParameter::FromFFI(const capi::RefListParameter* ptr) {
+inline const RefListParameter* RefListParameter::FromFFI(const ::capi::RefListParameter* ptr) {
   return reinterpret_cast<const RefListParameter*>(ptr);
 }
 
-inline RefListParameter* RefListParameter::FromFFI(capi::RefListParameter* ptr) {
+inline RefListParameter* RefListParameter::FromFFI(::capi::RefListParameter* ptr) {
   return reinterpret_cast<RefListParameter*>(ptr);
 }
 
 inline void RefListParameter::operator delete(void* ptr) {
-  capi::RefListParameter_destroy(reinterpret_cast<capi::RefListParameter*>(ptr));
+  capi::RefListParameter_destroy(reinterpret_cast<::capi::RefListParameter*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/ResultOpaque.d.hpp
+++ b/feature_tests/cpp2/include/ResultOpaque.d.hpp
@@ -40,10 +40,10 @@ public:
 
   inline void assert_integer(int32_t i) const;
 
-  inline const capi::ResultOpaque* AsFFI() const;
-  inline capi::ResultOpaque* AsFFI();
-  inline static const ResultOpaque* FromFFI(const capi::ResultOpaque* ptr);
-  inline static ResultOpaque* FromFFI(capi::ResultOpaque* ptr);
+  inline const ::capi::ResultOpaque* AsFFI() const;
+  inline ::capi::ResultOpaque* AsFFI();
+  inline static const ResultOpaque* FromFFI(const ::capi::ResultOpaque* ptr);
+  inline static ResultOpaque* FromFFI(::capi::ResultOpaque* ptr);
   inline static void operator delete(void* ptr);
 private:
   ResultOpaque() = delete;

--- a/feature_tests/cpp2/include/ResultOpaque.hpp
+++ b/feature_tests/cpp2/include/ResultOpaque.hpp
@@ -17,38 +17,37 @@
 namespace capi {
     extern "C" {
     
-    typedef struct ResultOpaque_new_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_result;
+    typedef struct ResultOpaque_new_result {union {::capi::ResultOpaque* ok; ::capi::ErrorEnum err;}; bool is_ok;} ResultOpaque_new_result;
     ResultOpaque_new_result ResultOpaque_new(int32_t i);
     
-    typedef struct ResultOpaque_new_failing_foo_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_failing_foo_result;
+    typedef struct ResultOpaque_new_failing_foo_result {union {::capi::ResultOpaque* ok; ::capi::ErrorEnum err;}; bool is_ok;} ResultOpaque_new_failing_foo_result;
     ResultOpaque_new_failing_foo_result ResultOpaque_new_failing_foo();
     
-    typedef struct ResultOpaque_new_failing_bar_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_failing_bar_result;
+    typedef struct ResultOpaque_new_failing_bar_result {union {::capi::ResultOpaque* ok; ::capi::ErrorEnum err;}; bool is_ok;} ResultOpaque_new_failing_bar_result;
     ResultOpaque_new_failing_bar_result ResultOpaque_new_failing_bar();
     
-    typedef struct ResultOpaque_new_failing_unit_result {union {ResultOpaque* ok; }; bool is_ok;} ResultOpaque_new_failing_unit_result;
+    typedef struct ResultOpaque_new_failing_unit_result {union {::capi::ResultOpaque* ok; }; bool is_ok;} ResultOpaque_new_failing_unit_result;
     ResultOpaque_new_failing_unit_result ResultOpaque_new_failing_unit();
     
-    typedef struct ResultOpaque_new_failing_struct_result {union {ResultOpaque* ok; ErrorStruct err;}; bool is_ok;} ResultOpaque_new_failing_struct_result;
+    typedef struct ResultOpaque_new_failing_struct_result {union {::capi::ResultOpaque* ok; ::capi::ErrorStruct err;}; bool is_ok;} ResultOpaque_new_failing_struct_result;
     ResultOpaque_new_failing_struct_result ResultOpaque_new_failing_struct(int32_t i);
     
-    typedef struct ResultOpaque_new_in_err_result {union { ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_err_result;
+    typedef struct ResultOpaque_new_in_err_result {union { ::capi::ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_err_result;
     ResultOpaque_new_in_err_result ResultOpaque_new_in_err(int32_t i);
     
     typedef struct ResultOpaque_new_int_result {union {int32_t ok; }; bool is_ok;} ResultOpaque_new_int_result;
     ResultOpaque_new_int_result ResultOpaque_new_int(int32_t i);
     
-    typedef struct ResultOpaque_new_in_enum_err_result {union {ErrorEnum ok; ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_enum_err_result;
+    typedef struct ResultOpaque_new_in_enum_err_result {union {::capi::ErrorEnum ok; ::capi::ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_enum_err_result;
     ResultOpaque_new_in_enum_err_result ResultOpaque_new_in_enum_err(int32_t i);
     
-    void ResultOpaque_assert_integer(const ResultOpaque* self, int32_t i);
+    void ResultOpaque_assert_integer(const ::capi::ResultOpaque* self, int32_t i);
     
     
     void ResultOpaque_destroy(ResultOpaque* self);
     
     } // extern "C"
 }
-
 inline diplomat::result<std::unique_ptr<ResultOpaque>, ErrorEnum> ResultOpaque::new_(int32_t i) {
   auto result = capi::ResultOpaque_new(i);
   return result.is_ok ? diplomat::result<std::unique_ptr<ResultOpaque>, ErrorEnum>(diplomat::Ok<std::unique_ptr<ResultOpaque>>(std::unique_ptr<ResultOpaque>(ResultOpaque::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<ResultOpaque>, ErrorEnum>(diplomat::Err<ErrorEnum>(ErrorEnum::FromFFI(result.err)));
@@ -94,24 +93,24 @@ inline void ResultOpaque::assert_integer(int32_t i) const {
     i);
 }
 
-inline const capi::ResultOpaque* ResultOpaque::AsFFI() const {
-  return reinterpret_cast<const capi::ResultOpaque*>(this);
+inline const ::capi::ResultOpaque* ResultOpaque::AsFFI() const {
+  return reinterpret_cast<const ::capi::ResultOpaque*>(this);
 }
 
-inline capi::ResultOpaque* ResultOpaque::AsFFI() {
-  return reinterpret_cast<capi::ResultOpaque*>(this);
+inline ::capi::ResultOpaque* ResultOpaque::AsFFI() {
+  return reinterpret_cast<::capi::ResultOpaque*>(this);
 }
 
-inline const ResultOpaque* ResultOpaque::FromFFI(const capi::ResultOpaque* ptr) {
+inline const ResultOpaque* ResultOpaque::FromFFI(const ::capi::ResultOpaque* ptr) {
   return reinterpret_cast<const ResultOpaque*>(ptr);
 }
 
-inline ResultOpaque* ResultOpaque::FromFFI(capi::ResultOpaque* ptr) {
+inline ResultOpaque* ResultOpaque::FromFFI(::capi::ResultOpaque* ptr) {
   return reinterpret_cast<ResultOpaque*>(ptr);
 }
 
 inline void ResultOpaque::operator delete(void* ptr) {
-  capi::ResultOpaque_destroy(reinterpret_cast<capi::ResultOpaque*>(ptr));
+  capi::ResultOpaque_destroy(reinterpret_cast<::capi::ResultOpaque*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/Two.d.hpp
+++ b/feature_tests/cpp2/include/Two.d.hpp
@@ -17,10 +17,10 @@ namespace capi {
 class Two {
 public:
 
-  inline const capi::Two* AsFFI() const;
-  inline capi::Two* AsFFI();
-  inline static const Two* FromFFI(const capi::Two* ptr);
-  inline static Two* FromFFI(capi::Two* ptr);
+  inline const ::capi::Two* AsFFI() const;
+  inline ::capi::Two* AsFFI();
+  inline static const Two* FromFFI(const ::capi::Two* ptr);
+  inline static Two* FromFFI(::capi::Two* ptr);
   inline static void operator delete(void* ptr);
 private:
   Two() = delete;

--- a/feature_tests/cpp2/include/Two.hpp
+++ b/feature_tests/cpp2/include/Two.hpp
@@ -20,25 +20,24 @@ namespace capi {
     
     } // extern "C"
 }
-
-inline const capi::Two* Two::AsFFI() const {
-  return reinterpret_cast<const capi::Two*>(this);
+inline const ::capi::Two* Two::AsFFI() const {
+  return reinterpret_cast<const ::capi::Two*>(this);
 }
 
-inline capi::Two* Two::AsFFI() {
-  return reinterpret_cast<capi::Two*>(this);
+inline ::capi::Two* Two::AsFFI() {
+  return reinterpret_cast<::capi::Two*>(this);
 }
 
-inline const Two* Two::FromFFI(const capi::Two* ptr) {
+inline const Two* Two::FromFFI(const ::capi::Two* ptr) {
   return reinterpret_cast<const Two*>(ptr);
 }
 
-inline Two* Two::FromFFI(capi::Two* ptr) {
+inline Two* Two::FromFFI(::capi::Two* ptr) {
   return reinterpret_cast<Two*>(ptr);
 }
 
 inline void Two::operator delete(void* ptr) {
-  capi::Two_destroy(reinterpret_cast<capi::Two*>(ptr));
+  capi::Two_destroy(reinterpret_cast<::capi::Two*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/UnimportedEnum.d.hpp
+++ b/feature_tests/cpp2/include/UnimportedEnum.d.hpp
@@ -18,6 +18,7 @@ namespace capi {
     } UnimportedEnum;
 }
 
+
 class UnimportedEnum {
 public:
   enum Value {
@@ -33,8 +34,8 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline capi::UnimportedEnum AsFFI() const;
-  inline static UnimportedEnum FromFFI(capi::UnimportedEnum c_enum);
+  inline ::capi::UnimportedEnum AsFFI() const;
+  inline static UnimportedEnum FromFFI(::capi::UnimportedEnum c_enum);
 private:
     Value value;
 };

--- a/feature_tests/cpp2/include/UnimportedEnum.hpp
+++ b/feature_tests/cpp2/include/UnimportedEnum.hpp
@@ -18,17 +18,15 @@ namespace capi {
     
     } // extern "C"
 }
-
-
-inline capi::UnimportedEnum UnimportedEnum::AsFFI() const {
-  return static_cast<capi::UnimportedEnum>(value);
+inline ::capi::UnimportedEnum UnimportedEnum::AsFFI() const {
+  return static_cast<::capi::UnimportedEnum>(value);
 }
 
-inline UnimportedEnum UnimportedEnum::FromFFI(capi::UnimportedEnum c_enum) {
+inline UnimportedEnum UnimportedEnum::FromFFI(::capi::UnimportedEnum c_enum) {
   switch (c_enum) {
-    case capi::UnimportedEnum_A:
-    case capi::UnimportedEnum_B:
-    case capi::UnimportedEnum_C:
+    case ::capi::UnimportedEnum_A:
+    case ::capi::UnimportedEnum_B:
+    case ::capi::UnimportedEnum_C:
       return static_cast<UnimportedEnum::Value>(c_enum);
     default:
       abort();

--- a/feature_tests/cpp2/include/Unnamespaced.d.hpp
+++ b/feature_tests/cpp2/include/Unnamespaced.d.hpp
@@ -11,6 +11,7 @@
 #include "CPPRenamedAttrEnum.d.hpp"
 
 namespace ns {
+namespace capi {typedef struct AttrOpaque1Renamed AttrOpaque1Renamed; }
 class AttrOpaque1Renamed;
 class CPPRenamedAttrEnum;
 }
@@ -27,10 +28,10 @@ public:
 
   inline void use_namespaced(const ns::AttrOpaque1Renamed& _n) const;
 
-  inline const capi::Unnamespaced* AsFFI() const;
-  inline capi::Unnamespaced* AsFFI();
-  inline static const Unnamespaced* FromFFI(const capi::Unnamespaced* ptr);
-  inline static Unnamespaced* FromFFI(capi::Unnamespaced* ptr);
+  inline const ::capi::Unnamespaced* AsFFI() const;
+  inline ::capi::Unnamespaced* AsFFI();
+  inline static const Unnamespaced* FromFFI(const ::capi::Unnamespaced* ptr);
+  inline static Unnamespaced* FromFFI(::capi::Unnamespaced* ptr);
   inline static void operator delete(void* ptr);
 private:
   Unnamespaced() = delete;

--- a/feature_tests/cpp2/include/Unnamespaced.hpp
+++ b/feature_tests/cpp2/include/Unnamespaced.hpp
@@ -17,16 +17,15 @@
 namespace capi {
     extern "C" {
     
-    Unnamespaced* namespace_Unnamespaced_make(AttrEnum _e);
+    ::capi::Unnamespaced* namespace_Unnamespaced_make(ns::capi::AttrEnum _e);
     
-    void namespace_Unnamespaced_use_namespaced(const Unnamespaced* self, const AttrOpaque1* _n);
+    void namespace_Unnamespaced_use_namespaced(const ::capi::Unnamespaced* self, const ns::capi::AttrOpaque1* _n);
     
     
     void namespace_Unnamespaced_destroy(Unnamespaced* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<Unnamespaced> Unnamespaced::make(ns::CPPRenamedAttrEnum _e) {
   auto result = capi::namespace_Unnamespaced_make(_e.AsFFI());
   return std::unique_ptr<Unnamespaced>(Unnamespaced::FromFFI(result));
@@ -37,24 +36,24 @@ inline void Unnamespaced::use_namespaced(const ns::AttrOpaque1Renamed& _n) const
     _n.AsFFI());
 }
 
-inline const capi::Unnamespaced* Unnamespaced::AsFFI() const {
-  return reinterpret_cast<const capi::Unnamespaced*>(this);
+inline const ::capi::Unnamespaced* Unnamespaced::AsFFI() const {
+  return reinterpret_cast<const ::capi::Unnamespaced*>(this);
 }
 
-inline capi::Unnamespaced* Unnamespaced::AsFFI() {
-  return reinterpret_cast<capi::Unnamespaced*>(this);
+inline ::capi::Unnamespaced* Unnamespaced::AsFFI() {
+  return reinterpret_cast<::capi::Unnamespaced*>(this);
 }
 
-inline const Unnamespaced* Unnamespaced::FromFFI(const capi::Unnamespaced* ptr) {
+inline const Unnamespaced* Unnamespaced::FromFFI(const ::capi::Unnamespaced* ptr) {
   return reinterpret_cast<const Unnamespaced*>(ptr);
 }
 
-inline Unnamespaced* Unnamespaced::FromFFI(capi::Unnamespaced* ptr) {
+inline Unnamespaced* Unnamespaced::FromFFI(::capi::Unnamespaced* ptr) {
   return reinterpret_cast<Unnamespaced*>(ptr);
 }
 
 inline void Unnamespaced::operator delete(void* ptr) {
-  capi::namespace_Unnamespaced_destroy(reinterpret_cast<capi::Unnamespaced*>(ptr));
+  capi::namespace_Unnamespaced_destroy(reinterpret_cast<::capi::Unnamespaced*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/include/Unnamespaced.hpp
+++ b/feature_tests/cpp2/include/Unnamespaced.hpp
@@ -17,9 +17,9 @@
 namespace capi {
     extern "C" {
     
-    ::capi::Unnamespaced* namespace_Unnamespaced_make(ns::capi::AttrEnum _e);
+    ::capi::Unnamespaced* namespace_Unnamespaced_make(ns::capi::CPPRenamedAttrEnum _e);
     
-    void namespace_Unnamespaced_use_namespaced(const ::capi::Unnamespaced* self, const ns::capi::AttrOpaque1* _n);
+    void namespace_Unnamespaced_use_namespaced(const ::capi::Unnamespaced* self, const ns::capi::AttrOpaque1Renamed* _n);
     
     
     void namespace_Unnamespaced_destroy(Unnamespaced* self);

--- a/feature_tests/cpp2/include/Utf16Wrap.d.hpp
+++ b/feature_tests/cpp2/include/Utf16Wrap.d.hpp
@@ -25,10 +25,10 @@ public:
 
   inline std::u16string_view owned() const;
 
-  inline const capi::Utf16Wrap* AsFFI() const;
-  inline capi::Utf16Wrap* AsFFI();
-  inline static const Utf16Wrap* FromFFI(const capi::Utf16Wrap* ptr);
-  inline static Utf16Wrap* FromFFI(capi::Utf16Wrap* ptr);
+  inline const ::capi::Utf16Wrap* AsFFI() const;
+  inline ::capi::Utf16Wrap* AsFFI();
+  inline static const Utf16Wrap* FromFFI(const ::capi::Utf16Wrap* ptr);
+  inline static Utf16Wrap* FromFFI(::capi::Utf16Wrap* ptr);
   inline static void operator delete(void* ptr);
 private:
   Utf16Wrap() = delete;

--- a/feature_tests/cpp2/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp2/include/Utf16Wrap.hpp
@@ -17,7 +17,7 @@ namespace capi {
     
     ::capi::Utf16Wrap* Utf16Wrap_from_utf16(const char16_t* input_data, size_t input_len);
     
-    void Utf16Wrap_get_debug_str(const ::capi::Utf16Wrap* self, DiplomatWrite* write);
+    void Utf16Wrap_get_debug_str(const ::capi::Utf16Wrap* self, ::capi::DiplomatWrite* write);
     
     DiplomatString16View Utf16Wrap_borrow_cont(const ::capi::Utf16Wrap* self);
     
@@ -36,7 +36,7 @@ inline std::unique_ptr<Utf16Wrap> Utf16Wrap::from_utf16(std::u16string_view inpu
 
 inline std::string Utf16Wrap::get_debug_str() const {
   std::string output;
-  capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  ::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   capi::Utf16Wrap_get_debug_str(this->AsFFI(),
     &write);
   return output;

--- a/feature_tests/cpp2/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp2/include/Utf16Wrap.hpp
@@ -15,20 +15,19 @@
 namespace capi {
     extern "C" {
     
-    Utf16Wrap* Utf16Wrap_from_utf16(const char16_t* input_data, size_t input_len);
+    ::capi::Utf16Wrap* Utf16Wrap_from_utf16(const char16_t* input_data, size_t input_len);
     
-    void Utf16Wrap_get_debug_str(const Utf16Wrap* self, DiplomatWrite* write);
+    void Utf16Wrap_get_debug_str(const ::capi::Utf16Wrap* self, DiplomatWrite* write);
     
-    DiplomatString16View Utf16Wrap_borrow_cont(const Utf16Wrap* self);
+    DiplomatString16View Utf16Wrap_borrow_cont(const ::capi::Utf16Wrap* self);
     
-    DiplomatString16View Utf16Wrap_owned(const Utf16Wrap* self);
+    DiplomatString16View Utf16Wrap_owned(const ::capi::Utf16Wrap* self);
     
     
     void Utf16Wrap_destroy(Utf16Wrap* self);
     
     } // extern "C"
 }
-
 inline std::unique_ptr<Utf16Wrap> Utf16Wrap::from_utf16(std::u16string_view input) {
   auto result = capi::Utf16Wrap_from_utf16(input.data(),
     input.size());
@@ -53,24 +52,24 @@ inline std::u16string_view Utf16Wrap::owned() const {
   return std::u16string_view(result.data, result.len);
 }
 
-inline const capi::Utf16Wrap* Utf16Wrap::AsFFI() const {
-  return reinterpret_cast<const capi::Utf16Wrap*>(this);
+inline const ::capi::Utf16Wrap* Utf16Wrap::AsFFI() const {
+  return reinterpret_cast<const ::capi::Utf16Wrap*>(this);
 }
 
-inline capi::Utf16Wrap* Utf16Wrap::AsFFI() {
-  return reinterpret_cast<capi::Utf16Wrap*>(this);
+inline ::capi::Utf16Wrap* Utf16Wrap::AsFFI() {
+  return reinterpret_cast<::capi::Utf16Wrap*>(this);
 }
 
-inline const Utf16Wrap* Utf16Wrap::FromFFI(const capi::Utf16Wrap* ptr) {
+inline const Utf16Wrap* Utf16Wrap::FromFFI(const ::capi::Utf16Wrap* ptr) {
   return reinterpret_cast<const Utf16Wrap*>(ptr);
 }
 
-inline Utf16Wrap* Utf16Wrap::FromFFI(capi::Utf16Wrap* ptr) {
+inline Utf16Wrap* Utf16Wrap::FromFFI(::capi::Utf16Wrap* ptr) {
   return reinterpret_cast<Utf16Wrap*>(ptr);
 }
 
 inline void Utf16Wrap::operator delete(void* ptr) {
-  capi::Utf16Wrap_destroy(reinterpret_cast<capi::Utf16Wrap*>(ptr));
+  capi::Utf16Wrap_destroy(reinterpret_cast<::capi::Utf16Wrap*>(ptr));
 }
 
 

--- a/feature_tests/cpp2/tests/attrs.cpp
+++ b/feature_tests/cpp2/tests/attrs.cpp
@@ -10,9 +10,9 @@ int main(int argc, char *argv[]) {
     simple_assert_eq("method should call", r->abirenamed(), 123);
 
     // These C names should also resolve
-    void* renamed = (void*)capi::renamed_on_abi_only;
+    void* renamed = (void*)ns::capi::renamed_on_abi_only;
     std::cout<<"Renamed function at "<<renamed<<std::endl;
-    renamed = (void*)capi::namespace_AttrOpaque1_method;
+    renamed = (void*)ns::capi::namespace_AttrOpaque1_method;
     std::cout<<"Renamed function at "<<renamed<<std::endl;
 
     ns::CPPRenamedAttrEnum e = ns::CPPRenamedAttrEnum::A;

--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -29,16 +29,34 @@ impl<'tcx> CFormatter<'tcx> {
 
     /// Resolve and format a named type for use in code (without the namespace)
     pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
-        // Currently don't do anything fancy
-        // Eventually apply rename rules and such
+        let resolved = self.tcx.resolve_type(id);
+        let name = resolved.name().as_str().into();
+        // Only apply renames in cpp mode, in pure C mode you'd want the
+        // method names to match the type names.
+        // Potential future improvement: Use alias attributes in pure C mode.
+        if self.is_for_cpp {
+            resolved.attrs().rename.apply(name)
+        } else {
+            name
+        }
+    }
+
+    /// Format the type name for usage in ABI-relevant contexts: methods/dtors
+    pub fn fmt_type_name_for_abi(&self, id: TypeId) -> Cow<'tcx, str> {
         self.tcx.resolve_type(id).name().as_str().into()
     }
     /// Resolve and format a named type for use in code (with a namespace, if needed by C++)
     pub fn fmt_type_name_maybe_namespaced(&self, id: TypeId) -> Cow<'tcx, str> {
-        // Currently don't do anything fancy
-        // Eventually apply rename rules and such
         let resolved = self.tcx.resolve_type(id);
-        let name = self.tcx.resolve_type(id).name().as_str().into();
+        let name = resolved.name().as_str().into();
+        // Only apply renames in cpp mode, in pure C mode you'd want the
+        // method names to match the type names.
+        // Potential future improvement: Use alias attributes in pure C mode.
+        let name = if self.is_for_cpp {
+            resolved.attrs().rename.apply(name)
+        } else {
+            name
+        };
         if self.is_for_cpp {
             if let Some(ref ns) = resolved.attrs().namespace {
                 format!("{ns}::{CAPI_NAMESPACE}::{name}").into()
@@ -93,7 +111,7 @@ impl<'tcx> CFormatter<'tcx> {
 
     /// Format a method
     pub fn fmt_method_name(&self, ty: TypeId, method: &hir::Method) -> String {
-        let ty_name = self.fmt_type_name(ty);
+        let ty_name = self.fmt_type_name_for_abi(ty);
         let method_name = method.name.as_str();
         let put_together = format!("{ty_name}_{method_name}");
         method.attrs.abi_rename.apply(put_together.into()).into()
@@ -116,7 +134,7 @@ impl<'tcx> CFormatter<'tcx> {
 
     /// Resolve and format a type's destructor
     pub fn fmt_dtor_name(&self, ty: TypeId) -> String {
-        let ty_name = self.fmt_type_name(ty);
+        let ty_name = self.fmt_type_name_for_abi(ty);
         let renamed = self.tcx.resolve_type(ty).attrs().abi_rename.apply(ty_name);
         format!("{renamed}_destroy")
     }

--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -43,7 +43,7 @@ impl<'tcx> CFormatter<'tcx> {
             if let Some(ref ns) = resolved.attrs().namespace {
                 format!("{ns}::{CAPI_NAMESPACE}::{name}").into()
             } else {
-                format!("{CAPI_NAMESPACE}::{name}").into()
+                format!("::{CAPI_NAMESPACE}::{name}").into()
             }
         } else {
             name
@@ -107,7 +107,7 @@ impl<'tcx> CFormatter<'tcx> {
             if let Some(ref ns) = resolved.attrs().namespace {
                 format!("{ns}::{CAPI_NAMESPACE}::{method}")
             } else {
-                format!("{CAPI_NAMESPACE}::{method}")
+                format!("::{CAPI_NAMESPACE}::{method}")
             }
         } else {
             method

--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -189,4 +189,12 @@ impl<'tcx> CFormatter<'tcx> {
         };
         format!("Diplomat{prim}View{mtb}")
     }
+
+    pub(crate) fn fmt_diplomat_write(&self) -> &'static str {
+        if self.is_for_cpp {
+            "::capi::DiplomatWrite*"
+        } else {
+            "DiplomatWrite*"
+        }
+    }
 }

--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -117,21 +117,6 @@ impl<'tcx> CFormatter<'tcx> {
         method.attrs.abi_rename.apply(put_together.into()).into()
     }
 
-    pub fn fmt_method_name_namespaced(&self, ty: TypeId, method: &hir::Method) -> String {
-        let method = self.fmt_method_name(ty, method);
-
-        if self.is_for_cpp {
-            let resolved = self.tcx.resolve_type(ty);
-            if let Some(ref ns) = resolved.attrs().namespace {
-                format!("{ns}::{CAPI_NAMESPACE}::{method}")
-            } else {
-                format!("::{CAPI_NAMESPACE}::{method}")
-            }
-        } else {
-            method
-        }
-    }
-
     /// Resolve and format a type's destructor
     pub fn fmt_dtor_name(&self, ty: TypeId) -> String {
         let ty_name = self.fmt_type_name_for_abi(ty);

--- a/tool/src/c2/mod.rs
+++ b/tool/src/c2/mod.rs
@@ -3,6 +3,7 @@ mod header;
 mod ty;
 
 pub use self::formatter::CFormatter;
+pub(crate) use self::formatter::CAPI_NAMESPACE;
 pub(crate) use self::header::Header;
 pub(crate) use self::ty::TyGenContext;
 
@@ -33,7 +34,7 @@ impl<'tcx> CContext<'tcx> {
         CContext {
             tcx,
             files,
-            formatter: CFormatter::new(tcx),
+            formatter: CFormatter::new(tcx, is_for_cpp),
             errors: ErrorStore::default(),
             is_for_cpp,
         }

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -392,7 +392,7 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
             Type::Primitive(prim) => self.formatter.fmt_primitive_as_c(prim),
             Type::Opaque(ref op) => {
                 let op_id = op.tcx_id.into();
-                let ty_name = self.formatter.fmt_type_name(op_id);
+                let ty_name = self.formatter.fmt_type_name_maybe_namespaced(op_id);
                 if self.tcx.resolve_type(op_id).attrs().disable {
                     self.errors
                         .push_error(format!("Found usage of disabled type {ty_name}"))
@@ -407,7 +407,7 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
             }
             Type::Struct(ref st) => {
                 let st_id = st.id();
-                let ty_name = self.formatter.fmt_type_name(st_id);
+                let ty_name = self.formatter.fmt_type_name_maybe_namespaced(st_id);
                 if self.tcx.resolve_type(st_id).attrs().disable {
                     self.errors
                         .push_error(format!("Found usage of disabled type {ty_name}"))
@@ -419,7 +419,7 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
             }
             Type::Enum(ref e) => {
                 let id = e.tcx_id.into();
-                let ty_name = self.formatter.fmt_type_name(id);
+                let ty_name = self.formatter.fmt_type_name_maybe_namespaced(id);
                 if self.tcx.resolve_type(id).attrs().disable {
                     self.errors
                         .push_error(format!("Found usage of disabled type {ty_name}"))

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -228,7 +228,7 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
         let return_ty: Cow<str> = match method.output {
             ReturnType::Infallible(SuccessType::Unit) => "void".into(),
             ReturnType::Infallible(SuccessType::Write) => {
-                param_decls.push(("DiplomatWrite*".into(), "write".into()));
+                param_decls.push((self.formatter.fmt_diplomat_write().into(), "write".into()));
                 "void".into()
             }
             ReturnType::Infallible(SuccessType::OutType(ref o)) => self.gen_ty_name(o, header),
@@ -241,7 +241,8 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
                 };
                 let ok_ty = match ok {
                     SuccessType::Write => {
-                        param_decls.push(("DiplomatWrite*".into(), "write".into()));
+                        param_decls
+                            .push((self.formatter.fmt_diplomat_write().into(), "write".into()));
                         None
                     }
                     SuccessType::Unit => None,

--- a/tool/src/cpp2/formatter.rs
+++ b/tool/src/cpp2/formatter.rs
@@ -84,8 +84,8 @@ impl<'tcx> Cpp2Formatter<'tcx> {
         ident.into()
     }
 
-    pub fn fmt_c_type_name<'a>(&self, id: TypeId) -> Cow<'a, str> {
-        format!("capi::{}", self.c.fmt_type_name(id)).into()
+    pub fn fmt_c_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
+        self.c.fmt_type_name_maybe_namespaced(id)
     }
 
     pub fn fmt_c_ptr<'a>(&self, ident: &'a str, mutability: hir::Mutability) -> Cow<'a, str> {

--- a/tool/src/cpp2/formatter.rs
+++ b/tool/src/cpp2/formatter.rs
@@ -20,7 +20,7 @@ pub struct Cpp2Formatter<'tcx> {
 impl<'tcx> Cpp2Formatter<'tcx> {
     pub fn new(tcx: &'tcx TypeContext) -> Self {
         Self {
-            c: CFormatter::new(tcx),
+            c: CFormatter::new(tcx, true),
         }
     }
 

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -10,6 +10,8 @@ use diplomat_core::hir::{
 };
 use std::borrow::Cow;
 
+use crate::c2::CAPI_NAMESPACE;
+
 impl<'tcx> super::Cpp2Context<'tcx> {
     pub fn gen_ty(&self, id: TypeId, ty: TypeDef<'tcx>) {
         if ty.attrs().disable {
@@ -182,6 +184,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             type_name: &'a str,
             ctype: &'a str,
             methods: &'a [MethodInfo<'a>],
+            namespace: Option<&'a str>,
             c_impl_header: C2Header,
         }
 
@@ -191,6 +194,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             type_name: &type_name,
             ctype: &ctype,
             methods: methods.as_slice(),
+            namespace: ty.attrs.namespace.as_deref(),
             c_impl_header,
         }
         .render_into(self.impl_header)
@@ -246,6 +250,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             ctype: &'a str,
             dtor_name: &'a str,
             methods: &'a [MethodInfo<'a>],
+            namespace: Option<&'a str>,
             c_impl_header: C2Header,
         }
 
@@ -256,6 +261,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             ctype: &ctype,
             dtor_name: &dtor_name,
             methods: methods.as_slice(),
+            namespace: ty.attrs.namespace.as_deref(),
             c_impl_header,
         }
         .render_into(self.impl_header)
@@ -336,6 +342,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             cpp_to_c_fields: &'a [NamedExpression<'a>],
             c_to_cpp_fields: &'a [NamedExpression<'a>],
             methods: &'a [MethodInfo<'a>],
+            namespace: Option<&'a str>,
             c_impl_header: C2Header,
         }
 
@@ -347,6 +354,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             cpp_to_c_fields: cpp_to_c_fields.as_slice(),
             c_to_cpp_fields: c_to_cpp_fields.as_slice(),
             methods: methods.as_slice(),
+            namespace: def.attrs.namespace.as_deref(),
             c_impl_header,
         }
         .render_into(self.impl_header)

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -494,6 +494,8 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
                 };
                 let ret = ret.into_owned().into();
 
+                // We don't append a header for this, since we already have a forward.
+                // Note that we also need a forward for the C type in case of structs. The forward handling manages this.
                 self.decl_header
                     .append_forward(def, &type_name_unnamespaced);
                 self.impl_header
@@ -512,6 +514,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
                         .push_error(format!("Found usage of disabled type {type_name}"))
                 }
 
+                // This can be cleaned up with https://github.com/rust-diplomat/diplomat/issues/514
                 self.decl_header
                     .append_forward(def, &type_name_unnamespaced);
                 self.decl_header
@@ -533,6 +536,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
                         .push_error(format!("Found usage of disabled type {type_name}"))
                 }
 
+                // This can be cleaned up with https://github.com/rust-diplomat/diplomat/issues/514
                 self.decl_header
                     .append_forward(def, &type_name_unnamespaced);
                 self.decl_header

--- a/tool/src/dart/formatter.rs
+++ b/tool/src/dart/formatter.rs
@@ -32,7 +32,7 @@ impl<'tcx> DartFormatter<'tcx> {
         strip_prefix: Option<String>,
     ) -> Self {
         Self {
-            c: CFormatter::new(tcx),
+            c: CFormatter::new(tcx, false),
             docs_url_generator,
             strip_prefix,
         }

--- a/tool/src/js2/formatter.rs
+++ b/tool/src/js2/formatter.rs
@@ -66,7 +66,7 @@ impl<'tcx> JSFormatter<'tcx> {
         strip_prefix: Option<String>,
     ) -> Self {
         Self {
-            c_formatter: CFormatter::new(tcx),
+            c_formatter: CFormatter::new(tcx, false),
             docs_url_gen,
             strip_prefix,
         }

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -24,7 +24,7 @@ impl<'tcx> KotlinFormatter<'tcx> {
     pub fn new(tcx: &'tcx TypeContext, strip_prefix: Option<String>) -> Self {
         Self {
             tcx,
-            c: CFormatter::new(tcx),
+            c: CFormatter::new(tcx, false),
             strip_prefix,
         }
     }

--- a/tool/templates/cpp2/base.h.jinja
+++ b/tool/templates/cpp2/base.h.jinja
@@ -26,7 +26,8 @@ namespace {{ns}} {
 {%- for forward in namespace_forward.1 %}
 {%- match forward %}
 	{%- when Forward::Class with (name) ~%}
-		class {{ name }};
+		namespace capi {typedef struct {{name}} {{name}}; }
+class {{ name }};
 	{%- when Forward::Struct with (name) ~%}
 		struct {{ name }};
 	{%- when Forward::EnumStruct with (name) ~%}

--- a/tool/templates/cpp2/enum_decl.h.jinja
+++ b/tool/templates/cpp2/enum_decl.h.jinja
@@ -1,10 +1,11 @@
-namespace capi {
-    {{ c_header.body|trim|indent(4) }}
-}
-
 {% if let Some(ns) = namespace -%}
 namespace {{ns}} {
 {%endif-%}
+namespace {{self::CAPI_NAMESPACE}} {
+    {{ c_header.body|trim|indent(4) }}
+}
+
+
 class {{type_name_unnamespaced}} {
 public:
 	enum Value {

--- a/tool/templates/cpp2/enum_impl.h.jinja
+++ b/tool/templates/cpp2/enum_impl.h.jinja
@@ -1,7 +1,12 @@
-namespace capi {
+{% if let Some(ns) = namespace -%}
+namespace {{ns}} {
+{%endif-%}
+namespace {{self::CAPI_NAMESPACE}} {
     {{ c_impl_header.body|trim|indent(4) }}
 }
-
+{% if namespace.is_some() -%}
+}
+{%endif-%}
 
 inline {{ctype}} {{type_name}}::AsFFI() const {
 	return static_cast<{{ctype}}>(value);

--- a/tool/templates/cpp2/method_impl.h.jinja
+++ b/tool/templates/cpp2/method_impl.h.jinja
@@ -14,7 +14,7 @@ inline {##}
 	{%- endfor -%}
 	{%- if m.method.output.is_write() %}
 	std::string output;
-	capi::DiplomatWrite write = diplomat::WriteFromString(output);
+	::capi::DiplomatWrite write = diplomat::WriteFromString(output);
 	{%- endif %}
 	{% if !m.method.output.is_ffi_unit() -%}
 	auto result = {##}

--- a/tool/templates/cpp2/opaque_decl.h.jinja
+++ b/tool/templates/cpp2/opaque_decl.h.jinja
@@ -1,7 +1,3 @@
-namespace capi {
-    {{ c_header.body|trim|indent(4) }}
-}
-
 {% let const_ptr = fmt.fmt_c_ptr(type_name, Mutability::Immutable) -%}
 {% let mut_ptr = fmt.fmt_c_ptr(type_name, Mutability::Mutable) -%}
 {% let const_cptr = fmt.fmt_c_ptr(ctype, Mutability::Immutable) -%}
@@ -12,6 +8,9 @@ namespace capi {
 {%- if let Some(ns) = namespace -%}
 namespace {{ns}} {
 {%endif-%}
+namespace {{self::CAPI_NAMESPACE}} {
+    {{ c_header.body|trim|indent(4) }}
+}
 
 class {{type_name_unnamespaced}} {
 public:

--- a/tool/templates/cpp2/opaque_impl.h.jinja
+++ b/tool/templates/cpp2/opaque_impl.h.jinja
@@ -1,6 +1,12 @@
-namespace capi {
+{% if let Some(ns) = namespace -%}
+namespace {{ns}} {
+{%endif-%}
+namespace {{self::CAPI_NAMESPACE}} {
     {{ c_impl_header.body|trim|indent(4) }}
 }
+{% if namespace.is_some() -%}
+}
+{%endif-%}
 
 {% let const_ptr = fmt.fmt_c_ptr(type_name, Mutability::Immutable) -%}
 {% let mut_ptr = fmt.fmt_c_ptr(type_name, Mutability::Mutable) -%}

--- a/tool/templates/cpp2/struct_decl.h.jinja
+++ b/tool/templates/cpp2/struct_decl.h.jinja
@@ -1,10 +1,10 @@
-namespace capi {
-    {{ c_header.body|trim|indent(4) }}
-}
-
 {% if let Some(ns) = namespace -%}
 namespace {{ns}} {
 {%endif-%}
+namespace {{self::CAPI_NAMESPACE}} {
+    {{ c_header.body|trim|indent(4) }}
+}
+
 struct {{type_name_unnamespaced}} {
 {%- for field in fields %}
 	{{field.type_name}} {{field.var_name}};

--- a/tool/templates/cpp2/struct_impl.h.jinja
+++ b/tool/templates/cpp2/struct_impl.h.jinja
@@ -1,6 +1,12 @@
-namespace capi {
+{% if let Some(ns) = namespace -%}
+namespace {{ns}} {
+{%endif-%}
+namespace {{self::CAPI_NAMESPACE}} {
     {{ c_impl_header.body|trim|indent(4) }}
 }
+{% if namespace.is_some() -%}
+}
+{%endif-%}
 
 {% for m in methods -%}
 {% include "method_impl.h.jinja" %}


### PR DESCRIPTION
Fixes https://github.com/rust-diplomat/diplomat/issues/427, fixes #432

Now all C code is hidden behind the relevant C++ namespaces. Diplomat-generated C++ code no longer pollutes the global namespace if configured not to.
