### PR TITLE
Typescript: Make Array<char> into Array<string> because there is no char type

### DIFF
--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -191,7 +191,8 @@ impl<'tcx> JSFormatter<'tcx> {
     pub fn fmt_primitive_list_type(&self, primitive: hir::PrimitiveType) -> &'static str {
         match primitive {
             hir::PrimitiveType::Bool => "Array<boolean>",
-            hir::PrimitiveType::Char => "Array<char>",
+            // TODO: Can't exactly test for characters with Typescript, but we could create a type guard?
+            hir::PrimitiveType::Char => "Array<string>",
             hir::PrimitiveType::Byte => "Uint8Array",
             hir::PrimitiveType::Int(hir::IntType::I64 | hir::IntType::U64) => "Array<bigint>",
             hir::PrimitiveType::Int(_)

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -191,7 +191,7 @@ impl<'tcx> JSFormatter<'tcx> {
     pub fn fmt_primitive_list_type(&self, primitive: hir::PrimitiveType) -> &'static str {
         match primitive {
             hir::PrimitiveType::Bool => "Array<boolean>",
-            hir::PrimitiveType::Char => "Array<codepoint>",
+            hir::PrimitiveType::Char => "string",
             hir::PrimitiveType::Byte => "Uint8Array",
             hir::PrimitiveType::Int(hir::IntType::I64 | hir::IntType::U64) => "Array<bigint>",
             hir::PrimitiveType::Int(_)

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -191,8 +191,7 @@ impl<'tcx> JSFormatter<'tcx> {
     pub fn fmt_primitive_list_type(&self, primitive: hir::PrimitiveType) -> &'static str {
         match primitive {
             hir::PrimitiveType::Bool => "Array<boolean>",
-            // TODO: Can't exactly test for characters with Typescript, but we could create a type guard?
-            hir::PrimitiveType::Char => "Array<string>",
+            hir::PrimitiveType::Char => "Array<codepoint>",
             hir::PrimitiveType::Byte => "Uint8Array",
             hir::PrimitiveType::Int(hir::IntType::I64 | hir::IntType::U64) => "Array<bigint>",
             hir::PrimitiveType::Int(_)

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -191,7 +191,7 @@ impl<'tcx> JSFormatter<'tcx> {
     pub fn fmt_primitive_list_type(&self, primitive: hir::PrimitiveType) -> &'static str {
         match primitive {
             hir::PrimitiveType::Bool => "Array<boolean>",
-            hir::PrimitiveType::Char => "string",
+            hir::PrimitiveType::Char => "Array<codepoint>",
             hir::PrimitiveType::Byte => "Uint8Array",
             hir::PrimitiveType::Int(hir::IntType::I64 | hir::IntType::U64) => "Array<bigint>",
             hir::PrimitiveType::Int(_)


### PR DESCRIPTION
Should fix the TS build errors we're seeing in ICU4X