### PR TITLE
More JS slice borrowing

### DIFF
--- a/example/js/lib/api/Locale.mjs
+++ b/example/js/lib/api/Locale.mjs
@@ -41,9 +41,9 @@ export class Locale {
     static new_(name) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const nameSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, name)).splat()];
+        const nameSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, name));
         
-        const result = wasm.icu4x_Locale_new_mv1(...nameSlice);
+        const result = wasm.icu4x_Locale_new_mv1(...nameSlice.splat());
     
         try {
             return new Locale(diplomatRuntime.internalConstructor, result, []);

--- a/example/js/lib/api/diplomat-runtime.mjs
+++ b/example/js/lib/api/diplomat-runtime.mjs
@@ -434,8 +434,6 @@ export class DiplomatReceiveBuf {
  */
 export class CleanupArena {
     #items = [];
-
-    #edgeArray = [];
     
     constructor() {
     }
@@ -449,10 +447,35 @@ export class CleanupArena {
         this.#items.push(item);
         return item;
     }
+    /**
+     * Create a new CleanupArena, append it to any edge arrays passed down, and return it.
+     * @param {Array} edgeArrays
+     * @returns {CleanupArena}
+     */
+    createWith(...edgeArrays) {
+        let self = new CleanupArena();
+        for (edgeArray of edgeArrays) {
+            if (edgeArray != null) {
+                edgeArray.push(self);
+            }
+        }
+        DiplomatBufferFinalizer.register(self, self.free);
+        return self;
+    }
 
-    createWith(edgeArray) {
-        this.#edgeArray = edgeArray;
-        DiplomatBufferFinalizer.register(this, this.free);
+    /**
+     * If given edge arrays, create a new CleanupArena, append it to any edge arrays passed down, and return it.
+     * Else return the function-local cleanup arena
+     * @param {CleanupArena} functionCleanupArena
+     * @param {Array} edgeArrays
+     * @returns {DiplomatBuf}
+     */
+    maybeCreateWith(functionCleanupArena, ...edgeArrays) {
+        if (edgeArrays.length > 0) {
+            return CleanupArena.createWith(...edgeArrays);
+        } else {
+            return functionCleanupArena
+        }
     }
 
     free() {

--- a/feature_tests/js/api/BorrowedFields.mjs
+++ b/feature_tests/js/api/BorrowedFields.mjs
@@ -72,16 +72,16 @@ export class BorrowedFields {
 
     static fromBarAndStrings(bar, dstr16, utf8Str) {
         let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const dstr16Slice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16)).splat()];
+        const dstr16Slice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16));
         
-        const utf8StrSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8Str)).splat()];
+        const utf8StrSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8Str));
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 24, 4, false);
         
         // This lifetime edge depends on lifetimes 'x
         let xEdges = [bar, dstr16Slice, utf8StrSlice];
         
-        const result = wasm.BorrowedFields_from_bar_and_strings(diplomatReceive.buffer, bar.ffiValue, ...dstr16Slice, ...utf8StrSlice);
+        const result = wasm.BorrowedFields_from_bar_and_strings(diplomatReceive.buffer, bar.ffiValue, ...dstr16Slice.splat(), ...utf8StrSlice.splat());
     
         try {
             return new BorrowedFields(diplomatRuntime.internalConstructor, diplomatReceive.buffer, xEdges);

--- a/feature_tests/js/api/BorrowedFields.mjs
+++ b/feature_tests/js/api/BorrowedFields.mjs
@@ -71,10 +71,10 @@ export class BorrowedFields {
     };
 
     static fromBarAndStrings(bar, dstr16, utf8Str) {
-        let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const dstr16Slice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16));
+        let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();
+        const dstr16Slice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16));
         
-        const utf8StrSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8Str));
+        const utf8StrSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8Str));
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 24, 4, false);
         
@@ -88,7 +88,7 @@ export class BorrowedFields {
         }
         
         finally {
-            functionGarbageCollector.garbageCollect();
+            functionGarbageCollectorGrip.releaseToGarbageCollector();
         
             diplomatReceive.free();
         }

