### PR TITLE
Adding reserved class names

### DIFF
--- a/feature_tests/js/api/MyStruct.mjs
+++ b/feature_tests/js/api/MyStruct.mjs
@@ -134,7 +134,7 @@ export class MyStruct {
         try {
             if (!diplomatReceive.resultFlag) {
                 const cause = new MyZst();
-                throw new Error('MyZst', { cause });
+                throw new globalThis.Error('MyZst', { cause });
             }
     
         }

--- a/feature_tests/js/api/ResultOpaque.mjs
+++ b/feature_tests/js/api/ResultOpaque.mjs
@@ -36,7 +36,7 @@ export class ResultOpaque {
         try {
             if (!diplomatReceive.resultFlag) {
                 const cause = ErrorEnum[Array.from(ErrorEnum.values.keys())[diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer)]];
-                throw new Error('ErrorEnum: ' + cause.value, { cause });
+                throw new globalThis.Error('ErrorEnum: ' + cause.value, { cause });
             }
             return new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomatReceive.buffer), []);
         }
@@ -54,7 +54,7 @@ export class ResultOpaque {
         try {
             if (!diplomatReceive.resultFlag) {
                 const cause = ErrorEnum[Array.from(ErrorEnum.values.keys())[diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer)]];
-                throw new Error('ErrorEnum: ' + cause.value, { cause });
+                throw new globalThis.Error('ErrorEnum: ' + cause.value, { cause });
             }
             return new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomatReceive.buffer), []);
         }
@@ -72,7 +72,7 @@ export class ResultOpaque {
         try {
             if (!diplomatReceive.resultFlag) {
                 const cause = ErrorEnum[Array.from(ErrorEnum.values.keys())[diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer)]];
-                throw new Error('ErrorEnum: ' + cause.value, { cause });
+                throw new globalThis.Error('ErrorEnum: ' + cause.value, { cause });
             }
             return new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomatReceive.buffer), []);
         }
@@ -107,7 +107,7 @@ export class ResultOpaque {
         try {
             if (!diplomatReceive.resultFlag) {
                 const cause = new ErrorStruct()._fromFFI(diplomatReceive.buffer);
-                throw new Error('ErrorStruct: ' + cause.toString(), { cause });
+                throw new globalThis.Error('ErrorStruct: ' + cause.toString(), { cause });
             }
             return new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomatReceive.buffer), []);
         }
@@ -125,7 +125,7 @@ export class ResultOpaque {
         try {
             if (!diplomatReceive.resultFlag) {
                 const cause = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomatReceive.buffer), []);
-                throw new Error('ResultOpaque: ' + cause.toString(), { cause });
+                throw new globalThis.Error('ResultOpaque: ' + cause.toString(), { cause });
             }
     
         }
