### PR TITLE
Allow trait impls in bridge code

### DIFF
--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -170,8 +170,6 @@ impl Module {
 
                 Item::Impl(imp) => {
                     if analyze_types {
-                        assert!(imp.trait_.is_none());
-
                         let self_path = match imp.self_ty.as_ref() {
                             syn::Type::Path(s) => PathType::from(s),
                             _ => panic!("Self type not found"),

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -169,7 +169,7 @@ impl Module {
                 }
 
                 Item::Impl(imp) => {
-                    if analyze_types {
+                    if analyze_types && imp.trait_.is_none() {
                         let self_path = match imp.self_ty.as_ref() {
                             syn::Type::Path(s) => PathType::from(s),
                             _ => panic!("Self type not found"),


### PR DESCRIPTION
This allows writing 

```rust
#[diplomat::bridge]
mod bidi {
  // types
  // trait impls
}
```

instead of

```rust
mod bidi {
  #[diplomat::bridge]
  mod ffi {
    // types
  }
  // trait impls  
}