--- a/feature_tests/js/api/BorrowedFields.mjs
+++ b/feature_tests/js/api/BorrowedFields.mjs
@@ -49,7 +49,7 @@ export class BorrowedFields {
         functionCleanupArena,
         appendArrayMap
     ) {
-        return [...(appendArrayMap["aAppendArray"].length > 0 ? diplomatRuntime.CleanupArena.createWith(appendArrayMap["aAppendArray"]) : functionCleanupArena).alloc(diplomatRuntime.DiplomatBuf.str16(wasm, this.#a)).splat(), ...(appendArrayMap["aAppendArray"].length > 0 ? diplomatRuntime.CleanupArena.createWith(appendArrayMap["aAppendArray"]) : functionCleanupArena).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#b)).splat(), ...(appendArrayMap["aAppendArray"].length > 0 ? diplomatRuntime.CleanupArena.createWith(appendArrayMap["aAppendArray"]) : functionCleanupArena).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#c)).splat()]
+        return [...diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['aAppendArray']).alloc(diplomatRuntime.DiplomatBuf.str16(wasm, this.#a)).splat(), ...diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['aAppendArray']).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#b)).splat(), ...diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['aAppendArray']).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#c)).splat()]
     }
 
     #fromFFI(ptr, aEdges) {

--- a/feature_tests/js/api/BorrowedFieldsReturning.mjs
+++ b/feature_tests/js/api/BorrowedFieldsReturning.mjs
@@ -30,7 +30,7 @@ export class BorrowedFieldsReturning {
         functionCleanupArena,
         appendArrayMap
     ) {
-        return [...(appendArrayMap["aAppendArray"].length > 0 ? diplomatRuntime.CleanupArena.createWith(appendArrayMap["aAppendArray"]) : functionCleanupArena).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#bytes)).splat()]
+        return [...diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['aAppendArray']).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#bytes)).splat()]
     }
 
     #fromFFI(ptr, aEdges) {

--- a/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
+++ b/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
@@ -51,7 +51,7 @@ export class BorrowedFieldsWithBounds {
         functionCleanupArena,
         appendArrayMap
     ) {
-        return [...(appendArrayMap["aAppendArray"].length > 0 ? diplomatRuntime.CleanupArena.createWith(appendArrayMap["aAppendArray"]) : functionCleanupArena).alloc(diplomatRuntime.DiplomatBuf.str16(wasm, this.#fieldA)).splat(), ...(appendArrayMap["bAppendArray"].length > 0 ? diplomatRuntime.CleanupArena.createWith(appendArrayMap["bAppendArray"]) : functionCleanupArena).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#fieldB)).splat(), ...(appendArrayMap["cAppendArray"].length > 0 ? diplomatRuntime.CleanupArena.createWith(appendArrayMap["cAppendArray"]) : functionCleanupArena).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#fieldC)).splat()]
+        return [...diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['aAppendArray']).alloc(diplomatRuntime.DiplomatBuf.str16(wasm, this.#fieldA)).splat(), ...diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['bAppendArray']).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#fieldB)).splat(), ...diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['cAppendArray']).alloc(diplomatRuntime.DiplomatBuf.str8(wasm, this.#fieldC)).splat()]
     }
 
     #fromFFI(ptr, aEdges, bEdges, cEdges) {

--- a/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
+++ b/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
@@ -92,9 +92,9 @@ export class BorrowedFieldsWithBounds {
 
     static fromFooAndStrings(foo, dstr16X, utf8StrZ) {
         let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const dstr16XSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16X)).splat()];
+        const dstr16XSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16X));
         
-        const utf8StrZSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrZ)).splat()];
+        const utf8StrZSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrZ));
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 24, 4, false);
         
@@ -107,7 +107,7 @@ export class BorrowedFieldsWithBounds {
         // This lifetime edge depends on lifetimes 'z
         let zEdges = [utf8StrZSlice];
         
-        const result = wasm.BorrowedFieldsWithBounds_from_foo_and_strings(diplomatReceive.buffer, foo.ffiValue, ...dstr16XSlice, ...utf8StrZSlice);
+        const result = wasm.BorrowedFieldsWithBounds_from_foo_and_strings(diplomatReceive.buffer, foo.ffiValue, ...dstr16XSlice.splat(), ...utf8StrZSlice.splat());
     
         try {
             return new BorrowedFieldsWithBounds(diplomatRuntime.internalConstructor, diplomatReceive.buffer, xEdges, yEdges, zEdges);

--- a/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
+++ b/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
@@ -91,10 +91,10 @@ export class BorrowedFieldsWithBounds {
     };
 
     static fromFooAndStrings(foo, dstr16X, utf8StrZ) {
-        let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const dstr16XSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16X));
+        let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();
+        const dstr16XSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16X));
         
-        const utf8StrZSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrZ));
+        const utf8StrZSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrZ));
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 24, 4, false);
         
