### PR TITLE
Support diplomat::attr(auto)

### DIFF
--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -195,6 +195,8 @@ pub enum DiplomatBackendAttrCfg {
     Any(Vec<DiplomatBackendAttrCfg>),
     All(Vec<DiplomatBackendAttrCfg>),
     Star,
+    // "auto", smartly figure out based on the attribute used
+    Auto,
     BackendName(String),
     NameValue(String, String),
 }
@@ -204,7 +206,9 @@ impl Parse for DiplomatBackendAttrCfg {
         let lookahead = input.lookahead1();
         if lookahead.peek(Ident) {
             let name: Ident = input.parse()?;
-            if name == "not" {
+            if name == "auto" {
+                Ok(DiplomatBackendAttrCfg::Auto)
+            } else if name == "not" {
                 let content;
                 let _paren = syn::parenthesized!(content in input);
                 Ok(DiplomatBackendAttrCfg::Not(Box::new(content.parse()?)))

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -116,6 +116,7 @@ impl Attrs {
         // No special inheritance, was already appropriately inherited in AST
         this.abi_rename = ast.abi_rename.clone();
 
+        let support = validator.attrs_supported();
         for attr in &ast.attrs {
             let satisfies = match validator.satisfies_cfg(&attr.cfg) {
                 Ok(satisfies) => satisfies,
@@ -575,7 +576,7 @@ impl Attrs {
 /// ```ignore
 /// struct Sample {}
 /// impl Sample {
-///     #[diplomat::attr(supports = constructors, constructor)]
+///     #[diplomat::attr(constructor)]
 ///     pub fn new() -> Box<Self> {
 ///         Box::new(Sample{})
 ///     }
@@ -588,14 +589,10 @@ impl Attrs {
 /// factory Sample()
 /// ```
 ///
-/// If a backend does not support a specific `#[diplomat::attr(...)]`, it will error.
+/// If a backend does not support a specific `#[diplomat::attr(...)]`, it may error.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct BackendAttrSupport {
-    /// Renaming types/methods, usually to make them more idiomatic.
-    ///
-    /// This is supported by all backends *except for C*.
-    pub renaming: bool,
     /// Namespacing types, e.g. C++ `namespace`.
     pub namespacing: bool,
     /// Rust can directly acccess the memory of this language, like C and C++.
@@ -750,7 +747,6 @@ impl AttributeValidator for BasicAttributeValidator {
         Ok(if name == "supports" {
             // destructure so new fields are forced to be added
             let BackendAttrSupport {
-                renaming,
                 namespacing,
                 memory_sharing,
                 non_exhaustive_structs,
@@ -769,7 +765,6 @@ impl AttributeValidator for BasicAttributeValidator {
                 indexing,
             } = self.support;
             match value {
-                "renaming" => renaming,
                 "namespacing" => namespacing,
                 "memory_sharing" => memory_sharing,
                 "non_exhaustive_structs" => non_exhaustive_structs,

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -868,7 +868,7 @@ mod tests {
 
     #[test]
     fn test_auto() {
-        uitest_lowering_attr! { {let mut x = hir::BackendAttrSupport::default(); x.comparators = true; x},
+        uitest_lowering_attr! { hir::BackendAttrSupport { comparators: true, ..Default::default()},
             #[diplomat::bridge]
             mod ffi {
                 use std::cmp;

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__auto.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__auto.snap
@@ -1,0 +1,5 @@
+---
+source: core/src/hir/attrs.rs
+expression: output
+---
+Lowering error in Opaque::next: `iterator` not supported in backend tests

--- a/example/src/data_provider.rs
+++ b/example/src/data_provider.rs
@@ -1,6 +1,6 @@
 #[diplomat::bridge]
 #[diplomat::abi_rename = "icu4x_{0}_mv1"]
-#[diplomat::attr(*, namespace = "icu4x")]
+#[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     use icu_provider::AnyProvider;
 
@@ -11,7 +11,7 @@ pub mod ffi {
 
     impl DataProvider {
         #[diplomat::rust_link(icu_testdata::get_static_provider, Fn)]
-        #[diplomat::attr(*, named_constructor = "static")]
+        #[diplomat::attr(auto, named_constructor = "static")]
         pub fn new_static() -> Box<DataProvider> {
             #[allow(deprecated)]
             let provider = icu_testdata::any();

--- a/example/src/decimal.rs
+++ b/example/src/decimal.rs
@@ -2,7 +2,7 @@
 
 #[diplomat::bridge]
 #[diplomat::abi_rename = "icu4x_{0}_mv1"]
-#[diplomat::attr(*, namespace = "icu4x")]
+#[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     use diplomat_runtime::DiplomatWrite;
     use icu_provider::DataLocale;
@@ -36,7 +36,7 @@ pub mod ffi {
     }
 
     impl FixedDecimalFormatterOptions {
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn default() -> Self {
             Self {
                 grouping_strategy: FixedDecimalGroupingStrategy::Auto,

--- a/example/src/fixed_decimal.rs
+++ b/example/src/fixed_decimal.rs
@@ -1,6 +1,6 @@
 #[diplomat::bridge]
 #[diplomat::abi_rename = "icu4x_{0}_mv1"]
-#[diplomat::attr(*, namespace = "icu4x")]
+#[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     use diplomat_runtime::DiplomatWrite;
     use writeable::Writeable;
@@ -11,7 +11,7 @@ pub mod ffi {
 
     impl FixedDecimal {
         /// Construct an [`FixedDecimal`] from an integer.
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new(v: i32) -> Box<FixedDecimal> {
             Box::new(FixedDecimal(fixed_decimal::FixedDecimal::from(v)))
         }

--- a/example/src/locale.rs
+++ b/example/src/locale.rs
@@ -1,6 +1,6 @@
 #[diplomat::bridge]
 #[diplomat::abi_rename = "icu4x_{0}_mv1"]
-#[diplomat::attr(*, namespace = "icu4x")]
+#[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     #[diplomat::opaque]
     /// An  Locale, capable of representing strings like `"en-US"`.
@@ -9,7 +9,7 @@ pub mod ffi {
 
     impl Locale {
         /// Construct an [`Locale`] from a locale identifier represented as a string.
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new(name: &DiplomatStr) -> Box<Locale> {
             Box::new(Locale(icu::locid::Locale::try_from_bytes(name).unwrap()))
         }

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -1,33 +1,33 @@
 #[diplomat::bridge]
 #[diplomat::abi_rename = "namespace_{0}"]
 #[diplomat::attr(not(any(c)), rename = "Renamed{0}")]
-#[diplomat::attr(*, namespace = "ns")]
+#[diplomat::attr(auto, namespace = "ns")]
 pub mod ffi {
     #[derive(Clone)]
     #[diplomat::opaque]
-    #[diplomat::attr(*, rename = "AttrOpaque1Renamed")]
+    #[diplomat::attr(auto, rename = "AttrOpaque1Renamed")]
     pub struct AttrOpaque1;
 
     impl AttrOpaque1 {
-        #[diplomat::attr(*, rename = "totally_not_{0}")]
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, rename = "totally_not_{0}")]
+        #[diplomat::attr(auto, constructor)]
         pub fn new() -> Box<AttrOpaque1> {
             Box::new(AttrOpaque1)
         }
 
-        #[diplomat::attr(*, rename = "method_renamed")]
-        #[diplomat::attr(*, getter = "method")]
+        #[diplomat::attr(auto, rename = "method_renamed")]
+        #[diplomat::attr(auto, getter = "method")]
         pub fn method(&self) -> u8 {
             77
         }
 
         #[diplomat::abi_rename("renamed_on_abi_only")]
-        #[diplomat::attr(*, getter = "abirenamed")]
+        #[diplomat::attr(auto, getter = "abirenamed")]
         pub fn abirenamed(&self) -> u8 {
             123
         }
 
-        #[diplomat::attr(*, disable)]
+        #[diplomat::attr(auto, disable)]
         pub fn method_disabled(&self) {
             println!("disabled in hir");
         }
@@ -42,17 +42,17 @@ pub mod ffi {
     pub enum AttrEnum {
         A,
         B,
-        #[diplomat::attr(*, rename = "Renamed")]
+        #[diplomat::attr(auto, rename = "Renamed")]
         C,
     }
 
     #[diplomat::opaque]
-    #[diplomat::attr(*, namespace = "")]
-    #[diplomat::attr(*, rename = "Unnamespaced")]
+    #[diplomat::attr(auto, namespace = "")]
+    #[diplomat::attr(auto, rename = "Unnamespaced")]
     pub struct Unnamespaced;
 
     impl Unnamespaced {
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn make(_e: AttrEnum) -> Box<Self> {
             Box::new(Self)
         }
@@ -68,7 +68,7 @@ pub mod ffi {
         pub fn new(int: u8) -> Box<Self> {
             Box::new(Self(int))
         }
-        #[diplomat::attr(*, comparison)]
+        #[diplomat::attr(auto, comparison)]
         pub fn cmp(&self, other: &Comparable) -> core::cmp::Ordering {
             self.0.cmp(&other.0)
         }
@@ -88,25 +88,25 @@ pub mod ffi {
     pub struct MyIndexer(Vec<String>);
 
     impl MyIterable {
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new(x: &[u8]) -> Box<Self> {
             Box::new(Self(x.into()))
         }
-        #[diplomat::attr(*, iterable)]
+        #[diplomat::attr(auto, iterable)]
         pub fn iter<'a>(&'a self) -> Box<MyIterator<'a>> {
             Box::new(MyIterator(self.0.iter()))
         }
     }
 
     impl<'a> MyIterator<'a> {
-        #[diplomat::attr(*, iterator)]
+        #[diplomat::attr(auto, iterator)]
         pub fn next(&mut self) -> Option<u8> {
             self.0.next().copied()
         }
     }
 
     impl MyIndexer {
-        #[diplomat::attr(*, indexer)]
+        #[diplomat::attr(auto, indexer)]
         pub fn get<'a>(&'a self, i: usize) -> Option<&'a DiplomatStr> {
             self.0.get(i).as_ref().map(|string| string.as_bytes())
         }
@@ -121,14 +121,14 @@ pub mod ffi {
     struct OpaqueIterator<'a>(Box<dyn Iterator<Item = AttrOpaque1> + 'a>);
 
     impl OpaqueIterable {
-        #[diplomat::attr(*, iterable)]
+        #[diplomat::attr(auto, iterable)]
         pub fn iter<'a>(&'a self) -> Box<OpaqueIterator<'a>> {
             Box::new(OpaqueIterator(Box::new(self.0.iter().cloned())))
         }
     }
 
     impl<'a> OpaqueIterator<'a> {
-        #[diplomat::attr(*, iterator)]
+        #[diplomat::attr(auto, iterator)]
         pub fn next(&'a mut self) -> Option<Box<AttrOpaque1>> {
             self.0.next().map(Box::new)
         }

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -61,7 +61,7 @@ pub mod ffi {
     }
 
     #[diplomat::opaque]
-    #[diplomat::attr(any(c, kotlin, cpp, js), disable)]
+    #[diplomat::attr(not(supports = comparators), disable)]
     pub struct Comparable(u8);
 
     impl Comparable {

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -75,16 +75,16 @@ pub mod ffi {
     }
 
     #[diplomat::opaque]
-    #[diplomat::attr(any(c, cpp, js), disable)]
+    #[diplomat::attr(not(supports = iterators), disable)]
     pub struct MyIterable(Vec<u8>);
 
     #[diplomat::opaque]
-    #[diplomat::attr(any(c, cpp, js), disable)]
+    #[diplomat::attr(not(supports = iterators), disable)]
     pub struct MyIterator<'a>(std::slice::Iter<'a, u8>);
 
     #[diplomat::opaque]
-    #[diplomat::attr(any(c, cpp, js), disable)]
-    #[diplomat::attr(dart, disable)]
+    #[diplomat::attr(not(supports = indexing), disable)]
+    #[diplomat::attr(dart, disable)] // currently broken in Dart: #590
     pub struct MyIndexer(Vec<String>);
 
     impl MyIterable {
@@ -113,11 +113,11 @@ pub mod ffi {
     }
 
     #[diplomat::opaque]
-    #[diplomat::attr(any(c, cpp, js), disable)]
+    #[diplomat::attr(not(supports = iterators), disable)]
     struct OpaqueIterable(Vec<AttrOpaque1>);
 
     #[diplomat::opaque]
-    #[diplomat::attr(any(c, cpp, js), disable)]
+    #[diplomat::attr(not(supports = iterators), disable)]
     struct OpaqueIterator<'a>(Box<dyn Iterator<Item = AttrOpaque1> + 'a>);
 
     impl OpaqueIterable {

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -25,17 +25,17 @@ pub mod ffi {
         bytes: &'a DiplomatStr,
     }
     impl<'a> Foo<'a> {
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new(x: &'a DiplomatStr) -> Box<Self> {
             Box::new(Foo(x))
         }
 
-        #[diplomat::attr(*, getter = "bar")]
+        #[diplomat::attr(auto, getter = "bar")]
         pub fn get_bar<'b>(&'b self) -> Box<Bar<'b, 'a>> {
             Box::new(Bar(self))
         }
 
-        #[diplomat::attr(*, named_constructor = "static")]
+        #[diplomat::attr(auto, named_constructor = "static")]
         pub fn new_static(x: &'static DiplomatStr) -> Box<Self> {
             Box::new(Foo(x))
         }
@@ -44,12 +44,12 @@ pub mod ffi {
             BorrowedFieldsReturning { bytes: self.0 }
         }
 
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn extract_from_fields(fields: BorrowedFields<'a>) -> Box<Self> {
             Box::new(Foo(fields.b))
         }
 
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         /// Test that the extraction logic correctly pins the right fields
         pub fn extract_from_bounds<'x, 'y: 'x + 'a, 'z: 'x + 'y>(
             bounds: BorrowedFieldsWithBounds<'x, 'y, 'z>,
@@ -121,7 +121,7 @@ pub mod ffi {
     // FIXME(#191): This test breaks the C++ codegen
     impl<'b, 'a: 'b> Bar<'b, 'a> {
         #[diplomat::skip_if_ast]
-        #[diplomat::attr(*, getter)]
+        #[diplomat::attr(auto, getter)]
         pub fn foo(&'b self) -> &'b Foo<'a> {
             self.0
         }
@@ -138,7 +138,7 @@ pub mod ffi {
     impl<'o> One<'o> {
         // Holds: [hold]
         #[allow(clippy::extra_unused_lifetimes)]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn transitivity<'a, 'b: 'a, 'c: 'b, 'd: 'c, 'e: 'd, 'x>(
             hold: &'x One<'e>,
             nohold: &One<'x>,
@@ -149,7 +149,7 @@ pub mod ffi {
 
         // Holds: [hold]
         #[allow(clippy::extra_unused_lifetimes)]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn cycle<'a: 'b, 'b: 'c, 'c: 'a, 'x>(
             hold: &Two<'x, 'b>,
             nohold: &'x One<'x>,
@@ -159,7 +159,7 @@ pub mod ffi {
         }
 
         // Holds: [a, b, c, d]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn many_dependents<'a, 'b: 'a, 'c: 'a, 'd: 'b + 'x, 'x, 'y>(
             a: &'x One<'a>,
             b: &'b One<'a>,
@@ -172,7 +172,7 @@ pub mod ffi {
         }
 
         // Holds: [hold]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn return_outlives_param<'short, 'long: 'short>(
             hold: &Two<'long, 'short>,
             nohold: &'short One<'short>,
@@ -182,7 +182,7 @@ pub mod ffi {
         }
 
         // Holds: [top, left, right, bottom]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn diamond_top<'top, 'left: 'top, 'right: 'top, 'bottom: 'left + 'right>(
             top: &One<'top>,
             left: &One<'left>,
@@ -198,7 +198,7 @@ pub mod ffi {
         }
 
         // Holds: [left, bottom]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn diamond_left<'top, 'left: 'top, 'right: 'top, 'bottom: 'left + 'right>(
             top: &One<'top>,
             left: &One<'left>,
@@ -213,7 +213,7 @@ pub mod ffi {
         }
 
         // Holds: [right, bottom]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn diamond_right<'top, 'left: 'top, 'right: 'top, 'bottom: 'left + 'right>(
             top: &One<'top>,
             left: &One<'left>,
@@ -228,7 +228,7 @@ pub mod ffi {
         }
 
         // Holds: [bottom]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn diamond_bottom<'top, 'left: 'top, 'right: 'top, 'bottom: 'left + 'right>(
             top: &One<'top>,
             left: &One<'left>,
@@ -240,7 +240,7 @@ pub mod ffi {
         }
 
         // Holds: [a, b, c, d]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn diamond_and_nested_types<'a, 'b: 'a, 'c: 'b, 'd: 'b + 'c, 'x, 'y>(
             a: &One<'a>,
             b: &'y One<'b>,
@@ -259,7 +259,7 @@ pub mod ffi {
 
         // Holds: [implicit_hold, explicit_hold]
         #[allow(clippy::extra_unused_lifetimes)]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn implicit_bounds<'a, 'b: 'a, 'c: 'b, 'd: 'c, 'x, 'y>(
             explicit_hold: &'d One<'x>, // implies that 'x: 'd
             implicit_hold: &One<'x>,
@@ -274,7 +274,7 @@ pub mod ffi {
 
         // Holds: [a, b, c]
         #[allow(clippy::needless_lifetimes)]
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn implicit_bounds_deep<'a, 'b, 'c, 'd, 'x>(
             explicit_: &'a One<'b>,
             implicit_1: &'b One<'c>,

--- a/feature_tests/src/selftype.rs
+++ b/feature_tests/src/selftype.rs
@@ -7,7 +7,7 @@ mod ffi {
     struct RefList<'a>((&'a RefListParameter, Option<Box<Self>>));
 
     impl<'b> RefList<'b> {
-        #[diplomat::attr(*, named_constructor)]
+        #[diplomat::attr(auto, named_constructor)]
         pub fn node(data: &'b RefListParameter) -> Box<Self> {
             Box::new(RefList((data, None)))
         }

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -7,12 +7,12 @@ mod ffi {
     struct MyString(String);
 
     impl MyString {
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new(v: &DiplomatStr) -> Box<MyString> {
             Box::new(Self(String::from_utf8(v.to_owned()).unwrap()))
         }
 
-        #[diplomat::attr(*, named_constructor = "unsafe")]
+        #[diplomat::attr(auto, named_constructor = "unsafe")]
         pub fn new_unsafe(v: &str) -> Box<MyString> {
             Box::new(Self(v.to_string()))
         }
@@ -27,12 +27,12 @@ mod ffi {
             Box::new(Self(core::str::from_utf8(v[0]).unwrap().into()))
         }
 
-        #[diplomat::attr(*, setter = "str")]
+        #[diplomat::attr(auto, setter = "str")]
         pub fn set_str(&mut self, new_str: &DiplomatStr) {
             self.0 = String::from_utf8(new_str.to_owned()).unwrap();
         }
 
-        #[diplomat::attr(*, getter = "str")]
+        #[diplomat::attr(auto, getter = "str")]
         pub fn get_str(&self, write: &mut DiplomatWrite) {
             let _infallible = write!(write, "{}", self.0);
         }
@@ -48,37 +48,37 @@ mod ffi {
 
     impl Float64Vec {
         #[diplomat::attr(not(supports = memory_sharing), disable)]
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new(v: &[f64]) -> Box<Float64Vec> {
             Box::new(Self(v.to_vec()))
         }
 
-        #[diplomat::attr(*, named_constructor = "bool")]
+        #[diplomat::attr(auto, named_constructor = "bool")]
         pub fn new_bool(v: &[bool]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
 
-        #[diplomat::attr(*, named_constructor = "i16")]
+        #[diplomat::attr(auto, named_constructor = "i16")]
         pub fn new_i16(v: &[i16]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as f64).collect()))
         }
 
-        #[diplomat::attr(*, named_constructor = "u16")]
+        #[diplomat::attr(auto, named_constructor = "u16")]
         pub fn new_u16(v: &[u16]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as f64).collect()))
         }
 
-        #[diplomat::attr(*, named_constructor = "isize")]
+        #[diplomat::attr(auto, named_constructor = "isize")]
         pub fn new_isize(v: &[isize]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as f64).collect()))
         }
 
-        #[diplomat::attr(*, named_constructor = "usize")]
+        #[diplomat::attr(auto, named_constructor = "usize")]
         pub fn new_usize(v: &[usize]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as f64).collect()))
         }
 
-        #[diplomat::attr(*, named_constructor = "f64BeBytes")]
+        #[diplomat::attr(auto, named_constructor = "f64BeBytes")]
         pub fn new_f64_be_bytes(v: &[DiplomatByte]) -> Box<Float64Vec> {
             Box::new(Self(
                 v.chunks_exact(8)
@@ -88,12 +88,12 @@ mod ffi {
         }
 
         #[diplomat::attr(supports = memory_sharing, disable)]
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new_from_owned(v: Box<[f64]>) -> Box<Float64Vec> {
             Box::new(Self(v.into()))
         }
 
-        #[diplomat::attr(*, getter = "asSlice")]
+        #[diplomat::attr(auto, getter = "asSlice")]
         pub fn as_slice<'a>(&'a self) -> &'a [f64] {
             &self.0
         }
@@ -106,7 +106,7 @@ mod ffi {
             self.0 = new_slice.to_vec();
         }
 
-        #[diplomat::attr(*, stringifier)]
+        #[diplomat::attr(auto, stringifier)]
         pub fn to_string(&self, w: &mut DiplomatWrite) {
             let _infallible = write!(w, "{:?}", self.0);
         }
@@ -116,7 +116,7 @@ mod ffi {
             &self.0
         }
 
-        #[diplomat::attr(*, indexer)]
+        #[diplomat::attr(auto, indexer)]
         pub fn get(&self, i: usize) -> Option<f64> {
             self.0.get(i).copied()
         }

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -49,7 +49,7 @@ pub mod ffi {
     pub struct MyZst;
 
     impl Opaque {
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new() -> Box<Opaque> {
             Box::new(Opaque("".into()))
         }
@@ -140,7 +140,7 @@ pub mod ffi {
     }
 
     impl Utf16Wrap {
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn from_utf16(input: &DiplomatStr16) -> Box<Self> {
             Box::new(Self(input.into()))
         }
@@ -165,7 +165,7 @@ pub mod ffi {
     }
 
     impl MyStruct {
-        #[diplomat::attr(*, constructor)]
+        #[diplomat::attr(auto, constructor)]
         pub fn new() -> MyStruct {
             MyStruct {
                 a: 17,

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -15,7 +15,6 @@ use diplomat_core::hir::BackendAttrSupport;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = false;
     a.namespacing = false;
     a.memory_sharing = true;
     a.non_exhaustive_structs = false;

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -15,12 +15,23 @@ use diplomat_core::hir::BackendAttrSupport;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = false;
+    a.namespacing = false;
     a.memory_sharing = true;
     a.non_exhaustive_structs = false;
     a.method_overloading = false;
     a.utf8_strings = true;
     a.utf16_strings = true;
+
+    a.constructors = false;
+    a.named_constructors = false;
     a.fallible_constructors = false;
+    a.accessors = false;
+    a.comparators = false;
+    a.stringifiers = false;
+    a.iterators = false;
+    a.iterables = false;
+    a.indexing = false;
 
     a
 }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -10,7 +10,6 @@ use ty::TyGenContext;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = true;
     a.namespacing = true;
     a.memory_sharing = true;
     a.non_exhaustive_structs = false;

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -10,12 +10,23 @@ use ty::TyGenContext;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = true;
+    a.namespacing = true;
     a.memory_sharing = true;
     a.non_exhaustive_structs = false;
     a.method_overloading = true;
     a.utf8_strings = true;
     a.utf16_strings = true;
+
+    a.constructors = false; // TODO
+    a.named_constructors = false;
     a.fallible_constructors = false;
+    a.accessors = false;
+    a.comparators = false; // TODO
+    a.stringifiers = false; // TODO
+    a.iterators = false; // TODO
+    a.iterables = false; // TODO
+    a.indexing = false; // TODO
 
     a
 }

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -21,12 +21,23 @@ use formatter::DartFormatter;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = true;
+    a.namespacing = false;
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;
     a.method_overloading = false;
     a.utf8_strings = false;
     a.utf16_strings = true;
+
+    a.constructors = true;
+    a.named_constructors = true;
     a.fallible_constructors = true;
+    a.accessors = true;
+    a.stringifiers = true;
+    a.comparators = true;
+    a.iterators = true;
+    a.iterables = true;
+    a.indexing = true;
 
     a
 }

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -21,7 +21,6 @@ use formatter::DartFormatter;
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = true;
     a.namespacing = false;
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -32,12 +32,23 @@ impl FileType {
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = true;
+    a.namespacing = false;
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;
     a.method_overloading = false;
     a.utf8_strings = false;
     a.utf16_strings = true;
+
+    a.constructors = false;
+    a.named_constructors = false;
     a.fallible_constructors = false;
+    a.accessors = true;
+    a.comparators = false;
+    a.stringifiers = false; // TODO
+    a.iterators = false; // TODO
+    a.iterables = false; // TODO
+    a.indexing = false;
 
     a
 }

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -32,7 +32,6 @@ impl FileType {
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = true;
     a.namespacing = false;
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -23,12 +23,23 @@ use serde::{Deserialize, Serialize};
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
+    a.renaming = true;
+    a.namespacing = false; // TODO
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;
     a.method_overloading = true;
     a.utf8_strings = false;
     a.utf16_strings = true;
+
+    a.constructors = false; // TODO
+    a.named_constructors = false; // TODO
     a.fallible_constructors = false; // TODO
+    a.accessors = false;
+    a.stringifiers = false; // TODO
+    a.comparators = false; // TODO
+    a.iterators = true;
+    a.iterables = true;
+    a.indexing = true;
 
     a
 }

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -23,7 +23,6 @@ use serde::{Deserialize, Serialize};
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
-    a.renaming = true;
     a.namespacing = false; // TODO
     a.memory_sharing = false;
     a.non_exhaustive_structs = true;


### PR DESCRIPTION
Builds on top of https://github.com/rust-diplomat/diplomat/pull/584

This is the change I proposed in #563

This makes it clearer as to when the attribute is automatically deciding which backend to target, and brings back some error messages when you try and unconditionally force an unsupported attribute on a backend.