### PR TITLE
JS Whitespace Fix on Methods

### DIFF
--- a/example/js/lib/api/DataProvider.mjs
+++ b/example/js/lib/api/DataProvider.mjs
@@ -38,7 +38,8 @@ export class DataProvider {
         return this.#ptr;
     }
 
-    static newStatic() {const result = wasm.icu4x_DataProvider_new_static_mv1();
+    static newStatic() {
+        const result = wasm.icu4x_DataProvider_new_static_mv1();
     
         try {
             return new DataProvider(diplomatRuntime.internalConstructor, result, []);
@@ -47,7 +48,8 @@ export class DataProvider {
         finally {}
     }
 
-    static returnsResult() {const result = wasm.icu4x_DataProvider_returns_result_mv1();
+    static returnsResult() {
+        const result = wasm.icu4x_DataProvider_returns_result_mv1();
     
         try {
             return result === 1;

--- a/example/js/lib/api/FixedDecimal.mjs
+++ b/example/js/lib/api/FixedDecimal.mjs
@@ -36,7 +36,8 @@ export class FixedDecimal {
         return this.#ptr;
     }
 
-    static new_(v) {const result = wasm.icu4x_FixedDecimal_new_mv1(v);
+    static new_(v) {
+        const result = wasm.icu4x_FixedDecimal_new_mv1(v);
     
         try {
             return new FixedDecimal(diplomatRuntime.internalConstructor, result, []);
@@ -54,6 +55,7 @@ export class FixedDecimal {
 
     toString() {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
+        
         const result = wasm.icu4x_FixedDecimal_to_string_mv1(this.ffiValue, write.buffer);
     
         try {

--- a/example/js/lib/api/FixedDecimalFormatter.mjs
+++ b/example/js/lib/api/FixedDecimalFormatter.mjs
@@ -46,6 +46,7 @@ export class FixedDecimalFormatter {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.icu4x_FixedDecimalFormatter_try_new_mv1(diplomatReceive.buffer, locale.ffiValue, provider.ffiValue, ...options._intoFFI(functionCleanupArena, {}));
     
         try {

--- a/example/js/lib/api/FixedDecimalFormatterOptions.mjs
+++ b/example/js/lib/api/FixedDecimalFormatterOptions.mjs
@@ -54,6 +54,7 @@ export class FixedDecimalFormatterOptions {
 
     static default_() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, false);
+        
         const result = wasm.icu4x_FixedDecimalFormatterOptions_default_mv1(diplomatReceive.buffer);
     
         try {

--- a/example/js/lib/api/Locale.mjs
+++ b/example/js/lib/api/Locale.mjs
@@ -42,6 +42,7 @@ export class Locale {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const nameSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, name)).splat()];
+        
         const result = wasm.icu4x_Locale_new_mv1(...nameSlice);
     
         try {

--- a/feature_tests/js/api/AttrOpaque1Renamed.mjs
+++ b/feature_tests/js/api/AttrOpaque1Renamed.mjs
@@ -35,7 +35,8 @@ export class AttrOpaque1Renamed {
         return this.#ptr;
     }
 
-    static totallyNotNew() {const result = wasm.namespace_AttrOpaque1_new();
+    static totallyNotNew() {
+        const result = wasm.namespace_AttrOpaque1_new();
     
         try {
             return new AttrOpaque1Renamed(diplomatRuntime.internalConstructor, result, []);
@@ -44,7 +45,8 @@ export class AttrOpaque1Renamed {
         finally {}
     }
 
-    get methodRenamed() {const result = wasm.namespace_AttrOpaque1_method(this.ffiValue);
+    get methodRenamed() {
+        const result = wasm.namespace_AttrOpaque1_method(this.ffiValue);
     
         try {
             return result;
@@ -53,7 +55,8 @@ export class AttrOpaque1Renamed {
         finally {}
     }
 
-    get abirenamed() {const result = wasm.renamed_on_abi_only(this.ffiValue);
+    get abirenamed() {
+        const result = wasm.renamed_on_abi_only(this.ffiValue);
     
         try {
             return result;

--- a/feature_tests/js/api/Bar.mjs
+++ b/feature_tests/js/api/Bar.mjs
@@ -48,6 +48,7 @@ export class Bar {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.Bar_foo(this.ffiValue);
     
         try {

--- a/feature_tests/js/api/BorrowedFields.mjs
+++ b/feature_tests/js/api/BorrowedFields.mjs
@@ -80,6 +80,7 @@ export class BorrowedFields {
         
         // This lifetime edge depends on lifetimes 'x
         let xEdges = [bar, dstr16Slice, utf8StrSlice];
+        
         const result = wasm.BorrowedFields_from_bar_and_strings(diplomatReceive.buffer, bar.ffiValue, ...dstr16Slice, ...utf8StrSlice);
     
         try {

--- a/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
+++ b/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
@@ -106,6 +106,7 @@ export class BorrowedFieldsWithBounds {
         
         // This lifetime edge depends on lifetimes 'z
         let zEdges = [utf8StrZSlice];
+        
         const result = wasm.BorrowedFieldsWithBounds_from_foo_and_strings(diplomatReceive.buffer, foo.ffiValue, ...dstr16XSlice, ...utf8StrZSlice);
     
         try {

--- a/feature_tests/js/api/CyclicStructA.mjs
+++ b/feature_tests/js/api/CyclicStructA.mjs
@@ -43,6 +43,7 @@ export class CyclicStructA {
 
     static getB() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 1, 1, false);
+        
         const result = wasm.CyclicStructA_get_b(diplomatReceive.buffer);
     
         try {

--- a/feature_tests/js/api/CyclicStructB.mjs
+++ b/feature_tests/js/api/CyclicStructB.mjs
@@ -43,6 +43,7 @@ export class CyclicStructB {
 
     static getA() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 1, 1, false);
+        
         const result = wasm.CyclicStructB_get_a(diplomatReceive.buffer);
     
         try {

--- a/feature_tests/js/api/Float64Vec.mjs
+++ b/feature_tests/js/api/Float64Vec.mjs
@@ -37,6 +37,7 @@ export class Float64Vec {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "boolean")).splat()];
+        
         const result = wasm.Float64Vec_new_bool(...vSlice);
     
         try {
@@ -52,6 +53,7 @@ export class Float64Vec {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "i16")).splat()];
+        
         const result = wasm.Float64Vec_new_i16(...vSlice);
     
         try {
@@ -67,6 +69,7 @@ export class Float64Vec {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u16")).splat()];
+        
         const result = wasm.Float64Vec_new_u16(...vSlice);
     
         try {
@@ -82,6 +85,7 @@ export class Float64Vec {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "i32")).splat()];
+        
         const result = wasm.Float64Vec_new_isize(...vSlice);
     
         try {
@@ -97,6 +101,7 @@ export class Float64Vec {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u32")).splat()];
+        
         const result = wasm.Float64Vec_new_usize(...vSlice);
     
         try {
@@ -112,6 +117,7 @@ export class Float64Vec {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u8")).splat()];
+        
         const result = wasm.Float64Vec_new_f64_be_bytes(...vSlice);
     
         try {
@@ -127,6 +133,7 @@ export class Float64Vec {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "f64")).splat()];
+        
         const result = wasm.Float64Vec_new_from_owned(...vSlice);
     
         try {
@@ -143,6 +150,7 @@ export class Float64Vec {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.Float64Vec_as_slice(diplomatReceive.buffer, this.ffiValue);
     
         try {
@@ -198,6 +206,7 @@ export class Float64Vec {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.Float64Vec_borrow(diplomatReceive.buffer, this.ffiValue);
     
         try {
@@ -211,6 +220,7 @@ export class Float64Vec {
 
     get(i) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 9, 8, true);
+        
         const result = wasm.Float64Vec_get(diplomatReceive.buffer, this.ffiValue, i);
     
         try {

--- a/feature_tests/js/api/Foo.mjs
+++ b/feature_tests/js/api/Foo.mjs
@@ -47,6 +47,7 @@ export class Foo {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [xSlice];
+        
         const result = wasm.Foo_new(...xSlice);
     
         try {
@@ -64,6 +65,7 @@ export class Foo {
         
         // This lifetime edge depends on lifetimes 'a, 'b
         let bEdges = [this];
+        
         const result = wasm.Foo_get_bar(this.ffiValue);
     
         try {
@@ -78,6 +80,7 @@ export class Foo {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.Foo_as_returning(diplomatReceive.buffer, this.ffiValue);
     
         try {
@@ -94,6 +97,7 @@ export class Foo {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [...fields._fieldsForLifetimeA];
+        
         const result = wasm.Foo_extract_from_fields(...fields._intoFFI(functionCleanupArena, {aAppendArray: [aEdges],}));
     
         try {
@@ -113,6 +117,7 @@ export class Foo {
         
         // This lifetime edge depends on lifetimes 'a, 'y, 'z
         let aEdges = [...bounds._fieldsForLifetimeB, ...bounds._fieldsForLifetimeC, anotherStringSlice];
+        
         const result = wasm.Foo_extract_from_bounds(...bounds._intoFFI(functionCleanupArena, {bAppendArray: [aEdges],cAppendArray: [aEdges],}), ...anotherStringSlice);
     
         try {

--- a/feature_tests/js/api/MyEnum.mjs
+++ b/feature_tests/js/api/MyEnum.mjs
@@ -44,7 +44,8 @@ export class MyEnum {
     static E = new MyEnum("E");
     static F = new MyEnum("F");
 
-    intoValue() {const result = wasm.MyEnum_into_value(this.ffiValue);
+    intoValue() {
+        const result = wasm.MyEnum_into_value(this.ffiValue);
     
         try {
             return result;
@@ -53,7 +54,8 @@ export class MyEnum {
         finally {}
     }
 
-    static getA() {const result = wasm.MyEnum_get_a();
+    static getA() {
+        const result = wasm.MyEnum_get_a();
     
         try {
             return (() => {for (let i of MyEnum.values) { if(i[1] === result) return MyEnum[i[0]]; } return null;})();

--- a/feature_tests/js/api/MyString.mjs
+++ b/feature_tests/js/api/MyString.mjs
@@ -37,6 +37,7 @@ export class MyString {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v)).splat()];
+        
         const result = wasm.MyString_new(...vSlice);
     
         try {
@@ -52,6 +53,7 @@ export class MyString {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v)).splat()];
+        
         const result = wasm.MyString_new_unsafe(...vSlice);
     
         try {
@@ -67,6 +69,7 @@ export class MyString {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v)).splat()];
+        
         const result = wasm.MyString_new_owned(...vSlice);
     
         try {
@@ -82,6 +85,7 @@ export class MyString {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.strs(wasm, v, "string8")).splat()];
+        
         const result = wasm.MyString_new_from_first(...vSlice);
     
         try {

--- a/feature_tests/js/api/MyStruct.mjs
+++ b/feature_tests/js/api/MyStruct.mjs
@@ -110,6 +110,7 @@ export class MyStruct {
 
     static new_() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 28, 8, false);
+        
         const result = wasm.MyStruct_new(diplomatReceive.buffer);
     
         try {
@@ -123,6 +124,7 @@ export class MyStruct {
 
     intoA() {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
+        
         const result = wasm.MyStruct_into_a(...this._intoFFI());
     
         try {
@@ -134,7 +136,8 @@ export class MyStruct {
         }
     }
 
-    static returnsZstResult() {const result = wasm.MyStruct_returns_zst_result();
+    static returnsZstResult() {
+        const result = wasm.MyStruct_returns_zst_result();
     
         try {
             if (result !== 1) {
@@ -147,7 +150,8 @@ export class MyStruct {
         finally {}
     }
 
-    static failsZstResult() {const result = wasm.MyStruct_fails_zst_result();
+    static failsZstResult() {
+        const result = wasm.MyStruct_fails_zst_result();
     
         try {
             if (result !== 1) {

--- a/feature_tests/js/api/NestedBorrowedFields.mjs
+++ b/feature_tests/js/api/NestedBorrowedFields.mjs
@@ -113,6 +113,7 @@ export class NestedBorrowedFields {
         
         // This lifetime edge depends on lifetimes 'z
         let zEdges = [foo, dstr16ZSlice, utf8StrZSlice];
+        
         const result = wasm.NestedBorrowedFields_from_bar_and_foo_and_strings(diplomatReceive.buffer, bar.ffiValue, foo.ffiValue, ...dstr16XSlice, ...dstr16ZSlice, ...utf8StrYSlice, ...utf8StrZSlice);
     
         try {

--- a/feature_tests/js/api/One.mjs
+++ b/feature_tests/js/api/One.mjs
@@ -41,6 +41,7 @@ export class One {
     static transitivity(hold, nohold) {
         // This lifetime edge depends on lifetimes 'a, 'b, 'c, 'd, 'e
         let aEdges = [hold];
+        
         const result = wasm.One_transitivity(hold.ffiValue, nohold.ffiValue);
     
         try {
@@ -53,6 +54,7 @@ export class One {
     static cycle(hold, nohold) {
         // This lifetime edge depends on lifetimes 'a, 'b, 'c
         let aEdges = [hold];
+        
         const result = wasm.One_cycle(hold.ffiValue, nohold.ffiValue);
     
         try {
@@ -65,6 +67,7 @@ export class One {
     static manyDependents(a, b, c, d, nohold) {
         // This lifetime edge depends on lifetimes 'a, 'b, 'c, 'd
         let aEdges = [a, b, c, d];
+        
         const result = wasm.One_many_dependents(a.ffiValue, b.ffiValue, c.ffiValue, d.ffiValue, nohold.ffiValue);
     
         try {
@@ -77,6 +80,7 @@ export class One {
     static returnOutlivesParam(hold, nohold) {
         // This lifetime edge depends on lifetimes 'long
         let longEdges = [hold];
+        
         const result = wasm.One_return_outlives_param(hold.ffiValue, nohold.ffiValue);
     
         try {
@@ -89,6 +93,7 @@ export class One {
     static diamondTop(top, left, right, bottom) {
         // This lifetime edge depends on lifetimes 'top, 'left, 'right, 'bottom
         let topEdges = [top, left, right, bottom];
+        
         const result = wasm.One_diamond_top(top.ffiValue, left.ffiValue, right.ffiValue, bottom.ffiValue);
     
         try {
@@ -101,6 +106,7 @@ export class One {
     static diamondLeft(top, left, right, bottom) {
         // This lifetime edge depends on lifetimes 'left, 'bottom
         let leftEdges = [left, bottom];
+        
         const result = wasm.One_diamond_left(top.ffiValue, left.ffiValue, right.ffiValue, bottom.ffiValue);
     
         try {
@@ -113,6 +119,7 @@ export class One {
     static diamondRight(top, left, right, bottom) {
         // This lifetime edge depends on lifetimes 'right, 'bottom
         let rightEdges = [right, bottom];
+        
         const result = wasm.One_diamond_right(top.ffiValue, left.ffiValue, right.ffiValue, bottom.ffiValue);
     
         try {
@@ -125,6 +132,7 @@ export class One {
     static diamondBottom(top, left, right, bottom) {
         // This lifetime edge depends on lifetimes 'bottom
         let bottomEdges = [bottom];
+        
         const result = wasm.One_diamond_bottom(top.ffiValue, left.ffiValue, right.ffiValue, bottom.ffiValue);
     
         try {
@@ -137,6 +145,7 @@ export class One {
     static diamondAndNestedTypes(a, b, c, d, nohold) {
         // This lifetime edge depends on lifetimes 'a, 'b, 'c, 'd
         let aEdges = [a, b, c, d];
+        
         const result = wasm.One_diamond_and_nested_types(a.ffiValue, b.ffiValue, c.ffiValue, d.ffiValue, nohold.ffiValue);
     
         try {
@@ -149,6 +158,7 @@ export class One {
     static implicitBounds(explicitHold, implicitHold, nohold) {
         // This lifetime edge depends on lifetimes 'a, 'b, 'c, 'd, 'x
         let aEdges = [explicitHold, implicitHold];
+        
         const result = wasm.One_implicit_bounds(explicitHold.ffiValue, implicitHold.ffiValue, nohold.ffiValue);
     
         try {
@@ -161,6 +171,7 @@ export class One {
     static implicitBoundsDeep(explicit, implicit1, implicit2, nohold) {
         // This lifetime edge depends on lifetimes 'a, 'b, 'c, 'd
         let aEdges = [explicit, implicit1, implicit2];
+        
         const result = wasm.One_implicit_bounds_deep(explicit.ffiValue, implicit1.ffiValue, implicit2.ffiValue, nohold.ffiValue);
     
         try {

--- a/feature_tests/js/api/Opaque.mjs
+++ b/feature_tests/js/api/Opaque.mjs
@@ -35,7 +35,8 @@ export class Opaque {
         return this.#ptr;
     }
 
-    static new_() {const result = wasm.Opaque_new();
+    static new_() {
+        const result = wasm.Opaque_new();
     
         try {
             return new Opaque(diplomatRuntime.internalConstructor, result, []);
@@ -48,6 +49,7 @@ export class Opaque {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const inputSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, input)).splat()];
+        
         const result = wasm.Opaque_try_from_utf8(...inputSlice);
     
         try {
@@ -63,6 +65,7 @@ export class Opaque {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const inputSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, input)).splat()];
+        
         const result = wasm.Opaque_from_str(...inputSlice);
     
         try {
@@ -98,7 +101,8 @@ export class Opaque {
         }
     }
 
-    static returnsUsize() {const result = wasm.Opaque_returns_usize();
+    static returnsUsize() {
+        const result = wasm.Opaque_returns_usize();
     
         try {
             return result;
@@ -109,6 +113,7 @@ export class Opaque {
 
     static returnsImported() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, false);
+        
         const result = wasm.Opaque_returns_imported(diplomatReceive.buffer);
     
         try {
@@ -120,7 +125,8 @@ export class Opaque {
         }
     }
 
-    static cmp() {const result = wasm.Opaque_cmp();
+    static cmp() {
+        const result = wasm.Opaque_cmp();
     
         try {
             return result;

--- a/feature_tests/js/api/OpaqueMutexedString.mjs
+++ b/feature_tests/js/api/OpaqueMutexedString.mjs
@@ -34,7 +34,8 @@ export class OpaqueMutexedString {
         return this.#ptr;
     }
 
-    static fromUsize(number) {const result = wasm.OpaqueMutexedString_from_usize(number);
+    static fromUsize(number) {
+        const result = wasm.OpaqueMutexedString_from_usize(number);
     
         try {
             return new OpaqueMutexedString(diplomatRuntime.internalConstructor, result, []);
@@ -53,6 +54,7 @@ export class OpaqueMutexedString {
     borrow() {
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.OpaqueMutexedString_borrow(this.ffiValue);
     
         try {
@@ -65,6 +67,7 @@ export class OpaqueMutexedString {
     static borrowOther(other) {
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [other];
+        
         const result = wasm.OpaqueMutexedString_borrow_other(other.ffiValue);
     
         try {
@@ -77,6 +80,7 @@ export class OpaqueMutexedString {
     borrowSelfOrOther(other) {
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this, other];
+        
         const result = wasm.OpaqueMutexedString_borrow_self_or_other(this.ffiValue, other.ffiValue);
     
         try {
@@ -86,7 +90,8 @@ export class OpaqueMutexedString {
         finally {}
     }
 
-    getLenAndAdd(other) {const result = wasm.OpaqueMutexedString_get_len_and_add(this.ffiValue, other);
+    getLenAndAdd(other) {
+        const result = wasm.OpaqueMutexedString_get_len_and_add(this.ffiValue, other);
     
         try {
             return result;
@@ -100,6 +105,7 @@ export class OpaqueMutexedString {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.OpaqueMutexedString_dummy_str(diplomatReceive.buffer, this.ffiValue);
     
         try {
@@ -111,7 +117,8 @@ export class OpaqueMutexedString {
         }
     }
 
-    wrapper() {const result = wasm.OpaqueMutexedString_wrapper(this.ffiValue);
+    wrapper() {
+        const result = wasm.OpaqueMutexedString_wrapper(this.ffiValue);
     
         try {
             return new Utf16Wrap(diplomatRuntime.internalConstructor, result, []);

--- a/feature_tests/js/api/OptionOpaque.mjs
+++ b/feature_tests/js/api/OptionOpaque.mjs
@@ -34,7 +34,8 @@ export class OptionOpaque {
         return this.#ptr;
     }
 
-    static new_(i) {const result = wasm.OptionOpaque_new(i);
+    static new_(i) {
+        const result = wasm.OptionOpaque_new(i);
     
         try {
             return result === 0 ? null : new OptionOpaque(diplomatRuntime.internalConstructor, result, []);
@@ -43,7 +44,8 @@ export class OptionOpaque {
         finally {}
     }
 
-    static newNone() {const result = wasm.OptionOpaque_new_none();
+    static newNone() {
+        const result = wasm.OptionOpaque_new_none();
     
         try {
             return result === 0 ? null : new OptionOpaque(diplomatRuntime.internalConstructor, result, []);
@@ -54,6 +56,7 @@ export class OptionOpaque {
 
     static returns() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 17, 4, true);
+        
         const result = wasm.OptionOpaque_returns(diplomatReceive.buffer);
     
         try {
@@ -70,6 +73,7 @@ export class OptionOpaque {
 
     optionIsize() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.OptionOpaque_option_isize(diplomatReceive.buffer, this.ffiValue);
     
         try {
@@ -86,6 +90,7 @@ export class OptionOpaque {
 
     optionUsize() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.OptionOpaque_option_usize(diplomatReceive.buffer, this.ffiValue);
     
         try {
@@ -102,6 +107,7 @@ export class OptionOpaque {
 
     optionI32() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.OptionOpaque_option_i32(diplomatReceive.buffer, this.ffiValue);
     
         try {
@@ -118,6 +124,7 @@ export class OptionOpaque {
 
     optionU32() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.OptionOpaque_option_u32(diplomatReceive.buffer, this.ffiValue);
     
         try {
@@ -134,6 +141,7 @@ export class OptionOpaque {
 
     static newStruct() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 16, 4, false);
+        
         const result = wasm.OptionOpaque_new_struct(diplomatReceive.buffer);
     
         try {
@@ -147,6 +155,7 @@ export class OptionOpaque {
 
     static newStructNones() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 16, 4, false);
+        
         const result = wasm.OptionOpaque_new_struct_nones(diplomatReceive.buffer);
     
         try {
@@ -165,7 +174,8 @@ export class OptionOpaque {
         finally {}
     }
 
-    static optionOpaqueArgument(arg) {const result = wasm.OptionOpaque_option_opaque_argument(arg.ffiValue ?? 0);
+    static optionOpaqueArgument(arg) {
+        const result = wasm.OptionOpaque_option_opaque_argument(arg.ffiValue ?? 0);
     
         try {
             return result;

--- a/feature_tests/js/api/OptionString.mjs
+++ b/feature_tests/js/api/OptionString.mjs
@@ -37,6 +37,7 @@ export class OptionString {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const diplomatStrSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, diplomatStr)).splat()];
+        
         const result = wasm.OptionString_new(...diplomatStrSlice);
     
         try {
@@ -50,6 +51,7 @@ export class OptionString {
 
     write() {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
+        
         const result = wasm.OptionString_write(this.ffiValue, write.buffer);
     
         try {
@@ -66,6 +68,7 @@ export class OptionString {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.OptionString_borrow(diplomatReceive.buffer, this.ffiValue);
     
         try {

--- a/feature_tests/js/api/RefList.mjs
+++ b/feature_tests/js/api/RefList.mjs
@@ -41,6 +41,7 @@ export class RefList {
     static node(data) {
         // This lifetime edge depends on lifetimes 'b
         let bEdges = [data];
+        
         const result = wasm.RefList_node(data.ffiValue);
     
         try {

--- a/feature_tests/js/api/RenamedMyIterable.mjs
+++ b/feature_tests/js/api/RenamedMyIterable.mjs
@@ -38,6 +38,7 @@ export class RenamedMyIterable {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const xSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, x, "u8")).splat()];
+        
         const result = wasm.namespace_MyIterable_new(...xSlice);
     
         try {
@@ -52,6 +53,7 @@ export class RenamedMyIterable {
     [Symbol.iterator]() {
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.namespace_MyIterable_iter(this.ffiValue);
     
         try {

--- a/feature_tests/js/api/RenamedMyIterator.mjs
+++ b/feature_tests/js/api/RenamedMyIterator.mjs
@@ -39,6 +39,7 @@ export class RenamedMyIterator {
 
     #iteratorNext() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 2, 1, true);
+        
         const result = wasm.namespace_MyIterator_next(diplomatReceive.buffer, this.ffiValue);
     
         try {

--- a/feature_tests/js/api/RenamedOpaqueIterable.mjs
+++ b/feature_tests/js/api/RenamedOpaqueIterable.mjs
@@ -37,6 +37,7 @@ export class RenamedOpaqueIterable {
     [Symbol.iterator]() {
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.namespace_OpaqueIterable_iter(this.ffiValue);
     
         try {

--- a/feature_tests/js/api/RenamedOpaqueIterator.mjs
+++ b/feature_tests/js/api/RenamedOpaqueIterator.mjs
@@ -38,7 +38,8 @@ export class RenamedOpaqueIterator {
         return this.#ptr;
     }
 
-    #iteratorNext() {const result = wasm.namespace_OpaqueIterator_next(this.ffiValue);
+    #iteratorNext() {
+        const result = wasm.namespace_OpaqueIterator_next(this.ffiValue);
     
         try {
             return result === 0 ? null : new AttrOpaque1Renamed(diplomatRuntime.internalConstructor, result, []);

--- a/feature_tests/js/api/ResultOpaque.mjs
+++ b/feature_tests/js/api/ResultOpaque.mjs
@@ -37,6 +37,7 @@ export class ResultOpaque {
 
     static new_(i) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.ResultOpaque_new(diplomatReceive.buffer, i);
     
         try {
@@ -54,6 +55,7 @@ export class ResultOpaque {
 
     static newFailingFoo() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.ResultOpaque_new_failing_foo(diplomatReceive.buffer);
     
         try {
@@ -71,6 +73,7 @@ export class ResultOpaque {
 
     static newFailingBar() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.ResultOpaque_new_failing_bar(diplomatReceive.buffer);
     
         try {
@@ -88,6 +91,7 @@ export class ResultOpaque {
 
     static newFailingUnit() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.ResultOpaque_new_failing_unit(diplomatReceive.buffer);
     
         try {
@@ -104,6 +108,7 @@ export class ResultOpaque {
 
     static newFailingStruct(i) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 9, 4, true);
+        
         const result = wasm.ResultOpaque_new_failing_struct(diplomatReceive.buffer, i);
     
         try {
@@ -121,6 +126,7 @@ export class ResultOpaque {
 
     static newInErr(i) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.ResultOpaque_new_in_err(diplomatReceive.buffer, i);
     
         try {
@@ -138,6 +144,7 @@ export class ResultOpaque {
 
     static newInt(i) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.ResultOpaque_new_int(diplomatReceive.buffer, i);
     
         try {
@@ -154,6 +161,7 @@ export class ResultOpaque {
 
     static newInEnumErr(i) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
         const result = wasm.ResultOpaque_new_in_enum_err(diplomatReceive.buffer, i);
     
         try {

--- a/feature_tests/js/api/Unnamespaced.mjs
+++ b/feature_tests/js/api/Unnamespaced.mjs
@@ -35,7 +35,8 @@ export class Unnamespaced {
         return this.#ptr;
     }
 
-    static make(e) {const result = wasm.namespace_Unnamespaced_make(e.ffiValue);
+    static make(e) {
+        const result = wasm.namespace_Unnamespaced_make(e.ffiValue);
     
         try {
             return new Unnamespaced(diplomatRuntime.internalConstructor, result, []);

--- a/feature_tests/js/api/Utf16Wrap.mjs
+++ b/feature_tests/js/api/Utf16Wrap.mjs
@@ -37,6 +37,7 @@ export class Utf16Wrap {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const inputSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, input)).splat()];
+        
         const result = wasm.Utf16Wrap_from_utf16(...inputSlice);
     
         try {
@@ -66,6 +67,7 @@ export class Utf16Wrap {
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [this];
+        
         const result = wasm.Utf16Wrap_borrow_cont(diplomatReceive.buffer, this.ffiValue);
     
         try {

--- a/tool/templates/js/method.js.jinja
+++ b/tool/templates/js/method.js.jinja
@@ -38,7 +38,8 @@
     {%- endfor -%}
 
 
-    {%~ if !method_output_is_ffi_unit %}const result = {% endif %}wasm.{{ abi_name }}(
+    {%~ if !method_output_is_ffi_unit %}
+    const result = {% endif %}wasm.{{ abi_name }}(
         {%- for param in param_conversions -%}
         {%- if !loop.first %}, {% endif -%}
         {{ param }}


### PR DESCRIPTION
Just a small whitespace fix that had been bugging me that I forgot to fix in the last PR