@@ -114,7 +114,7 @@ export class BorrowedFieldsWithBounds {
         }
         
         finally {
-            functionGarbageCollector.garbageCollect();
+            functionGarbageCollectorGrip.releaseToGarbageCollector();
         
             diplomatReceive.free();
         }

--- a/feature_tests/js/api/Float64Vec.mjs
+++ b/feature_tests/js/api/Float64Vec.mjs
@@ -36,9 +36,9 @@ export class Float64Vec {
     static newBool(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "boolean")).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "boolean"));
         
-        const result = wasm.Float64Vec_new_bool(...vSlice);
+        const result = wasm.Float64Vec_new_bool(...vSlice.splat());
     
         try {
             return new Float64Vec(diplomatRuntime.internalConstructor, result, []);
@@ -52,9 +52,9 @@ export class Float64Vec {
     static newI16(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "i16")).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "i16"));
         
-        const result = wasm.Float64Vec_new_i16(...vSlice);
+        const result = wasm.Float64Vec_new_i16(...vSlice.splat());
     
         try {
             return new Float64Vec(diplomatRuntime.internalConstructor, result, []);
@@ -68,9 +68,9 @@ export class Float64Vec {
     static newU16(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u16")).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u16"));
         
-        const result = wasm.Float64Vec_new_u16(...vSlice);
+        const result = wasm.Float64Vec_new_u16(...vSlice.splat());
     
         try {
             return new Float64Vec(diplomatRuntime.internalConstructor, result, []);
@@ -84,9 +84,9 @@ export class Float64Vec {
     static newIsize(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "i32")).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "i32"));
         
-        const result = wasm.Float64Vec_new_isize(...vSlice);
+        const result = wasm.Float64Vec_new_isize(...vSlice.splat());
     
         try {
             return new Float64Vec(diplomatRuntime.internalConstructor, result, []);
@@ -100,9 +100,9 @@ export class Float64Vec {
     static newUsize(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u32")).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u32"));
         
-        const result = wasm.Float64Vec_new_usize(...vSlice);
+        const result = wasm.Float64Vec_new_usize(...vSlice.splat());
     
         try {
             return new Float64Vec(diplomatRuntime.internalConstructor, result, []);
@@ -116,9 +116,9 @@ export class Float64Vec {
     static newF64BeBytes(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u8")).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "u8"));
         
-        const result = wasm.Float64Vec_new_f64_be_bytes(...vSlice);
+        const result = wasm.Float64Vec_new_f64_be_bytes(...vSlice.splat());
     
         try {
             return new Float64Vec(diplomatRuntime.internalConstructor, result, []);
@@ -132,9 +132,9 @@ export class Float64Vec {
     static newFromOwned(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "f64")).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "f64"));
         
-        const result = wasm.Float64Vec_new_from_owned(...vSlice);
+        const result = wasm.Float64Vec_new_from_owned(...vSlice.splat());
     
         try {
             return new Float64Vec(diplomatRuntime.internalConstructor, result, []);
@@ -165,8 +165,8 @@ export class Float64Vec {
     fillSlice(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "f64")).splat()];
-        wasm.Float64Vec_fill_slice(this.ffiValue, ...vSlice);
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, v, "f64"));
+        wasm.Float64Vec_fill_slice(this.ffiValue, ...vSlice.splat());
     
         try {}
         
@@ -178,8 +178,8 @@ export class Float64Vec {
     setValue(newSlice) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const newSliceSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, newSlice, "f64")).splat()];
