### PR TITLE
cleanups: do more quasiquoting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,6 @@ dependencies = [
  "displaydoc",
  "either",
  "insta",
- "lazy_static",
  "proc-macro2",
  "quote",
  "serde",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,6 @@ all-features = true
 syn = { version = "2", features = [ "full", "extra-traits" ] }
 quote = "1.0"
 proc-macro2 = "1.0.27"
-lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 displaydoc = { version = "0.2", optional = true }
 smallvec = "1.9.0"

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -371,8 +371,8 @@ impl TypeName {
     pub fn to_syn(&self) -> syn::Type {
         match self {
             TypeName::Primitive(name) => {
-                let ident = name.to_ident();
-                syn::parse_quote_spanned!(Span::call_site() => #ident)
+                let primitive = primitive.to_ident();
+                syn::parse_quote_spanned!(Span::call_site() => #primitive)
             }
             TypeName::Ordering => syn::parse_quote_spanned!(Span::call_site() => i8),
             TypeName::Named(name) | TypeName::SelfType(name) => {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -452,7 +452,7 @@ impl TypeName {
                 syn::parse_quote_spanned!(Span::call_site() => #reference [#primitive])
             }
             TypeName::PrimitiveSlice(None, primitive) => {
-                let primitive = name.to_ident();
+                let primitive = primitive.to_ident();
                 syn::parse_quote_spanned!(Span::call_site() => Box<[#primitive]>)
             }
             TypeName::Unit => syn::parse_quote_spanned!(Span::call_site() => ()),

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -446,10 +446,10 @@ impl TypeName {
                 syn::parse_quote_spanned!(Span::call_site() => &[&str])
             }
             TypeName::PrimitiveSlice(Some((lifetime, mutability)), name) => {
-                let primitive_name = name.to_ident();
+                let primitive = primitive.to_ident();
                 let reference = ReferenceDisplay(lifetime, mutability);
 
-                syn::parse_quote_spanned!(Span::call_site() => #reference [#primitive_name])
+                syn::parse_quote_spanned!(Span::call_site() => #reference [#primitive])
             }
             TypeName::PrimitiveSlice(None, name) => {
                 let primitive_name = name.to_ident();

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -452,8 +452,8 @@ impl TypeName {
                 syn::parse_quote_spanned!(Span::call_site() => #reference [#primitive])
             }
             TypeName::PrimitiveSlice(None, primitive) => {
-                let primitive_name = name.to_ident();
-                syn::parse_quote_spanned!(Span::call_site() => Box<[#primitive_name]>)
+                let primitive = name.to_ident();
+                syn::parse_quote_spanned!(Span::call_site() => Box<[#primitive]>)
             }
             TypeName::Unit => syn::parse_quote_spanned!(Span::call_site() => ()),
         }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -370,7 +370,7 @@ impl TypeName {
     /// Converts the [`TypeName`] back into an AST node that can be spliced into a program.
     pub fn to_syn(&self) -> syn::Type {
         match self {
-            TypeName::Primitive(name) => {
+            TypeName::Primitive(primitive) => {
                 let primitive = primitive.to_ident();
                 syn::parse_quote_spanned!(Span::call_site() => #primitive)
             }
@@ -445,13 +445,13 @@ impl TypeName {
             TypeName::StrSlice(StringEncoding::Utf8) => {
                 syn::parse_quote_spanned!(Span::call_site() => &[&str])
             }
-            TypeName::PrimitiveSlice(Some((lifetime, mutability)), name) => {
+            TypeName::PrimitiveSlice(Some((lifetime, mutability)), primitive) => {
                 let primitive = primitive.to_ident();
                 let reference = ReferenceDisplay(lifetime, mutability);
 
                 syn::parse_quote_spanned!(Span::call_site() => #reference [#primitive])
             }
-            TypeName::PrimitiveSlice(None, name) => {
+            TypeName::PrimitiveSlice(None, primitive) => {
                 let primitive_name = name.to_ident();
                 syn::parse_quote_spanned!(Span::call_site() => Box<[#primitive_name]>)
             }


### PR DESCRIPTION
We should be using `quote!()` and friends almost anywhere we manually construct `syn` ASTs. It's cleaner, easier to read and edit. Split out of https://github.com/rust-diplomat/diplomat/pull/558 .

There's an argument to be made that our `to_syn()` should always be returning TokenStreams, it's not really worth it to reparse streams all the time. (`diplomat` is nowhere close to having perf issues so that's an optimization I'm not making right now, but I'm noting it if anyone wishes to spend time on it)