### PR TITLE
Stop using CFormatter in non-C backends

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,4 +36,4 @@ strck_ident = { version = "0.1", features = ["rust"] }
 either = {version = "1.9.0", optional = true, default-features = false}
 
 [dev-dependencies]
-insta = "1.7.1"
+insta = { version = "1.7.1", features = ["yaml"] }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -16,8 +16,8 @@ pub struct Method {
     /// Lines of documentation for the method.
     pub docs: Docs,
 
-    /// The name of the FFI function wrapping around the method.
-    pub full_path_name: Ident,
+    /// The name of the generated `extern "C"` function
+    pub abi_name: Ident,
 
     /// The `self` param of the method, if any.
     pub self_param: Option<SelfParam>,
@@ -95,7 +95,7 @@ impl Method {
         Method {
             name: Ident::from(method_ident),
             docs: Docs::from_attrs(&m.attrs),
-            full_path_name: Ident::from(&extern_ident),
+            abi_name: Ident::from(&extern_ident),
             self_param,
             params: all_params,
             return_type: return_ty,

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__cfged_method.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__cfged_method.snap
@@ -12,7 +12,7 @@ docs:
           - batz
       typ: FnInStruct
       display: Normal
-full_path_name: MyStructContainingMethod_foo
+abi_name: MyStructContainingMethod_foo
 self_param: ~
 params:
   - name: x

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -12,7 +12,7 @@ docs:
           - batz
       typ: FnInStruct
       display: Normal
-full_path_name: MyStructContainingMethod_foo
+abi_name: MyStructContainingMethod_foo
 self_param:
   reference:
     - Anonymous

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -6,7 +6,7 @@ name: foo
 docs:
   - ""
   - []
-full_path_name: MyStructContainingMethod_foo
+abi_name: MyStructContainingMethod_foo
 self_param:
   reference:
     - Anonymous

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
@@ -12,7 +12,7 @@ docs:
           - batz
       typ: FnInEnum
       display: Normal
-full_path_name: MyStructContainingMethod_foo
+abi_name: MyStructContainingMethod_foo
 self_param: ~
 params:
   - name: x

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
@@ -12,7 +12,7 @@ docs:
           - batz
       typ: FnInStruct
       display: Normal
-full_path_name: MyStructContainingMethod_foo
+abi_name: MyStructContainingMethod_foo
 self_param: ~
 params:
   - name: x

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
@@ -18,7 +18,7 @@ declared_types:
           docs:
             - ""
             - []
-          full_path_name: Foo_pub_fn
+          abi_name: Foo_pub_fn
           self_param: ~
           params: []
           return_type: ~

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/modules.rs
-expression: "Module::from_syn(&syn::parse_quote! {\n                mod ffi\n                {\n                    struct NonOpaqueStruct\n                    { a : i32, b : Box < NonOpaqueStruct > } impl\n                    NonOpaqueStruct\n                    {\n                        pub fn new(x : i32) -> NonOpaqueStruct\n                        { unimplemented! () ; } pub fn\n                        set_a(& mut self, new_a : i32) { self.a = new_a ; }\n                    } #[diplomat :: opaque] struct OpaqueStruct\n                    { a : SomeExternalType } impl OpaqueStruct\n                    {\n                        pub fn new() -> Box < OpaqueStruct > { unimplemented! () ; }\n                        pub fn get_string(& self) -> String { unimplemented! () }\n                    }\n                }\n            }, true)"
+expression: "Module::from_syn(&syn::parse_quote! {\n                mod ffi\n                {\n                    struct NonOpaqueStruct { a: i32, b: Box<NonOpaqueStruct> }\n                    impl NonOpaqueStruct\n                    {\n                        pub fn new(x: i32) -> NonOpaqueStruct { unimplemented!(); }\n                        pub fn set_a(&mut self, new_a: i32) { self.a = new_a; }\n                    } #[diplomat::opaque] struct OpaqueStruct\n                    { a: SomeExternalType } impl OpaqueStruct\n                    {\n                        pub fn new() -> Box<OpaqueStruct> { unimplemented!(); } pub\n                        fn get_string(&self) -> String { unimplemented!() }\n                    }\n                }\n            }, true)"
 ---
 name: ffi
 imports: []
@@ -117,6 +117,6 @@ declared_types:
           attrs: {}
       mutability: Immutable
       attrs: {}
+      dtor_abi_name: OpaqueStruct_destroy
 sub_modules: []
 attrs: {}
-

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -31,7 +31,7 @@ declared_types:
           docs:
             - ""
             - []
-          full_path_name: NonOpaqueStruct_new
+          abi_name: NonOpaqueStruct_new
           self_param: ~
           params:
             - name: x
@@ -49,7 +49,7 @@ declared_types:
           docs:
             - ""
             - []
-          full_path_name: NonOpaqueStruct_set_a
+          abi_name: NonOpaqueStruct_set_a
           self_param:
             reference:
               - Anonymous
@@ -80,7 +80,7 @@ declared_types:
           docs:
             - ""
             - []
-          full_path_name: OpaqueStruct_new
+          abi_name: OpaqueStruct_new
           self_param: ~
           params: []
           return_type:
@@ -96,7 +96,7 @@ declared_types:
           docs:
             - ""
             - []
-          full_path_name: OpaqueStruct_get_string
+          abi_name: OpaqueStruct_get_string
           self_param:
             reference:
               - Anonymous

--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -64,6 +64,8 @@ pub struct OpaqueStruct {
     pub methods: Vec<Method>,
     pub mutability: Mutability,
     pub attrs: Attrs,
+    /// The ABI name of the generated destructor
+    pub dtor_abi_name: Ident,
 }
 
 impl OpaqueStruct {
@@ -71,13 +73,18 @@ impl OpaqueStruct {
     pub fn new(strct: &syn::ItemStruct, mutability: Mutability, parent_attrs: &Attrs) -> Self {
         let mut attrs = parent_attrs.clone();
         attrs.add_attrs(&strct.attrs);
+        let name = Ident::from(&strct.ident);
+        let dtor_abi_name = format!("{}_destroy", name);
+        let dtor_abi_name = String::from(attrs.abi_rename.apply(dtor_abi_name.into()));
+        let dtor_abi_name = Ident::from(dtor_abi_name);
         OpaqueStruct {
-            name: Ident::from(&strct.ident),
+            name,
             docs: Docs::from_attrs(&strct.attrs),
             lifetimes: LifetimeEnv::from_struct_item(strct, &[]),
             methods: vec![],
             mutability,
             attrs,
+            dtor_abi_name,
         }
     }
 }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -53,12 +53,6 @@ impl CustomType {
         }
     }
 
-    // /// The name of the destructor in C
-    // pub fn dtor_name(&self) -> String {
-    //     let name = format!("{}_destroy", self.name());
-    //     self.attrs().abi_rename.apply(name.into()).into()
-    // }
-
     /// Get the doc lines of the custom type.
     pub fn docs(&self) -> &Docs {
         match self {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -53,11 +53,11 @@ impl CustomType {
         }
     }
 
-    /// The name of the destructor in C
-    pub fn dtor_name(&self) -> String {
-        let name = format!("{}_destroy", self.name());
-        self.attrs().abi_rename.apply(name.into()).into()
-    }
+    // /// The name of the destructor in C
+    // pub fn dtor_name(&self) -> String {
+    //     let name = format!("{}_destroy", self.name());
+    //     self.attrs().abi_rename.apply(name.into()).into()
+    // }
 
     /// Get the doc lines of the custom type.
     pub fn docs(&self) -> &Docs {

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -54,6 +54,9 @@ pub struct OpaqueDef {
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
     pub special_method_presence: SpecialMethodPresence,
+
+    /// The ABI name of the generated destructor
+    pub dtor_abi_name: IdentBuf,
 }
 
 /// The enum type.
@@ -120,6 +123,7 @@ impl OpaqueDef {
         attrs: Attrs,
         lifetimes: LifetimeEnv,
         special_method_presence: SpecialMethodPresence,
+        dtor_abi_name: IdentBuf,
     ) -> Self {
         Self {
             docs,
@@ -128,6 +132,7 @@ impl OpaqueDef {
             attrs,
             lifetimes,
             special_method_presence,
+            dtor_abi_name,
         }
     }
 }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -459,7 +459,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let (param_self, param_ltl) = if let Some(self_param) = method.self_param.as_ref() {
             let (param_self, param_ltl) =
-                self.lower_self_param(self_param, self_param_ltl, &method.full_path_name, in_path)?;
+                self.lower_self_param(self_param, self_param_ltl, &method.abi_name, in_path)?;
             (Some(param_self), param_ltl)
         } else {
             (None, SelfParamLifetimeLowerer::no_self_ref(self_param_ltl))

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -257,6 +257,7 @@ impl<'ast> LoweringContext<'ast> {
         let ast_opaque = item.item;
         self.errors.set_item(ast_opaque.name.as_str());
         let name = self.lower_ident(&ast_opaque.name, "opaque name");
+        let dtor_abi_name = self.lower_ident(&ast_opaque.dtor_abi_name, "opaque dtor abi name");
 
         let attrs = self.attr_validator.attr_from_ast(
             &ast_opaque.attrs,
@@ -284,6 +285,7 @@ impl<'ast> LoweringContext<'ast> {
             attrs,
             lifetimes?,
             special_method_presence,
+            dtor_abi_name?,
         );
         self.attr_validator.validate(
             &def.attrs,
@@ -482,7 +484,7 @@ impl<'ast> LoweringContext<'ast> {
         let hir_method = Method {
             docs: method.docs.clone(),
             name: name?,
-            abi_name: abi_name,
+            abi_name,
             lifetime_env,
             param_self,
             params,

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -478,9 +478,11 @@ impl<'ast> LoweringContext<'ast> {
             self.attr_validator
                 .attr_from_ast(&method.attrs, method_parent_attrs, &mut self.errors);
 
+        let abi_name = self.lower_ident(&method.abi_name, "method abi name")?;
         let hir_method = Method {
             docs: method.docs.clone(),
             name: name?,
+            abi_name: abi_name,
             lifetime_env,
             param_self,
             params,

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -17,13 +17,22 @@ pub mod borrowing_param;
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Method {
+    /// Documentation specified on the method
     pub docs: Docs,
+    /// The name of the method as initially declared.
     pub name: IdentBuf,
+    /// The name of the generated `extern "C"` function
+    pub abi_name: IdentBuf,
+    /// The lifetimes introduced in this method and surrounding impl block.
     pub lifetime_env: LifetimeEnv,
 
+    /// An &self, &mut self, or Self parameter
     pub param_self: Option<ParamSelf>,
+    /// The parameters of the method
     pub params: Vec<Param>,
+    /// The output type, including whether it returns a Result/Option/Writeable/etc
     pub output: ReturnType,
+    /// Resolved (and inherited) diplomat::attr attributes on this method
     pub attrs: Attrs,
 }
 

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__elision_in_struct.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__elision_in_struct.snap
@@ -8,6 +8,7 @@ Method {
         [],
     ),
     name: "elided",
+    abi_name: "Opaque_elided",
     lifetime_env: LifetimeEnv {
         nodes: [],
         num_lifetimes: 3,

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -46,6 +46,7 @@ TypeContext {
                         [],
                     ),
                     name: "new",
+                    abi_name: "OutStruct_new",
                     lifetime_env: LifetimeEnv {
                         nodes: [
                             BoundedLifetime {
@@ -172,6 +173,7 @@ TypeContext {
                         [],
                     ),
                     name: "rustc_elision",
+                    abi_name: "Struct_rustc_elision",
                     lifetime_env: LifetimeEnv {
                         nodes: [
                             BoundedLifetime {
@@ -310,6 +312,7 @@ TypeContext {
                 iterator: None,
                 iterable: None,
             },
+            dtor_abi_name: "Opaque_destroy",
         },
     ],
     enums: [],

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -12,6 +12,7 @@ use crate::hir;
 use crate::{ast, Env};
 use core::fmt::{self, Display};
 use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Index;
 
@@ -141,6 +142,12 @@ impl TypeContext {
     /// Prefer using `resolve_type()` for simplicity.
     pub fn resolve_enum(&self, id: EnumId) -> &EnumDef {
         self.enums.index(id.0)
+    }
+
+    /// Resolve and format a named type for use in diagnostics
+    /// (don't apply rename rules and such)
+    pub fn fmt_type_name_diagnostics(&self, id: TypeId) -> Cow<str> {
+        self.resolve_type(id).name().as_str().into()
     }
 
     /// Lower the AST to the HIR while simultaneously performing validation.

--- a/example/c/include/FixedDecimalFormatterOptions.h
+++ b/example/c/include/FixedDecimalFormatterOptions.h
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 FixedDecimalFormatterOptions icu4x_FixedDecimalFormatterOptions_default_mv1();
-void icu4x_FixedDecimalFormatterOptions_destroy_mv1(FixedDecimalFormatterOptions* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/example/c/include/FixedDecimalGroupingStrategy.h
+++ b/example/c/include/FixedDecimalGroupingStrategy.h
@@ -24,7 +24,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void icu4x_FixedDecimalGroupingStrategy_destroy_mv1(FixedDecimalGroupingStrategy* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/example/cpp/include/FixedDecimalFormatterOptions.h
+++ b/example/cpp/include/FixedDecimalFormatterOptions.h
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 FixedDecimalFormatterOptions icu4x_FixedDecimalFormatterOptions_default_mv1();
-void icu4x_FixedDecimalFormatterOptions_destroy_mv1(FixedDecimalFormatterOptions* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/example/cpp/include/FixedDecimalGroupingStrategy.h
+++ b/example/cpp/include/FixedDecimalGroupingStrategy.h
@@ -24,7 +24,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void icu4x_FixedDecimalGroupingStrategy_destroy_mv1(FixedDecimalGroupingStrategy* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/AttrEnum.h
+++ b/feature_tests/c/include/AttrEnum.h
@@ -23,7 +23,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void namespace_AttrEnum_destroy(AttrEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/BorrowedFields.h
+++ b/feature_tests/c/include/BorrowedFields.h
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 BorrowedFields BorrowedFields_from_bar_and_strings(const Bar* bar, const char16_t* dstr16_data, size_t dstr16_len, const char* utf8_str_data, size_t utf8_str_len);
-void BorrowedFields_destroy(BorrowedFields* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/BorrowedFieldsReturning.h
+++ b/feature_tests/c/include/BorrowedFieldsReturning.h
@@ -21,7 +21,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void BorrowedFieldsReturning_destroy(BorrowedFieldsReturning* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/BorrowedFieldsWithBounds.h
+++ b/feature_tests/c/include/BorrowedFieldsWithBounds.h
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 BorrowedFieldsWithBounds BorrowedFieldsWithBounds_from_foo_and_strings(const Foo* foo, const char16_t* dstr16_x_data, size_t dstr16_x_len, const char* utf8_str_z_data, size_t utf8_str_z_len);
-void BorrowedFieldsWithBounds_destroy(BorrowedFieldsWithBounds* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/ContiguousEnum.h
+++ b/feature_tests/c/include/ContiguousEnum.h
@@ -24,7 +24,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void ContiguousEnum_destroy(ContiguousEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/ErrorEnum.h
+++ b/feature_tests/c/include/ErrorEnum.h
@@ -22,7 +22,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void ErrorEnum_destroy(ErrorEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/ErrorStruct.h
+++ b/feature_tests/c/include/ErrorStruct.h
@@ -22,7 +22,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void ErrorStruct_destroy(ErrorStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/ImportedStruct.h
+++ b/feature_tests/c/include/ImportedStruct.h
@@ -24,7 +24,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void ImportedStruct_destroy(ImportedStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/MyEnum.h
+++ b/feature_tests/c/include/MyEnum.h
@@ -29,7 +29,6 @@ extern "C" {
 int8_t MyEnum_into_value(MyEnum self);
 
 MyEnum MyEnum_get_a();
-void MyEnum_destroy(MyEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/MyStruct.h
+++ b/feature_tests/c/include/MyStruct.h
@@ -32,7 +32,6 @@ extern "C" {
 MyStruct MyStruct_new();
 
 uint8_t MyStruct_into_a(MyStruct self);
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/NestedBorrowedFields.h
+++ b/feature_tests/c/include/NestedBorrowedFields.h
@@ -30,7 +30,6 @@ extern "C" {
 #endif
 
 NestedBorrowedFields NestedBorrowedFields_from_bar_and_foo_and_strings(const Bar* bar, const Foo* foo, const char16_t* dstr16_x_data, size_t dstr16_x_len, const char16_t* dstr16_z_data, size_t dstr16_z_len, const char* utf8_str_y_data, size_t utf8_str_y_len, const char* utf8_str_z_data, size_t utf8_str_z_len);
-void NestedBorrowedFields_destroy(NestedBorrowedFields* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/OptionStruct.h
+++ b/feature_tests/c/include/OptionStruct.h
@@ -28,7 +28,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void OptionStruct_destroy(OptionStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/c/include/UnimportedEnum.h
+++ b/feature_tests/c/include/UnimportedEnum.h
@@ -23,7 +23,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void UnimportedEnum_destroy(UnimportedEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/AttrEnum.h
+++ b/feature_tests/cpp/include/AttrEnum.h
@@ -23,7 +23,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void namespace_AttrEnum_destroy(AttrEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/BorrowedFields.h
+++ b/feature_tests/cpp/include/BorrowedFields.h
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 BorrowedFields BorrowedFields_from_bar_and_strings(const Bar* bar, const char16_t* dstr16_data, size_t dstr16_len, const char* utf8_str_data, size_t utf8_str_len);
-void BorrowedFields_destroy(BorrowedFields* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/BorrowedFieldsReturning.h
+++ b/feature_tests/cpp/include/BorrowedFieldsReturning.h
@@ -21,7 +21,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void BorrowedFieldsReturning_destroy(BorrowedFieldsReturning* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/BorrowedFieldsWithBounds.h
+++ b/feature_tests/cpp/include/BorrowedFieldsWithBounds.h
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 BorrowedFieldsWithBounds BorrowedFieldsWithBounds_from_foo_and_strings(const Foo* foo, const char16_t* dstr16_x_data, size_t dstr16_x_len, const char* utf8_str_z_data, size_t utf8_str_z_len);
-void BorrowedFieldsWithBounds_destroy(BorrowedFieldsWithBounds* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/ContiguousEnum.h
+++ b/feature_tests/cpp/include/ContiguousEnum.h
@@ -24,7 +24,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void ContiguousEnum_destroy(ContiguousEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/ErrorEnum.h
+++ b/feature_tests/cpp/include/ErrorEnum.h
@@ -22,7 +22,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void ErrorEnum_destroy(ErrorEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/ErrorStruct.h
+++ b/feature_tests/cpp/include/ErrorStruct.h
@@ -22,7 +22,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void ErrorStruct_destroy(ErrorStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/ImportedStruct.h
+++ b/feature_tests/cpp/include/ImportedStruct.h
@@ -24,7 +24,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void ImportedStruct_destroy(ImportedStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/MyEnum.h
+++ b/feature_tests/cpp/include/MyEnum.h
@@ -29,7 +29,6 @@ extern "C" {
 int8_t MyEnum_into_value(MyEnum self);
 
 MyEnum MyEnum_get_a();
-void MyEnum_destroy(MyEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/MyStruct.h
+++ b/feature_tests/cpp/include/MyStruct.h
@@ -32,7 +32,6 @@ extern "C" {
 MyStruct MyStruct_new();
 
 uint8_t MyStruct_into_a(MyStruct self);
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/NestedBorrowedFields.h
+++ b/feature_tests/cpp/include/NestedBorrowedFields.h
@@ -30,7 +30,6 @@ extern "C" {
 #endif
 
 NestedBorrowedFields NestedBorrowedFields_from_bar_and_foo_and_strings(const Bar* bar, const Foo* foo, const char16_t* dstr16_x_data, size_t dstr16_x_len, const char16_t* dstr16_z_data, size_t dstr16_z_len, const char* utf8_str_y_data, size_t utf8_str_y_len, const char* utf8_str_z_data, size_t utf8_str_z_len);
-void NestedBorrowedFields_destroy(NestedBorrowedFields* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/OptionStruct.h
+++ b/feature_tests/cpp/include/OptionStruct.h
@@ -28,7 +28,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void OptionStruct_destroy(OptionStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/feature_tests/cpp/include/UnimportedEnum.h
+++ b/feature_tests/cpp/include/UnimportedEnum.h
@@ -23,7 +23,6 @@ namespace capi {
 extern "C" {
 #endif
 
-void UnimportedEnum_destroy(UnimportedEnum* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -452,28 +452,30 @@ fn gen_bridge(mut input: ItemMod) -> ItemMod {
             new_contents.push(gen_custom_type_method(custom_type, m));
         });
 
-        let destroy_ident = Ident::new(custom_type.dtor_name().as_str(), Span::call_site());
+        if let ast::CustomType::Opaque(opaque) = custom_type {
+            let destroy_ident = Ident::new(opaque.dtor_abi_name.as_str(), Span::call_site());
 
-        let type_ident = custom_type.name().to_syn();
+            let type_ident = custom_type.name().to_syn();
 
-        let (lifetime_defs, lifetimes) = if let Some(lifetime_env) = custom_type.lifetimes() {
-            (
-                quote! { <#lifetime_env> },
-                lifetime_env.lifetimes_to_tokens(),
-            )
-        } else {
-            (quote! {}, quote! {})
-        };
+            let (lifetime_defs, lifetimes) = if let Some(lifetime_env) = custom_type.lifetimes() {
+                (
+                    quote! { <#lifetime_env> },
+                    lifetime_env.lifetimes_to_tokens(),
+                )
+            } else {
+                (quote! {}, quote! {})
+            };
 
-        let cfg = cfgs_to_stream(&custom_type.attrs().cfg);
+            let cfg = cfgs_to_stream(&custom_type.attrs().cfg);
 
-        // for now, body is empty since all we need to do is drop the box
-        // TODO(#13): change to take a `*mut` and handle DST boxes appropriately
-        new_contents.push(Item::Fn(syn::parse_quote! {
-            #[no_mangle]
-            #cfg
-            extern "C" fn #destroy_ident#lifetime_defs(this: Box<#type_ident#lifetimes>) {}
-        }));
+            // for now, body is empty since all we need to do is drop the box
+            // TODO(#13): change to take a `*mut` and handle DST boxes appropriately
+            new_contents.push(Item::Fn(syn::parse_quote! {
+                #[no_mangle]
+                #cfg
+                extern "C" fn #destroy_ident#lifetime_defs(this: Box<#type_ident#lifetimes>) {}
+            }));
+        }
     }
 
     ItemMod {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -207,7 +207,7 @@ fn gen_params_invocation(param: &ast::Param, expanded_params: &mut Vec<Expr>) {
 fn gen_custom_type_method(strct: &ast::CustomType, m: &ast::Method) -> Item {
     let self_ident = Ident::new(strct.name().as_str(), Span::call_site());
     let method_ident = Ident::new(m.name.as_str(), Span::call_site());
-    let extern_ident = Ident::new(m.full_path_name.as_str(), Span::call_site());
+    let extern_ident = Ident::new(m.abi_name.as_str(), Span::call_site());
 
     let mut all_params = vec![];
     m.params.iter().for_each(|p| {

--- a/macro/src/snapshots/diplomat__tests__cfged_method-2.snap
+++ b/macro/src/snapshots/diplomat__tests__cfged_method-2.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} #[cfg(feature = \"bar\")] impl Foo\n                                {\n                                    #[cfg(feature = \"foo\")] pub fn bar(s : u8)\n                                    { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} #[cfg(feature = \"bar\")] impl Foo\n                                {\n                                    #[cfg(feature = \"foo\")] pub fn bar(s: u8)\n                                    { unimplemented!() }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -20,7 +20,4 @@ mod ffi {
     extern "C" fn Foo_bar(s: u8) {
         Foo::bar(s)
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__cfged_method.snap
+++ b/macro/src/snapshots/diplomat__tests__cfged_method.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    #[cfg(feature = \"foo\")] pub fn bar(s : u8)\n                                    { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    #[cfg(feature = \"foo\")] pub fn bar(s: u8)\n                                    { unimplemented!() }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -18,7 +18,4 @@ mod ffi {
     extern "C" fn Foo_bar(s: u8) {
         Foo::bar(s)
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__method_taking_mutable_slice.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_mutable_slice.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn fill_slice(s : & mut [f64]) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn fill_slice(s: &mut [f64]) { unimplemented!() } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -20,7 +20,4 @@ mod ffi {
             unsafe { core::slice::from_raw_parts_mut(s_diplomat_data, s_diplomat_len) }
         })
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__method_taking_owned_slice.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_owned_slice.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn fill_slice(s : Box < [u16] >) { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn fill_slice(s: Box<[u16]>) { unimplemented!() } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -25,7 +25,4 @@ mod ffi {
             }
         })
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__method_taking_owned_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_owned_str.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn something_with_str(s : Box < str >)\n                                    { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn something_with_str(s: Box<str>) { unimplemented!() }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -24,7 +24,4 @@ mod ffi {
             }
         })
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__method_taking_slice.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_slice.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn from_slice(s : & [f64]) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn from_slice(s: &[f64]) { unimplemented!() } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -20,7 +20,4 @@ mod ffi {
             unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) }
         })
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__method_taking_str.snap
+++ b/macro/src/snapshots/diplomat__tests__method_taking_str.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn from_str(s : & DiplomatStr) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn from_str(s: &DiplomatStr) { unimplemented!() } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -20,7 +20,4 @@ mod ffi {
             unsafe { core::slice::from_raw_parts(s_diplomat_data, s_diplomat_len) }
         })
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__mod_with_enum.snap
+++ b/macro/src/snapshots/diplomat__tests__mod_with_enum.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                enum Abc { A, B = 123, } impl Abc\n                                { pub fn do_something(& self) { unimplemented! () } }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                enum Abc { A, B = 123, } impl Abc\n                                { pub fn do_something(&self) { unimplemented!() } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -19,7 +19,4 @@ mod ffi {
     extern "C" fn Abc_do_something(this: &Abc) {
         this.do_something()
     }
-    #[no_mangle]
-    extern "C" fn Abc_destroy(this: Box<Abc>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__mod_with_rust_result.snap
+++ b/macro/src/snapshots/diplomat__tests__mod_with_rust_result.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                {\n                                    pub fn bar(& self) -> Result < (), () >\n                                    { unimplemented! () }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                struct Foo {} impl Foo\n                                { pub fn bar(&self) -> Result<(), ()> { unimplemented!() } }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -16,7 +16,4 @@ mod ffi {
     extern "C" fn Foo_bar(this: &Foo) -> diplomat_runtime::DiplomatResult<(), ()> {
         this.bar().into()
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }
-

--- a/macro/src/snapshots/diplomat__tests__mod_with_write_result.snap
+++ b/macro/src/snapshots/diplomat__tests__mod_with_write_result.snap
@@ -21,6 +21,4 @@ mod ffi {
         to.flush();
         ret.into()
     }
-    #[no_mangle]
-    extern "C" fn Foo_destroy(this: Box<Foo>) {}
 }

--- a/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
+++ b/macro/src/snapshots/diplomat__tests__multilevel_borrows.snap
@@ -1,6 +1,6 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                #[diplomat :: opaque] struct Foo < 'a > (& 'a str) ;\n                                #[diplomat :: opaque] struct Bar < 'b, 'a : 'b >\n                                (& 'b Foo < 'a >) ; struct Baz < 'x, 'y >\n                                { foo : & 'y Foo < 'x >, } impl < 'a > Foo < 'a >\n                                {\n                                    pub fn new(x : & 'a str) -> Box < Foo < 'a >>\n                                    { unimplemented! () } pub fn get_bar < 'b > (& 'b self) ->\n                                    Box < Bar < 'b, 'a >> { unimplemented! () } pub fn get_baz <\n                                    'b > (& 'b self) -> Baz < 'b, 'a > { Bax { foo : self } }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                #[diplomat::opaque] struct Foo<'a>(&'a str);\n                                #[diplomat::opaque] struct Bar<'b, 'a: 'b>(&'b Foo<'a>);\n                                struct Baz<'x, 'y> { foo: &'y Foo<'x>, } impl<'a> Foo<'a>\n                                {\n                                    pub fn new(x: &'a str) -> Box<Foo<'a>> { unimplemented!() }\n                                    pub fn get_bar<'b>(&'b self) -> Box<Bar<'b, 'a>>\n                                    { unimplemented!() } pub fn get_baz<'b>(&'b self) -> Baz<'b,\n                                    'a> { Bax { foo: self } }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     struct Foo<'a>(&'a str);
@@ -25,8 +25,6 @@ mod ffi {
     #[no_mangle]
     extern "C" fn Bar_destroy<'b, 'a: 'b>(this: Box<Bar<'b, 'a>>) {}
     #[no_mangle]
-    extern "C" fn Baz_destroy<'x: 'y, 'y>(this: Box<Baz<'x, 'y>>) {}
-    #[no_mangle]
     extern "C" fn Foo_new<'a>(x_diplomat_data: *const u8, x_diplomat_len: usize) -> Box<Foo<'a>> {
         Foo::new(if x_diplomat_len == 0 {
             Default::default()
@@ -50,4 +48,3 @@ mod ffi {
     #[no_mangle]
     extern "C" fn Foo_destroy<'a>(this: Box<Foo<'a>>) {}
 }
-

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -153,16 +153,18 @@ fn gen_struct_header(
         writeln!(out)?;
     }
 
-    write!(out, "void {}(", typ.dtor_name())?;
-    gen_type(
-        &ast::TypeName::Box(Box::new(ast::TypeName::Named(ast::PathType::new(
-            ast::Path::empty().sub_path(typ.name().clone()),
-        )))),
-        in_path,
-        env,
-        out,
-    )?;
-    writeln!(out, " self);")?;
+    if let ast::CustomType::Opaque(opaque) = typ {
+        write!(out, "void {}(", opaque.dtor_abi_name)?;
+        gen_type(
+            &ast::TypeName::Box(Box::new(ast::TypeName::Named(ast::PathType::new(
+                ast::Path::empty().sub_path(typ.name().clone()),
+            )))),
+            in_path,
+            env,
+            out,
+        )?;
+        writeln!(out, " self);")?;
+    }
 
     writeln!(out)?;
 

--- a/tool/src/c/snapshots/diplomat_tool__c__structs__tests__simple_non_opaque_struct@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__structs__tests__simple_non_opaque_struct@MyStruct.h.snap
@@ -31,11 +31,9 @@ MyStruct MyStruct_new(uint8_t a, uint8_t b);
 uint8_t MyStruct_get_a(const MyStruct* self);
 
 void MyStruct_set_b(MyStruct* self, uint8_t b);
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"
 } // namespace capi
 #endif
 #endif
-

--- a/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Bar.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Bar.h.snap
@@ -27,11 +27,9 @@ namespace capi {
 extern "C" {
 #endif
 
-void Bar_destroy(Bar* self);
 
 #ifdef __cplusplus
 } // extern "C"
 } // namespace capi
 #endif
 #endif
-

--- a/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Foo.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__tests__cross_module_struct_fields@Foo.h.snap
@@ -27,11 +27,9 @@ namespace capi {
 extern "C" {
 #endif
 
-void Foo_destroy(Foo* self);
 
 #ifdef __cplusplus
 } // extern "C"
 } // namespace capi
 #endif
 #endif
-

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__empty_result_types@MyStruct.h.snap
@@ -34,11 +34,9 @@ extern "C" {
 #endif
 
 MyStruct MyStruct_new();
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"
 } // namespace capi
 #endif
 #endif
-

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__option_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__option_types@MyStruct.h.snap
@@ -25,11 +25,9 @@ namespace capi {
 extern "C" {
 #endif
 
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"
 } // namespace capi
 #endif
 #endif
-

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__pointer_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__pointer_types@MyStruct.h.snap
@@ -28,11 +28,9 @@ extern "C" {
 #endif
 
 MyStruct MyStruct_new(const MyOpaqueStruct* foo, MyOpaqueStruct* bar);
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"
 } // namespace capi
 #endif
 #endif
-

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__result_types@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__result_types@MyStruct.h.snap
@@ -29,11 +29,9 @@ extern "C" {
 #endif
 
 diplomat_result_MyStruct_uint8_t MyStruct_new();
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"
 } // namespace capi
 #endif
 #endif
-

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__unit_type@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__unit_type@MyStruct.h.snap
@@ -25,11 +25,9 @@ extern "C" {
 #endif
 
 void MyStruct_something(const MyStruct* self);
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"
 } // namespace capi
 #endif
 #endif
-

--- a/tool/src/c/snapshots/diplomat_tool__c__types__tests__write_out@MyStruct.h.snap
+++ b/tool/src/c/snapshots/diplomat_tool__c__types__tests__write_out@MyStruct.h.snap
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 void MyStruct_write(const MyStruct* self, DiplomatWrite* to);
-void MyStruct_destroy(MyStruct* self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tool/src/c/structs.rs
+++ b/tool/src/c/structs.rs
@@ -68,7 +68,7 @@ pub fn gen_method<W: fmt::Write>(
         }
     }
 
-    write!(out, " {}(", method.full_path_name)?;
+    write!(out, " {}(", method.abi_name)?;
 
     let mut first = true;
     if let Some(self_param) = &method.self_param {

--- a/tool/src/c2/formatter.rs
+++ b/tool/src/c2/formatter.rs
@@ -109,26 +109,6 @@ impl<'tcx> CFormatter<'tcx> {
         ident.into()
     }
 
-    /// Format a method
-    pub fn fmt_method_name(&self, ty: TypeId, method: &hir::Method) -> String {
-        let ty_name = self.fmt_type_name_for_abi(ty);
-        let method_name = method.name.as_str();
-        let put_together = format!("{ty_name}_{method_name}");
-        method.attrs.abi_rename.apply(put_together.into()).into()
-    }
-
-    /// Resolve and format a type's destructor
-    pub fn fmt_dtor_name(&self, ty: TypeId) -> String {
-        let ty_name = self.fmt_type_name_for_abi(ty);
-        let dtor_name = format!("{ty_name}_destroy");
-        self.tcx
-            .resolve_type(ty)
-            .attrs()
-            .abi_rename
-            .apply(dtor_name.into())
-            .into()
-    }
-
     pub fn fmt_ptr<'a>(&self, ident: &'a str, mutability: hir::Mutability) -> Cow<'a, str> {
         // TODO: Where is the right place to put `const` here?
         if mutability.is_mutable() {

--- a/tool/src/c2/ty.rs
+++ b/tool/src/c2/ty.rs
@@ -183,7 +183,7 @@ impl<'cx, 'tcx> TyGenContext<'cx, 'tcx> {
                 continue;
             }
             let _guard = self.errors.set_context_method(
-                self.formatter.fmt_type_name_diagnostics(self.id),
+                self.tcx.fmt_type_name_diagnostics(self.id),
                 method.name.as_str().into(),
             );
             methods.push(self.gen_method(method, &mut impl_header));

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -305,7 +305,7 @@ fn gen_method<W: fmt::Write>(
                 writeln!(
                     &mut method_body,
                     "capi::{}({});",
-                    method.full_path_name,
+                    method.abi_name,
                     all_params_invocation.join(", ")
                 )?;
 
@@ -318,7 +318,7 @@ fn gen_method<W: fmt::Write>(
                 let out_expr = gen_rust_to_cpp(
                     &format!(
                         "capi::{}({})",
-                        method.full_path_name,
+                        method.abi_name,
                         all_params_invocation.join(", ")
                     ),
                     "out_value",

--- a/tool/src/cpp/structs.rs
+++ b/tool/src/cpp/structs.rs
@@ -40,7 +40,7 @@ pub fn gen_struct<W: fmt::Write>(
                 writeln!(
                     &mut deleter_operator_body,
                     "capi::{}(l);",
-                    custom_type.dtor_name()
+                    opaque.dtor_abi_name
                 )?;
                 writeln!(&mut deleter_body, "}}")?;
                 writeln!(out, "}};")?;

--- a/tool/src/cpp2/formatter.rs
+++ b/tool/src/cpp2/formatter.rs
@@ -47,12 +47,6 @@ impl<'tcx> Cpp2Formatter<'tcx> {
         }
     }
 
-    /// Resolve and format a named type for use in diagnostics
-    /// (don't apply rename rules and such)
-    pub fn fmt_type_name_diagnostics(&self, id: TypeId) -> Cow<'tcx, str> {
-        self.c.fmt_type_name_diagnostics(id)
-    }
-
     /// Resolve and format the name of a type for use in header names
     pub fn fmt_decl_header_path(&self, id: TypeId) -> String {
         let type_name = self.fmt_type_name_unnamespaced(id);

--- a/tool/src/cpp2/formatter.rs
+++ b/tool/src/cpp2/formatter.rs
@@ -162,7 +162,7 @@ impl<'tcx> Cpp2Formatter<'tcx> {
         }
     }
 
-    fn namespace_c_method_name(&self, ty: TypeId, name: &str) -> String {
+    pub fn namespace_c_method_name(&self, ty: TypeId, name: &str) -> String {
         let resolved = self.c.tcx().resolve_type(ty);
         if let Some(ref ns) = resolved.attrs().namespace {
             format!("{ns}::{CAPI_NAMESPACE}::{name}")
@@ -171,12 +171,6 @@ impl<'tcx> Cpp2Formatter<'tcx> {
         }
     }
 
-    pub fn fmt_c_method_name(&self, ty: TypeId, method: &hir::Method) -> String {
-        self.namespace_c_method_name(ty, &self.c.fmt_method_name(ty, method))
-    }
-    pub fn fmt_c_dtor_name(&self, ty: TypeId) -> String {
-        self.namespace_c_method_name(ty, &self.c.fmt_dtor_name(ty))
-    }
     /// Get the primitive type as a C type
     pub fn fmt_primitive_as_c(&self, prim: hir::PrimitiveType) -> Cow<'static, str> {
         self.c.fmt_primitive_as_c(prim)

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -266,7 +266,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             fmt: &self.cx.formatter,
             type_name: &type_name,
             ctype: &ctype,
-            dtor_name: dtor_name,
+            dtor_name,
             methods: methods.as_slice(),
             namespace: ty.attrs.namespace.as_deref(),
             c_header: c_impl_header,
@@ -379,7 +379,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             return None;
         }
         let _guard = self.cx.errors.set_context_method(
-            self.cx.formatter.fmt_type_name_diagnostics(id),
+            self.cx.tcx.fmt_type_name_diagnostics(id),
             method.name.as_str().into(),
         );
         let method_name = self.cx.formatter.fmt_method_name(method);
@@ -453,7 +453,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             method,
             return_ty,
             method_name,
-            abi_name: abi_name,
+            abi_name,
             pre_qualifiers,
             post_qualifiers,
             param_decls,

--- a/tool/src/cpp2/ty.rs
+++ b/tool/src/cpp2/ty.rs
@@ -106,7 +106,7 @@ struct MethodInfo<'a> {
     /// The C++ method name
     method_name: Cow<'a, str>,
     /// The C method name
-    c_method_name: Cow<'a, str>,
+    abi_name: String,
     /// Qualifiers for the function that come before the declaration (like "static")
     pre_qualifiers: Vec<Cow<'a, str>>,
     /// Qualifiers for the function that come after the declaration (like "const")
@@ -208,7 +208,11 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
         let type_name = self.cx.formatter.fmt_type_name(id);
         let type_name_unnamespaced = self.cx.formatter.fmt_type_name_unnamespaced(id);
         let ctype = self.cx.formatter.fmt_c_type_name(id);
-        let dtor_name = self.cx.formatter.fmt_c_dtor_name(id);
+        let dtor_name = self
+            .cx
+            .formatter
+            .namespace_c_method_name(id, ty.dtor_abi_name.as_str());
+
         let c_header = self.c.gen_opaque_def(ty);
         let c_impl_header = self.c.gen_impl(ty.into());
 
@@ -251,7 +255,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             fmt: &'a Cpp2Formatter<'a>,
             type_name: &'a str,
             ctype: &'a str,
-            dtor_name: &'a str,
+            dtor_name: String,
             methods: &'a [MethodInfo<'a>],
             namespace: Option<&'a str>,
             c_header: C2Header,
@@ -262,7 +266,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             fmt: &self.cx.formatter,
             type_name: &type_name,
             ctype: &ctype,
-            dtor_name: &dtor_name,
+            dtor_name: dtor_name,
             methods: methods.as_slice(),
             namespace: ty.attrs.namespace.as_deref(),
             c_header: c_impl_header,
@@ -379,7 +383,10 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             method.name.as_str().into(),
         );
         let method_name = self.cx.formatter.fmt_method_name(method);
-        let c_method_name = self.cx.formatter.fmt_c_method_name(id, method).into();
+        let abi_name = self
+            .cx
+            .formatter
+            .namespace_c_method_name(id, method.abi_name.as_str());
         let mut param_decls = Vec::new();
         let mut cpp_to_c_params = Vec::new();
 
@@ -446,7 +453,7 @@ impl<'ccx, 'tcx: 'ccx, 'header> TyGenContext<'ccx, 'tcx, 'header> {
             method,
             return_ty,
             method_name,
-            c_method_name,
+            abi_name: abi_name,
             pre_qualifiers,
             post_qualifiers,
             param_decls,

--- a/tool/src/dart/formatter.rs
+++ b/tool/src/dart/formatter.rs
@@ -1,6 +1,5 @@
 //! This module contains functions for formatting types
 
-use crate::c2::CFormatter;
 use diplomat_core::ast::{DocsUrlGenerator, MarkdownStyle};
 use diplomat_core::hir::{self, TypeContext, TypeId};
 use heck::ToLowerCamelCase;
@@ -16,7 +15,7 @@ use std::borrow::Cow;
 /// This type may be used by other backends attempting to figure out the names
 /// of C types and methods.
 pub(super) struct DartFormatter<'tcx> {
-    c: CFormatter<'tcx>,
+    tcx: &'tcx TypeContext,
     docs_url_generator: &'tcx DocsUrlGenerator,
 }
 
@@ -27,7 +26,7 @@ const DISALLOWED_CORE_TYPES: &[&str] = &["Object", "String"];
 impl<'tcx> DartFormatter<'tcx> {
     pub fn new(tcx: &'tcx TypeContext, docs_url_generator: &'tcx DocsUrlGenerator) -> Self {
         Self {
-            c: CFormatter::new(tcx, false),
+            tcx,
             docs_url_generator,
         }
     }
@@ -70,7 +69,7 @@ impl<'tcx> DartFormatter<'tcx> {
 
     /// Resolve and format a named type for use in code
     pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
-        let resolved = self.c.tcx().resolve_type(id);
+        let resolved = self.tcx.resolve_type(id);
 
         let candidate = resolved.name().as_str();
 

--- a/tool/src/dart/formatter.rs
+++ b/tool/src/dart/formatter.rs
@@ -81,12 +81,6 @@ impl<'tcx> DartFormatter<'tcx> {
         resolved.attrs().rename.apply(candidate.into())
     }
 
-    /// Resolve and format a named type for use in diagnostics
-    /// (don't apply rename rules and such)
-    pub fn fmt_type_name_diagnostics(&self, id: TypeId) -> Cow<'tcx, str> {
-        self.c.fmt_type_name_diagnostics(id)
-    }
-
     /// Format an enum variant.
     pub fn fmt_enum_variant(&self, variant: &'tcx hir::EnumVariant) -> Cow<'tcx, str> {
         let name = variant.name.as_str().to_lower_camel_case().into();

--- a/tool/src/dart/formatter.rs
+++ b/tool/src/dart/formatter.rs
@@ -68,10 +68,6 @@ impl<'tcx> DartFormatter<'tcx> {
             .replace(" \n", "\n")
     }
 
-    pub fn fmt_destructor_name(&self, id: TypeId) -> String {
-        self.c.fmt_dtor_name(id)
-    }
-
     /// Resolve and format a named type for use in code
     pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
         let resolved = self.c.tcx().resolve_type(id);
@@ -148,10 +144,6 @@ impl<'tcx> DartFormatter<'tcx> {
         } else {
             name
         }
-    }
-
-    pub fn fmt_c_method_name<'a>(&self, ty: TypeId, method: &'a hir::Method) -> Cow<'a, str> {
-        self.c.fmt_method_name(ty, method).into()
     }
 
     pub fn fmt_string(&self) -> &'static str {

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -389,7 +389,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
         let mut visitor = method.borrowing_param_visitor(self.tcx);
 
         let _guard = self.errors.set_context_method(
-            self.formatter.fmt_type_name_diagnostics(id),
+            self.tcx.fmt_type_name_diagnostics(id),
             method.name.as_str().into(),
         );
 

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -183,7 +183,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             .flat_map(|method| self.gen_method_info(id, method, type_name))
             .collect::<Vec<_>>();
 
-        let destructor = self.formatter.fmt_destructor_name(id);
+        let destructor = &ty.dtor_abi_name;
         let special = self.gen_special_method_info(&ty.special_method_presence);
 
         #[derive(Template)]
@@ -192,7 +192,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             type_name: &'a str,
             methods: &'a [MethodInfo<'a>],
             docs: String,
-            destructor: String,
+            destructor: &'a str,
             lifetimes: &'a LifetimeEnv,
             special: SpecialMethodGenInfo<'a>,
         }
@@ -200,7 +200,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
         ImplTemplate {
             type_name,
             methods: methods.as_slice(),
-            destructor,
+            destructor: destructor.as_str(),
             docs: self.formatter.fmt_docs(&ty.docs),
             lifetimes: &ty.lifetimes,
             special,
@@ -393,7 +393,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             method.name.as_str().into(),
         );
 
-        let c_method_name = self.formatter.fmt_c_method_name(id, method);
+        let abi_name = method.abi_name.as_str();
 
         let mut param_decls_dart = Vec::new();
         let mut param_types_ffi = Vec::new();
@@ -563,7 +563,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
             method,
             docs,
             declaration,
-            c_method_name,
+            abi_name,
             param_types_ffi,
             param_types_ffi_cast,
             param_names_ffi,
@@ -1215,8 +1215,8 @@ struct MethodInfo<'a> {
     docs: String,
     /// The declaration (everything before the parameter list)
     declaration: String,
-    /// The C method name
-    c_method_name: Cow<'a, str>,
+    /// The ABI name of the method
+    abi_name: &'a str,
 
     // The types for the FFI declaration. The uncast types are the types
     // from the `dart:ffi` package, the cast types are native Dart types.

--- a/tool/src/dotnet/raw.rs
+++ b/tool/src/dotnet/raw.rs
@@ -129,7 +129,7 @@ pub fn gen<'ast>(
                 writeln!(
                     out,
                     r#"[DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "{}", ExactSpelling = true)]"#,
-                    typ.dtor_name()
+                    opaque.dtor_abi_name
                 )?;
                 writeln!(out, "public static unsafe extern void Destroy({}* self);", typ.name())
             })

--- a/tool/src/dotnet/raw.rs
+++ b/tool/src/dotnet/raw.rs
@@ -208,7 +208,7 @@ fn gen_method(
         out,
         " {}(",
         method
-            .full_path_name
+            .abi_name
             .as_str()
             .replace(&format!("{}_", typ.name()), "")
             .to_upper_camel_case()
@@ -320,7 +320,7 @@ fn gen_annotations_for_method(method: &ast::Method, out: &mut dyn fmt::Write) ->
     writeln!(
         out,
         r#"[DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "{}", ExactSpelling = true)]"#,
-        method.full_path_name
+        method.abi_name
     )?;
     match &method.return_type {
         Some(ast::TypeName::Primitive(ast::PrimitiveType::bool)) => {

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -240,7 +240,7 @@ type Offset = Option<NonZeroUsize>;
 /// An [`fmt::Display`] type representing an invocation of a WASM function.
 pub struct Invocation {
     /// Name of the method in the WASM namespace.
-    full_path_name: ast::Ident,
+    abi_name: ast::Ident,
 
     /// Arguments to invoke the function with.
     args: Vec<String>, // FIXME: use `Vec<Argument>`
@@ -248,16 +248,16 @@ pub struct Invocation {
 
 impl Invocation {
     /// Create a new [`Invocation`].
-    pub fn new(full_path_name: ast::Ident, args: Vec<String>) -> Self {
+    pub fn new(abi_name: ast::Ident, args: Vec<String>) -> Self {
         Invocation {
-            full_path_name,
+            abi_name,
             args,
         }
     }
 
     /// Invoke the function without passing in a return buffer.
     pub fn scalar(&self) -> impl fmt::Display + '_ {
-        display::expr(move |f| write!(f, "wasm.{}({})", self.full_path_name, Csv(&self.args[..])))
+        display::expr(move |f| write!(f, "wasm.{}({})", self.abi_name, Csv(&self.args[..])))
     }
 
     /// Invoke the function with a provided return buffer.
@@ -269,7 +269,7 @@ impl Invocation {
             write!(
                 f,
                 "wasm.{}({})",
-                self.full_path_name,
+                self.abi_name,
                 display::expr(|f| {
                     write!(f, "{buf}")?;
                     for param in &self.args {

--- a/tool/src/js/conversions.rs
+++ b/tool/src/js/conversions.rs
@@ -249,10 +249,7 @@ pub struct Invocation {
 impl Invocation {
     /// Create a new [`Invocation`].
     pub fn new(abi_name: ast::Ident, args: Vec<String>) -> Self {
-        Invocation {
-            abi_name,
-            args,
-        }
+        Invocation { abi_name, args }
     }
 
     /// Invoke the function without passing in a return buffer.

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -326,7 +326,7 @@ fn gen_method<W: fmt::Write>(
             let diplomat_out = display::expr(|f| {
                 let display_return_type = display::expr(|f| {
                     let invocation =
-                        Invocation::new(method.full_path_name.clone(), all_param_exprs.clone());
+                        Invocation::new(method.abi_name.clone(), all_param_exprs.clone());
 
                     if let Some(ref typ) = method.return_type {
                         let mut borrows: Vec<Argument> = entries

--- a/tool/src/js/structs.rs
+++ b/tool/src/js/structs.rs
@@ -145,7 +145,7 @@ pub fn gen_struct<W: fmt::Write>(
                 "const {}_box_destroy_registry = new FinalizationRegistry(underlying => {});",
                 opaque.name,
                 display::block(|mut f| {
-                    writeln!(f, "wasm.{}(underlying);", custom_type.dtor_name())
+                    writeln!(f, "wasm.{}(underlying);", opaque.dtor_abi_name)
                 })
             )?;
             writeln!(out)?;

--- a/tool/src/js2/formatter.rs
+++ b/tool/src/js2/formatter.rs
@@ -74,10 +74,6 @@ impl<'tcx> JSFormatter<'tcx> {
             .apply(type_def.name().as_str().into())
     }
 
-    pub fn fmt_type_name_diagnostics(&self, type_id: TypeId) -> Cow<'tcx, str> {
-        self.c_formatter.fmt_type_name_diagnostics(type_id)
-    }
-
     pub fn fmt_file_name_extensionless(&self, type_name: &str) -> String {
         type_name.to_string()
     }

--- a/tool/src/js2/formatter.rs
+++ b/tool/src/js2/formatter.rs
@@ -6,8 +6,6 @@ use diplomat_core::{
 };
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 
-use crate::c2::CFormatter;
-
 use super::FileType;
 
 const RESERVED: &[&str] = &[
@@ -51,7 +49,7 @@ const RESERVED: &[&str] = &[
 /// Helper class for us to format JS identifiers from the HIR.
 pub(super) struct JSFormatter<'tcx> {
     /// Per [`CFormatter`]'s documentation we use it for support.
-    c_formatter: CFormatter<'tcx>,
+    tcx: &'tcx TypeContext,
 
     /// For generating doc.rs links
     docs_url_gen: &'tcx DocsUrlGenerator,
@@ -59,14 +57,11 @@ pub(super) struct JSFormatter<'tcx> {
 
 impl<'tcx> JSFormatter<'tcx> {
     pub fn new(tcx: &'tcx TypeContext, docs_url_gen: &'tcx DocsUrlGenerator) -> Self {
-        Self {
-            c_formatter: CFormatter::new(tcx, false),
-            docs_url_gen,
-        }
+        Self { tcx, docs_url_gen }
     }
 
     pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
-        let type_def = self.c_formatter.tcx().resolve_type(id);
+        let type_def = self.tcx.resolve_type(id);
 
         type_def
             .attrs()

--- a/tool/src/js2/formatter.rs
+++ b/tool/src/js2/formatter.rs
@@ -283,10 +283,6 @@ impl<'tcx> JSFormatter<'tcx> {
         }
     }
 
-    pub fn fmt_c_method_name<'a>(&self, type_id: TypeId, method: &'a hir::Method) -> Cow<'a, str> {
-        self.c_formatter.fmt_method_name(type_id, method).into()
-    }
-
     pub fn fmt_param_name<'a>(&self, param_name: &'a str) -> Cow<'a, str> {
         param_name.to_lower_camel_case().into()
     }
@@ -304,8 +300,5 @@ impl<'tcx> JSFormatter<'tcx> {
         variant.attrs.rename.apply(name)
     }
 
-    pub fn fmt_destructor_name(&self, type_id: TypeId) -> String {
-        self.c_formatter.fmt_dtor_name(type_id)
-    }
     // #endregion
 }

--- a/tool/src/js2/type_generation/mod.rs
+++ b/tool/src/js2/type_generation/mod.rs
@@ -100,7 +100,7 @@ impl<'jsctx, 'tcx> TypeGenerationContext<'jsctx, 'tcx> {
             self.generate_special_method_body(&opaque_def.special_method_presence, self.typescript);
         methods.push(special_method_body);
 
-        let destructor = self.js_ctx.formatter.fmt_destructor_name(type_id);
+        let destructor = opaque_def.dtor_abi_name.as_str();
 
         #[derive(Template)]
         #[template(path = "js2/opaque.js.jinja", escape = "none")]
@@ -110,7 +110,7 @@ impl<'jsctx, 'tcx> TypeGenerationContext<'jsctx, 'tcx> {
 
             lifetimes: &'a LifetimeEnv,
             methods: Vec<String>,
-            destructor: String,
+            destructor: &'a str,
 
             docs: String,
         }
@@ -264,8 +264,10 @@ impl<'jsctx, 'tcx> TypeGenerationContext<'jsctx, 'tcx> {
             method.name.as_str().into(),
         );
 
+        let abi_name = method.abi_name.as_str();
+
         let mut method_info = MethodInfo {
-            c_method_name: self.js_ctx.formatter.fmt_c_method_name(type_id, method),
+            abi_name,
             typescript,
             method: Some(method),
             needs_slice_cleanup: false,
@@ -442,7 +444,7 @@ struct MethodInfo<'info> {
     method: Option<&'info Method>,
     method_decl: String,
     /// Native C method name
-    c_method_name: Cow<'info, str>,
+    abi_name: &'info str,
 
     needs_slice_cleanup: bool,
 

--- a/tool/src/js2/type_generation/mod.rs
+++ b/tool/src/js2/type_generation/mod.rs
@@ -260,7 +260,7 @@ impl<'jsctx, 'tcx> TypeGenerationContext<'jsctx, 'tcx> {
         let mut visitor = method.borrowing_param_visitor(self.js_ctx.tcx);
 
         let _guard = self.js_ctx.errors.set_context_method(
-            self.js_ctx.formatter.fmt_type_name_diagnostics(type_id),
+            self.js_ctx.tcx.fmt_type_name_diagnostics(type_id),
             method.name.as_str().into(),
         );
 

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -58,10 +58,6 @@ impl<'tcx> KotlinFormatter<'tcx> {
         "Array<String>"
     }
 
-    pub fn fmt_c_method_name<'a>(&self, ty: TypeId, method: &'a hir::Method) -> Cow<'a, str> {
-        self.c.fmt_method_name(ty, method).into()
-    }
-
     pub fn fmt_primitive_as_ffi(&self, prim: PrimitiveType) -> &'static str {
         match prim {
             PrimitiveType::Bool => "Byte",

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -1,4 +1,3 @@
-use crate::c2::CFormatter;
 use diplomat_core::hir::{
     self,
     borrowing_param::{LifetimeEdge, LifetimeEdgeKind},
@@ -11,7 +10,6 @@ use std::{borrow::Cow, iter::once};
 /// This type mediates all formatting
 pub(super) struct KotlinFormatter<'tcx> {
     tcx: &'tcx TypeContext,
-    c: CFormatter<'tcx>,
     strip_prefix: Option<String>,
 }
 
@@ -22,11 +20,7 @@ const DISALLOWED_CORE_TYPES: &[&str] = &["Object", "String"];
 
 impl<'tcx> KotlinFormatter<'tcx> {
     pub fn new(tcx: &'tcx TypeContext, strip_prefix: Option<String>) -> Self {
-        Self {
-            tcx,
-            c: CFormatter::new(tcx, false),
-            strip_prefix,
-        }
+        Self { tcx, strip_prefix }
     }
 
     pub fn fmt_void(&self) -> &'static str {
@@ -333,7 +327,7 @@ impl<'tcx> KotlinFormatter<'tcx> {
     }
 
     pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
-        let resolved = self.c.tcx().resolve_type(id);
+        let resolved = self.tcx.resolve_type(id);
 
         let candidate: Cow<str> = if let Some(strip_prefix) = self.strip_prefix.as_ref() {
             resolved

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1510,7 +1510,7 @@ mod test {
 
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (type_id, TypeDef::Enum(enum_def)) = all_types
+        if let (_id, TypeDef::Enum(enum_def)) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {
@@ -1526,7 +1526,7 @@ mod test {
             let type_name = enum_def.name.to_string();
             // test that we can render and that it doesn't panic
             let (_, enum_code) =
-                ty_gen_cx.gen_enum_def(enum_def, type_id, &type_name, "dev.gigapixel", "somelib");
+                ty_gen_cx.gen_enum_def(enum_def, &type_name, "dev.gigapixel", "somelib");
             insta::assert_snapshot!(enum_code)
         }
     }
@@ -1574,7 +1574,7 @@ mod test {
 
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (type_id, TypeDef::Struct(strct)) = all_types
+        if let (_id, TypeDef::Struct(strct)) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {
@@ -1590,7 +1590,7 @@ mod test {
             let type_name = strct.name.to_string();
             // test that we can render and that it doesn't panic
             let (_, struct_code) =
-                ty_gen_cx.gen_struct_def(strct, type_id, &type_name, "dev.gigapixel", "somelib");
+                ty_gen_cx.gen_struct_def(strct, &type_name, "dev.gigapixel", "somelib");
             insta::assert_snapshot!(struct_code)
         }
     }
@@ -1679,7 +1679,7 @@ mod test {
         };
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (type_id, TypeDef::Opaque(opaque_def)) = all_types
+        if let (_id, TypeDef::Opaque(opaque_def)) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {

--- a/tool/templates/c2/impl.h.jinja
+++ b/tool/templates/c2/impl.h.jinja
@@ -2,7 +2,7 @@
 extern "C" {
 {%- endif %}
 {% for method in methods %}
-{{ method.return_ty }} {{ method.name }}({{ method.params }});
+{{ method.return_ty }} {{ method.abi_name }}({{ method.params }});
 {% endfor %}
 {%~ match dtor_name %}
 {% when Some with (dtor_name) ~%}

--- a/tool/templates/cpp2/method_impl.h.jinja
+++ b/tool/templates/cpp2/method_impl.h.jinja
@@ -19,7 +19,7 @@ inline {##}
 	{% if !m.method.output.is_ffi_unit() -%}
 	auto result = {##}
 	{%- endif -%}
-	{{ m.c_method_name }}(
+	{{ m.abi_name }}(
 		{%- for param in m.cpp_to_c_params %}
 		{%- if !loop.first %},
 		{% endif -%}

--- a/tool/templates/dart/method.dart.jinja
+++ b/tool/templates/dart/method.dart.jinja
@@ -33,7 +33,7 @@
     {%- if !m.method.output.is_ffi_unit() %}
     final result = {% else %}
     {% endif -%}
-    _{{ m.c_method_name -}}(
+    _{{ m.abi_name -}}(
         {%- for param in m.param_conversions %}
         {%- if loop.first %}{% else %}, {% endif -%}
         {{ param }}

--- a/tool/templates/dart/native_method.dart.jinja
+++ b/tool/templates/dart/native_method.dart.jinja
@@ -1,10 +1,10 @@
-@meta.ResourceIdentifier('{{ m.c_method_name }}')
+@meta.ResourceIdentifier('{{ m.abi_name }}')
 @ffi.Native<{{ m.return_type_ffi }} Function({%- for param in m.param_types_ffi %}
       {%- if !loop.first %}, {% endif -%}
       {{ param }}
-  {%- endfor -%})>(isLeaf: true, symbol: '{{ m.c_method_name }}')
+  {%- endfor -%})>(isLeaf: true, symbol: '{{ m.abi_name }}')
 // ignore: non_constant_identifier_names
-external {{ m.return_type_ffi_cast }} _{{ m.c_method_name }}({%- for (param, name) in m.param_types_ffi_cast.iter().zip(m.param_names_ffi.iter()) %}
+external {{ m.return_type_ffi_cast }} _{{ m.abi_name }}({%- for (param, name) in m.param_types_ffi_cast.iter().zip(m.param_names_ffi.iter()) %}
         {%- if !loop.first %}, {% endif -%}
         {{ param }} {{ name }}
       {%- endfor -%});

--- a/tool/templates/js2/method.js.jinja
+++ b/tool/templates/js2/method.js.jinja
@@ -36,7 +36,7 @@
     {%- endfor -%}
 
 
-    {%~ if !method.output.is_ffi_unit() %}const result = {% endif %}wasm.{{ c_method_name }}(
+    {%~ if !method.output.is_ffi_unit() %}const result = {% endif %}wasm.{{ abi_name }}(
         {%- for param in param_conversions -%}
         {%- if !loop.first %}, {% endif -%}
         {{ param }}


### PR DESCRIPTION
CFormatter is mostly only used to get abi names. These are unaffected by backend attributes or other backend-specific things, and should not be obtained via a backend-specific formatter, they should be obtained via the HIR directly.



This should make changes like #546 less entangled, too. Unfortunately this conflicts with that PR, but it's not too big.

Now the only code that should need to invoke CFormatter is code that actually needs C-like code (e.g. the C++ backend)


cc @robertbastian