### PR TITLE
Fixing wrong primitive slice constructor

### DIFF
--- a/feature_tests/js/api/Float64Vec.mjs
+++ b/feature_tests/js/api/Float64Vec.mjs
@@ -138,7 +138,7 @@ export class Float64Vec {
         const result = wasm.Float64Vec_as_slice(diplomatReceive.buffer, this.ffiValue);
     
         try {
-            return new diplomatRuntime.DiplomatPrimitiveSlice.getSlice(wasm, diplomatReceive.buffer, "f64", aEdges);
+            return new diplomatRuntime.DiplomatSlicePrimitive.getSlice(wasm, diplomatReceive.buffer, "f64", aEdges);
         }
         
         finally {
@@ -193,7 +193,7 @@ export class Float64Vec {
         const result = wasm.Float64Vec_borrow(diplomatReceive.buffer, this.ffiValue);
     
         try {
-            return new diplomatRuntime.DiplomatPrimitiveSlice.getSlice(wasm, diplomatReceive.buffer, "f64", aEdges);
+            return new diplomatRuntime.DiplomatSlicePrimitive.getSlice(wasm, diplomatReceive.buffer, "f64", aEdges);
         }
         
         finally {

--- a/tool/src/js/type_generation/converter.rs
+++ b/tool/src/js/type_generation/converter.rs
@@ -203,7 +203,7 @@ impl<'jsctx, 'tcx> TyGenContext<'jsctx, 'tcx> {
                 // Slices are always returned to us by way of pointers, so we assume that we can just access DiplomatReceiveBuf's helper functions:
                 match slice {
                     hir::Slice::Primitive(_, primitive_type) => format!(
-                        r#"new diplomatRuntime.DiplomatPrimitiveSlice.getSlice(wasm, {variable_name}, "{}", {edges})"#,
+                        r#"new diplomatRuntime.DiplomatSlicePrimitive.getSlice(wasm, {variable_name}, "{}", {edges})"#,
                         self.formatter.fmt_primitive_list_view(primitive_type)
                     )
                     .into(),


### PR DESCRIPTION
My mistake, just called it the wrong thing in `converter.rs`