-        wasm.Float64Vec_set_value(this.ffiValue, ...newSliceSlice);
+        const newSliceSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, newSlice, "f64"));
+        wasm.Float64Vec_set_value(this.ffiValue, ...newSliceSlice.splat());
     
         try {}
         

--- a/feature_tests/js/api/Foo.mjs
+++ b/feature_tests/js/api/Foo.mjs
@@ -42,8 +42,8 @@ export class Foo {
     }
 
     static new_(x) {
-        let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const xSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, x));
+        let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();
+        const xSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, x));
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [xSlice];
@@ -55,7 +55,7 @@ export class Foo {
         }
         
         finally {
-            functionGarbageCollector.garbageCollect();
+            functionGarbageCollectorGrip.releaseToGarbageCollector();
         }
     }
 
@@ -112,8 +112,8 @@ export class Foo {
     static extractFromBounds(bounds, anotherString) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const anotherStringSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, anotherString));
+        let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();
+        const anotherStringSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, anotherString));
         
         // This lifetime edge depends on lifetimes 'a, 'y, 'z
         let aEdges = [...bounds._fieldsForLifetimeB, ...bounds._fieldsForLifetimeC, anotherStringSlice];
@@ -127,7 +127,7 @@ export class Foo {
         finally {
             functionCleanupArena.free();
         
-            functionGarbageCollector.garbageCollect();
+            functionGarbageCollectorGrip.releaseToGarbageCollector();
         }
     }
 }

--- a/feature_tests/js/api/Foo.mjs
+++ b/feature_tests/js/api/Foo.mjs
@@ -43,12 +43,12 @@ export class Foo {
 
     static new_(x) {
         let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const xSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, x)).splat()];
+        const xSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, x));
         
         // This lifetime edge depends on lifetimes 'a
         let aEdges = [xSlice];
         
-        const result = wasm.Foo_new(...xSlice);
+        const result = wasm.Foo_new(...xSlice.splat());
     
         try {
             return new Foo(diplomatRuntime.internalConstructor, result, [], aEdges);
@@ -113,12 +113,12 @@ export class Foo {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const anotherStringSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, anotherString)).splat()];
+        const anotherStringSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, anotherString));
         
         // This lifetime edge depends on lifetimes 'a, 'y, 'z
         let aEdges = [...bounds._fieldsForLifetimeB, ...bounds._fieldsForLifetimeC, anotherStringSlice];
         
-        const result = wasm.Foo_extract_from_bounds(...bounds._intoFFI(functionCleanupArena, {bAppendArray: [aEdges],cAppendArray: [aEdges],}), ...anotherStringSlice);
+        const result = wasm.Foo_extract_from_bounds(...bounds._intoFFI(functionCleanupArena, {bAppendArray: [aEdges],cAppendArray: [aEdges],}), ...anotherStringSlice.splat());
     
         try {
             return new Foo(diplomatRuntime.internalConstructor, result, [], aEdges);

--- a/feature_tests/js/api/MyString.mjs
+++ b/feature_tests/js/api/MyString.mjs
@@ -36,9 +36,9 @@ export class MyString {
     static new_(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v)).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v));
         
-        const result = wasm.MyString_new(...vSlice);
+        const result = wasm.MyString_new(...vSlice.splat());
     
         try {
             return new MyString(diplomatRuntime.internalConstructor, result, []);
@@ -52,9 +52,9 @@ export class MyString {
     static newUnsafe(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v)).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v));
         
-        const result = wasm.MyString_new_unsafe(...vSlice);
+        const result = wasm.MyString_new_unsafe(...vSlice.splat());
     
         try {
             return new MyString(diplomatRuntime.internalConstructor, result, []);
@@ -68,9 +68,9 @@ export class MyString {
     static newOwned(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v)).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v));
         
