### PR TITLE
Windows Fix for moving docs into backend folder in support/function.ds

### DIFF
--- a/support/functions.ds
+++ b/support/functions.ds
@@ -74,6 +74,6 @@ fn generate_generic
 
     if not ${docs_folder_is_empty}
         rm -r "${backend}/${docs_folder}"
-        mv "tmp/${docs_folder}" "${backend}/${docs_folder}/.."
+        mv "tmp/${docs_folder}/" "${backend}/${docs_folder}/.."
     end
 end


### PR DESCRIPTION
Returns `Access is denied. (os error 5)` without.

This is probably another windows specific fix.