### PR TITLE
Fixing code generation for `Result<bool>` in Kotlin

### DIFF
--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
@@ -88,7 +88,7 @@ class OptionOpaque internal constructor (
         fun optionOpaqueArgument(arg: OptionOpaque?): Boolean {
             
             val returnVal = lib.OptionOpaque_option_opaque_argument(arg?.handle);
-            return returnVal > 0
+            return (returnVal > 0)
         }
     }
     

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -695,7 +695,12 @@ return string{return_type_modifier}"#
         match o {
             Type::Primitive(prim) => {
                 let maybe_unsized_modifier = self.formatter.fmt_unsized_conversion(*prim, false);
-                format!("return {val_name}{return_type_modifier}{maybe_unsized_modifier}")
+                match prim {
+                    PrimitiveType::Bool => {
+                        format!("return ({val_name}{maybe_unsized_modifier}){return_type_modifier}")
+                    }
+                    _ => format!("return {val_name}{return_type_modifier}{maybe_unsized_modifier}"),
+                }
             }
             Type::Opaque(opaque_path) => self.gen_opaque_return_conversion(
                 opaque_path,
@@ -2020,6 +2025,10 @@ mod test {
                     }
 
                     pub fn get_u_byte_slice<'a>() -> &'a [u8] {
+                        todo!()
+                    }
+
+                    pub fn boolean_result() -> Result<bool, ()> {
                         todo!()
                     }
                 }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 1828
+assertion_line: 2057
 expression: struct_code
 ---
 package dev.gigapixel.somelib
@@ -15,6 +15,7 @@ internal interface MyNativeStructLib: Library {
     fun MyNativeStruct_new(): MyNativeStructNative
     fun MyNativeStruct_test_multi_arg_callback(f: DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native, x: Int): Int
     fun MyNativeStruct_get_u_byte_slice(): Slice
+    fun MyNativeStruct_boolean_result(): ResultByteUnit
 }
 
 internal class MyNativeStructNative: Structure(), Structure.ByValue {
@@ -146,6 +147,16 @@ class MyNativeStruct internal constructor (
             
             val returnVal = lib.MyNativeStruct_get_u_byte_slice();
                 return PrimitiveArrayTools.getUByteArray(returnVal)
+        }
+        
+        fun booleanResult(): Res<Boolean, Unit> {
+            
+            val returnVal = lib.MyNativeStruct_boolean_result();
+            if (returnVal.isOk == 1.toByte()) {
+                return (returnVal.union.ok > 0).ok()
+            } else {
+                return Err(Unit)
+            }
         }
     }
 


### PR DESCRIPTION
The general case for dealing with `Result` in Kotlin doesn't work for booleans.
Previously, generating the Kotlin code for a Rust function that returned a `Result<bool>` would be as follows:

Rust
```
pub fn test() -> Result<bool, ()> {
    todo!()            
}
```

Generated Kotlin (with the bug specified in a comment):
```
    fun test(): Res<Boolean, Unit> {
          val returnVal = lib.Why_test();
          if (returnVal.isOk == 1.toByte()) {
              return returnVal.union.ok.ok() > 0 // THIS IS A BUG THIS IS INVALID
          } else {
              return Err(Unit)
          }
      }
```

For booleans, this error line should instead be `return (returnVal.union.ok > 0).ok()` . This CL fixes this problem.
