### PR TITLE
Fixing hardcoded library path in some kotlin templates

### DIFF
--- a/tool/templates/kotlin/Enum.kt.jinja
+++ b/tool/templates/kotlin/Enum.kt.jinja
@@ -42,7 +42,7 @@ enum class {{type_name}}
 
     companion object {
         internal val libClass: Class<{{type_name}}Lib> = {{type_name}}Lib::class.java
-        internal val lib: {{type_name}}Lib = Native.load("somelib", libClass)
+        internal val lib: {{type_name}}Lib = Native.load("{{lib_name}}", libClass)
 
         {%- match (variants_for_native) %}
         {%- when EnumVariants::NonContiguous with (variants) %}

--- a/tool/templates/kotlin/Struct.kt.jinja
+++ b/tool/templates/kotlin/Struct.kt.jinja
@@ -51,7 +51,7 @@ class {{type_name}} internal constructor (
     {% if !fields.is_empty() -%}
     companion object {
         internal val libClass: Class<{{type_name}}Lib> = {{type_name}}Lib::class.java
-        internal val lib: {{type_name}}Lib = Native.load("somelib", libClass)
+        internal val lib: {{type_name}}Lib = Native.load("{{lib_name}}", libClass)
         val NATIVESIZE: Long = Native.getNativeSize({{type_name}}Native::class.java).toLong()
 {%- for m in companion_methods %}
         {{m|indent(8)}}


### PR DESCRIPTION
Some of the Kotlin templates had the library name hardcoded as `"somelib"`. This CL fixes this bug and replaces `"somelib"` with the general `"{{lib_name}}"`.