### PR TITLE
c-in-cpp: Don't generate struct/enum tags

### DIFF
--- a/example/c2/include/ICU4XDataProvider.d.h
+++ b/example/c2/include/ICU4XDataProvider.d.h
@@ -16,5 +16,4 @@ typedef struct ICU4XDataProvider ICU4XDataProvider;
 
 
 
-
 #endif // ICU4XDataProvider_D_H

--- a/example/c2/include/ICU4XFixedDecimal.d.h
+++ b/example/c2/include/ICU4XFixedDecimal.d.h
@@ -16,5 +16,4 @@ typedef struct ICU4XFixedDecimal ICU4XFixedDecimal;
 
 
 
-
 #endif // ICU4XFixedDecimal_D_H

--- a/example/c2/include/ICU4XFixedDecimalFormatter.d.h
+++ b/example/c2/include/ICU4XFixedDecimalFormatter.d.h
@@ -16,5 +16,4 @@ typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter;
 
 
 
-
 #endif // ICU4XFixedDecimalFormatter_D_H

--- a/example/c2/include/ICU4XLocale.d.h
+++ b/example/c2/include/ICU4XLocale.d.h
@@ -16,5 +16,4 @@ typedef struct ICU4XLocale ICU4XLocale;
 
 
 
-
 #endif // ICU4XLocale_D_H

--- a/example/cpp2/include/ICU4XDataProvider.d.hpp
+++ b/example/cpp2/include/ICU4XDataProvider.d.hpp
@@ -10,14 +10,14 @@
 #include "diplomat_runtime.hpp"
 
 namespace icu4x {
-namespace capi {typedef struct ICU4XDataProvider ICU4XDataProvider; }
+namespace capi { struct ICU4XDataProvider; }
 class ICU4XDataProvider;
 }
 
 
 namespace icu4x {
 namespace capi {
-    typedef struct ICU4XDataProvider ICU4XDataProvider;
+    struct ICU4XDataProvider;
 } // namespace capi
 } // namespace
 

--- a/example/cpp2/include/ICU4XFixedDecimal.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimal.d.hpp
@@ -10,14 +10,14 @@
 #include "diplomat_runtime.hpp"
 
 namespace icu4x {
-namespace capi {typedef struct ICU4XFixedDecimal ICU4XFixedDecimal; }
+namespace capi { struct ICU4XFixedDecimal; }
 class ICU4XFixedDecimal;
 }
 
 
 namespace icu4x {
 namespace capi {
-    typedef struct ICU4XFixedDecimal ICU4XFixedDecimal;
+    struct ICU4XFixedDecimal;
 } // namespace capi
 } // namespace
 

--- a/example/cpp2/include/ICU4XFixedDecimalFormatter.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatter.d.hpp
@@ -10,13 +10,13 @@
 #include "diplomat_runtime.hpp"
 
 namespace icu4x {
-namespace capi {typedef struct ICU4XDataProvider ICU4XDataProvider; }
+namespace capi { struct ICU4XDataProvider; }
 class ICU4XDataProvider;
-namespace capi {typedef struct ICU4XFixedDecimal ICU4XFixedDecimal; }
+namespace capi { struct ICU4XFixedDecimal; }
 class ICU4XFixedDecimal;
-namespace capi {typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter; }
+namespace capi { struct ICU4XFixedDecimalFormatter; }
 class ICU4XFixedDecimalFormatter;
-namespace capi {typedef struct ICU4XLocale ICU4XLocale; }
+namespace capi { struct ICU4XLocale; }
 class ICU4XLocale;
 struct ICU4XFixedDecimalFormatterOptions;
 }
@@ -24,7 +24,7 @@ struct ICU4XFixedDecimalFormatterOptions;
 
 namespace icu4x {
 namespace capi {
-    typedef struct ICU4XFixedDecimalFormatter ICU4XFixedDecimalFormatter;
+    struct ICU4XFixedDecimalFormatter;
 } // namespace capi
 } // namespace
 

