### PR TITLE
Add DiplomatOption<T>

### DIFF
--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -173,7 +173,7 @@ impl LifetimeEnv {
                 };
                 self.extend_implicit_lifetime_bounds(typ, behind_ref);
             }
-            TypeName::Option(typ) => self.extend_implicit_lifetime_bounds(typ, None),
+            TypeName::Option(typ, _) => self.extend_implicit_lifetime_bounds(typ, None),
             TypeName::Result(ok, err, _) => {
                 self.extend_implicit_lifetime_bounds(ok, None);
                 self.extend_implicit_lifetime_bounds(err, None);

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -197,7 +197,7 @@ impl Method {
             .as_ref()
             .map(|return_type| match return_type {
                 TypeName::Unit => true,
-                TypeName::Result(ok, _, _) | TypeName::Option(ok) => {
+                TypeName::Result(ok, _, _) | TypeName::Option(ok, _) => {
                     matches!(ok.as_ref(), TypeName::Unit)
                 }
 

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-4.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-4.snap
@@ -1,12 +1,12 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from_syn(&syn::parse_quote! { Option < Ref < 'object >> }, None)"
+expression: "TypeName::from_syn(&syn::parse_quote! { Option<Ref<'object>> }, None)"
 ---
 Option:
-  Named:
-    path:
-      elements:
-        - Ref
-    lifetimes:
-      - Named: object
-
+  - Named:
+      path:
+        elements:
+          - Ref
+      lifetimes:
+        - Named: object
+  - Stdlib

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option-2.snap
@@ -1,11 +1,11 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from_syn(&syn::parse_quote! { Option < MyLocalStruct > }, None)"
+expression: "TypeName::from_syn(&syn::parse_quote! { Option<MyLocalStruct> }, None)"
 ---
 Option:
-  Named:
-    path:
-      elements:
-        - MyLocalStruct
-    lifetimes: []
-
+  - Named:
+      path:
+        elements:
+          - MyLocalStruct
+      lifetimes: []
+  - Stdlib

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__typename_option.snap
@@ -1,7 +1,7 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from_syn(&syn::parse_quote! { Option < i32 > }, None)"
+expression: "TypeName::from_syn(&syn::parse_quote! { Option<i32> }, None)"
 ---
 Option:
-  Primitive: i32
-
+  - Primitive: i32
+  - Stdlib

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -521,6 +521,14 @@ impl TypeName {
                 TypeName::PrimitiveSlice(ltmt.clone(), *prim, StdlibOrDiplomat::Diplomat)
             }
             TypeName::Ordering => TypeName::Primitive(PrimitiveType::i8),
+            TypeName::Option(inner, _stdlib) => match **inner {
+                // Option<&T>/Option<Box<T>> are the ffi-safe way to specify options
+                TypeName::Reference(..) | TypeName::Box(..) => {
+                    TypeName::Option(inner.clone(), StdlibOrDiplomat::Stdlib)
+                }
+                // For other types (primitives, structs, enums) we need DiplomatOption
+                _ => TypeName::Option(inner.clone(), StdlibOrDiplomat::Diplomat),
+            },
             _ => self.clone(),
         }
     }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -479,6 +479,9 @@ fn get_ty_from_syn_path(p: &syn::TypePath) -> Option<&syn::Type> {
 
 impl TypeName {
     /// Is this type safe to be passed across the FFI boundary?
+    ///
+    /// This also marks DiplomatOption<&T> as FFI-unsafe: these are technically safe from an ABI standpoint
+    /// however Diplomat always expects these to be equivalent to a nullable pointer, so Option<&T> is required.
     pub fn is_ffi_safe(&self) -> bool {
         match self {
             TypeName::Primitive(..) | TypeName::Named(_) | TypeName::SelfType(_) | TypeName::Reference(..) |
@@ -503,6 +506,9 @@ impl TypeName {
     }
 
     /// What's the FFI safe version of this type?
+    ///
+    /// This also marks DiplomatOption<&T> as FFI-unsafe: these are technically safe from an ABI standpoint
+    /// however Diplomat always expects these to be equivalent to a nullable pointer, so Option<&T> is required.
     pub fn ffi_safe_version(&self) -> TypeName {
         match self {
             TypeName::StrReference(lt, encoding, StdlibOrDiplomat::Stdlib) => {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -484,19 +484,19 @@ impl TypeName {
             TypeName::Primitive(..) | TypeName::Named(_) | TypeName::SelfType(_) | TypeName::Reference(..) |
             TypeName::Box(..) |
             // can only be passed across the FFI boundary; callbacks are input-only
-            TypeName::Function(..)
+            TypeName::Function(..) |
             // These are specified using FFI-safe diplomat_runtime types
-            | TypeName::StrReference(.., StdlibOrDiplomat::Diplomat) | TypeName::StrSlice(.., StdlibOrDiplomat::Diplomat) |TypeName::PrimitiveSlice(.., StdlibOrDiplomat::Diplomat) => true,
+            TypeName::StrReference(.., StdlibOrDiplomat::Diplomat) | TypeName::StrSlice(.., StdlibOrDiplomat::Diplomat) |TypeName::PrimitiveSlice(.., StdlibOrDiplomat::Diplomat) => true,
             // These are special anyway and shouldn't show up in structs
-            TypeName::Unit | TypeName::Write | TypeName::Result(..)
+            TypeName::Unit | TypeName::Write | TypeName::Result(..) |
             // This is basically only useful in return types
-            | TypeName::Ordering
+            TypeName::Ordering |
             // These are specified using Rust stdlib types and not safe across FFI
-            | TypeName::StrReference(.., StdlibOrDiplomat::Stdlib) | TypeName::StrSlice(.., StdlibOrDiplomat::Stdlib) | TypeName::PrimitiveSlice(.., StdlibOrDiplomat::Stdlib)  => false,
-             TypeName::Option(inner, stdlib) => match **inner {
+            TypeName::StrReference(.., StdlibOrDiplomat::Stdlib) | TypeName::StrSlice(.., StdlibOrDiplomat::Stdlib) | TypeName::PrimitiveSlice(.., StdlibOrDiplomat::Stdlib)  => false,
+            TypeName::Option(inner, stdlib) => match **inner {
                 // Option<&T>/Option<Box<T>> are the ffi-safe way to specify options
                 TypeName::Reference(..) | TypeName::Box(..) => *stdlib == StdlibOrDiplomat::Stdlib,
-                // For other types (primitives, structs, enums) you should use DiplomatOption
+                // For other types (primitives, structs, enums) we need DiplomatOption
                 _ => *stdlib == StdlibOrDiplomat::Diplomat,
              }
         }

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__unsupported_features.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__unsupported_features.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/hir/attrs.rs
+expression: output
+---
+Lowering error in OutStruct: Options of structs/enums/primitives not supported by this backend
+Lowering error in Struct: Options of structs/enums/primitives not supported by this backend
+Lowering error in Struct2: Options of structs/enums/primitives not supported by this backend
+Lowering error in Opaque::take_option: Options of structs/enums/primitives not supported by this backend

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
@@ -2,7 +2,7 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in BadStructFields: found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = u8
+Lowering error in BadStructFields: Found FFI-unsafe type Option<u8> in struct field BadStructFields.field1, consider using DiplomatOption<u8>
 Lowering error in BadStructFields: Found FFI-unsafe type Result<u8, u8> in struct field BadStructFields.field2, consider using Result<u8, u8>
 Lowering error in BadStructFields: Results can only appear as the top-level return type of methods
 Lowering error in InStructWithOutField: found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = OtherOpaque

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/hir/type_context.rs
+expression: output
+---
+Lowering error in BrokenStruct: Found FFI-unsafe type Option<u8> in struct field BrokenStruct.regular_option, consider using DiplomatOption<u8>
+Lowering error in BrokenStruct: Found FFI-unsafe type Option<CustomStruct> in struct field BrokenStruct.regular_option, consider using DiplomatOption<CustomStruct>
+Lowering error in Foo::diplo_option_ref: found DiplomatOption<&T>, please use Option<&T> (DiplomatOption is for primitives, structs, and enums)
+Lowering error in Foo::diplo_option_box: found DiplomatOption<Box<T>>, please use Option<Box<T>> (DiplomatOption is for primitives, structs, and enums)

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
@@ -2,8 +2,6 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo: found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = u8
+Lowering error in Foo: Found FFI-unsafe type Option<u8> in struct field Foo.field, consider using DiplomatOption<u8>
 Lowering error in Foo::do_thing: found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = Option<u16>
 Lowering error in Foo::do_thing2: Results can only appear as the top-level return type of methods
-Lowering error in Foo::do_thing2: found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = u16
-

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -787,4 +787,52 @@ mod tests {
             }
         };
     }
+
+    #[test]
+    fn test_option() {
+        uitest_lowering! {
+            #[diplomat::bridge]
+                mod ffi {
+                use diplomat_runtime::DiplomatOption;
+                #[diplomat::opaque]
+                struct Foo {}
+                struct CustomStruct {
+                    num: u8,
+                    b: bool,
+                    diplo_option: DiplomatOption<u8>,
+                }
+
+                struct BrokenStruct {
+                    regular_option: Option<u8>,
+                    regular_option: Option<CustomStruct>,
+                }
+                impl Foo {
+                    pub fn diplo_option_u8(x: DiplomatOption<u8>) -> DiplomatOption<u8> {
+                        x
+                    }
+                    pub fn diplo_option_ref(x: DiplomatOption<&Foo>) -> DiplomatOption<&Foo> {
+                        x
+                    }
+                    pub fn diplo_option_box() -> DiplomatOption<Box<Foo>> {
+                        x
+                    }
+                    pub fn diplo_option_struct(x: DiplomatOption<CustomStruct>) -> DiplomatOption<CustomStruct> {
+                        x
+                    }
+                    pub fn option_u8(x: Option<u8>) -> Option<u8> {
+                        x
+                    }
+                    pub fn option_ref(x: Option<&Foo>) -> Option<&Foo> {
+                        x
+                    }
+                    pub fn option_box() -> Option<Box<Foo>> {
+                        x
+                    }
+                    pub fn option_struct(x: Option<CustomStruct>) -> Option<CustomStruct> {
+                        x
+                    }
+                }
+            }
+        };
+    }
 }

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -498,7 +498,8 @@ mod tests {
 
             let mut output = String::new();
 
-            let attr_validator = hir::BasicAttributeValidator::new("tests");
+            let mut attr_validator = hir::BasicAttributeValidator::new("tests");
+            attr_validator.support.option = true;
             match hir::TypeContext::from_syn(&parsed, attr_validator) {
                 Ok(_context) => (),
                 Err(e) => {

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -23,6 +23,14 @@ pub enum Type<P: TyPosition = Everywhere> {
     Enum(EnumPath),
     Slice(Slice),
     Callback(P::CallbackInstantiation), // only a Callback if P == InputOnly
+    /// `DiplomatOption<T>`, for  a primitive, struct, or enum `T`.
+    ///
+    /// In some cases this can be specified as `Option<T>`, but under the hood it gets translated to
+    /// the DiplomatOption FFI-compatible union type.
+    ///
+    /// This is *different* from `Option<&T>` and `Option<Box<T>` for an opaque `T`: That is represented as
+    /// a nullable pointer.
+    DiplomatOption(Box<Type<P>>),
 }
 
 /// Type that can appear in the `self` position.
@@ -92,6 +100,7 @@ impl<P: TyPosition<StructPath = StructPath>> Type<P> {
             }),
             Type::Opaque(_) | Type::Slice(_) | Type::Callback(_) => (1, 1),
             Type::Primitive(_) | Type::Enum(_) => (0, 0),
+            Type::DiplomatOption(ty) => ty.field_leaf_lifetime_counts(tcx),
         }
     }
 }

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -30,6 +30,9 @@ pub enum Type<P: TyPosition = Everywhere> {
     ///
     /// This is *different* from `Option<&T>` and `Option<Box<T>` for an opaque `T`: That is represented as
     /// a nullable pointer.
+    ///
+    /// This does not get used when the user writes `-> Option<T>` (for non-opaque T):
+    /// that will always use [`ReturnType::Nullable`](crate::hir::ReturnType::Nullable).
     DiplomatOption(Box<Type<P>>),
 }
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -51,6 +51,11 @@ fn param_conversion(
         } else {
             quote!(let #name = #name.into();)
         }),
+        // Convert Option<struct/enum/primitive> and DiplomatOption<opaque>
+        // simplify the check by just checking is_ffi_safe()
+        ast::TypeName::Option(..) if !param_type.is_ffi_safe() => {
+            Some(quote!(let #name = #name.into();))
+        }
         ast::TypeName::Function(in_types, out_type) => {
             let cb_wrap_ident = &name;
             let mut cb_param_list = vec![];

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -32,6 +32,9 @@ fn param_ty(param_ty: &ast::TypeName) -> syn::Type {
             // not Rust stdlib types (which are not FFI-safe and must be converted)
             prim.get_diplomat_slice_type(ltmt)
         }
+        ast::TypeName::Option(..) if !param_ty.is_ffi_safe() => {
+            param_ty.ffi_safe_version().to_syn()
+        }
         _ => param_ty.to_syn(),
     }
 }

--- a/macro/src/snapshots/diplomat__tests__both_kinds_of_option.snap
+++ b/macro/src/snapshots/diplomat__tests__both_kinds_of_option.snap
@@ -1,0 +1,86 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                use diplomat_runtime::DiplomatOption; #[diplomat::opaque]\n                                struct Foo {} struct CustomStruct\n                                { num: u8, b: bool, diplo_option: DiplomatOption<u8>, } impl\n                                Foo\n                                {\n                                    pub fn diplo_option_u8(x: DiplomatOption<u8>) ->\n                                    DiplomatOption<u8> { x } pub fn\n                                    diplo_option_ref(x: DiplomatOption<&Foo>) ->\n                                    DiplomatOption<&Foo> { x } pub fn diplo_option_box() ->\n                                    DiplomatOption<Box<Foo>> { x } pub fn\n                                    diplo_option_struct(x: DiplomatOption<CustomStruct>) ->\n                                    DiplomatOption<CustomStruct> { x } pub fn\n                                    option_u8(x: Option<u8>) -> Option<u8> { x } pub fn\n                                    option_ref(x: Option<&Foo>) -> Option<&Foo> { x } pub fn\n                                    option_box() -> Option<Box<Foo>> { x } pub fn\n                                    option_struct(x: Option<CustomStruct>) ->\n                                    Option<CustomStruct> { x }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+---
+mod ffi {
+    use diplomat_runtime::DiplomatOption;
+    struct Foo {}
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct CustomStruct {
+        num: u8,
+        b: bool,
+        diplo_option: DiplomatOption<u8>,
+    }
+    impl Foo {
+        pub fn diplo_option_u8(x: DiplomatOption<u8>) -> DiplomatOption<u8> {
+            x
+        }
+        pub fn diplo_option_ref(x: DiplomatOption<&Foo>) -> DiplomatOption<&Foo> {
+            x
+        }
+        pub fn diplo_option_box() -> DiplomatOption<Box<Foo>> {
+            x
+        }
+        pub fn diplo_option_struct(
+            x: DiplomatOption<CustomStruct>,
+        ) -> DiplomatOption<CustomStruct> {
+            x
+        }
+        pub fn option_u8(x: Option<u8>) -> Option<u8> {
+            x
+        }
+        pub fn option_ref(x: Option<&Foo>) -> Option<&Foo> {
+            x
+        }
+        pub fn option_box() -> Option<Box<Foo>> {
+            x
+        }
+        pub fn option_struct(x: Option<CustomStruct>) -> Option<CustomStruct> {
+            x
+        }
+    }
+    use diplomat_runtime::*;
+    #[no_mangle]
+    extern "C" fn Foo_diplo_option_u8(
+        x: diplomat_runtime::DiplomatOption<u8>,
+    ) -> diplomat_runtime::DiplomatResult<u8, ()> {
+        Foo::diplo_option_u8(x)
+    }
+    #[no_mangle]
+    extern "C" fn Foo_diplo_option_ref(
+        x: diplomat_runtime::DiplomatOption<&Foo>,
+    ) -> diplomat_runtime::DiplomatOption<&Foo> {
+        Foo::diplo_option_ref(x).into()
+    }
+    #[no_mangle]
+    extern "C" fn Foo_diplo_option_box() -> diplomat_runtime::DiplomatOption<Box<Foo>> {
+        Foo::diplo_option_box().into()
+    }
+    #[no_mangle]
+    extern "C" fn Foo_diplo_option_struct(
+        x: diplomat_runtime::DiplomatOption<CustomStruct>,
+    ) -> diplomat_runtime::DiplomatResult<CustomStruct, ()> {
+        Foo::diplo_option_struct(x)
+    }
+    #[no_mangle]
+    extern "C" fn Foo_option_u8(x: Option<u8>) -> diplomat_runtime::DiplomatResult<u8, ()> {
+        Foo::option_u8(x).ok_or(()).into()
+    }
+    #[no_mangle]
+    extern "C" fn Foo_option_ref(x: Option<&Foo>) -> Option<&Foo> {
+        Foo::option_ref(x)
+    }
+    #[no_mangle]
+    extern "C" fn Foo_option_box() -> Option<Box<Foo>> {
+        Foo::option_box()
+    }
+    #[no_mangle]
+    extern "C" fn Foo_option_struct(
+        x: Option<CustomStruct>,
+    ) -> diplomat_runtime::DiplomatResult<CustomStruct, ()> {
+        Foo::option_struct(x).ok_or(()).into()
+    }
+    #[no_mangle]
+    extern "C" fn Foo_destroy(this: Box<Foo>) {}
+}

--- a/macro/src/snapshots/diplomat__tests__both_kinds_of_option.snap
+++ b/macro/src/snapshots/diplomat__tests__both_kinds_of_option.snap
@@ -40,6 +40,7 @@ mod ffi {
             x
         }
     }
+    use core::ffi::c_void;
     use diplomat_runtime::*;
     #[no_mangle]
     extern "C" fn Foo_diplo_option_u8(
@@ -51,6 +52,7 @@ mod ffi {
     extern "C" fn Foo_diplo_option_ref(
         x: diplomat_runtime::DiplomatOption<&Foo>,
     ) -> diplomat_runtime::DiplomatOption<&Foo> {
+        let x = x.into();
         Foo::diplo_option_ref(x).into()
     }
     #[no_mangle]
@@ -65,6 +67,7 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Foo_option_u8(x: Option<u8>) -> diplomat_runtime::DiplomatResult<u8, ()> {
+        let x = x.into();
         Foo::option_u8(x).ok_or(()).into()
     }
     #[no_mangle]
@@ -79,6 +82,7 @@ mod ffi {
     extern "C" fn Foo_option_struct(
         x: Option<CustomStruct>,
     ) -> diplomat_runtime::DiplomatResult<CustomStruct, ()> {
+        let x = x.into();
         Foo::option_struct(x).ok_or(()).into()
     }
     #[no_mangle]

--- a/macro/src/snapshots/diplomat__tests__both_kinds_of_option.snap
+++ b/macro/src/snapshots/diplomat__tests__both_kinds_of_option.snap
@@ -49,9 +49,7 @@ mod ffi {
         Foo::diplo_option_u8(x)
     }
     #[no_mangle]
-    extern "C" fn Foo_diplo_option_ref(
-        x: diplomat_runtime::DiplomatOption<&Foo>,
-    ) -> diplomat_runtime::DiplomatOption<&Foo> {
+    extern "C" fn Foo_diplo_option_ref(x: Option<&Foo>) -> diplomat_runtime::DiplomatOption<&Foo> {
         let x = x.into();
         Foo::diplo_option_ref(x).into()
     }
@@ -66,7 +64,9 @@ mod ffi {
         Foo::diplo_option_struct(x)
     }
     #[no_mangle]
-    extern "C" fn Foo_option_u8(x: Option<u8>) -> diplomat_runtime::DiplomatResult<u8, ()> {
+    extern "C" fn Foo_option_u8(
+        x: diplomat_runtime::DiplomatOption<u8>,
+    ) -> diplomat_runtime::DiplomatResult<u8, ()> {
         let x = x.into();
         Foo::option_u8(x).ok_or(()).into()
     }
@@ -80,7 +80,7 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Foo_option_struct(
-        x: Option<CustomStruct>,
+        x: diplomat_runtime::DiplomatOption<CustomStruct>,
     ) -> diplomat_runtime::DiplomatResult<CustomStruct, ()> {
         let x = x.into();
         Foo::option_struct(x).ok_or(()).into()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,13 +21,7 @@ mod callback;
 pub use callback::DiplomatCallback;
 
 mod result;
-pub use result::DiplomatResult;
-
-/// A type to represent Option<T> over FFI.
-/// 
-/// Used internally to handle `Option<T>` arguments and return types, and needs to be
-/// used explicitly for optional struct fields.
-pub type DiplomatOption<T> = DiplomatResult<T, ()>;
+pub use result::{DiplomatOption, DiplomatResult};
 
 /// Like [`char`], but unvalidated.
 pub type DiplomatChar = u32;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,9 +23,10 @@ pub use callback::DiplomatCallback;
 mod result;
 pub use result::DiplomatResult;
 
-/// A type to represent Option<T> over FFI. Prefer using Option<T> with boxes and reference
-/// types, and in return types, use this in structs/fn args. The macro will perform autoconversions
-/// between these types when found in args (but not in structs)
+/// A type to represent Option<T> over FFI.
+/// 
+/// Used internally to handle `Option<T>` arguments and return types, and needs to be
+/// used explicitly for optional struct fields.
 pub type DiplomatOption<T> = DiplomatResult<T, ()>;
 
 /// Like [`char`], but unvalidated.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,6 +23,10 @@ pub use callback::DiplomatCallback;
 mod result;
 pub use result::DiplomatResult;
 
+/// A type to represent Option<T> over FFI. Prefer using Option<T> with boxes and reference
+/// types, and in return types, use this in structs/fn args.
+pub type DiplomatOption<T> = DiplomatResult<T, ()>;
+
 /// Like [`char`], but unvalidated.
 pub type DiplomatChar = u32;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -24,7 +24,8 @@ mod result;
 pub use result::DiplomatResult;
 
 /// A type to represent Option<T> over FFI. Prefer using Option<T> with boxes and reference
-/// types, and in return types, use this in structs/fn args.
+/// types, and in return types, use this in structs/fn args. The macro will perform autoconversions
+/// between these types when found in args (but not in structs)
 pub type DiplomatOption<T> = DiplomatResult<T, ()>;
 
 /// Like [`char`], but unvalidated.

--- a/runtime/src/result.rs
+++ b/runtime/src/result.rs
@@ -47,6 +47,18 @@ impl<T, E> From<Result<T, E>> for DiplomatResult<T, E> {
     }
 }
 
+impl<T> From<Option<T>> for DiplomatResult<T, ()> {
+    fn from(option: Option<T>) -> Self {
+        option.ok_or(()).into()
+    }
+}
+
+impl<T> From<DiplomatResult<T, ()>> for Option<T> {
+    fn from(result: DiplomatResult<T, ()>) -> Self {
+        Result::<T, ()>::from(result).ok()
+    }
+}
+
 impl<T, E> From<DiplomatResult<T, E>> for Result<T, E> {
     fn from(mut result: DiplomatResult<T, E>) -> Result<T, E> {
         unsafe {

--- a/runtime/src/result.rs
+++ b/runtime/src/result.rs
@@ -15,6 +15,12 @@ pub struct DiplomatResult<T, E> {
     pub is_ok: bool,
 }
 
+/// A type to represent Option<T> over FFI.
+///
+/// Used internally to handle `Option<T>` arguments and return types, and needs to be
+/// used explicitly for optional struct fields.
+pub type DiplomatOption<T> = DiplomatResult<T, ()>;
+
 impl<T, E> Drop for DiplomatResult<T, E> {
     fn drop(&mut self) {
         unsafe {
@@ -47,14 +53,14 @@ impl<T, E> From<Result<T, E>> for DiplomatResult<T, E> {
     }
 }
 
-impl<T> From<Option<T>> for DiplomatResult<T, ()> {
+impl<T> From<Option<T>> for DiplomatOption<T> {
     fn from(option: Option<T>) -> Self {
         option.ok_or(()).into()
     }
 }
 
-impl<T> From<DiplomatResult<T, ()>> for Option<T> {
-    fn from(result: DiplomatResult<T, ()>) -> Self {
+impl<T> From<DiplomatOption<T>> for Option<T> {
+    fn from(result: DiplomatOption<T>) -> Self {
         Result::<T, ()>::from(result).ok()
     }
 }


### PR DESCRIPTION
This is a draft PR for fixing https://github.com/rust-diplomat/diplomat/issues/246

<s>Based on https://github.com/rust-diplomat/diplomat/pull/615 (first commit is "Add `DiplomatOption<T>`"</s>

This adds a `DiplomatOption<T>` that is able to hold structs and primitives, for use in non-return positions.