### PR TITLE
Use Type<InputOnly> in params

### DIFF
--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -13,9 +13,9 @@
 //!
 //! Broadly speaking, the Nomicon defines the elision rules are such:
 //! 1. If there's a `&self` or `&mut self`, the lifetime of that borrow
-//! corresponds to elision in the output.
+//!    corresponds to elision in the output.
 //! 2. Otherwise, if there's exactly one lifetime in the input, then that lifetime
-//! corresponds to elision in the output.
+//!    corresponds to elision in the output.
 //! 3. If neither of these cases hold, then the output cannot contain elision.
 //!
 //! What the Nomicon doesn't tell you is that there are weird corner cases around

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeSet;
 use std::ops::Deref;
 
-use super::{Attrs, Docs, Ident, IdentBuf, OutType, SelfType, Type, TypeContext};
+use super::{Attrs, Docs, Ident, IdentBuf, InputOnly, OutType, SelfType, Type, TypeContext};
 
 use super::lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
 
@@ -69,7 +69,7 @@ pub struct ParamSelf {
 #[non_exhaustive]
 pub struct Param {
     pub name: IdentBuf,
-    pub ty: Type,
+    pub ty: Type<InputOnly>,
 }
 
 impl SuccessType {
@@ -188,7 +188,7 @@ impl ParamSelf {
 }
 
 impl Param {
-    pub(super) fn new(name: IdentBuf, ty: Type) -> Self {
+    pub(super) fn new(name: IdentBuf, ty: Type<InputOnly>) -> Self {
         Self { name, ty }
     }
 }

--- a/core/src/hir/methods/borrowing_field.rs
+++ b/core/src/hir/methods/borrowing_field.rs
@@ -7,7 +7,9 @@ use std::fmt::{self, Write};
 
 use smallvec::SmallVec;
 
-use crate::hir::{paths, Ident, Method, SelfType, Slice, Type, TypeContext};
+use crate::hir::{
+    paths, Borrow, Ident, Method, SelfType, Slice, StructPath, TyPosition, Type, TypeContext,
+};
 
 use crate::hir::lifetimes::{Lifetime, Lifetimes, MaybeStatic};
 
@@ -180,8 +182,8 @@ impl<'m> BorrowingFieldVisitor<'m> {
     }
 
     /// Returns a new [`BorrowingFieldsVisitor`] corresponding to a type.
-    fn from_type(
-        ty: &'m Type,
+    fn from_type<P: TyPosition<StructPath = StructPath, OpaqueOwnership = Borrow>>(
+        ty: &'m Type<P>,
         tcx: &'m TypeContext,
         parent: ParentId,
         method_lifetimes: &Lifetimes,

--- a/core/src/hir/methods/borrowing_param.rs
+++ b/core/src/hir/methods/borrowing_param.rs
@@ -81,7 +81,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::hir::{self, Method, StructDef, TyPosition, TypeContext};
+use crate::hir::{self, Method, StructDef, StructPath, TyPosition, TypeContext};
 
 use crate::hir::lifetimes::{Lifetime, LifetimeEnv, MaybeStatic};
 use crate::hir::ty_position::StructPathLike;
@@ -173,7 +173,11 @@ impl<'tcx> BorrowingParamVisitor<'tcx> {
     /// lifetime or lifetimes longer than it are used by this parameter. In other words, check if
     /// it is possible for data in the return type with this lifetime to have been borrowed from this parameter.
     /// If so, add code that will yield the ownership-relevant parts of this object to incoming_edges for that lifetime.
-    pub fn visit_param(&mut self, ty: &hir::Type, param_name: &str) -> ParamBorrowInfo<'tcx> {
+    pub fn visit_param<P: TyPosition<StructPath = StructPath>>(
+        &mut self,
+        ty: &hir::Type<P>,
+        param_name: &str,
+    ) -> ParamBorrowInfo<'tcx> {
         let mut is_borrowed = false;
         if self.used_method_lifetimes.is_empty() {
             if let hir::Type::Slice(..) = *ty {

--- a/core/src/hir/paths.rs
+++ b/core/src/hir/paths.rs
@@ -31,12 +31,12 @@ pub struct StructPath<P: TyPosition = Everywhere> {
 /// Diplomat uses are:
 ///
 /// 1. `OpaquePath<Optional, MaybeOwn>`: Opaques in return types,
-/// which can be optional and either owned or borrowed.
+///    which can be optional and either owned or borrowed.
 /// 2. `OpaquePath<Optional, Borrow>`: Opaques in method parameters, which can
-/// be optional but must be borrowed, since most languages don't have a way to
-/// entirely give up ownership of a value.
+///    be optional but must be borrowed, since most languages don't have a way to
+///    entirely give up ownership of a value.
 /// 3. `OpaquePath<NonOptional, Borrow>`: Opaques in the `&self` position, which
-/// cannot be optional and must be borrowed for the same reason as above.
+///    cannot be optional and must be borrowed for the same reason as above.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct OpaquePath<Opt, Owner> {

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -76,7 +76,9 @@ pub struct Borrow {
     pub mutability: Mutability,
 }
 
-impl Type {
+// This is implemented on InputOnly and Everywhere types. Could be extended
+// if we genericize .resolve() later.
+impl<P: TyPosition<StructPath = StructPath>> Type<P> {
     /// Return the number of fields and leaves that will show up in the [`LifetimeTree`]
     /// returned by [`Param::lifetime_tree`] and [`ParamSelf::lifetime_tree`].
     ///

--- a/runtime/src/write.rs
+++ b/runtime/src/write.rs
@@ -166,7 +166,7 @@ pub extern "C" fn diplomat_buffer_write_create(cap: usize) -> *mut DiplomatWrite
 /// # Safety
 /// - The returned pointer is valid until the passed writable is destroyed.
 /// - `this` must be a pointer to a valid [`DiplomatWrite`] constructed by
-/// [`diplomat_buffer_write_create()`].
+///   [`diplomat_buffer_write_create()`].
 #[no_mangle]
 pub extern "C" fn diplomat_buffer_write_get_bytes(this: &DiplomatWrite) -> *mut u8 {
     if this.grow_failed {
@@ -182,7 +182,7 @@ pub extern "C" fn diplomat_buffer_write_get_bytes(this: &DiplomatWrite) -> *mut 
 ///
 /// # Safety
 /// - `this` must be a pointer to a valid [`DiplomatWrite`] constructed by
-/// [`diplomat_buffer_write_create()`].
+///   [`diplomat_buffer_write_create()`].
 #[no_mangle]
 pub extern "C" fn diplomat_buffer_write_len(this: &DiplomatWrite) -> usize {
     if this.grow_failed {
@@ -196,7 +196,7 @@ pub extern "C" fn diplomat_buffer_write_len(this: &DiplomatWrite) -> usize {
 ///
 /// # Safety
 /// - `this` must be a pointer to a valid [`DiplomatWrite`] constructed by
-/// [`diplomat_buffer_write_create()`].
+///   [`diplomat_buffer_write_create()`].
 #[no_mangle]
 pub unsafe extern "C" fn diplomat_buffer_write_destroy(this: *mut DiplomatWrite) {
     let this = Box::from_raw(this);

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 
-use diplomat_core::hir::{self, DemoInfo, Method, OpaqueDef, StructDef, Type, TypeContext};
+use diplomat_core::hir::{
+    self, DemoInfo, Method, OpaqueDef, StructDef, StructPath, TyPosition, Type, TypeContext,
+};
 
 use crate::{js::formatter::JSFormatter, ErrorStore};
 
@@ -206,9 +208,9 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
     /// 2. Go a step deeper and look at its possible constructors to call evaluate_param on.
     ///
     /// `node` - Represents the current function of the parameter we're evaluating. See [`MethodDependency`] for more on its purpose.
-    fn evaluate_param(
+    fn evaluate_param<P: TyPosition<StructPath = StructPath>>(
         &mut self,
-        param_type: &Type,
+        param_type: &Type<P>,
         param_name: String,
         node: &mut MethodDependency,
         method_attrs: DemoInfo,

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -3,8 +3,8 @@ use diplomat_core::hir::borrowing_param::{BorrowedLifetimeInfo, ParamBorrowInfo}
 use diplomat_core::hir::{
     self, BackendAttrSupport, Borrow, Lifetime, LifetimeEnv, Lifetimes, MaybeOwn, MaybeStatic,
     Method, Mutability, OpaquePath, Optional, OutType, Param, PrimitiveType, ReturnableStructDef,
-    SelfType, Slice, SpecialMethod, StringEncoding, StructField, StructPathLike, TyPosition, Type,
-    TypeContext, TypeDef,
+    SelfType, Slice, SpecialMethod, StringEncoding, StructField, StructPath, StructPathLike,
+    TyPosition, Type, TypeContext, TypeDef,
 };
 use diplomat_core::hir::{ReturnType, SuccessType};
 
@@ -236,7 +236,11 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
         }
     }
 
-    fn gen_kt_to_c_for_type(&self, ty: &Type, name: Cow<'cx, str>) -> Cow<'cx, str> {
+    fn gen_kt_to_c_for_type<P: TyPosition<StructPath = StructPath, OpaqueOwnership = Borrow>>(
+        &self,
+        ty: &Type<P>,
+        name: Cow<'cx, str>,
+    ) -> Cow<'cx, str> {
         match *ty {
             Type::Primitive(prim) => self
                 .formatter


### PR DESCRIPTION
Should avoid CanBeInputType in https://github.com/rust-diplomat/diplomat/pull/552