--- a/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalFormatterOptions.d.hpp
@@ -18,10 +18,10 @@ class ICU4XFixedDecimalGroupingStrategy;
 
 namespace icu4x {
 namespace capi {
-    typedef struct ICU4XFixedDecimalFormatterOptions {
+    struct ICU4XFixedDecimalFormatterOptions {
       icu4x::capi::ICU4XFixedDecimalGroupingStrategy grouping_strategy;
       bool some_other_config;
-    } ICU4XFixedDecimalFormatterOptions;
+    };
 } // namespace capi
 } // namespace
 

--- a/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
+++ b/example/cpp2/include/ICU4XFixedDecimalGroupingStrategy.d.hpp
@@ -12,12 +12,12 @@
 
 namespace icu4x {
 namespace capi {
-    typedef enum ICU4XFixedDecimalGroupingStrategy {
+    enum ICU4XFixedDecimalGroupingStrategy {
       ICU4XFixedDecimalGroupingStrategy_Auto = 0,
       ICU4XFixedDecimalGroupingStrategy_Never = 1,
       ICU4XFixedDecimalGroupingStrategy_Always = 2,
       ICU4XFixedDecimalGroupingStrategy_Min2 = 3,
-    } ICU4XFixedDecimalGroupingStrategy;
+    };
 } // namespace capi
 } // namespace
 

