### PR TITLE
Implementing destructors for Kotlin callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,6 @@ name = "diplomat-runtime"
 version = "0.8.1"
 dependencies = [
  "jni",
- "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytes"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+
+[[package]]
 name = "calendrical_calculations"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +157,12 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -239,6 +251,16 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -368,6 +390,7 @@ dependencies = [
 name = "diplomat-runtime"
 version = "0.8.1"
 dependencies = [
+ "jni",
  "log",
 ]
 
@@ -999,6 +1022,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1426,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1604,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -1553,6 +1627,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1587,6 +1676,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -1596,6 +1691,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1611,6 +1712,12 @@ checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -1620,6 +1727,12 @@ name = "windows_i686_gnu"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1635,6 +1748,12 @@ checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -1647,6 +1766,12 @@ checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -1656,6 +1781,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -606,7 +606,7 @@ impl TypeName {
             TypeName::Function(_input_types, output_type) => {
                 let output_type = output_type.to_syn();
                 // should be DiplomatCallback<function_output_type>
-                syn::parse_quote_spanned!(Span::call_site() => DiplomatCallback<#output_type>)
+                syn::parse_quote_spanned!(Span::call_site() => core::mem::ManuallyDrop<DiplomatCallback<#output_type>>)
             }
         }
     }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -606,7 +606,7 @@ impl TypeName {
             TypeName::Function(_input_types, output_type) => {
                 let output_type = output_type.to_syn();
                 // should be DiplomatCallback<function_output_type>
-                syn::parse_quote_spanned!(Span::call_site() => core::mem::ManuallyDrop<DiplomatCallback<#output_type>>)
+                syn::parse_quote_spanned!(Span::call_site() => DiplomatCallback<#output_type>)
             }
         }
     }

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -51,7 +51,7 @@ internal class DiplomatJVMRuntime {
         val libClass: Class<DiplomatJVMRuntimeLib> = DiplomatJVMRuntimeLib::class.java
         val lib: DiplomatJVMRuntimeLib = Native.load("somelib", libClass, Collections.singletonMap(Library.OPTION_ALLOW_OBJECTS, true))
 
-        fun getRustCookie(obj: Object): Pointer {
+        fun buildRustCookie(obj: Object): Pointer {
             return lib.create_rust_jvm_cookie(JNIEnv.CURRENT, obj);
         }
 

--- a/feature_tests/Cargo.toml
+++ b/feature_tests/Cargo.toml
@@ -14,5 +14,5 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 
 [dependencies]
 diplomat = { path = "../macro" }
-diplomat-runtime = { path = "../runtime", feature = ["log"] }
+diplomat-runtime = { path = "../runtime", feature = ["log", "jvm-callback-support"] }
 log = { version = "0.4" }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
@@ -68,7 +68,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomat
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomatCallback_f(cb_wrap)
         }
     }
@@ -117,7 +117,7 @@ internal class DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h 
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h(cb_wrap)
         }
     }
@@ -166,7 +166,7 @@ internal class DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCall
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f(cb_wrap)
         }
     }
@@ -215,7 +215,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f(cb_wrap)
         }
     }
@@ -264,7 +264,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g(cb_wrap)
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
@@ -39,7 +39,11 @@ internal class DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomat
                 }
             }
     @JvmField
-    internal var destructor: Pointer = Pointer(0L);
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
@@ -51,7 +55,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomat
     internal val nativeStruct: DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomatCallback_f_Native) {
     val data_: Pointer = nativeStruct.data_
     val run_callback: Callback = nativeStruct.run_callback
-    val destructor: Pointer = nativeStruct.destructor
+    val destructor: Callback = nativeStruct.destructor
 
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomatCallback_f_Native::class.java).toLong()
@@ -64,6 +68,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomat
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomatCallback_f(cb_wrap)
         }
     }
@@ -83,7 +88,11 @@ internal class DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h_
                 }
             }
     @JvmField
