### PR TITLE
Error if 'auto' is used in a context where it is useless

### DIFF
--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__auto.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__auto.snap
@@ -3,3 +3,5 @@ source: core/src/hir/attrs.rs
 expression: output
 ---
 Lowering error in Opaque::next: `iterator` not supported in backend tests
+Lowering error in Opaque::auto_doesnt_work_on_renames: Diplomat attribute rename gated on 'auto' but is not one that works with 'auto'
+Lowering error in Opaque::auto_doesnt_work_on_disables: Diplomat attribute disable gated on 'auto' but is not one that works with 'auto'

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -5,17 +5,17 @@
 pub mod ffi {
     #[derive(Clone)]
     #[diplomat::opaque]
-    #[diplomat::attr(auto, rename = "AttrOpaque1Renamed")]
+    #[diplomat::attr(*, rename = "AttrOpaque1Renamed")]
     pub struct AttrOpaque1;
 
     impl AttrOpaque1 {
-        #[diplomat::attr(auto, rename = "totally_not_{0}")]
+        #[diplomat::attr(*, rename = "totally_not_{0}")]
         #[diplomat::attr(auto, constructor)]
         pub fn new() -> Box<AttrOpaque1> {
             Box::new(AttrOpaque1)
         }
 
-        #[diplomat::attr(auto, rename = "method_renamed")]
+        #[diplomat::attr(*, rename = "method_renamed")]
         #[diplomat::attr(auto, getter = "method")]
         pub fn method(&self) -> u8 {
             77
@@ -27,7 +27,7 @@ pub mod ffi {
             123
         }
 
-        #[diplomat::attr(auto, disable)]
+        #[diplomat::attr(*, disable)]
         pub fn method_disabled(&self) {
             println!("disabled in hir");
         }
@@ -42,13 +42,13 @@ pub mod ffi {
     pub enum AttrEnum {
         A,
         B,
-        #[diplomat::attr(auto, rename = "Renamed")]
+        #[diplomat::attr(*, rename = "Renamed")]
         C,
     }
 
     #[diplomat::opaque]
     #[diplomat::attr(auto, namespace = "")]
-    #[diplomat::attr(auto, rename = "Unnamespaced")]
+    #[diplomat::attr(*, rename = "Unnamespaced")]
     pub struct Unnamespaced;
 
     impl Unnamespaced {


### PR DESCRIPTION
Something I realized #585 could have done with after making a mistake in https://github.com/unicode-org/icu4x/pull/5277

I also suspect this code could be cleaned up by splitting the "parse an attribute" step from the "validate an attribute" step, if we had a nice parsed attribute enum a lot of this code could become smaller methods on ValidatedDiplomatAttr.