-        const result = wasm.MyString_new_owned(...vSlice);
+        const result = wasm.MyString_new_owned(...vSlice.splat());
     
         try {
             return new MyString(diplomatRuntime.internalConstructor, result, []);
@@ -84,9 +84,9 @@ export class MyString {
     static newFromFirst(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const vSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.strs(wasm, v, "string8")).splat()];
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.strs(wasm, v, "string8"));
         
-        const result = wasm.MyString_new_from_first(...vSlice);
+        const result = wasm.MyString_new_from_first(...vSlice.splat());
     
         try {
             return new MyString(diplomatRuntime.internalConstructor, result, []);
@@ -100,8 +100,8 @@ export class MyString {
     set str(newStr) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const newStrSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, newStr)).splat()];
-        wasm.MyString_set_str(this.ffiValue, ...newStrSlice);
+        const newStrSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, newStr));
+        wasm.MyString_set_str(this.ffiValue, ...newStrSlice.splat());
     
         try {}
         
@@ -126,10 +126,10 @@ export class MyString {
     static stringTransform(foo) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const fooSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, foo)).splat()];
+        const fooSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, foo));
         
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
-        wasm.MyString_string_transform(...fooSlice, write.buffer);
+        wasm.MyString_string_transform(...fooSlice.splat(), write.buffer);
     
         try {
             return write.readString8();

--- a/feature_tests/js/api/NestedBorrowedFields.mjs
+++ b/feature_tests/js/api/NestedBorrowedFields.mjs
@@ -95,13 +95,13 @@ export class NestedBorrowedFields {
 
     static fromBarAndFooAndStrings(bar, foo, dstr16X, dstr16Z, utf8StrY, utf8StrZ) {
         let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const dstr16XSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16X)).splat()];
+        const dstr16XSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16X));
         
-        const dstr16ZSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16Z)).splat()];
+        const dstr16ZSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16Z));
         
-        const utf8StrYSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrY)).splat()];
+        const utf8StrYSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrY));
         
-        const utf8StrZSlice = [...functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrZ)).splat()];
+        const utf8StrZSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrZ));
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 72, 4, false);
         
@@ -114,7 +114,7 @@ export class NestedBorrowedFields {
         // This lifetime edge depends on lifetimes 'z
         let zEdges = [foo, dstr16ZSlice, utf8StrZSlice];
         
-        const result = wasm.NestedBorrowedFields_from_bar_and_foo_and_strings(diplomatReceive.buffer, bar.ffiValue, foo.ffiValue, ...dstr16XSlice, ...dstr16ZSlice, ...utf8StrYSlice, ...utf8StrZSlice);
+        const result = wasm.NestedBorrowedFields_from_bar_and_foo_and_strings(diplomatReceive.buffer, bar.ffiValue, foo.ffiValue, ...dstr16XSlice.splat(), ...dstr16ZSlice.splat(), ...utf8StrYSlice.splat(), ...utf8StrZSlice.splat());
     
         try {
             return new NestedBorrowedFields(diplomatRuntime.internalConstructor, diplomatReceive.buffer, xEdges, yEdges, zEdges);

--- a/feature_tests/js/api/NestedBorrowedFields.mjs
+++ b/feature_tests/js/api/NestedBorrowedFields.mjs
@@ -94,14 +94,14 @@ export class NestedBorrowedFields {
     };
 
     static fromBarAndFooAndStrings(bar, foo, dstr16X, dstr16Z, utf8StrY, utf8StrZ) {
-        let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
-        const dstr16XSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16X));
+        let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();
+        const dstr16XSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16X));
         
-        const dstr16ZSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16Z));
+        const dstr16ZSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, dstr16Z));
         
-        const utf8StrYSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrY));
+        const utf8StrYSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrY));
         
-        const utf8StrZSlice = functionGarbageCollector.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrZ));
+        const utf8StrZSlice = functionGarbageCollectorGrip.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, utf8StrZ));
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 72, 4, false);
         
@@ -121,7 +121,7 @@ export class NestedBorrowedFields {
         }
         
         finally {
-            functionGarbageCollector.garbageCollect();
+            functionGarbageCollectorGrip.releaseToGarbageCollector();
         
             diplomatReceive.free();
         }