-    internal var destructor: Pointer = Pointer(0L);
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
@@ -95,7 +104,7 @@ internal class DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h 
     internal val nativeStruct: DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h_Native) {
     val data_: Pointer = nativeStruct.data_
     val run_callback: Callback = nativeStruct.run_callback
-    val destructor: Pointer = nativeStruct.destructor
+    val destructor: Callback = nativeStruct.destructor
 
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h_Native::class.java).toLong()
@@ -108,6 +117,7 @@ internal class DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h 
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h_Native()
             cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h(cb_wrap)
         }
     }
@@ -127,7 +137,11 @@ internal class DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCall
                 }
             }
     @JvmField
-    internal var destructor: Pointer = Pointer(0L);
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
@@ -139,7 +153,7 @@ internal class DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCall
     internal val nativeStruct: DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f_Native) {
     val data_: Pointer = nativeStruct.data_
     val run_callback: Callback = nativeStruct.run_callback
-    val destructor: Pointer = nativeStruct.destructor
+    val destructor: Callback = nativeStruct.destructor
 
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f_Native::class.java).toLong()
@@ -152,6 +166,7 @@ internal class DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCall
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f(cb_wrap)
         }
     }
@@ -171,7 +186,11 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
                 }
             }
     @JvmField
-    internal var destructor: Pointer = Pointer(0L);
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
@@ -183,7 +202,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
     internal val nativeStruct: DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f_Native) {
     val data_: Pointer = nativeStruct.data_
     val run_callback: Callback = nativeStruct.run_callback
-    val destructor: Pointer = nativeStruct.destructor
+    val destructor: Callback = nativeStruct.destructor
 
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f_Native::class.java).toLong()
@@ -196,6 +215,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f(cb_wrap)
         }
     }
@@ -215,7 +235,11 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
                 }
             }
     @JvmField
