### PR TITLE
Fixing bug in `Result<T>` when `T` is a primitive that requires modification in the Kotlin code generation

### DIFF
--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
@@ -46,13 +46,13 @@ class AttrOpaque1 internal constructor (
     fun method(): UByte {
         
         val returnVal = lib.namespace_AttrOpaque1_method(handle);
-        return returnVal.toUByte()
+        return (returnVal.toUByte())
     }
     
     fun abirenamed(): UByte {
         
         val returnVal = lib.renamed_on_abi_only(handle);
-        return returnVal.toUByte()
+        return (returnVal.toUByte())
     }
     
     fun useUnnamespaced(un: Unnamespaced): Unit {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
@@ -281,25 +281,25 @@ class CallbackWrapper internal constructor (
         fun testMultiArgCallback(f: (Int)->Int, x: Int): Int {
             
             val returnVal = lib.CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomatCallback_f.fromCallback(f).nativeStruct, x);
-            return returnVal
+            return (returnVal)
         }
         
         fun testNoArgs(h: ()->Unit): Int {
             
             val returnVal = lib.CallbackWrapper_test_no_args(DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h.fromCallback(h).nativeStruct);
-            return returnVal
+            return (returnVal)
         }
         
         fun testCbWithStruct(f: (CallbackTestingStruct)->Int): Int {
             
             val returnVal = lib.CallbackWrapper_test_cb_with_struct(DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f.fromCallback(f).nativeStruct);
-            return returnVal
+            return (returnVal)
         }
         
         fun testMultipleCbArgs(f: ()->Int, g: (Int)->Int): Int {
             
             val returnVal = lib.CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f.fromCallback(f).nativeStruct, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g.fromCallback(g).nativeStruct);
-            return returnVal
+            return (returnVal)
         }
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyEnum.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyEnum.kt
@@ -52,6 +52,6 @@ enum class MyEnum(val inner: Int) {
     fun intoValue(): Byte {
         
         val returnVal = lib.MyEnum_into_value(this.toNative());
-        return returnVal
+        return (returnVal)
     }
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
@@ -82,7 +82,7 @@ class MyStruct internal constructor (
     fun intoA(): UByte {
         
         val returnVal = lib.MyStruct_into_a(nativeStruct);
-        return returnVal.toUByte()
+        return (returnVal.toUByte())
     }
 
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
@@ -72,7 +72,7 @@ class Opaque internal constructor (
         fun returnsUsize(): ULong {
             
             val returnVal = lib.Opaque_returns_usize();
-            return returnVal.toULong()
+            return (returnVal.toULong())
         }
         
         fun returnsImported(): ImportedStruct {
@@ -86,7 +86,7 @@ class Opaque internal constructor (
         fun cmp(): Byte {
             
             val returnVal = lib.Opaque_cmp();
-            return returnVal
+            return (returnVal)
         }
     }
     

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
@@ -82,7 +82,7 @@ class OpaqueMutexedString internal constructor (
     fun getLenAndAdd(other: ULong): ULong {
         
         val returnVal = lib.OpaqueMutexedString_get_len_and_add(handle, other.toLong());
-        return returnVal.toULong()
+        return (returnVal.toULong())
     }
     
     fun dummyStr(): String {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
@@ -126,7 +126,7 @@ class ResultOpaque internal constructor (
             
             val returnVal = lib.ResultOpaque_new_int(i);
             if (returnVal.isOk == 1.toByte()) {
-                return returnVal.union.ok.ok()
+                return (returnVal.union.ok).ok()
             } else {
                 return Err(Unit)
             }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitWrapper.kt
@@ -33,13 +33,13 @@ class TraitWrapper internal constructor (
         fun testWithTrait(t: TesterTrait, x: Int): Int {
             
             val returnVal = lib.TraitWrapper_test_with_trait(DiplomatTrait_TesterTrait_Wrapper.fromTraitObj(t).nativeStruct, x);
-            return returnVal
+            return (returnVal)
         }
         
         fun testTraitWithStruct(t: TesterTrait): Int {
             
             val returnVal = lib.TraitWrapper_test_trait_with_struct(DiplomatTrait_TesterTrait_Wrapper.fromTraitObj(t).nativeStruct);
-            return returnVal
+            return (returnVal)
         }
     }
 

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -695,12 +695,7 @@ return string{return_type_modifier}"#
         match o {
             Type::Primitive(prim) => {
                 let maybe_unsized_modifier = self.formatter.fmt_unsized_conversion(*prim, false);
-                match prim {
-                    PrimitiveType::Bool => {
-                        format!("return ({val_name}{maybe_unsized_modifier}){return_type_modifier}")
-                    }
-                    _ => format!("return {val_name}{return_type_modifier}{maybe_unsized_modifier}"),
-                }
+                format!("return ({val_name}{maybe_unsized_modifier}){return_type_modifier}")
             }
             Type::Opaque(opaque_path) => self.gen_opaque_return_conversion(
                 opaque_path,
@@ -2029,6 +2024,10 @@ mod test {
                     }
 
                     pub fn boolean_result() -> Result<bool, ()> {
+                        todo!()
+                    }
+
+                    pub fn ubyte_result() -> Result<u8, ()> {
                         todo!()
                     }
                 }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2042
+assertion_line: 2261
 expression: result
 ---
 package dev.gigapixel.somelib;
@@ -37,13 +37,13 @@ class MyOpaqueStruct internal constructor (
         fun getByte(): UByte {
             
             val returnVal = lib.MyOpaqueStruct_get_byte();
-            return returnVal.toUByte()
+            return (returnVal.toUByte())
         }
         
         fun getStringWrapper(in1: Int): Int {
             
             val returnVal = lib.MyOpaqueStruct_get_string_wrapper(in1);
-            return returnVal
+            return (returnVal)
         }
     }
 

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2057
+assertion_line: 2058
 expression: struct_code
 ---
 package dev.gigapixel.somelib
@@ -16,6 +16,7 @@ internal interface MyNativeStructLib: Library {
     fun MyNativeStruct_test_multi_arg_callback(f: DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native, x: Int): Int
     fun MyNativeStruct_get_u_byte_slice(): Slice
     fun MyNativeStruct_boolean_result(): ResultByteUnit
+    fun MyNativeStruct_ubyte_result(): ResultByteUnit
 }
 
 internal class MyNativeStructNative: Structure(), Structure.ByValue {
@@ -140,7 +141,7 @@ class MyNativeStruct internal constructor (
         fun testMultiArgCallback(f: (Int)->Int, x: Int): Int {
             
             val returnVal = lib.MyNativeStruct_test_multi_arg_callback(DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f.fromCallback(f).nativeStruct, x);
-            return returnVal
+            return (returnVal)
         }
         
         fun getUByteSlice(): UByteArray {
@@ -154,6 +155,16 @@ class MyNativeStruct internal constructor (
             val returnVal = lib.MyNativeStruct_boolean_result();
             if (returnVal.isOk == 1.toByte()) {
                 return (returnVal.union.ok > 0).ok()
+            } else {
+                return Err(Unit)
+            }
+        }
+        
+        fun ubyteResult(): Res<UByte, Unit> {
+            
+            val returnVal = lib.MyNativeStruct_ubyte_result();
+            if (returnVal.isOk == 1.toByte()) {
+                return (returnVal.union.ok.toUByte()).ok()
             } else {
                 return Err(Unit)
             }


### PR DESCRIPTION
The modification applied to primitives when returned as a result were specified in the wrong order in the Kotlin code generation. 

For example, the following Rust:
```
pub fn test() -> Result<u32, ()> {
    todo!()
}
```

Generated the following Kotlin, with the bug specified with a comment:
```
      fun test(): Res<UInt, Unit> {
            val returnVal = lib.Why_test();
            if (returnVal.isOk == 1.toByte()) {
                return returnVal.union.ok.ok().toUInt() // THIS IS A BUG
            } else {
                return Err(Unit)
            }
        }
```

The buggy line should actually be `return (returnVal.union.ok.toUInt()).ok()` . This CL fixes the bug, for `u32` and for all other primitives that require modification on return as a `Res` in Kotlin.