--- a/feature_tests/js/api/Opaque.mjs
+++ b/feature_tests/js/api/Opaque.mjs
@@ -48,9 +48,9 @@ export class Opaque {
     static tryFromUtf8(input) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const inputSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, input)).splat()];
+        const inputSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, input));
         
-        const result = wasm.Opaque_try_from_utf8(...inputSlice);
+        const result = wasm.Opaque_try_from_utf8(...inputSlice.splat());
     
         try {
             return result === 0 ? null : new Opaque(diplomatRuntime.internalConstructor, result, []);
@@ -64,9 +64,9 @@ export class Opaque {
     static fromStr(input) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const inputSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, input)).splat()];
+        const inputSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, input));
         
-        const result = wasm.Opaque_from_str(...inputSlice);
+        const result = wasm.Opaque_from_str(...inputSlice.splat());
     
         try {
             return new Opaque(diplomatRuntime.internalConstructor, result, []);

--- a/feature_tests/js/api/OptionString.mjs
+++ b/feature_tests/js/api/OptionString.mjs
@@ -36,9 +36,9 @@ export class OptionString {
     static new_(diplomatStr) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const diplomatStrSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, diplomatStr)).splat()];
+        const diplomatStrSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, diplomatStr));
         
-        const result = wasm.OptionString_new(...diplomatStrSlice);
+        const result = wasm.OptionString_new(...diplomatStrSlice.splat());
     
         try {
             return result === 0 ? null : new OptionString(diplomatRuntime.internalConstructor, result, []);

--- a/feature_tests/js/api/RenamedMyIterable.mjs
+++ b/feature_tests/js/api/RenamedMyIterable.mjs
@@ -37,9 +37,9 @@ export class RenamedMyIterable {
     static new_(x) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const xSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, x, "u8")).splat()];
+        const xSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, x, "u8"));
         
-        const result = wasm.namespace_MyIterable_new(...xSlice);
+        const result = wasm.namespace_MyIterable_new(...xSlice.splat());
     
         try {
             return new RenamedMyIterable(diplomatRuntime.internalConstructor, result, []);

--- a/feature_tests/js/api/Utf16Wrap.mjs
+++ b/feature_tests/js/api/Utf16Wrap.mjs
@@ -36,9 +36,9 @@ export class Utf16Wrap {
     static fromUtf16(input) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
-        const inputSlice = [...functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, input)).splat()];
+        const inputSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, input));
         