-    internal var destructor: Pointer = Pointer(0L);
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
@@ -227,7 +251,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
     internal val nativeStruct: DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g_Native) {
     val data_: Pointer = nativeStruct.data_
     val run_callback: Callback = nativeStruct.run_callback
-    val destructor: Pointer = nativeStruct.destructor
+    val destructor: Callback = nativeStruct.destructor
 
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g_Native::class.java).toLong()
@@ -240,6 +264,7 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
             }
             val cb_wrap = DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g_Native()
             cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
             return DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g(cb_wrap)
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -51,7 +51,7 @@ internal class DiplomatJVMRuntime {
         val libClass: Class<DiplomatJVMRuntimeLib> = DiplomatJVMRuntimeLib::class.java
         val lib: DiplomatJVMRuntimeLib = Native.load("somelib", libClass, Collections.singletonMap(Library.OPTION_ALLOW_OBJECTS, true))
 
-        fun getRustCookie(obj: Object): Pointer {
+        fun buildRustCookie(obj: Object): Pointer {
             return lib.create_rust_jvm_cookie(JNIEnv.CURRENT, obj);
         }
 

--- a/macro/src/snapshots/diplomat__tests__callback_arguments.snap
+++ b/macro/src/snapshots/diplomat__tests__callback_arguments.snap
@@ -39,10 +39,7 @@ mod ffi {
     use core::ffi::c_void;
     use diplomat_runtime::*;
     #[no_mangle]
-    extern "C" fn Wrapper_test_multi_arg_callback(
-        f: core::mem::ManuallyDrop<DiplomatCallback<i32>>,
-        x: i32,
-    ) -> i32 {
+    extern "C" fn Wrapper_test_multi_arg_callback(f: DiplomatCallback<i32>, x: i32) -> i32 {
         let f = move |arg0: i32| unsafe {
             std::mem::transmute::<
                 unsafe extern "C" fn(*const c_void, ...) -> i32,
@@ -52,9 +49,7 @@ mod ffi {
         Wrapper::test_multi_arg_callback(f, x)
     }
     #[no_mangle]
-    extern "C" fn Wrapper_test_multiarg_void_callback(
-        f: core::mem::ManuallyDrop<DiplomatCallback<()>>,
-    ) {
+    extern "C" fn Wrapper_test_multiarg_void_callback(f: DiplomatCallback<()>) {
         let f = move |arg0: i32, arg1: &str| unsafe {
             let arg1: diplomat_runtime::DiplomatUtf8StrSlice = arg1.into();
             std::mem::transmute::<
@@ -69,7 +64,7 @@ mod ffi {
         Wrapper::test_multiarg_void_callback(f)
     }
     #[no_mangle]
-    extern "C" fn Wrapper_test_mod_array(g: core::mem::ManuallyDrop<DiplomatCallback<()>>) {
+    extern "C" fn Wrapper_test_mod_array(g: DiplomatCallback<()>) {
         let g = move |arg0: &[u8]| unsafe {
             let arg0: diplomat_runtime::DiplomatSlice<u8> = arg0.into();
             std::mem::transmute::<
@@ -80,7 +75,7 @@ mod ffi {
         Wrapper::test_mod_array(g)
     }
     #[no_mangle]
-    extern "C" fn Wrapper_test_no_args(h: core::mem::ManuallyDrop<DiplomatCallback<()>>) -> i32 {
+    extern "C" fn Wrapper_test_no_args(h: DiplomatCallback<()>) -> i32 {
         let h = move || unsafe {
             std::mem::transmute::<
                 unsafe extern "C" fn(*const c_void, ...) -> (),
@@ -90,9 +85,7 @@ mod ffi {
         Wrapper::test_no_args(h)
     }
     #[no_mangle]
-    extern "C" fn Wrapper_test_cb_with_struct(
-        f: core::mem::ManuallyDrop<DiplomatCallback<i32>>,
-    ) -> i32 {
+    extern "C" fn Wrapper_test_cb_with_struct(f: DiplomatCallback<i32>) -> i32 {
         let f = move |arg0: TestingStruct| unsafe {
             std::mem::transmute::<
                 unsafe extern "C" fn(*const c_void, ...) -> i32,
@@ -103,8 +96,8 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Wrapper_test_multiple_cb_args(
-        f: core::mem::ManuallyDrop<DiplomatCallback<i32>>,
-        g: core::mem::ManuallyDrop<DiplomatCallback<i32>>,
+        f: DiplomatCallback<i32>,
+        g: DiplomatCallback<i32>,
     ) -> i32 {
         let f = move || unsafe {
             std::mem::transmute::<

--- a/macro/src/snapshots/diplomat__tests__callback_arguments.snap
+++ b/macro/src/snapshots/diplomat__tests__callback_arguments.snap
@@ -1,5 +1,6 @@
 ---
 source: macro/src/lib.rs
+assertion_line: 858
 expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                pub struct Wrapper { cant_be_empty: bool, } pub struct\n                                TestingStruct { x: i32, y: i32, } impl Wrapper\n                                {\n                                    pub fn\n                                    test_multi_arg_callback(f: impl Fn(i32) -> i32, x: i32) ->\n                                    i32 { f(10 + x) } pub fn\n                                    test_multiarg_void_callback(f: impl Fn(i32, &str))\n                                    { f(-10, \"hello it's a string\\0\"); } pub fn\n                                    test_mod_array(g: impl Fn(&[u8]))\n                                    {\n                                        let bytes: Vec<u8> = vec![0x11, 0x22];\n                                        g(bytes.as_slice().into());\n                                    } pub fn test_no_args(h: impl Fn()) -> i32 { h(); -5 } pub\n                                    fn test_cb_with_struct(f: impl Fn(TestingStruct) -> i32) ->\n                                    i32 { let arg = TestingStruct { x: 1, y: 5, }; f(arg) } pub\n                                    fn\n                                    test_multiple_cb_args(f: impl Fn() -> i32, g: impl Fn(i32)\n                                    -> i32) -> i32 { f() + g(5) }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
@@ -38,7 +39,10 @@ mod ffi {
     use core::ffi::c_void;
     use diplomat_runtime::*;
     #[no_mangle]
-    extern "C" fn Wrapper_test_multi_arg_callback(f: DiplomatCallback<i32>, x: i32) -> i32 {
+    extern "C" fn Wrapper_test_multi_arg_callback(
+        f: core::mem::ManuallyDrop<DiplomatCallback<i32>>,
+        x: i32,
+    ) -> i32 {
         let f = move |arg0: i32| unsafe {
             std::mem::transmute::<
                 unsafe extern "C" fn(*const c_void, ...) -> i32,
@@ -48,7 +52,9 @@ mod ffi {
         Wrapper::test_multi_arg_callback(f, x)
     }
     #[no_mangle]
-    extern "C" fn Wrapper_test_multiarg_void_callback(f: DiplomatCallback<()>) {
+    extern "C" fn Wrapper_test_multiarg_void_callback(
+        f: core::mem::ManuallyDrop<DiplomatCallback<()>>,
+    ) {
         let f = move |arg0: i32, arg1: &str| unsafe {
             let arg1: diplomat_runtime::DiplomatUtf8StrSlice = arg1.into();
             std::mem::transmute::<
@@ -63,7 +69,7 @@ mod ffi {
         Wrapper::test_multiarg_void_callback(f)
     }
     #[no_mangle]
-    extern "C" fn Wrapper_test_mod_array(g: DiplomatCallback<()>) {
+    extern "C" fn Wrapper_test_mod_array(g: core::mem::ManuallyDrop<DiplomatCallback<()>>) {
         let g = move |arg0: &[u8]| unsafe {
             let arg0: diplomat_runtime::DiplomatSlice<u8> = arg0.into();
             std::mem::transmute::<
@@ -74,7 +80,7 @@ mod ffi {
         Wrapper::test_mod_array(g)
     }
     #[no_mangle]
-    extern "C" fn Wrapper_test_no_args(h: DiplomatCallback<()>) -> i32 {
+    extern "C" fn Wrapper_test_no_args(h: core::mem::ManuallyDrop<DiplomatCallback<()>>) -> i32 {
         let h = move || unsafe {
             std::mem::transmute::<
                 unsafe extern "C" fn(*const c_void, ...) -> (),
@@ -84,7 +90,9 @@ mod ffi {
         Wrapper::test_no_args(h)
     }
     #[no_mangle]
-    extern "C" fn Wrapper_test_cb_with_struct(f: DiplomatCallback<i32>) -> i32 {
+    extern "C" fn Wrapper_test_cb_with_struct(
+        f: core::mem::ManuallyDrop<DiplomatCallback<i32>>,
+    ) -> i32 {
         let f = move |arg0: TestingStruct| unsafe {
             std::mem::transmute::<
                 unsafe extern "C" fn(*const c_void, ...) -> i32,
@@ -95,8 +103,8 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Wrapper_test_multiple_cb_args(
-        f: DiplomatCallback<i32>,
-        g: DiplomatCallback<i32>,
+        f: core::mem::ManuallyDrop<DiplomatCallback<i32>>,
+        g: core::mem::ManuallyDrop<DiplomatCallback<i32>>,
     ) -> i32 {
         let f = move || unsafe {
             std::mem::transmute::<

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -18,6 +18,9 @@ repository = "https://github.com/rust-diplomat/diplomat"
 [lib]
 path = "src/lib.rs"
 
+[features]
+jvm-callback-support = ["dep:jni"]
+default = ["jvm-callback-support"]
+
 [dependencies]
-log = { version = "0.4", optional = true }
-jni = "0.21"
+jni = { version  = "0.21", optional = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,3 +20,4 @@ path = "src/lib.rs"
 
 [dependencies]
 log = { version = "0.4", optional = true }
+jni = "0.21"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,7 +20,6 @@ path = "src/lib.rs"
 
 [features]
 jvm-callback-support = ["dep:jni"]
-default = ["jvm-callback-support"]
 
 [dependencies]
 jni = { version  = "0.21", optional = true }

--- a/runtime/src/callback.rs
+++ b/runtime/src/callback.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "jvm-callback-support")]
 use alloc::boxed::Box;
 use core::ffi::c_void;
+#[cfg(feature = "jvm-callback-support")]
 use jni::{
     objects::{GlobalRef, JObject},
     sys::jlong,
@@ -33,6 +35,7 @@ impl<ReturnType> Drop for DiplomatCallback<ReturnType> {
 // this can then be stored as a field in a struct, so that the struct
 // is not deallocated until the JVM calls a destructor that unwraps
 // the GlobalRef so it can be dropped.
+#[cfg(feature = "jvm-callback-support")]
 #[no_mangle]
 extern "system" fn create_rust_jvm_cookie<'local>(
     env: JNIEnv<'local>,
@@ -42,6 +45,7 @@ extern "system" fn create_rust_jvm_cookie<'local>(
     Box::into_raw(Box::new(global_ref)) as jlong
 }
 
+#[cfg(feature = "jvm-callback-support")]
 #[no_mangle]
 extern "system" fn destroy_rust_jvm_cookie(global_ref_boxed: jlong) {
     unsafe {

--- a/runtime/src/callback.rs
+++ b/runtime/src/callback.rs
@@ -34,7 +34,7 @@ impl<ReturnType> Drop for DiplomatCallback<ReturnType> {
 // is not deallocated until the JVM calls a destructor that unwraps
 // the GlobalRef so it can be dropped.
 #[no_mangle]
-extern "system" fn JVM_create_GC_root_in_rust<'local>(
+extern "system" fn create_rust_jvm_cookie<'local>(
     env: JNIEnv<'local>,
     obj_to_ref: JObject<'local>,
 ) -> jlong {
@@ -43,7 +43,7 @@ extern "system" fn JVM_create_GC_root_in_rust<'local>(
 }
 
 #[no_mangle]
-extern "system" fn JVM_drop_GC_root_in_rust(global_ref_boxed: jlong) {
+extern "system" fn destroy_rust_jvm_cookie(global_ref_boxed: jlong) {
     unsafe {
         drop(Box::from_raw(global_ref_boxed as *mut GlobalRef));
     }

--- a/runtime/src/callback.rs
+++ b/runtime/src/callback.rs
@@ -1,4 +1,10 @@
+use alloc::boxed::Box;
 use core::ffi::c_void;
+use jni::{
+    objects::{GlobalRef, JObject},
+    sys::jlong,
+    JNIEnv,
+};
 
 // struct representing a callback from Rust into a foreign language
 // TODO restrict the return type?
@@ -20,5 +26,25 @@ impl<ReturnType> Drop for DiplomatCallback<ReturnType> {
                 (destructor)(self.data);
             }
         }
+    }
+}
+
+// return a pointer to a JNI GlobalRef, which is a JVM GC root to the object provided.
+// this can then be stored as a field in a struct, so that the struct
+// is not deallocated until the JVM calls a destructor that unwraps
+// the GlobalRef so it can be dropped.
+#[no_mangle]
+extern "system" fn JVM_create_GC_root_in_rust<'local>(
+    env: JNIEnv<'local>,
+    obj_to_ref: JObject<'local>,
+) -> jlong {
+    let global_ref = env.new_global_ref(obj_to_ref).unwrap();
+    Box::into_raw(Box::new(global_ref)) as jlong
+}
+
+#[no_mangle]
+extern "system" fn JVM_drop_GC_root_in_rust(global_ref_boxed: jlong) {
+    unsafe {
+        drop(Box::from_raw(global_ref_boxed as *mut GlobalRef));
     }
 }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -68,7 +68,11 @@ internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatC
                 }
             }
     @JvmField
-    internal var destructor: Pointer = Pointer(0L);
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
@@ -80,7 +84,7 @@ internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatC
     internal val nativeStruct: DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native) {
     val data_: Pointer = nativeStruct.data_
     val run_callback: Callback = nativeStruct.run_callback
-    val destructor: Pointer = nativeStruct.destructor
+    val destructor: Callback = nativeStruct.destructor
 
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native::class.java).toLong()
@@ -93,15 +97,9 @@ internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatC
             }
             val cb_wrap = DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = JVMTools.getRustGCRootPointer(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
             return DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f(cb_wrap)
         }
-    }
-
-    @Override
-    @SuppressWarnings("Finalize") // needed to deallocate the Rust object
-    fun finalize() {
-        JVMTools.dropGCRoot(this.nativeStruct.data_);
     }
 }
 class MyNativeStruct internal constructor (

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -97,7 +97,7 @@ internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatC
             }
             val cb_wrap = DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
             return DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f(cb_wrap)
         }
     }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -1,5 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
+assertion_line: 1823
 expression: struct_code
 ---
 package dev.gigapixel.somelib
@@ -92,8 +93,15 @@ internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatC
             }
             val cb_wrap = DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native()
             cb_wrap.run_callback = callback;
+            cb_wrap.data_ = JVMTools.getRustGCRootPointer(cb_wrap as Object);
             return DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f(cb_wrap)
         }
+    }
+
+    @Override
+    @SuppressWarnings("Finalize") // needed to deallocate the Rust object
+    fun finalize() {
+        JVMTools.dropGCRoot(this.nativeStruct.data_);
     }
 }
 class MyNativeStruct internal constructor (

--- a/tool/templates/kotlin/Callback.kt.jinja
+++ b/tool/templates/kotlin/Callback.kt.jinja
@@ -39,7 +39,14 @@ internal class {{name}} internal constructor (
             }
             val cb_wrap = {{name}}_Native()
             cb_wrap.run_callback = callback;
+            cb_wrap.data_ = JVMTools.getRustGCRootPointer(cb_wrap as Object);
             return {{name}}(cb_wrap)
         }
+    }
+
+    @Override
+    @SuppressWarnings("Finalize") // needed to deallocate the Rust object
+    fun finalize() {
+        JVMTools.dropGCRoot(this.nativeStruct.data_);
     }
 }

--- a/tool/templates/kotlin/Callback.kt.jinja
+++ b/tool/templates/kotlin/Callback.kt.jinja
@@ -14,7 +14,11 @@ internal class {{name}}_Native: Structure(), Structure.ByValue {
                 }
             }
     @JvmField
-    internal var destructor: Pointer = Pointer(0L);
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
@@ -26,7 +30,7 @@ internal class {{name}} internal constructor (
     internal val nativeStruct: {{name}}_Native) {
     val data_: Pointer = nativeStruct.data_
     val run_callback: Callback = nativeStruct.run_callback
-    val destructor: Pointer = nativeStruct.destructor
+    val destructor: Callback = nativeStruct.destructor
 
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize({{name}}_Native::class.java).toLong()
@@ -39,14 +43,8 @@ internal class {{name}} internal constructor (
             }
             val cb_wrap = {{name}}_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = JVMTools.getRustGCRootPointer(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
             return {{name}}(cb_wrap)
         }
-    }
-
-    @Override
-    @SuppressWarnings("Finalize") // needed to deallocate the Rust object
-    fun finalize() {
-        JVMTools.dropGCRoot(this.nativeStruct.data_);
     }
 }

--- a/tool/templates/kotlin/Callback.kt.jinja
+++ b/tool/templates/kotlin/Callback.kt.jinja
@@ -43,7 +43,7 @@ internal class {{name}} internal constructor (
             }
             val cb_wrap = {{name}}_Native()
             cb_wrap.run_callback = callback;
-            cb_wrap.data_ = DiplomatJVMRuntime.getRustCookie(cb_wrap as Object);
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
             return {{name}}(cb_wrap)
         }
     }

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -51,7 +51,7 @@ internal class DiplomatJVMRuntime {
         val libClass: Class<DiplomatJVMRuntimeLib> = DiplomatJVMRuntimeLib::class.java
         val lib: DiplomatJVMRuntimeLib = Native.load("{{lib_name}}", libClass, Collections.singletonMap(Library.OPTION_ALLOW_OBJECTS, true))
 
-        fun getRustCookie(obj: Object): Pointer {
+        fun buildRustCookie(obj: Object): Pointer {
             return lib.create_rust_jvm_cookie(JNIEnv.CURRENT, obj);
         }
 

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -41,22 +41,22 @@ object DW {
     }
 }
 
-internal interface JVMLibTools: Library {
-    fun JVM_create_GC_root_in_rust(env: JNIEnv, obj: Object): Pointer
-    fun JVM_drop_GC_root_in_rust(obj_pointer: Pointer): Unit
+internal interface DiplomatJVMRuntimeLib: Library {
+    fun create_rust_jvm_cookie(env: JNIEnv, obj: Object): Pointer
+    fun destroy_rust_jvm_cookie(obj_pointer: Pointer): Unit
 }
 
-internal class JVMTools {
+internal class DiplomatJVMRuntime {
     companion object {
-        val libClass: Class<JVMLibTools> = JVMLibTools::class.java
-        val lib: JVMLibTools = Native.load("{{lib_name}}", libClass, Collections.singletonMap(Library.OPTION_ALLOW_OBJECTS, true))
+        val libClass: Class<DiplomatJVMRuntimeLib> = DiplomatJVMRuntimeLib::class.java
+        val lib: DiplomatJVMRuntimeLib = Native.load("{{lib_name}}", libClass, Collections.singletonMap(Library.OPTION_ALLOW_OBJECTS, true))
 
-        fun getRustGCRootPointer (obj: Object): Pointer {
-            return lib.JVM_create_GC_root_in_rust(JNIEnv.CURRENT, obj);
+        fun getRustCookie(obj: Object): Pointer {
+            return lib.create_rust_jvm_cookie(JNIEnv.CURRENT, obj);
         }
 
-        fun dropGCRoot(obj_pointer: Pointer): Unit {
-            lib.JVM_drop_GC_root_in_rust(obj_pointer);
+        fun dropRustCookie(obj_pointer: Pointer): Unit {
+            lib.destroy_rust_jvm_cookie(obj_pointer);
         }
     }
 }

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -1,11 +1,13 @@
 package {{domain}}.{{lib_name}};
 
+import com.sun.jna.JNIEnv
 import com.sun.jna.Library
 import com.sun.jna.Memory
 import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
 import com.sun.jna.Union
+import java.util.Collections
 
 
 // We spawn a cleaner for the library which is responsible for cleaning opaque types.
@@ -35,6 +37,26 @@ object DW {
             return bytes.decodeToString();
         } finally {
             lib.diplomat_buffer_write_destroy(write);
+        }
+    }
+}
+
+internal interface JVMLibTools: Library {
+    fun JVM_create_GC_root_in_rust(env: JNIEnv, obj: Object): Pointer
+    fun JVM_drop_GC_root_in_rust(obj_pointer: Pointer): Unit
+}
+
+internal class JVMTools {
+    companion object {
+        val libClass: Class<JVMLibTools> = JVMLibTools::class.java
+        val lib: JVMLibTools = Native.load("{{lib_name}}", libClass, Collections.singletonMap(Library.OPTION_ALLOW_OBJECTS, true))
+
+        fun getRustGCRootPointer (obj: Object): Pointer {
+            return lib.JVM_create_GC_root_in_rust(JNIEnv.CURRENT, obj);
+        }
+
+        fun dropGCRoot(obj_pointer: Pointer): Unit {
+            lib.JVM_drop_GC_root_in_rust(obj_pointer);
         }
     }
 }


### PR DESCRIPTION
Adding support for proper memory management of callbacks passed to Rust from Kotlin -- now, they are stopped from being freed in Rust by a JNI `GlobalRef` to the callback wrapper object on the Kotlin side. The `GlobalRef` is removed in a finalizer on the Kotlin side.

This is addressing issue https://github.com/rust-diplomat/diplomat/issues/648