### PR TITLE
Code generation for trait support in Kotlin

### DIFF
--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
@@ -7,29 +7,29 @@ import com.sun.jna.Pointer
 import com.sun.jna.Structure
 
 interface TesterTrait {
-    fun test_trait_fn(x: Int): Int;
-    fun test_void_trait_fn(): Unit;
-    fun test_struct_trait_fn(s: TraitTestingStruct): Int;
+    fun testTraitFn(x: Int): Int;
+    fun testVoidTraitFn(): Unit;
+    fun testStructTraitFn(s: TraitTestingStruct): Int;
 }
 
 
-internal interface Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn: Callback {
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testTraitFn: Callback {
     fun invoke(ignored: Pointer?, x: Int ): Int
 }
-internal interface Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn: Callback {
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn: Callback {
     fun invoke(ignored: Pointer?): Unit
 }
-internal interface Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn: Callback {
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn: Callback {
     fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int
 }
 
-object TesterTrait_VTable_destructor: Callback {
+internal object TesterTrait_VTable_destructor: Callback {
     fun invoke(obj_pointer: Pointer) {
         DiplomatJVMRuntime.dropRustCookie(obj_pointer);
     }
 };
 
-class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.ByValue {
+internal class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.ByValue {
     @JvmField
     internal var destructor: Callback = TesterTrait_VTable_destructor;
     @JvmField
@@ -38,33 +38,33 @@ class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.ByValue {
     internal var alignment: Pointer = Pointer(0L);
     
     @JvmField
-    internal var run_test_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn
-        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn {
+    internal var run_testTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
                 override fun invoke(ignored: Pointer?, x: Int ): Int {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
     @JvmField
-    internal var run_test_void_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn
-        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn {
+    internal var run_testVoidTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn {
                 override fun invoke(ignored: Pointer?): Unit {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
     @JvmField
-    internal var run_test_struct_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn
-        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn {
+    internal var run_testStructTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn {
                 override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
-        return listOf("destructor", "size", "alignment", "run_test_trait_fn_callback", "run_test_void_trait_fn_callback", "run_test_struct_trait_fn_callback")
+        return listOf("destructor", "size", "alignment", "run_testTraitFn_callback", "run_testVoidTraitFn_callback", "run_testStructTraitFn_callback")
     }
 }
 
-class DiplomatTrait_TesterTrait_Wrapper_Native: Structure(), Structure.ByValue {
+internal class DiplomatTrait_TesterTrait_Wrapper_Native: Structure(), Structure.ByValue {
     @JvmField
     internal var data_: Pointer = Pointer(0L);
     @JvmField
@@ -77,7 +77,7 @@ class DiplomatTrait_TesterTrait_Wrapper_Native: Structure(), Structure.ByValue {
     }
 }
 
-class DiplomatTrait_TesterTrait_Wrapper internal constructor (
+internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
     internal val nativeStruct: DiplomatTrait_TesterTrait_Wrapper_Native) {
     val data_: Pointer = nativeStruct.data_
     val vtable: DiplomatTrait_TesterTrait_VTable_Native = nativeStruct.vtable
@@ -89,24 +89,24 @@ class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             val vtable = DiplomatTrait_TesterTrait_VTable_Native()
             
             
-            val test_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn {
+            val testTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
                 override fun invoke(ignored: Pointer?, x: Int ): Int {
-                    return trt_obj.test_trait_fn(x);
+                    return trt_obj.testTraitFn(x);
                 }
             }
-            vtable.run_test_trait_fn_callback = test_trait_fn;
-            val test_void_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn {
+            vtable.run_testTraitFn_callback = testTraitFn;
+            val testVoidTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn {
                 override fun invoke(ignored: Pointer?): Unit {
-                    return trt_obj.test_void_trait_fn();
+                    return trt_obj.testVoidTraitFn();
                 }
             }
-            vtable.run_test_void_trait_fn_callback = test_void_trait_fn;
-            val test_struct_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn {
+            vtable.run_testVoidTraitFn_callback = testVoidTraitFn;
+            val testStructTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn {
                 override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
-                    return trt_obj.test_struct_trait_fn(TraitTestingStruct(s));
+                    return trt_obj.testStructTraitFn(TraitTestingStruct(s));
                 }
             }
-            vtable.run_test_struct_trait_fn_callback = test_struct_trait_fn;
+            vtable.run_testStructTraitFn_callback = testStructTraitFn;
             val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
             native_wrapper.vtable = vtable;
             native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
@@ -1,0 +1,116 @@
+package dev.diplomattest.somelib
+
+import com.sun.jna.Callback
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+
+interface TesterTrait {
+    fun test_trait_fn(x: Int): Int;
+    fun test_void_trait_fn(): Unit;
+    fun test_struct_trait_fn(s: TraitTestingStruct): Int;
+}
+
+
+internal interface Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn: Callback {
+    fun invoke(ignored: Pointer?, x: Int ): Int
+}
+internal interface Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn: Callback {
+    fun invoke(ignored: Pointer?): Unit
+}
+internal interface Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn: Callback {
+    fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int
+}
+
+object TesterTrait_VTable_destructor: Callback {
+    fun invoke(obj_pointer: Pointer) {
+        DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+    }
+};
+
+class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var destructor: Callback = TesterTrait_VTable_destructor;
+    @JvmField
+    internal var size: Pointer = Pointer(0L);
+    @JvmField
+    internal var alignment: Pointer = Pointer(0L);
+    
+    @JvmField
+    internal var run_test_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn {
+                override fun invoke(ignored: Pointer?, x: Int ): Int {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
+    @JvmField
+    internal var run_test_void_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn {
+                override fun invoke(ignored: Pointer?): Unit {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
+    @JvmField
+    internal var run_test_struct_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn {
+                override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("destructor", "size", "alignment", "run_test_trait_fn_callback", "run_test_void_trait_fn_callback", "run_test_struct_trait_fn_callback")
+    }
+}
+
+class DiplomatTrait_TesterTrait_Wrapper_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var data_: Pointer = Pointer(0L);
+    @JvmField
+    internal var vtable: DiplomatTrait_TesterTrait_VTable_Native
+        = DiplomatTrait_TesterTrait_VTable_Native();
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("data_", "vtable")
+    }
+}
+
+class DiplomatTrait_TesterTrait_Wrapper internal constructor (
+    internal val nativeStruct: DiplomatTrait_TesterTrait_Wrapper_Native) {
+    val data_: Pointer = nativeStruct.data_
+    val vtable: DiplomatTrait_TesterTrait_VTable_Native = nativeStruct.vtable
+
+    companion object {
+        val NATIVESIZE: Long = Native.getNativeSize(DiplomatTrait_TesterTrait_Wrapper_Native::class.java).toLong()
+
+        fun fromTraitObj(trt_obj: TesterTrait): DiplomatTrait_TesterTrait_Wrapper {
+            val vtable = DiplomatTrait_TesterTrait_VTable_Native()
+            
+            
+            val test_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn {
+                override fun invoke(ignored: Pointer?, x: Int ): Int {
+                    return trt_obj.test_trait_fn(x);
+                }
+            }
+            vtable.run_test_trait_fn_callback = test_trait_fn;
+            val test_void_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn {
+                override fun invoke(ignored: Pointer?): Unit {
+                    return trt_obj.test_void_trait_fn();
+                }
+            }
+            vtable.run_test_void_trait_fn_callback = test_void_trait_fn;
+            val test_struct_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn {
+                override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
+                    return trt_obj.test_struct_trait_fn(TraitTestingStruct(s));
+                }
+            }
+            vtable.run_test_struct_trait_fn_callback = test_struct_trait_fn;
+            val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
+            native_wrapper.vtable = vtable;
+            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);
+            return DiplomatTrait_TesterTrait_Wrapper(native_wrapper);
+        }
+    }
+}

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitTestingStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitTestingStruct.kt
@@ -1,0 +1,35 @@
+package dev.diplomattest.somelib
+
+import com.sun.jna.Callback
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+
+internal interface TraitTestingStructLib: Library {
+}
+
+internal class TraitTestingStructNative: Structure(), Structure.ByValue {
+    @JvmField
+    internal var x: Int = 0;
+    @JvmField
+    internal var y: Int = 0;
+  
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("x", "y")
+    }
+}
+
+class TraitTestingStruct internal constructor (
+    internal val nativeStruct: TraitTestingStructNative) {
+    val x: Int = nativeStruct.x
+    val y: Int = nativeStruct.y
+
+    companion object {
+        internal val libClass: Class<TraitTestingStructLib> = TraitTestingStructLib::class.java
+        internal val lib: TraitTestingStructLib = Native.load("somelib", libClass)
+        val NATIVESIZE: Long = Native.getNativeSize(TraitTestingStructNative::class.java).toLong()
+    }
+
+}

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitWrapper.kt
@@ -1,0 +1,46 @@
+package dev.diplomattest.somelib
+
+import com.sun.jna.Callback
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+
+internal interface TraitWrapperLib: Library {
+    fun TraitWrapper_test_with_trait(t: DiplomatTrait_TesterTrait_Wrapper_Native, x: Int): Int
+    fun TraitWrapper_test_trait_with_struct(t: DiplomatTrait_TesterTrait_Wrapper_Native): Int
+}
+
+internal class TraitWrapperNative: Structure(), Structure.ByValue {
+    @JvmField
+    internal var cantBeEmpty: Byte = 0;
+  
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("cantBeEmpty")
+    }
+}
+
+class TraitWrapper internal constructor (
+    internal val nativeStruct: TraitWrapperNative) {
+    val cantBeEmpty: Boolean = nativeStruct.cantBeEmpty > 0
+
+    companion object {
+        internal val libClass: Class<TraitWrapperLib> = TraitWrapperLib::class.java
+        internal val lib: TraitWrapperLib = Native.load("somelib", libClass)
+        val NATIVESIZE: Long = Native.getNativeSize(TraitWrapperNative::class.java).toLong()
+        
+        fun testWithTrait(t: DiplomatTrait_TesterTrait_Wrapper, x: Int): Int {
+            
+            val returnVal = lib.TraitWrapper_test_with_trait(t.nativeStruct, x);
+            return returnVal
+        }
+        
+        fun testTraitWithStruct(t: DiplomatTrait_TesterTrait_Wrapper): Int {
+            
+            val returnVal = lib.TraitWrapper_test_trait_with_struct(t.nativeStruct);
+            return returnVal
+        }
+    }
+
+}

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitWrapper.kt
@@ -30,15 +30,15 @@ class TraitWrapper internal constructor (
         internal val lib: TraitWrapperLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(TraitWrapperNative::class.java).toLong()
         
-        fun testWithTrait(t: DiplomatTrait_TesterTrait_Wrapper, x: Int): Int {
+        fun testWithTrait(t: TesterTrait, x: Int): Int {
             
-            val returnVal = lib.TraitWrapper_test_with_trait(t.nativeStruct, x);
+            val returnVal = lib.TraitWrapper_test_with_trait(DiplomatTrait_TesterTrait_Wrapper.fromTraitObj(t).nativeStruct, x);
             return returnVal
         }
         
-        fun testTraitWithStruct(t: DiplomatTrait_TesterTrait_Wrapper): Int {
+        fun testTraitWithStruct(t: TesterTrait): Int {
             
-            val returnVal = lib.TraitWrapper_test_trait_with_struct(t.nativeStruct);
+            val returnVal = lib.TraitWrapper_test_trait_with_struct(DiplomatTrait_TesterTrait_Wrapper.fromTraitObj(t).nativeStruct);
             return returnVal
         }
     }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1139,4 +1139,40 @@ mod tests {
             .to_string()
         ));
     }
+
+    #[test]
+    fn traits() {
+        insta::assert_snapshot!(rustfmt_code(
+            &gen_bridge(parse_quote! {
+                mod ffi {
+                    pub struct TraitTestingStruct {
+                        x: i32,
+                        y: i32,
+                    }
+                    pub trait TesterTrait {
+                        fn test_trait_fn(&self, x: i32) -> i32;
+                        fn test_void_trait_fn(&self);
+                        fn test_struct_trait_fn(&self, s: TraitTestingStruct) -> i32;
+                    }
+                    pub struct Wrapper {
+                        cant_be_empty: bool,
+                    }
+
+                    impl Wrapper {
+                        pub fn test_with_trait(t: impl TesterTrait, x: i32) -> i32 {
+                            t.test_void_trait_fn();
+                            t.test_trait_fn(x)
+                        }
+
+                        pub fn test_trait_with_struct(t: impl TesterTrait) -> i32 {
+                            let arg = TraitTestingStruct { x: 1, y: 5 };
+                            t.test_struct_trait_fn(arg)
+                        }
+                    }
+                }
+            })
+            .to_token_stream()
+            .to_string()
+        ));
+    }
 }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1139,40 +1139,4 @@ mod tests {
             .to_string()
         ));
     }
-
-    #[test]
-    fn traits() {
-        insta::assert_snapshot!(rustfmt_code(
-            &gen_bridge(parse_quote! {
-                mod ffi {
-                    pub struct TraitTestingStruct {
-                        x: i32,
-                        y: i32,
-                    }
-                    pub trait TesterTrait {
-                        fn test_trait_fn(&self, x: i32) -> i32;
-                        fn test_void_trait_fn(&self);
-                        fn test_struct_trait_fn(&self, s: TraitTestingStruct) -> i32;
-                    }
-                    pub struct Wrapper {
-                        cant_be_empty: bool,
-                    }
-
-                    impl Wrapper {
-                        pub fn test_with_trait(t: impl TesterTrait, x: i32) -> i32 {
-                            t.test_void_trait_fn();
-                            t.test_trait_fn(x)
-                        }
-
-                        pub fn test_trait_with_struct(t: impl TesterTrait) -> i32 {
-                            let arg = TraitTestingStruct { x: 1, y: 5 };
-                            t.test_struct_trait_fn(arg)
-                        }
-                    }
-                }
-            })
-            .to_token_stream()
-            .to_string()
-        ));
-    }
 }

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -2,7 +2,7 @@ use diplomat_core::hir::{
     self,
     borrowing_param::{LifetimeEdge, LifetimeEdgeKind},
     FloatType, IntSizeType, IntType, LifetimeEnv, MaybeStatic, PrimitiveType, Slice,
-    StringEncoding, StructPathLike, TyPosition, Type, TypeContext, TypeId, TraitId,
+    StringEncoding, StructPathLike, TraitId, TyPosition, Type, TypeContext, TypeId,
 };
 use heck::ToLowerCamelCase;
 use std::{borrow::Cow, iter::once};

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -106,6 +106,23 @@ impl<'tcx> KotlinFormatter<'tcx> {
         }
     }
 
+    pub fn fmt_trait_method_name<'a>(&self, method: &'a hir::Callback) -> Cow<'a, str> {
+        if method.name.is_none() {
+            panic!("Trait methods need a name");
+        }
+        let name = method.name.clone().unwrap().as_str().to_lower_camel_case();
+        let name = if method.attrs.is_some() {
+            method.attrs.as_ref().unwrap().rename.apply(name.into())
+        } else {
+            name.into()
+        };
+        if INVALID_METHOD_NAMES.contains(&&*name) {
+            format!("{name}_").into()
+        } else {
+            name
+        }
+    }
+
     pub fn fmt_param_name<'a>(&self, ident: &'a str) -> Cow<'tcx, str> {
         ident.to_lower_camel_case().into()
     }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
@@ -1,0 +1,121 @@
+---
+source: tool/src/kotlin/mod.rs
+assertion_line: 2228
+expression: result
+---
+package dev.gigapixel.somelib
+
+import com.sun.jna.Callback
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+
+interface TesterTrait {
+    fun test_trait_fn(x: Int): Int;
+    fun test_void_trait_fn(): Unit;
+    fun test_struct_trait_fn(s: TraitTestingStruct): Int;
+}
+
+
+internal interface Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn: Callback {
+    fun invoke(ignored: Pointer?, x: Int ): Int
+}
+internal interface Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn: Callback {
+    fun invoke(ignored: Pointer?): Unit
+}
+internal interface Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn: Callback {
+    fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int
+}
+
+object TesterTrait_VTable_destructor: Callback {
+    fun invoke(obj_pointer: Pointer) {
+        DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+    }
+};
+
+class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var destructor: Callback = TesterTrait_VTable_destructor;
+    @JvmField
+    internal var size: Pointer = Pointer(0L);
+    @JvmField
+    internal var alignment: Pointer = Pointer(0L);
+    
+    @JvmField
+    internal var run_test_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn {
+                override fun invoke(ignored: Pointer?, x: Int ): Int {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
+    @JvmField
+    internal var run_test_void_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn {
+                override fun invoke(ignored: Pointer?): Unit {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
+    @JvmField
+    internal var run_test_struct_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn {
+                override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("destructor", "size", "alignment", "run_test_trait_fn_callback", "run_test_void_trait_fn_callback", "run_test_struct_trait_fn_callback")
+    }
+}
+
+class DiplomatTrait_TesterTrait_Wrapper_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var data_: Pointer = Pointer(0L);
+    @JvmField
+    internal var vtable: DiplomatTrait_TesterTrait_VTable_Native
+        = DiplomatTrait_TesterTrait_VTable_Native();
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("data_", "vtable")
+    }
+}
+
+class DiplomatTrait_TesterTrait_Wrapper internal constructor (
+    internal val nativeStruct: DiplomatTrait_TesterTrait_Wrapper_Native) {
+    val data_: Pointer = nativeStruct.data_
+    val vtable: DiplomatTrait_TesterTrait_VTable_Native = nativeStruct.vtable
+
+    companion object {
+        val NATIVESIZE: Long = Native.getNativeSize(DiplomatTrait_TesterTrait_Wrapper_Native::class.java).toLong()
+
+        fun fromTraitObj(trt_obj: TesterTrait): DiplomatTrait_TesterTrait_Wrapper {
+            val vtable = DiplomatTrait_TesterTrait_VTable_Native()
+            
+            
+            val test_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn {
+                override fun invoke(ignored: Pointer?, x: Int ): Int {
+                    return trt_obj.test_trait_fn(x);
+                }
+            }
+            vtable.run_test_trait_fn_callback = test_trait_fn;
+            val test_void_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn {
+                override fun invoke(ignored: Pointer?): Unit {
+                    return trt_obj.test_void_trait_fn();
+                }
+            }
+            vtable.run_test_void_trait_fn_callback = test_void_trait_fn;
+            val test_struct_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn {
+                override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
+                    return trt_obj.test_struct_trait_fn(TraitTestingStruct(s));
+                }
+            }
+            vtable.run_test_struct_trait_fn_callback = test_struct_trait_fn;
+            val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
+            native_wrapper.vtable = vtable;
+            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);
+            return DiplomatTrait_TesterTrait_Wrapper(native_wrapper);
+        }
+    }
+}

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2228
+assertion_line: 2256
 expression: result
 ---
 package dev.gigapixel.somelib
@@ -12,29 +12,29 @@ import com.sun.jna.Pointer
 import com.sun.jna.Structure
 
 interface TesterTrait {
-    fun test_trait_fn(x: Int): Int;
-    fun test_void_trait_fn(): Unit;
-    fun test_struct_trait_fn(s: TraitTestingStruct): Int;
+    fun testTraitFn(x: Int): Int;
+    fun testVoidTraitFn(): Unit;
+    fun testStructTraitFn(s: TraitTestingStruct): Int;
 }
 
 
-internal interface Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn: Callback {
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testTraitFn: Callback {
     fun invoke(ignored: Pointer?, x: Int ): Int
 }
-internal interface Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn: Callback {
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn: Callback {
     fun invoke(ignored: Pointer?): Unit
 }
-internal interface Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn: Callback {
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn: Callback {
     fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int
 }
 
-object TesterTrait_VTable_destructor: Callback {
+internal object TesterTrait_VTable_destructor: Callback {
     fun invoke(obj_pointer: Pointer) {
         DiplomatJVMRuntime.dropRustCookie(obj_pointer);
     }
 };
 
-class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.ByValue {
+internal class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.ByValue {
     @JvmField
     internal var destructor: Callback = TesterTrait_VTable_destructor;
     @JvmField
@@ -43,33 +43,33 @@ class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.ByValue {
     internal var alignment: Pointer = Pointer(0L);
     
     @JvmField
-    internal var run_test_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn
-        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn {
+    internal var run_testTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
                 override fun invoke(ignored: Pointer?, x: Int ): Int {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
     @JvmField
-    internal var run_test_void_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn
-        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn {
+    internal var run_testVoidTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn {
                 override fun invoke(ignored: Pointer?): Unit {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
     @JvmField
-    internal var run_test_struct_trait_fn_callback: Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn
-        = object :  Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn {
+    internal var run_testStructTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn {
                 override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
-        return listOf("destructor", "size", "alignment", "run_test_trait_fn_callback", "run_test_void_trait_fn_callback", "run_test_struct_trait_fn_callback")
+        return listOf("destructor", "size", "alignment", "run_testTraitFn_callback", "run_testVoidTraitFn_callback", "run_testStructTraitFn_callback")
     }
 }
 
-class DiplomatTrait_TesterTrait_Wrapper_Native: Structure(), Structure.ByValue {
+internal class DiplomatTrait_TesterTrait_Wrapper_Native: Structure(), Structure.ByValue {
     @JvmField
     internal var data_: Pointer = Pointer(0L);
     @JvmField
@@ -82,7 +82,7 @@ class DiplomatTrait_TesterTrait_Wrapper_Native: Structure(), Structure.ByValue {
     }
 }
 
-class DiplomatTrait_TesterTrait_Wrapper internal constructor (
+internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
     internal val nativeStruct: DiplomatTrait_TesterTrait_Wrapper_Native) {
     val data_: Pointer = nativeStruct.data_
     val vtable: DiplomatTrait_TesterTrait_VTable_Native = nativeStruct.vtable
@@ -94,24 +94,24 @@ class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             val vtable = DiplomatTrait_TesterTrait_VTable_Native()
             
             
-            val test_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_trait_fn {
+            val testTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
                 override fun invoke(ignored: Pointer?, x: Int ): Int {
-                    return trt_obj.test_trait_fn(x);
+                    return trt_obj.testTraitFn(x);
                 }
             }
-            vtable.run_test_trait_fn_callback = test_trait_fn;
-            val test_void_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_void_trait_fn {
+            vtable.run_testTraitFn_callback = testTraitFn;
+            val testVoidTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn {
                 override fun invoke(ignored: Pointer?): Unit {
-                    return trt_obj.test_void_trait_fn();
+                    return trt_obj.testVoidTraitFn();
                 }
             }
-            vtable.run_test_void_trait_fn_callback = test_void_trait_fn;
-            val test_struct_trait_fn: Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn = object :  Runner_DiplomatTraitMethod_TesterTrait_test_struct_trait_fn {
+            vtable.run_testVoidTraitFn_callback = testVoidTraitFn;
+            val testStructTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn {
                 override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
-                    return trt_obj.test_struct_trait_fn(TraitTestingStruct(s));
+                    return trt_obj.testStructTraitFn(TraitTestingStruct(s));
                 }
             }
-            vtable.run_test_struct_trait_fn_callback = test_struct_trait_fn;
+            vtable.run_testStructTraitFn_callback = testStructTraitFn;
             val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
             native_wrapper.vtable = vtable;
             native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);

--- a/tool/templates/kotlin/Trait.kt.jinja
+++ b/tool/templates/kotlin/Trait.kt.jinja
@@ -26,13 +26,13 @@ internal interface Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name
     {%- endfor %}
 {%- endif %}
 
-object {{trait_name}}_VTable_destructor: Callback {
+internal object {{trait_name}}_VTable_destructor: Callback {
     fun invoke(obj_pointer: Pointer) {
         DiplomatJVMRuntime.dropRustCookie(obj_pointer);
     }
 };
 
-class DiplomatTrait_{{trait_name}}_VTable_Native: Structure(), Structure.ByValue {
+internal class DiplomatTrait_{{trait_name}}_VTable_Native: Structure(), Structure.ByValue {
     @JvmField
     internal var destructor: Callback = {{trait_name}}_VTable_destructor;
     @JvmField
@@ -57,7 +57,7 @@ class DiplomatTrait_{{trait_name}}_VTable_Native: Structure(), Structure.ByValue
     }
 }
 
-class DiplomatTrait_{{trait_name}}_Wrapper_Native: Structure(), Structure.ByValue {
+internal class DiplomatTrait_{{trait_name}}_Wrapper_Native: Structure(), Structure.ByValue {
     @JvmField
     internal var data_: Pointer = Pointer(0L);
     @JvmField
@@ -70,7 +70,7 @@ class DiplomatTrait_{{trait_name}}_Wrapper_Native: Structure(), Structure.ByValu
     }
 }
 
-class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
+internal class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
     internal val nativeStruct: DiplomatTrait_{{trait_name}}_Wrapper_Native) {
     val data_: Pointer = nativeStruct.data_
     val vtable: DiplomatTrait_{{trait_name}}_VTable_Native = nativeStruct.vtable

--- a/tool/templates/kotlin/Trait.kt.jinja
+++ b/tool/templates/kotlin/Trait.kt.jinja
@@ -33,6 +33,12 @@ object {{trait_name}}_VTable_destructor: Callback {
 };
 
 class DiplomatTrait_{{trait_name}}_VTable_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var destructor: Callback = {{trait_name}}_VTable_destructor;
+    @JvmField
+    internal var size: Pointer = Pointer(0L);
+    @JvmField
+    internal var alignment: Pointer = Pointer(0L);
     {% if !trait_methods.is_empty() -%}
         {%- for trait_method in trait_methods %}
     @JvmField
@@ -45,12 +51,9 @@ class DiplomatTrait_{{trait_name}}_VTable_Native: Structure(), Structure.ByValue
         {%- endfor %}
     {% endif -%}
 
-    @JvmField
-    internal var destructor: Callback = {{trait_name}}_VTable_destructor;
-
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
-        return listOf({% if trait_method_names != "" %}{{trait_method_names}}, {% endif %} "destructor")
+        return listOf("destructor", "size", "alignment"{% if trait_method_names != "" %}, {{trait_method_names}}{% endif %})
     }
 }
 
@@ -75,7 +78,7 @@ class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize(DiplomatTrait_{{trait_name}}_Wrapper_Native::class.java).toLong()
 
-        fun fromTraitObj(trt_obj: DiplomatTraitInterface_{{trait_name}}): DiplomatTrait_{{trait_name}}_Wrapper {
+        fun fromTraitObj(trt_obj: {{trait_name}}): DiplomatTrait_{{trait_name}}_Wrapper {
             val vtable = DiplomatTrait_{{trait_name}}_VTable_Native()
             
             {% if !trait_methods.is_empty() -%}
@@ -90,6 +93,7 @@ class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
             {% endif -%}
             val native_wrapper = DiplomatTrait_{{trait_name}}_Wrapper_Native();
             native_wrapper.vtable = vtable;
+            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);
             return DiplomatTrait_{{trait_name}}_Wrapper(native_wrapper);
         }
     }

--- a/tool/templates/kotlin/Trait.kt.jinja
+++ b/tool/templates/kotlin/Trait.kt.jinja
@@ -1,0 +1,97 @@
+package {{domain}}.{{lib_name}}
+
+import com.sun.jna.Callback
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+
+interface {{trait_name}} {
+    {%- for m in trait_methods %}
+    fun {{m.name}}({{m.non_native_params_and_types}}): {{m.output_type}};
+    {%- endfor %}
+}
+
+{% if !callback_params.is_empty() -%}
+    {%- for callback_param in callback_params -%}
+        {{callback_param}}
+    {%- endfor %}
+{% endif -%}
+
+{% if !trait_methods.is_empty() -%}
+    {%- for trait_method in trait_methods %}
+internal interface Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}}: Callback {
+    fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.output_type}}
+}
+    {%- endfor %}
+{%- endif %}
+
+object {{trait_name}}_VTable_destructor: Callback {
+    fun invoke(obj_pointer: Pointer) {
+        DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+    }
+};
+
+class DiplomatTrait_{{trait_name}}_VTable_Native: Structure(), Structure.ByValue {
+    {% if !trait_methods.is_empty() -%}
+        {%- for trait_method in trait_methods %}
+    @JvmField
+    internal var run_{{trait_method.name}}_callback: Runner_DiplomatTraitMethod_TesterTrait_{{trait_method.name}}
+        = object :  Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}} {
+                override fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.output_type}} {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
+        {%- endfor %}
+    {% endif -%}
+
+    @JvmField
+    internal var destructor: Callback = {{trait_name}}_VTable_destructor;
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf({% if trait_method_names != "" %}{{trait_method_names}}, {% endif %} "destructor")
+    }
+}
+
+class DiplomatTrait_{{trait_name}}_Wrapper_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var data_: Pointer = Pointer(0L);
+    @JvmField
+    internal var vtable: DiplomatTrait_{{trait_name}}_VTable_Native
+        = DiplomatTrait_{{trait_name}}_VTable_Native();
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("data_", "vtable")
+    }
+}
+
+class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
+    internal val nativeStruct: DiplomatTrait_{{trait_name}}_Wrapper_Native) {
+    val data_: Pointer = nativeStruct.data_
+    val vtable: DiplomatTrait_{{trait_name}}_VTable_Native = nativeStruct.vtable
+
+    companion object {
+        val NATIVESIZE: Long = Native.getNativeSize(DiplomatTrait_{{trait_name}}_Wrapper_Native::class.java).toLong()
+
+        fun fromTraitObj(trt_obj: DiplomatTraitInterface_{{trait_name}}): DiplomatTrait_{{trait_name}}_Wrapper {
+            val vtable = DiplomatTrait_{{trait_name}}_VTable_Native()
+            
+            {% if !trait_methods.is_empty() -%}
+                {%- for trait_method in trait_methods %}
+            val {{trait_method.name}}: Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}} = object :  Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}} {
+                override fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.output_type}} {
+                    return trt_obj.{{trait_method.name}}({{trait_method.input_params}});
+                }
+            }
+            vtable.run_{{trait_method.name}}_callback = {{trait_method.name}};
+                {%- endfor %}
+            {% endif -%}
+            val native_wrapper = DiplomatTrait_{{trait_name}}_Wrapper_Native();
+            native_wrapper.vtable = vtable;
+            return DiplomatTrait_{{trait_name}}_Wrapper(native_wrapper);
+        }
+    }
+}
+


### PR DESCRIPTION
Code generation for trait support in the Kotlin backend.

We added trait support to Diplomat's internal representation and the C backend in [this PR](https://github.com/rust-diplomat/diplomat/pull/621). The trait design is described in [our design doc](https://docs.google.com/document/d/1Czt2Ea1VmlCBWIrvS0KBlc_Gpnh4ETui_tgQIXPxgT0/edit).