@@ -160,7 +160,7 @@ export class ResultOpaque {
         try {
             if (!diplomatReceive.resultFlag) {
                 const cause = new ResultOpaque(diplomatRuntime.ptrRead(wasm, diplomatReceive.buffer), []);
-                throw new Error('ResultOpaque: ' + cause.toString(), { cause });
+                throw new globalThis.Error('ResultOpaque: ' + cause.toString(), { cause });
             }
             return ErrorEnum[Array.from(ErrorEnum.values.keys())[diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer)]];
         }

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -125,7 +125,6 @@ impl<'tcx> JSFormatter<'tcx> {
             .rename
             .apply(type_def.name().as_str().into());
 
-        
         if RESERVED_TYPES.contains(&&*name) {
             format!("{name}_").into()
         } else {

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -126,10 +126,10 @@ impl<'tcx> JSFormatter<'tcx> {
             .apply(type_def.name().as_str().into());
 
         if RESERVED_TYPES.contains(&&*name) {
-            format!("{name}_").into()
-        } else {
-            name
+            panic!("{name} is not an allowed type. Please rename.")
         }
+
+        name
     }
 
     pub fn fmt_file_name_extensionless(&self, type_name: &str) -> String {

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -43,6 +43,66 @@ const RESERVED: &[&str] = &[
     "with",
 ];
 
+/// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
+const RESERVED_TYPES: &[&str] = &[
+    "Infinity",
+    "NaN",
+    "Object",
+    "Function",
+    "Boolean",
+    "Symbol",
+    "Error",
+    "AggregateError",
+    "EvalError",
+    "RangeError",
+    "ReferenceError",
+    "SyntaxError",
+    "TypeError",
+    "URIError",
+    "InternalError",
+    "Number",
+    "BigInt",
+    "Math",
+    "Date",
+    "String",
+    "RegExp",
+    "Array",
+    "Int8Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "Int16Array",
+    "Uint16Array",
+    "Int32Array",
+    "Uint32Array",
+    "BigInt64Array",
+    "BigUint64Array",
+    "Float16Array",
+    "Float32Array",
+    "Float64Array",
+    "Map",
+    "Set",
+    "WeakMap",
+    "WeakSet",
+    "ArrayBuffer",
+    "SharedArrayBuffer",
+    "DataView",
+    "Atomics",
+    "JSON",
+    "WeakRef",
+    "FinalizationRegistry",
+    "Iterator",
+    "AsyncIterator",
+    "Promise",
+    "GeneratorFunction",
+    "AsyncGeneratorFunction",
+    "Generator",
+    "AsyncGenerator",
+    "AsyncFunction",
+    "Reflect",
+    "Proxy",
+    "Intl",
+];
+
 /// Helper class for us to format JS identifiers from the HIR.
 pub(crate) struct JSFormatter<'tcx> {
     /// Per [`CFormatter`]'s documentation we use it for support.
@@ -60,10 +120,17 @@ impl<'tcx> JSFormatter<'tcx> {
     pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
         let type_def = self.tcx.resolve_type(id);
 
-        type_def
+        let name = type_def
             .attrs()
             .rename
-            .apply(type_def.name().as_str().into())
+            .apply(type_def.name().as_str().into());
+
+        
+        if RESERVED_TYPES.contains(&&*name) {
+            format!("{name}_").into()
+        } else {
+            name
+        }
     }
 
     pub fn fmt_file_name_extensionless(&self, type_name: &str) -> String {

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -37,6 +37,7 @@ const RESERVED: &[&str] = &[
     "true",
     "try",
     "typeof",
+    "undefined",
     "var",
     "void",
     "while",
@@ -47,60 +48,6 @@ const RESERVED: &[&str] = &[
 const RESERVED_TYPES: &[&str] = &[
     "Infinity",
     "NaN",
-    "Object",
-    "Function",
-    "Boolean",
-    "Symbol",
-    "Error",
-    "AggregateError",
-    "EvalError",
-    "RangeError",
-    "ReferenceError",
-    "SyntaxError",
-    "TypeError",
-    "URIError",
-    "InternalError",
-    "Number",
-    "BigInt",
-    "Math",
-    "Date",
-    "String",
-    "RegExp",
-    "Array",
-    "Int8Array",
-    "Uint8Array",
-    "Uint8ClampedArray",
-    "Int16Array",
-    "Uint16Array",
-    "Int32Array",
-    "Uint32Array",
-    "BigInt64Array",
-    "BigUint64Array",
-    "Float16Array",
-    "Float32Array",
-    "Float64Array",
-    "Map",
-    "Set",
-    "WeakMap",
-    "WeakSet",
-    "ArrayBuffer",
-    "SharedArrayBuffer",
-    "DataView",
-    "Atomics",
-    "JSON",
-    "WeakRef",
-    "FinalizationRegistry",
-    "Iterator",
-    "AsyncIterator",
-    "Promise",
-    "GeneratorFunction",
-    "AsyncGeneratorFunction",
-    "Generator",
-    "AsyncGenerator",
-    "AsyncFunction",
-    "Reflect",
-    "Proxy",
-    "Intl",
 ];
 
 /// Helper class for us to format JS identifiers from the HIR.
@@ -125,7 +72,7 @@ impl<'tcx> JSFormatter<'tcx> {
             .rename
             .apply(type_def.name().as_str().into());
 
-        if RESERVED_TYPES.contains(&&*name) {
+        if RESERVED_TYPES.contains(&&*name) || RESERVED.contains(&&*name)  {
             panic!("{name} is not an allowed type in JS. Please rename.")
         }
 

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -45,10 +45,7 @@ const RESERVED: &[&str] = &[
 ];
 
 /// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
-const RESERVED_TYPES: &[&str] = &[
-    "Infinity",
-    "NaN",
-];
+const RESERVED_TYPES: &[&str] = &["Infinity", "NaN"];
 
 /// Helper class for us to format JS identifiers from the HIR.
 pub(crate) struct JSFormatter<'tcx> {
@@ -72,7 +69,7 @@ impl<'tcx> JSFormatter<'tcx> {
             .rename
             .apply(type_def.name().as_str().into());
 
-        if RESERVED_TYPES.contains(&&*name) || RESERVED.contains(&&*name)  {
+        if RESERVED_TYPES.contains(&&*name) || RESERVED.contains(&&*name) {
             panic!("{name} is not an allowed type in JS. Please rename.")
         }
 

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -126,7 +126,7 @@ impl<'tcx> JSFormatter<'tcx> {
             .apply(type_def.name().as_str().into());
 
         if RESERVED_TYPES.contains(&&*name) {
-            panic!("{name} is not an allowed type. Please rename.")
+            panic!("{name} is not an allowed type in JS. Please rename.")
         }
 
         name

--- a/tool/src/js/type_generation/converter.rs
+++ b/tool/src/js/type_generation/converter.rs
@@ -438,7 +438,7 @@ impl<'jsctx, 'tcx> TyGenContext<'jsctx, 'tcx> {
                             let cause =
                                 self.gen_c_to_js_for_type(e, receive_deref, &method.lifetime_env);
                             format!(
-                            "const cause = {cause};\n    throw new Error({message}, {{ cause }})", 
+                            "const cause = {cause};\n    throw new globalThis.Error({message}, {{ cause }})", 
                             message = match e {
                                 Type::Enum(..) => format!("'{type_name}: ' + cause.value"),
                                 Type::Struct(s) if match s.resolve(self.tcx) {


### PR DESCRIPTION
Fixing an issue I had working with the demo generator.

There's a class that ICU4X js generates called `Error`, which creates a bug when diplomat's internal JS is trying to call the right error.

Not sure if we want all of these classes in here (especially if anyone wants to feel clever and override JS definitions through diplomat FFI files), but we should definitely limit the ability to create JS classes named `Error`.