### PR TITLE
JS2 Backend Fix for nullable return types

### DIFF
--- a/example/js2/api/ICU4XFixedDecimalFormatter.mjs
+++ b/example/js2/api/ICU4XFixedDecimalFormatter.mjs
@@ -47,7 +47,7 @@ export class ICU4XFixedDecimalFormatter {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4)) {
-                throw diplomatRuntime.FFIError(null);
+                throw new diplomatRuntime.FFIError(null);
             }
             return new ICU4XFixedDecimalFormatter(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), []);
         } finally {

--- a/feature_tests/js2/api/Float64Vec.mjs
+++ b/feature_tests/js2/api/Float64Vec.mjs
@@ -233,7 +233,7 @@ export class Float64Vec {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 8)) {
-                throw diplomatRuntime.FFIError(null);
+                return null;
             }
             return (new Float64Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
         } finally {

--- a/feature_tests/js2/api/OptionOpaque.mjs
+++ b/feature_tests/js2/api/OptionOpaque.mjs
@@ -59,7 +59,7 @@ export class OptionOpaque {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 16)) {
-                throw diplomatRuntime.FFIError(null);
+                return null;
             }
             return new OptionStruct(diplomat_receive_buffer);
         } finally {
@@ -77,7 +77,7 @@ export class OptionOpaque {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4)) {
-                throw diplomatRuntime.FFIError(null);
+                return null;
             }
             return (new Int32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
         } finally {
@@ -95,7 +95,7 @@ export class OptionOpaque {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4)) {
-                throw diplomatRuntime.FFIError(null);
+                return null;
             }
             return (new Uint32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
         } finally {
@@ -113,7 +113,7 @@ export class OptionOpaque {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4)) {
-                throw diplomatRuntime.FFIError(null);
+                return null;
             }
             return (new Int32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
         } finally {
@@ -131,7 +131,7 @@ export class OptionOpaque {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4)) {
-                throw diplomatRuntime.FFIError(null);
+                return null;
             }
             return (new Uint32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
         } finally {

--- a/feature_tests/js2/api/OptionString.mjs
+++ b/feature_tests/js2/api/OptionString.mjs
@@ -71,7 +71,7 @@ export class OptionString {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 8)) {
-                throw diplomatRuntime.FFIError(null);
+                return null;
             }
             return diplomatRuntime.DiplomatBuf.stringFromPtr(wasm.memory.buffer, diplomat_receive_buffer, "string8");
         } finally {

--- a/feature_tests/js2/api/ResultOpaque.mjs
+++ b/feature_tests/js2/api/ResultOpaque.mjs
@@ -92,7 +92,7 @@ export class ResultOpaque {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4)) {
-                throw diplomatRuntime.FFIError(null);
+                throw new diplomatRuntime.FFIError(null);
             }
             return new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomat_receive_buffer), []);
         } finally {
@@ -146,7 +146,7 @@ export class ResultOpaque {
         try {
     
             if (!diplomatRuntime.resultFlag(wasm, diplomat_receive_buffer, 4)) {
-                throw diplomatRuntime.FFIError(null);
+                throw new diplomatRuntime.FFIError(null);
             }
             return (new Int32Array(wasm.memory.buffer, diplomat_receive_buffer, 1))[0];
         } finally {

--- a/tool/src/js2/type_generation/converter.rs
+++ b/tool/src/js2/type_generation/converter.rs
@@ -473,7 +473,10 @@ impl<'jsctx, 'tcx> TypeGenerationContext<'jsctx, 'tcx> {
 						let receive_deref = self.gen_c_to_js_deref_for_type(e, "diplomat_receive_buffer".into(), 0);
 						format!("throw new diplomatRuntime.FFIError({})", self.gen_c_to_js_for_type(e, receive_deref, lifetime_environment))
 					},
-					_ => "throw diplomatRuntime.FFIError(null)".into(),
+                    // We don't want an error, we just want a null value that we can process.
+                    ReturnType::Nullable(_) => "return null".into(),
+                    // Otherwise we just error out with the Unit error:
+					_ => "throw new diplomatRuntime.FFIError(null)".into(),
 				});
 
                 Some(match ok {


### PR DESCRIPTION
JS2 backend used to throw an error instead of returning null for `-> Option<Type>` functions.

This adds a case to return null instead of an error for nullable return types.