### PR TITLE
Resurrect supports cfgs so we can gate against them

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -116,6 +116,7 @@ impl Attrs {
         // No special inheritance, was already appropriately inherited in AST
         this.abi_rename = ast.abi_rename.clone();
 
+        let support = validator.attrs_supported();
         for attr in &ast.attrs {
             let satisfies = match validator.satisfies_cfg(&attr.cfg) {
                 Ok(satisfies) => satisfies,
@@ -575,7 +576,7 @@ impl Attrs {
 /// ```ignore
 /// struct Sample {}
 /// impl Sample {
-///     #[diplomat::attr(supports = constructors, constructor)]
+///     #[diplomat::attr(constructor)]
 ///     pub fn new() -> Box<Self> {
 ///         Box::new(Sample{})
 ///     }
@@ -588,14 +589,10 @@ impl Attrs {
 /// factory Sample()
 /// ```
 ///
-/// If a backend does not support a specific `#[diplomat::attr(...)]`, it will error.
+/// If a backend does not support a specific `#[diplomat::attr(...)]`, it may error.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct BackendAttrSupport {
-    /// Renaming types/methods, usually to make them more idiomatic.
-    ///
-    /// This is supported by all backends *except for C*.
-    pub renaming: bool,
     /// Namespacing types, e.g. C++ `namespace`.
     pub namespacing: bool,
     /// Rust can directly acccess the memory of this language, like C and C++.
@@ -638,7 +635,6 @@ impl BackendAttrSupport {
     #[cfg(test)]
     fn all_true() -> Self {
         Self {
-            renaming: true,
             namespacing: true,
             memory_sharing: true,
             non_exhaustive_structs: true,
@@ -750,7 +746,6 @@ impl AttributeValidator for BasicAttributeValidator {
         Ok(if name == "supports" {
             // destructure so new fields are forced to be added
             let BackendAttrSupport {
-                renaming,
                 namespacing,
                 memory_sharing,
                 non_exhaustive_structs,
@@ -769,7 +764,6 @@ impl AttributeValidator for BasicAttributeValidator {
                 indexing,
             } = self.support;
             match value {
-                "renaming" => renaming,
                 "namespacing" => namespacing,
                 "memory_sharing" => memory_sharing,
                 "non_exhaustive_structs" => non_exhaustive_structs,

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -15,7 +15,6 @@ use diplomat_core::hir::BackendAttrSupport;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = false;
     a.namespacing = false;
     a.memory_sharing = true;
     a.non_exhaustive_structs = false;

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -15,12 +15,23 @@ use diplomat_core::hir::BackendAttrSupport;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = false;
+    a.namespacing = false;
     a.memory_sharing = true;
     a.non_exhaustive_structs = false;
     a.method_overloading = false;
     a.utf8_strings = true;
     a.utf16_strings = true;
+
+    a.constructors = false;
+    a.named_constructors = false;
     a.fallible_constructors = false;
+    a.accessors = false;
+    a.comparators = false;
+    a.stringifiers = false;
+    a.iterators = false;
+    a.iterables = false;
+    a.indexing = false;
 
     a
 }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -10,7 +10,6 @@ use ty::TyGenContext;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = true;
     a.namespacing = true;
     a.memory_sharing = true;
     a.non_exhaustive_structs = false;

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -10,12 +10,23 @@ use ty::TyGenContext;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = true;
+    a.namespacing = true;
     a.memory_sharing = true;
     a.non_exhaustive_structs = false;
     a.method_overloading = true;
     a.utf8_strings = true;
     a.utf16_strings = true;
+
+    a.constructors = false; // TODO
+    a.named_constructors = false;
     a.fallible_constructors = false;
+    a.accessors = false;
+    a.comparators = false; // TODO
+    a.stringifiers = false; // TODO
+    a.iterators = false; // TODO
+    a.iterables = false; // TODO
+    a.indexing = false; // TODO
 
     a
 }

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -21,12 +21,23 @@ use formatter::DartFormatter;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = true;
+    a.namespacing = false;
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;
     a.method_overloading = false;
     a.utf8_strings = false;
     a.utf16_strings = true;
+
+    a.constructors = true;
+    a.named_constructors = true;
     a.fallible_constructors = true;
+    a.accessors = true;
+    a.stringifiers = true;
+    a.comparators = true;
+    a.iterators = true;
+    a.iterables = true;
+    a.indexing = true;
 
     a
 }

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -21,7 +21,6 @@ use formatter::DartFormatter;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = true;
     a.namespacing = false;
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -32,12 +32,23 @@ impl FileType {
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = true;
+    a.namespacing = false;
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;
     a.method_overloading = false;
     a.utf8_strings = false;
     a.utf16_strings = true;
+
+    a.constructors = false;
+    a.named_constructors = false;
     a.fallible_constructors = false;
+    a.accessors = true;
+    a.comparators = false;
+    a.stringifiers = false; // TODO
+    a.iterators = false; // TODO
+    a.iterables = false; // TODO
+    a.indexing = false;
 
     a
 }

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -32,7 +32,6 @@ impl FileType {
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = true;
     a.namespacing = false;
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -23,12 +23,23 @@ use serde::{Deserialize, Serialize};
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = true;
+    a.namespacing = false; // TODO
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;
     a.method_overloading = true;
     a.utf8_strings = false;
     a.utf16_strings = true;
+
+    a.constructors = false; // TODO
+    a.named_constructors = false; // TODO
     a.fallible_constructors = false; // TODO
+    a.accessors = false;
+    a.stringifiers = false; // TODO
+    a.comparators = false; // TODO
+    a.iterators = true;
+    a.iterables = true;
+    a.indexing = true;
 
     a
 }

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -23,7 +23,6 @@ use serde::{Deserialize, Serialize};
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = true;
     a.namespacing = false; // TODO
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;


### PR DESCRIPTION
https://github.com/rust-diplomat/diplomat/pull/563 removed the *requirement* to check `supports = ` before using a special method, however it also removed the *ability* to do so.

That ability is still useful, specifically, to be able to do something like:

```rust
#[diplomat::attr(comparator)]
#[diplomat::attr(not(supports = comparator), disable]
fn compare(other: &Self) -> Ordering

#[diplomat::attr(supports = comparator), disable]
fn fancierCompare(other: &Self) -> FancyComparisonResult
```

e.g. if you decide to support comparators a different way.

Iterators in particular sound like a ripe target for this, we constrain iterator methods to behave a specific way and backends not wrapping them with iterator magic may wish for something different.


This PR brings that ability back.