### PR TITLE
Update pulldown_cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,12 +126,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
@@ -1164,15 +1158,22 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.8.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+checksum = "cb4e75767fbc9d92b90e4d0c011f61358cde9513b31ef07ea3631b15ffc3b4fd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "getopts",
  "memchr",
+ "pulldown-cmark-escape",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
@@ -1247,7 +1248,7 @@ version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -20,7 +20,7 @@ syn = { version = "2", features = [ "full", "extra-traits" ] }
 syn-inline-mod = "0.6.0"
 quote = "1.0"
 indenter = "0.3.3"
-pulldown-cmark = "0.8.0"
+pulldown-cmark = "0.11.0"
 clap = { features = ["color", "derive", "std", "suggestions"], version = "4.2" }
 colored = "2.0"
 serde = { features = ["derive"], version = "1.0.130" }


### PR DESCRIPTION
We're on an old version not in google3, @emarteca  is trying to import Diplomat to Google3 and shouldn't have to pull in this dep