-        const result = wasm.Utf16Wrap_from_utf16(...inputSlice);
+        const result = wasm.Utf16Wrap_from_utf16(...inputSlice.splat());
     
         try {
             return new Utf16Wrap(diplomatRuntime.internalConstructor, result, []);

--- a/feature_tests/js/api/diplomat-runtime.mjs
+++ b/feature_tests/js/api/diplomat-runtime.mjs
@@ -434,8 +434,6 @@ export class DiplomatReceiveBuf {
  */
 export class CleanupArena {
     #items = [];
-
-    #edgeArray = [];
     
     constructor() {
     }
@@ -449,10 +447,35 @@ export class CleanupArena {
         this.#items.push(item);
         return item;
     }
+    /**
+     * Create a new CleanupArena, append it to any edge arrays passed down, and return it.
+     * @param {Array} edgeArrays
+     * @returns {CleanupArena}
+     */
+    createWith(...edgeArrays) {
+        let self = new CleanupArena();
+        for (edgeArray of edgeArrays) {
+            if (edgeArray != null) {
+                edgeArray.push(self);
+            }
+        }
+        DiplomatBufferFinalizer.register(self, self.free);
+        return self;
+    }
 
-    createWith(edgeArray) {
-        this.#edgeArray = edgeArray;
-        DiplomatBufferFinalizer.register(this, this.free);
+    /**
+     * If given edge arrays, create a new CleanupArena, append it to any edge arrays passed down, and return it.
+     * Else return the function-local cleanup arena
+     * @param {CleanupArena} functionCleanupArena
+     * @param {Array} edgeArrays
+     * @returns {DiplomatBuf}
+     */
+    maybeCreateWith(functionCleanupArena, ...edgeArrays) {
+        if (edgeArrays.length > 0) {
+            return CleanupArena.createWith(...edgeArrays);
+        } else {
+            return functionCleanupArena
+        }
     }
 
     free() {

--- a/tool/src/js/type_generation/converter.rs
+++ b/tool/src/js/type_generation/converter.rs
@@ -51,6 +51,15 @@ pub(super) struct StructBorrowContext<'tcx> {
     pub param_info: StructBorrowInfo<'tcx>,
 }
 
+pub(super) enum JsToCConversionContext {
+    /// We're passing the result of this directly to params, should produce a comma separated list of fields
+    /// a single field, or a spread expression
+    List,
+    /// Preallocating a slice CleanupArena
+    /// Produces a DiplomatBuf (only for Slice types)
+    SlicePrealloc,
+}
+
 impl<'jsctx, 'tcx> TyGenContext<'jsctx, 'tcx> {
     // #region C to JS
     /// Given a type from Rust, convert it into something Typescript will understand.
@@ -574,6 +583,7 @@ impl<'jsctx, 'tcx> TyGenContext<'jsctx, 'tcx> {
         alloc: Option<&str>,
         // Whether to force padding
         force_padding: ForcePaddingStatus,
+        gen_context: JsToCConversionContext,
     ) -> Cow<'tcx, str> {
         match *ty {
             Type::Primitive(..) => js_name.clone(),
@@ -593,25 +603,32 @@ impl<'jsctx, 'tcx> TyGenContext<'jsctx, 'tcx> {
                         "Must provide some allocation anchor for slice conversion generation!",
                     );
 
+                    let (spread_pre, spread_post) =
+                        if let JsToCConversionContext::SlicePrealloc = gen_context {
+                            ("", "")
+                        } else {
+                            ("...", ".splat()")
+                        };
+
                     match slice {
                         hir::Slice::Str(_, encoding) => match encoding {
                             hir::StringEncoding::UnvalidatedUtf8
                             | hir::StringEncoding::Utf8 => {
-                                format!("...{alloc}.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, {js_name})).splat()")
+                                format!("{spread_pre}{alloc}.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, {js_name})){spread_post}")
                             }
                             _ => {
-                                format!("...{alloc}.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, {js_name})).splat()")
+                                format!("{spread_pre}{alloc}.alloc(diplomatRuntime.DiplomatBuf.str16(wasm, {js_name})){spread_post}")
                             }
                         },
                         hir::Slice::Strs(encoding) => format!(
-                            r#"...{alloc}.alloc(diplomatRuntime.DiplomatBuf.strs(wasm, {js_name}, "{}")).splat()"#,
+                            r#"{spread_pre}{alloc}.alloc(diplomatRuntime.DiplomatBuf.strs(wasm, {js_name}, "{}")){spread_post}"#,
                             match encoding {
                                 hir::StringEncoding::UnvalidatedUtf16 => "string16",
                                 _ => "string8",
                             }
                         ),
                         hir::Slice::Primitive(_, p) => format!(
-                            r#"...{alloc}.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, {js_name}, "{}")).splat()"#,
+                            r#"{spread_pre}{alloc}.alloc(diplomatRuntime.DiplomatBuf.slice(wasm, {js_name}, "{}")){spread_post}"#,
                             self.formatter.fmt_primitive_list_view(p)
                         ),
                         _ => unreachable!("Unknown Slice variant {ty:?}"),

--- a/tool/src/js/type_generation/mod.rs
+++ b/tool/src/js/type_generation/mod.rs
@@ -187,11 +187,9 @@ impl<'ctx, 'tcx> TyGenContext<'ctx, 'tcx> {
                     let hir::MaybeStatic::NonStatic(lt) = lt else {
                         panic!("'static not supported in JS backend");
                     };
+                    let lt_name = struct_def.lifetimes.fmt_lifetime(lt);
                     Some(
-                        format!(
-                            r#"(appendArrayMap["{lt_name}AppendArray"].length > 0 ? diplomatRuntime.CleanupArena.createWith(appendArrayMap["{lt_name}AppendArray"]) : functionCleanupArena)"#,
-                            lt_name = struct_def.lifetimes.fmt_lifetime(lt),
-                        )
+                        format!("diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['{lt_name}AppendArray'])")
                     )
                 } else {
                     None

--- a/tool/src/js/type_generation/mod.rs
+++ b/tool/src/js/type_generation/mod.rs
@@ -393,7 +393,7 @@ impl<'ctx, 'tcx> TyGenContext<'ctx, 'tcx> {
                             // I.e., Do we need it alive for at least as long as this function call?
                             ParamBorrowInfo::BorrowedSlice => {
                                 method_info.needs_slice_collection = true;
-                                "functionGarbageCollector"
+                                "functionGarbageCollectorGrip"
                             },
                             _ => unreachable!(
                                 "Slices must produce slice ParamBorrowInfo, found {param_borrow_kind:?}"
@@ -534,7 +534,7 @@ pub(super) struct MethodInfo<'info> {
 
     /// If we need to create a `CleanupArena` (see `runtime.mjs`) to free any [`SliceParam`]s that are present.
     needs_slice_cleanup: bool,
-    /// For calling .garbageCollect on slices.
+    /// For calling .releaseToGarbageCollector on slices.
     needs_slice_collection: bool,
 
     pub typescript: bool,

--- a/tool/templates/js/method.js.jinja
+++ b/tool/templates/js/method.js.jinja
@@ -9,7 +9,7 @@
     let functionCleanupArena = new diplomatRuntime.CleanupArena();
     {% endif -%}
     {%- if needs_slice_collection %}
-    let functionGarbageCollector = new diplomatRuntime.GarbageCollector();
+    let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();
     {%- endif -%}
 
     {% for slice in slice_params %}
@@ -59,7 +59,7 @@
         functionCleanupArena.free();
     {% endif -%}
     {%- if needs_slice_collection %}
-        functionGarbageCollector.garbageCollect();
+        functionGarbageCollectorGrip.releaseToGarbageCollector();
     {% endif -%}
     {% for cleanup in cleanup_expressions %}
         {{cleanup|indent(8)}}

--- a/tool/templates/js/runtime.mjs
+++ b/tool/templates/js/runtime.mjs
@@ -434,8 +434,6 @@ export class DiplomatReceiveBuf {
  */
 export class CleanupArena {
     #items = [];
-
-    #edgeArray = [];
     
     constructor() {
     }
@@ -449,10 +447,35 @@ export class CleanupArena {
         this.#items.push(item);
         return item;
     }
+    /**
+     * Create a new CleanupArena, append it to any edge arrays passed down, and return it.
+     * @param {Array} edgeArrays
+     * @returns {CleanupArena}
+     */
+    createWith(...edgeArrays) {
+        let self = new CleanupArena();
+        for (edgeArray of edgeArrays) {
+            if (edgeArray != null) {
+                edgeArray.push(self);
+            }
+        }
+        DiplomatBufferFinalizer.register(self, self.free);
+        return self;
+    }
 
-    createWith(edgeArray) {
-        this.#edgeArray = edgeArray;
-        DiplomatBufferFinalizer.register(this, this.free);
+    /**
+     * If given edge arrays, create a new CleanupArena, append it to any edge arrays passed down, and return it.
+     * Else return the function-local cleanup arena
+     * @param {CleanupArena} functionCleanupArena
+     * @param {Array} edgeArrays
+     * @returns {DiplomatBuf}
+     */
+    maybeCreateWith(functionCleanupArena, ...edgeArrays) {
+        if (edgeArrays.length > 0) {
+            return CleanupArena.createWith(...edgeArrays);
+        } else {
+            return functionCleanupArena
+        }
     }
 
     free() {


### PR DESCRIPTION
@ambiguousname was right, `gen_js_to_c_for_type` needs to sometimes generate stuff without the spread operator, specifically when doing slice preallocations, which are special.

Stumbled upon this when refactoring for option work.