--- a/example/cpp2/include/ICU4XLocale.d.hpp
+++ b/example/cpp2/include/ICU4XLocale.d.hpp
@@ -10,14 +10,14 @@
 #include "diplomat_runtime.hpp"
 
 namespace icu4x {
-namespace capi {typedef struct ICU4XLocale ICU4XLocale; }
+namespace capi { struct ICU4XLocale; }
 class ICU4XLocale;
 }
 
 
 namespace icu4x {
 namespace capi {
-    typedef struct ICU4XLocale ICU4XLocale;
+    struct ICU4XLocale;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/c2/include/AttrOpaque1.d.h
+++ b/feature_tests/c2/include/AttrOpaque1.d.h
@@ -16,5 +16,4 @@ typedef struct AttrOpaque1 AttrOpaque1;
 
 
 
-
 #endif // AttrOpaque1_D_H

--- a/feature_tests/c2/include/AttrOpaque2.d.h
+++ b/feature_tests/c2/include/AttrOpaque2.d.h
@@ -16,5 +16,4 @@ typedef struct AttrOpaque2 AttrOpaque2;
 
 
 
-
 #endif // AttrOpaque2_D_H

--- a/feature_tests/c2/include/Bar.d.h
+++ b/feature_tests/c2/include/Bar.d.h
@@ -16,5 +16,4 @@ typedef struct Bar Bar;
 
 
 
-
 #endif // Bar_D_H

--- a/feature_tests/c2/include/Float64Vec.d.h
+++ b/feature_tests/c2/include/Float64Vec.d.h
@@ -16,5 +16,4 @@ typedef struct Float64Vec Float64Vec;
 
 
 
-
 #endif // Float64Vec_D_H

--- a/feature_tests/c2/include/Foo.d.h
+++ b/feature_tests/c2/include/Foo.d.h
@@ -16,5 +16,4 @@ typedef struct Foo Foo;
 
 
 
-
 #endif // Foo_D_H

--- a/feature_tests/c2/include/MyString.d.h
+++ b/feature_tests/c2/include/MyString.d.h
@@ -16,5 +16,4 @@ typedef struct MyString MyString;
 
 
 
-
 #endif // MyString_D_H

--- a/feature_tests/c2/include/One.d.h
+++ b/feature_tests/c2/include/One.d.h
@@ -16,5 +16,4 @@ typedef struct One One;
 
 
 
-
 #endif // One_D_H

--- a/feature_tests/c2/include/Opaque.d.h
+++ b/feature_tests/c2/include/Opaque.d.h
@@ -16,5 +16,4 @@ typedef struct Opaque Opaque;
 
 
 
-
 #endif // Opaque_D_H

--- a/feature_tests/c2/include/OpaqueMutexedString.d.h
+++ b/feature_tests/c2/include/OpaqueMutexedString.d.h
@@ -16,5 +16,4 @@ typedef struct OpaqueMutexedString OpaqueMutexedString;
 
 
 
-
 #endif // OpaqueMutexedString_D_H

--- a/feature_tests/c2/include/OptionOpaque.d.h
+++ b/feature_tests/c2/include/OptionOpaque.d.h
@@ -16,5 +16,4 @@ typedef struct OptionOpaque OptionOpaque;
 
 
 
-
 #endif // OptionOpaque_D_H

--- a/feature_tests/c2/include/OptionOpaqueChar.d.h
+++ b/feature_tests/c2/include/OptionOpaqueChar.d.h
@@ -16,5 +16,4 @@ typedef struct OptionOpaqueChar OptionOpaqueChar;
 
 
 
-
 #endif // OptionOpaqueChar_D_H

--- a/feature_tests/c2/include/OptionString.d.h
+++ b/feature_tests/c2/include/OptionString.d.h
@@ -16,5 +16,4 @@ typedef struct OptionString OptionString;
 
 
 
-
 #endif // OptionString_D_H

--- a/feature_tests/c2/include/RefList.d.h
+++ b/feature_tests/c2/include/RefList.d.h
@@ -16,5 +16,4 @@ typedef struct RefList RefList;
 
 
 
-
 #endif // RefList_D_H

--- a/feature_tests/c2/include/RefListParameter.d.h
+++ b/feature_tests/c2/include/RefListParameter.d.h
@@ -16,5 +16,4 @@ typedef struct RefListParameter RefListParameter;
 
 
 
-
 #endif // RefListParameter_D_H

--- a/feature_tests/c2/include/ResultOpaque.d.h
+++ b/feature_tests/c2/include/ResultOpaque.d.h
@@ -16,5 +16,4 @@ typedef struct ResultOpaque ResultOpaque;
 
 
 
-
 #endif // ResultOpaque_D_H

--- a/feature_tests/c2/include/Two.d.h
+++ b/feature_tests/c2/include/Two.d.h
@@ -16,5 +16,4 @@ typedef struct Two Two;
 
 
 
-
 #endif // Two_D_H

--- a/feature_tests/c2/include/Unnamespaced.d.h
+++ b/feature_tests/c2/include/Unnamespaced.d.h
@@ -16,5 +16,4 @@ typedef struct Unnamespaced Unnamespaced;
 
 
 
-
 #endif // Unnamespaced_D_H

--- a/feature_tests/c2/include/Utf16Wrap.d.h
+++ b/feature_tests/c2/include/Utf16Wrap.d.h
@@ -16,5 +16,4 @@ typedef struct Utf16Wrap Utf16Wrap;
 
 
 
-
 #endif // Utf16Wrap_D_H

--- a/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp2/include/AttrOpaque1Renamed.d.hpp
@@ -9,10 +9,10 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct Unnamespaced Unnamespaced; }
+namespace diplomat::capi { struct Unnamespaced; }
 class Unnamespaced;
 namespace ns {
-namespace capi {typedef struct AttrOpaque1Renamed AttrOpaque1Renamed; }
+namespace capi { struct AttrOpaque1Renamed; }
 class AttrOpaque1Renamed;
 class CPPRenamedAttrEnum;
 }
@@ -20,7 +20,7 @@ class CPPRenamedAttrEnum;
 
 namespace ns {
 namespace capi {
-    typedef struct AttrOpaque1Renamed AttrOpaque1Renamed;
+    struct AttrOpaque1Renamed;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/Bar.d.hpp
+++ b/feature_tests/cpp2/include/Bar.d.hpp
@@ -9,13 +9,13 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct Foo Foo; }
+namespace diplomat::capi { struct Foo; }
 class Foo;
 
 
 namespace diplomat {
 namespace capi {
-    typedef struct Bar Bar;
+    struct Bar;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/BorrowedFields.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFields.d.hpp
@@ -9,17 +9,17 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct Bar Bar; }
+namespace diplomat::capi { struct Bar; }
 class Bar;
 
 
 namespace diplomat {
 namespace capi {
-    typedef struct BorrowedFields {
+    struct BorrowedFields {
       DiplomatString16View a;
       DiplomatStringView b;
       DiplomatStringView c;
-    } BorrowedFields;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/BorrowedFieldsReturning.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsReturning.d.hpp
@@ -12,9 +12,9 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct BorrowedFieldsReturning {
+    struct BorrowedFieldsReturning {
       DiplomatStringView bytes;
-    } BorrowedFieldsReturning;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/BorrowedFieldsWithBounds.d.hpp
+++ b/feature_tests/cpp2/include/BorrowedFieldsWithBounds.d.hpp
@@ -9,17 +9,17 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct Foo Foo; }
+namespace diplomat::capi { struct Foo; }
 class Foo;
 
 
 namespace diplomat {
 namespace capi {
-    typedef struct BorrowedFieldsWithBounds {
+    struct BorrowedFieldsWithBounds {
       DiplomatString16View field_a;
       DiplomatStringView field_b;
       DiplomatStringView field_c;
-    } BorrowedFieldsWithBounds;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrEnum.d.hpp
@@ -12,11 +12,11 @@
 
 namespace ns {
 namespace capi {
-    typedef enum CPPRenamedAttrEnum {
+    enum CPPRenamedAttrEnum {
       CPPRenamedAttrEnum_A = 0,
       CPPRenamedAttrEnum_B = 1,
       CPPRenamedAttrEnum_C = 2,
-    } CPPRenamedAttrEnum;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.d.hpp
+++ b/feature_tests/cpp2/include/CPPRenamedAttrOpaque2.d.hpp
@@ -12,7 +12,7 @@
 
 namespace ns {
 namespace capi {
-    typedef struct CPPRenamedAttrOpaque2 CPPRenamedAttrOpaque2;
+    struct CPPRenamedAttrOpaque2;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/ContiguousEnum.d.hpp
+++ b/feature_tests/cpp2/include/ContiguousEnum.d.hpp
@@ -12,12 +12,12 @@
 
 namespace diplomat {
 namespace capi {
-    typedef enum ContiguousEnum {
+    enum ContiguousEnum {
       ContiguousEnum_C = 0,
       ContiguousEnum_D = 1,
       ContiguousEnum_E = 2,
       ContiguousEnum_F = 3,
-    } ContiguousEnum;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/CyclicStructA.d.hpp
+++ b/feature_tests/cpp2/include/CyclicStructA.d.hpp
@@ -15,9 +15,9 @@ struct CyclicStructB;
 
 namespace diplomat {
 namespace capi {
-    typedef struct CyclicStructA {
+    struct CyclicStructA {
       diplomat::capi::CyclicStructB a;
-    } CyclicStructA;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/CyclicStructB.d.hpp
+++ b/feature_tests/cpp2/include/CyclicStructB.d.hpp
@@ -14,9 +14,9 @@ struct CyclicStructA;
 
 namespace diplomat {
 namespace capi {
-    typedef struct CyclicStructB {
+    struct CyclicStructB {
       uint8_t field;
-    } CyclicStructB;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/ErrorEnum.d.hpp
+++ b/feature_tests/cpp2/include/ErrorEnum.d.hpp
@@ -12,10 +12,10 @@
 
 namespace diplomat {
 namespace capi {
-    typedef enum ErrorEnum {
+    enum ErrorEnum {
       ErrorEnum_Foo = 0,
       ErrorEnum_Bar = 1,
-    } ErrorEnum;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/ErrorStruct.d.hpp
+++ b/feature_tests/cpp2/include/ErrorStruct.d.hpp
@@ -12,10 +12,10 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct ErrorStruct {
+    struct ErrorStruct {
       int32_t i;
       int32_t j;
-    } ErrorStruct;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp2/include/Float64Vec.d.hpp
@@ -12,7 +12,7 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct Float64Vec Float64Vec;
+    struct Float64Vec;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/Foo.d.hpp
+++ b/feature_tests/cpp2/include/Foo.d.hpp
@@ -9,7 +9,7 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct Bar Bar; }
+namespace diplomat::capi { struct Bar; }
 class Bar;
 struct BorrowedFields;
 struct BorrowedFieldsReturning;
@@ -18,7 +18,7 @@ struct BorrowedFieldsWithBounds;
 
 namespace diplomat {
 namespace capi {
-    typedef struct Foo Foo;
+    struct Foo;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/ImportedStruct.d.hpp
+++ b/feature_tests/cpp2/include/ImportedStruct.d.hpp
@@ -15,10 +15,10 @@ class UnimportedEnum;
 
 namespace diplomat {
 namespace capi {
-    typedef struct ImportedStruct {
+    struct ImportedStruct {
       diplomat::capi::UnimportedEnum foo;
       uint8_t count;
-    } ImportedStruct;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/MyEnum.d.hpp
+++ b/feature_tests/cpp2/include/MyEnum.d.hpp
@@ -12,14 +12,14 @@
 
 namespace diplomat {
 namespace capi {
-    typedef enum MyEnum {
+    enum MyEnum {
       MyEnum_A = -2,
       MyEnum_B = -1,
       MyEnum_C = 0,
       MyEnum_D = 1,
       MyEnum_E = 2,
       MyEnum_F = 3,
-    } MyEnum;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/MyString.d.hpp
+++ b/feature_tests/cpp2/include/MyString.d.hpp
@@ -12,7 +12,7 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct MyString MyString;
+    struct MyString;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/MyStruct.d.hpp
+++ b/feature_tests/cpp2/include/MyStruct.d.hpp
@@ -16,7 +16,7 @@ class MyEnum;
 
 namespace diplomat {
 namespace capi {
-    typedef struct MyStruct {
+    struct MyStruct {
       uint8_t a;
       bool b;
       uint8_t c;
@@ -24,7 +24,7 @@ namespace capi {
       int32_t e;
       char32_t f;
       diplomat::capi::MyEnum g;
-    } MyStruct;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/MyZst.d.hpp
+++ b/feature_tests/cpp2/include/MyZst.d.hpp
@@ -12,8 +12,8 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct MyZst {
-    } MyZst;
+    struct MyZst {
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/NestedBorrowedFields.d.hpp
+++ b/feature_tests/cpp2/include/NestedBorrowedFields.d.hpp
@@ -11,9 +11,9 @@
 #include "BorrowedFields.d.hpp"
 #include "BorrowedFieldsWithBounds.d.hpp"
 
-namespace capi {typedef struct Bar Bar; }
+namespace diplomat::capi { struct Bar; }
 class Bar;
-namespace capi {typedef struct Foo Foo; }
+namespace diplomat::capi { struct Foo; }
 class Foo;
 struct BorrowedFields;
 struct BorrowedFieldsWithBounds;
@@ -21,11 +21,11 @@ struct BorrowedFieldsWithBounds;
 
 namespace diplomat {
 namespace capi {
-    typedef struct NestedBorrowedFields {
+    struct NestedBorrowedFields {
       diplomat::capi::BorrowedFields fields;
       diplomat::capi::BorrowedFieldsWithBounds bounds;
       diplomat::capi::BorrowedFieldsWithBounds bounds2;
-    } NestedBorrowedFields;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/One.d.hpp
+++ b/feature_tests/cpp2/include/One.d.hpp
@@ -9,13 +9,13 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct Two Two; }
+namespace diplomat::capi { struct Two; }
 class Two;
 
 
 namespace diplomat {
 namespace capi {
-    typedef struct One One;
+    struct One;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/Opaque.d.hpp
+++ b/feature_tests/cpp2/include/Opaque.d.hpp
@@ -15,7 +15,7 @@ struct MyStruct;
 
 namespace diplomat {
 namespace capi {
-    typedef struct Opaque Opaque;
+    struct Opaque;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/OpaqueMutexedString.d.hpp
+++ b/feature_tests/cpp2/include/OpaqueMutexedString.d.hpp
@@ -9,13 +9,13 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct Utf16Wrap Utf16Wrap; }
+namespace diplomat::capi { struct Utf16Wrap; }
 class Utf16Wrap;
 
 
 namespace diplomat {
 namespace capi {
-    typedef struct OpaqueMutexedString OpaqueMutexedString;
+    struct OpaqueMutexedString;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp2/include/OptionOpaque.d.hpp
@@ -14,7 +14,7 @@ struct OptionStruct;
 
 namespace diplomat {
 namespace capi {
-    typedef struct OptionOpaque OptionOpaque;
+    struct OptionOpaque;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/OptionOpaqueChar.d.hpp
+++ b/feature_tests/cpp2/include/OptionOpaqueChar.d.hpp
@@ -12,7 +12,7 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct OptionOpaqueChar OptionOpaqueChar;
+    struct OptionOpaqueChar;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/OptionString.d.hpp
+++ b/feature_tests/cpp2/include/OptionString.d.hpp
@@ -12,7 +12,7 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct OptionString OptionString;
+    struct OptionString;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/OptionStruct.d.hpp
+++ b/feature_tests/cpp2/include/OptionStruct.d.hpp
@@ -9,20 +9,20 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct OptionOpaque OptionOpaque; }
+namespace diplomat::capi { struct OptionOpaque; }
 class OptionOpaque;
-namespace capi {typedef struct OptionOpaqueChar OptionOpaqueChar; }
+namespace diplomat::capi { struct OptionOpaqueChar; }
 class OptionOpaqueChar;
 
 
 namespace diplomat {
 namespace capi {
-    typedef struct OptionStruct {
+    struct OptionStruct {
       diplomat::capi::OptionOpaque* a;
       diplomat::capi::OptionOpaqueChar* b;
       uint32_t c;
       diplomat::capi::OptionOpaque* d;
-    } OptionStruct;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/RefList.d.hpp
+++ b/feature_tests/cpp2/include/RefList.d.hpp
@@ -9,13 +9,13 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
-namespace capi {typedef struct RefListParameter RefListParameter; }
+namespace diplomat::capi { struct RefListParameter; }
 class RefListParameter;
 
 
 namespace diplomat {
 namespace capi {
-    typedef struct RefList RefList;
+    struct RefList;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/RefListParameter.d.hpp
+++ b/feature_tests/cpp2/include/RefListParameter.d.hpp
@@ -12,7 +12,7 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct RefListParameter RefListParameter;
+    struct RefListParameter;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/ResultOpaque.d.hpp
+++ b/feature_tests/cpp2/include/ResultOpaque.d.hpp
@@ -15,7 +15,7 @@ class ErrorEnum;
 
 namespace diplomat {
 namespace capi {
-    typedef struct ResultOpaque ResultOpaque;
+    struct ResultOpaque;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/Two.d.hpp
+++ b/feature_tests/cpp2/include/Two.d.hpp
@@ -12,7 +12,7 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct Two Two;
+    struct Two;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/UnimportedEnum.d.hpp
+++ b/feature_tests/cpp2/include/UnimportedEnum.d.hpp
@@ -12,11 +12,11 @@
 
 namespace diplomat {
 namespace capi {
-    typedef enum UnimportedEnum {
+    enum UnimportedEnum {
       UnimportedEnum_A = 0,
       UnimportedEnum_B = 1,
       UnimportedEnum_C = 2,
-    } UnimportedEnum;
+    };
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/Unnamespaced.d.hpp
+++ b/feature_tests/cpp2/include/Unnamespaced.d.hpp
@@ -10,7 +10,7 @@
 #include "diplomat_runtime.hpp"
 
 namespace ns {
-namespace capi {typedef struct AttrOpaque1Renamed AttrOpaque1Renamed; }
+namespace capi { struct AttrOpaque1Renamed; }
 class AttrOpaque1Renamed;
 class CPPRenamedAttrEnum;
 }
@@ -18,7 +18,7 @@ class CPPRenamedAttrEnum;
 
 namespace diplomat {
 namespace capi {
-    typedef struct Unnamespaced Unnamespaced;
+    struct Unnamespaced;
 } // namespace capi
 } // namespace
 

--- a/feature_tests/cpp2/include/Utf16Wrap.d.hpp
+++ b/feature_tests/cpp2/include/Utf16Wrap.d.hpp
@@ -12,7 +12,7 @@
 
 namespace diplomat {
 namespace capi {
-    typedef struct Utf16Wrap Utf16Wrap;
+    struct Utf16Wrap;
 } // namespace capi
 } // namespace
 

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -74,6 +74,7 @@ struct EnumTemplate<'a> {
     ty: &'a hir::EnumDef,
     fmt: &'a CFormatter<'a>,
     ty_name: &'a str,
+    is_for_cpp: bool,
 }
 
 #[derive(Template)]
@@ -81,12 +82,14 @@ struct EnumTemplate<'a> {
 struct StructTemplate<'a> {
     ty_name: Cow<'a, str>,
     fields: Vec<(Cow<'a, str>, Cow<'a, str>)>,
+    is_for_cpp: bool,
 }
 
 #[derive(Template)]
 #[template(path = "c2/opaque.h.jinja", escape = "none")]
 struct OpaqueTemplate<'a> {
     ty_name: Cow<'a, str>,
+    is_for_cpp: bool,
 }
 
 #[derive(Template)]
@@ -125,6 +128,7 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
             ty: def,
             fmt: self.formatter,
             ty_name: &ty_name,
+            is_for_cpp: self.is_for_cpp,
         }
         .render_into(&mut decl_header)
         .unwrap();
@@ -135,9 +139,12 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
     pub fn gen_opaque_def(&self, _def: &'tcx hir::OpaqueDef) -> Header {
         let mut decl_header = Header::new(self.decl_header_path.clone(), self.is_for_cpp);
         let ty_name = self.formatter.fmt_type_name(self.id);
-        OpaqueTemplate { ty_name }
-            .render_into(&mut decl_header)
-            .unwrap();
+        OpaqueTemplate {
+            ty_name,
+            is_for_cpp: self.is_for_cpp,
+        }
+        .render_into(&mut decl_header)
+        .unwrap();
 
         decl_header
     }
@@ -156,9 +163,13 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
             );
         }
 
-        StructTemplate { ty_name, fields }
-            .render_into(&mut decl_header)
-            .unwrap();
+        StructTemplate {
+            ty_name,
+            fields,
+            is_for_cpp: self.is_for_cpp,
+        }
+        .render_into(&mut decl_header)
+        .unwrap();
 
         decl_header
     }

--- a/tool/templates/c2/enum.h.jinja
+++ b/tool/templates/c2/enum.h.jinja
@@ -1,7 +1,8 @@
-typedef enum {{ ty_name }} {
+{% if !is_for_cpp -%} typedef {% endif -%}
+enum {{ ty_name }} {
   {%- for enum_variant in ty.variants %}
   {{fmt.fmt_enum_variant(ty_name, enum_variant)}} = {{ enum_variant.discriminant }},
   {%- endfor %}
-} {{ ty_name }};
+} {%- if !is_for_cpp %} {{ ty_name }} {%- endif %};
 
 

--- a/tool/templates/c2/opaque.h.jinja
+++ b/tool/templates/c2/opaque.h.jinja
@@ -1,3 +1,5 @@
+{% if is_for_cpp -%}
+struct {{ ty_name }};
+{% else -%}
 typedef struct {{ ty_name }} {{ ty_name }};
-
-
+{% endif %}

--- a/tool/templates/c2/struct.h.jinja
+++ b/tool/templates/c2/struct.h.jinja
@@ -1,7 +1,8 @@
-typedef struct {{ty_name}} {
+{% if !is_for_cpp -%} typedef {% endif -%}
+struct {{ty_name}} {
 {%- for field in fields %}
   {{field.0}} {{field.1}};
 {%- endfor %}
-} {{ ty_name }};
+} {%- if !is_for_cpp %} {{ ty_name }} {%- endif %};
 
 

--- a/tool/templates/cpp2/base.h.jinja
+++ b/tool/templates/cpp2/base.h.jinja
@@ -26,7 +26,7 @@ namespace {{ns}} {
 {%- for forward in namespace_forward.1 %}
 {%- match forward %}
 	{%- when Forward::Class with (name) ~%}
-		namespace capi {typedef struct {{name}} {{name}}; }
+		namespace {% if namespace_forward.0.is_none() -%} diplomat:: {%- endif -%} capi { struct {{name}}; }
 class {{ name }};
 	{%- when Forward::Struct with (name) ~%}
 		struct {{ name }};


### PR DESCRIPTION
fixes https://github.com/rust-diplomat/diplomat/issues/541


In C++ `struct Foo {};` and `typedef struct Foo {..} Bar;` both generate types `Foo` in the main type namespace. In C, "struct tags" and "type names" occupy different kinds of namespaces, so `typedef struct Foo {..} Bar` is meaningful, but in C++ apparently these both occupy the same space.

This mostly works fine when using C code from C++, however it breaks a little bit because the forward decls sometimes conflict, see #541. This is another case of "C code is supposed to just work in C++ but it doesn't".