### PR TITLE
Fix dtor abi names in kotlin

### DIFF
--- a/example/dart/lib/src/DataProvider.g.dart
+++ b/example/dart/lib/src/DataProvider.g.dart
@@ -37,17 +37,17 @@ final class DataProvider implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('icu4x_DataProvider_destroy_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DataProvider_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DataProvider_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('icu4x_DataProvider_new_static_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_DataProvider_new_static_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_DataProvider_new_static_mv1();
 
-@meta.RecordUse('icu4x_DataProvider_returns_result_mv1')
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function()>(isLeaf: true, symbol: 'icu4x_DataProvider_returns_result_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_DataProvider_returns_result_mv1();

--- a/example/dart/lib/src/DataProvider.g.dart
+++ b/example/dart/lib/src/DataProvider.g.dart
@@ -37,17 +37,17 @@ final class DataProvider implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('icu4x_DataProvider_destroy_mv1')
+@meta.RecordUse('icu4x_DataProvider_destroy_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DataProvider_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DataProvider_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('icu4x_DataProvider_new_static_mv1')
+@meta.RecordUse('icu4x_DataProvider_new_static_mv1')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_DataProvider_new_static_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_DataProvider_new_static_mv1();
 
-@meta.ResourceIdentifier('icu4x_DataProvider_returns_result_mv1')
+@meta.RecordUse('icu4x_DataProvider_returns_result_mv1')
 @ffi.Native<_ResultVoidVoid Function()>(isLeaf: true, symbol: 'icu4x_DataProvider_returns_result_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_DataProvider_returns_result_mv1();

--- a/example/dart/lib/src/FixedDecimal.g.dart
+++ b/example/dart/lib/src/FixedDecimal.g.dart
@@ -48,22 +48,22 @@ final class FixedDecimal implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('icu4x_FixedDecimal_destroy_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_FixedDecimal_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_FixedDecimal_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('icu4x_FixedDecimal_new_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_FixedDecimal_new_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_FixedDecimal_new_mv1(int v);
 
-@meta.RecordUse('icu4x_FixedDecimal_multiply_pow10_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_FixedDecimal_multiply_pow10_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_FixedDecimal_multiply_pow10_mv1(ffi.Pointer<ffi.Opaque> self, int power);
 
-@meta.RecordUse('icu4x_FixedDecimal_to_string_mv1')
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_FixedDecimal_to_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_FixedDecimal_to_string_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);

--- a/example/dart/lib/src/FixedDecimal.g.dart
+++ b/example/dart/lib/src/FixedDecimal.g.dart
@@ -48,22 +48,22 @@ final class FixedDecimal implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('icu4x_FixedDecimal_destroy_mv1')
+@meta.RecordUse('icu4x_FixedDecimal_destroy_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_FixedDecimal_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_FixedDecimal_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('icu4x_FixedDecimal_new_mv1')
+@meta.RecordUse('icu4x_FixedDecimal_new_mv1')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_FixedDecimal_new_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_FixedDecimal_new_mv1(int v);
 
-@meta.ResourceIdentifier('icu4x_FixedDecimal_multiply_pow10_mv1')
+@meta.RecordUse('icu4x_FixedDecimal_multiply_pow10_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_FixedDecimal_multiply_pow10_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_FixedDecimal_multiply_pow10_mv1(ffi.Pointer<ffi.Opaque> self, int power);
 
-@meta.ResourceIdentifier('icu4x_FixedDecimal_to_string_mv1')
+@meta.RecordUse('icu4x_FixedDecimal_to_string_mv1')
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_FixedDecimal_to_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_FixedDecimal_to_string_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);

--- a/example/dart/lib/src/FixedDecimalFormatter.g.dart
+++ b/example/dart/lib/src/FixedDecimalFormatter.g.dart
@@ -46,17 +46,17 @@ final class FixedDecimalFormatter implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('icu4x_FixedDecimalFormatter_destroy_mv1')
+@meta.RecordUse('icu4x_FixedDecimalFormatter_destroy_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_FixedDecimalFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_FixedDecimalFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('icu4x_FixedDecimalFormatter_try_new_mv1')
+@meta.RecordUse('icu4x_FixedDecimalFormatter_try_new_mv1')
 @ffi.Native<_ResultOpaqueVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _FixedDecimalFormatterOptionsFfi)>(isLeaf: true, symbol: 'icu4x_FixedDecimalFormatter_try_new_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueVoid _icu4x_FixedDecimalFormatter_try_new_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> provider, _FixedDecimalFormatterOptionsFfi options);
 
-@meta.ResourceIdentifier('icu4x_FixedDecimalFormatter_format_write_mv1')
+@meta.RecordUse('icu4x_FixedDecimalFormatter_format_write_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_FixedDecimalFormatter_format_write_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_FixedDecimalFormatter_format_write_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> value, ffi.Pointer<ffi.Opaque> write);

--- a/example/dart/lib/src/FixedDecimalFormatter.g.dart
+++ b/example/dart/lib/src/FixedDecimalFormatter.g.dart
@@ -46,17 +46,17 @@ final class FixedDecimalFormatter implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('icu4x_FixedDecimalFormatter_destroy_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_FixedDecimalFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_FixedDecimalFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('icu4x_FixedDecimalFormatter_try_new_mv1')
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _FixedDecimalFormatterOptionsFfi)>(isLeaf: true, symbol: 'icu4x_FixedDecimalFormatter_try_new_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueVoid _icu4x_FixedDecimalFormatter_try_new_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> provider, _FixedDecimalFormatterOptionsFfi options);
 
-@meta.RecordUse('icu4x_FixedDecimalFormatter_format_write_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_FixedDecimalFormatter_format_write_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_FixedDecimalFormatter_format_write_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> value, ffi.Pointer<ffi.Opaque> write);

--- a/example/dart/lib/src/FixedDecimalFormatterOptions.g.dart
+++ b/example/dart/lib/src/FixedDecimalFormatterOptions.g.dart
@@ -56,7 +56,7 @@ final class FixedDecimalFormatterOptions {
       ]);
 }
 
-@meta.ResourceIdentifier('icu4x_FixedDecimalFormatterOptions_default_mv1')
+@meta.RecordUse('icu4x_FixedDecimalFormatterOptions_default_mv1')
 @ffi.Native<_FixedDecimalFormatterOptionsFfi Function()>(isLeaf: true, symbol: 'icu4x_FixedDecimalFormatterOptions_default_mv1')
 // ignore: non_constant_identifier_names
 external _FixedDecimalFormatterOptionsFfi _icu4x_FixedDecimalFormatterOptions_default_mv1();

--- a/example/dart/lib/src/FixedDecimalFormatterOptions.g.dart
+++ b/example/dart/lib/src/FixedDecimalFormatterOptions.g.dart
@@ -56,7 +56,7 @@ final class FixedDecimalFormatterOptions {
       ]);
 }
 
-@meta.RecordUse('icu4x_FixedDecimalFormatterOptions_default_mv1')
+@meta.RecordUse()
 @ffi.Native<_FixedDecimalFormatterOptionsFfi Function()>(isLeaf: true, symbol: 'icu4x_FixedDecimalFormatterOptions_default_mv1')
 // ignore: non_constant_identifier_names
 external _FixedDecimalFormatterOptionsFfi _icu4x_FixedDecimalFormatterOptions_default_mv1();

--- a/example/dart/lib/src/Locale.g.dart
+++ b/example/dart/lib/src/Locale.g.dart
@@ -32,12 +32,12 @@ final class Locale implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('icu4x_Locale_destroy_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Locale_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Locale_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('icu4x_Locale_new_mv1')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_new_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Locale_new_mv1(_SliceUtf8 name);

--- a/example/dart/lib/src/Locale.g.dart
+++ b/example/dart/lib/src/Locale.g.dart
@@ -32,12 +32,12 @@ final class Locale implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('icu4x_Locale_destroy_mv1')
+@meta.RecordUse('icu4x_Locale_destroy_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Locale_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Locale_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('icu4x_Locale_new_mv1')
+@meta.RecordUse('icu4x_Locale_new_mv1')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_new_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Locale_new_mv1(_SliceUtf8 name);

--- a/example/dart/lib/src/lib.g.dart
+++ b/example/dart/lib/src/lib.g.dart
@@ -52,12 +52,12 @@ final class _RustAlloc implements ffi.Allocator {
   }
 }
 
-@meta.ResourceIdentifier('diplomat_alloc')
+@meta.RecordUse('diplomat_alloc')
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
-@meta.ResourceIdentifier('diplomat_free')
+@meta.RecordUse('diplomat_free')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);
@@ -192,22 +192,22 @@ final class _Write {
   }
 }
 
-@meta.ResourceIdentifier('diplomat_buffer_write_create')
+@meta.RecordUse('diplomat_buffer_write_create')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_write_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_write_create(int len);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_len')
+@meta.RecordUse('diplomat_buffer_write_len')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_write_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_get_bytes')
+@meta.RecordUse('diplomat_buffer_write_get_bytes')
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_write_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_destroy')
+@meta.RecordUse('diplomat_buffer_write_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_write_destroy(ffi.Pointer<ffi.Opaque> ptr);

--- a/example/dart/lib/src/lib.g.dart
+++ b/example/dart/lib/src/lib.g.dart
@@ -52,12 +52,12 @@ final class _RustAlloc implements ffi.Allocator {
   }
 }
 
-@meta.RecordUse('diplomat_alloc')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
-@meta.RecordUse('diplomat_free')
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);
@@ -192,22 +192,22 @@ final class _Write {
   }
 }
 
-@meta.RecordUse('diplomat_buffer_write_create')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_write_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_write_create(int len);
 
-@meta.RecordUse('diplomat_buffer_write_len')
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_write_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.RecordUse('diplomat_buffer_write_get_bytes')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_write_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.RecordUse('diplomat_buffer_write_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_write_destroy(ffi.Pointer<ffi.Opaque> ptr);

--- a/example/dart/pubspec.lock
+++ b/example/dart/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "65.0.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.1"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: ac86d3abab0f165e4b8f561280ff4e066bceaac83c424dd19f1ae2c2fcd12ca9
+      sha256: "3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.1"
+    version: "1.8.0"
   crypto:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.1"
   lints:
     dependency: "direct dev"
     description:
@@ -165,26 +165,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.6"
   native_assets_cli:
     dependency: "direct main"
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   pool:
     dependency: transitive
     description:
@@ -253,26 +253,26 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -325,26 +325,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.25.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.6.4"
   typed_data:
     dependency: transitive
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -369,14 +369,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.1"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -397,9 +413,9 @@ packages:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: "1579d4a0340a83cf9e4d580ea51a16329c916973bffd5bd4b45e911b25d46bfd"
+      sha256: e9c1a3543d2da0db3e90270dbb1e4eebc985ee5e3ffe468d83224472b2194a5f
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
 sdks:
   dart: ">=3.4.0-204.0.dev <4.0.0"

--- a/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
@@ -45,32 +45,32 @@ final class AttrOpaque1Renamed implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('namespace_AttrOpaque1_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('namespace_AttrOpaque1_new')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'namespace_AttrOpaque1_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_AttrOpaque1_new();
 
-@meta.RecordUse('namespace_AttrOpaque1_method')
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_method')
 // ignore: non_constant_identifier_names
 external int _namespace_AttrOpaque1_method(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('renamed_on_abi_only')
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'renamed_on_abi_only')
 // ignore: non_constant_identifier_names
 external int _renamed_on_abi_only(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('namespace_AttrOpaque1_use_unnamespaced')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_use_unnamespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_use_unnamespaced(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> un);
 
-@meta.RecordUse('namespace_AttrOpaque1_use_namespaced')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_use_namespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_use_namespaced(ffi.Pointer<ffi.Opaque> self, int n);

--- a/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
@@ -45,32 +45,32 @@ final class AttrOpaque1Renamed implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('namespace_AttrOpaque1_destroy')
+@meta.RecordUse('namespace_AttrOpaque1_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('namespace_AttrOpaque1_new')
+@meta.RecordUse('namespace_AttrOpaque1_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'namespace_AttrOpaque1_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_AttrOpaque1_new();
 
-@meta.ResourceIdentifier('namespace_AttrOpaque1_method')
+@meta.RecordUse('namespace_AttrOpaque1_method')
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_method')
 // ignore: non_constant_identifier_names
 external int _namespace_AttrOpaque1_method(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('renamed_on_abi_only')
+@meta.RecordUse('renamed_on_abi_only')
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'renamed_on_abi_only')
 // ignore: non_constant_identifier_names
 external int _renamed_on_abi_only(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('namespace_AttrOpaque1_use_unnamespaced')
+@meta.RecordUse('namespace_AttrOpaque1_use_unnamespaced')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_use_unnamespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_use_unnamespaced(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> un);
 
-@meta.ResourceIdentifier('namespace_AttrOpaque1_use_namespaced')
+@meta.RecordUse('namespace_AttrOpaque1_use_namespaced')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'namespace_AttrOpaque1_use_namespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque1_use_namespaced(ffi.Pointer<ffi.Opaque> self, int n);

--- a/feature_tests/dart/lib/src/Bar.g.dart
+++ b/feature_tests/dart/lib/src/Bar.g.dart
@@ -35,12 +35,12 @@ final class Bar implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('Bar_destroy')
+@meta.RecordUse('Bar_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Bar_destroy')
 // ignore: non_constant_identifier_names
 external void _Bar_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('Bar_foo')
+@meta.RecordUse('Bar_foo')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Bar_foo')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Bar_foo(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/Bar.g.dart
+++ b/feature_tests/dart/lib/src/Bar.g.dart
@@ -35,12 +35,12 @@ final class Bar implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('Bar_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Bar_destroy')
 // ignore: non_constant_identifier_names
 external void _Bar_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('Bar_foo')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Bar_foo')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Bar_foo(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/BorrowedFields.g.dart
+++ b/feature_tests/dart/lib/src/BorrowedFields.g.dart
@@ -66,7 +66,7 @@ final class BorrowedFields {
   core.List<Object> get _fieldsForLifetimeA => [a, b, c];
 }
 
-@meta.RecordUse('BorrowedFields_from_bar_and_strings')
+@meta.RecordUse()
 @ffi.Native<_BorrowedFieldsFfi Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16, _SliceUtf8)>(isLeaf: true, symbol: 'BorrowedFields_from_bar_and_strings')
 // ignore: non_constant_identifier_names
 external _BorrowedFieldsFfi _BorrowedFields_from_bar_and_strings(ffi.Pointer<ffi.Opaque> bar, _SliceUtf16 dstr16, _SliceUtf8 utf8Str);

--- a/feature_tests/dart/lib/src/BorrowedFields.g.dart
+++ b/feature_tests/dart/lib/src/BorrowedFields.g.dart
@@ -66,7 +66,7 @@ final class BorrowedFields {
   core.List<Object> get _fieldsForLifetimeA => [a, b, c];
 }
 
-@meta.ResourceIdentifier('BorrowedFields_from_bar_and_strings')
+@meta.RecordUse('BorrowedFields_from_bar_and_strings')
 @ffi.Native<_BorrowedFieldsFfi Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16, _SliceUtf8)>(isLeaf: true, symbol: 'BorrowedFields_from_bar_and_strings')
 // ignore: non_constant_identifier_names
 external _BorrowedFieldsFfi _BorrowedFields_from_bar_and_strings(ffi.Pointer<ffi.Opaque> bar, _SliceUtf16 dstr16, _SliceUtf8 utf8Str);

--- a/feature_tests/dart/lib/src/BorrowedFieldsWithBounds.g.dart
+++ b/feature_tests/dart/lib/src/BorrowedFieldsWithBounds.g.dart
@@ -88,7 +88,7 @@ final class BorrowedFieldsWithBounds {
   core.List<Object> get _fieldsForLifetimeC => [fieldC];
 }
 
-@meta.RecordUse('BorrowedFieldsWithBounds_from_foo_and_strings')
+@meta.RecordUse()
 @ffi.Native<_BorrowedFieldsWithBoundsFfi Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16, _SliceUtf8)>(isLeaf: true, symbol: 'BorrowedFieldsWithBounds_from_foo_and_strings')
 // ignore: non_constant_identifier_names
 external _BorrowedFieldsWithBoundsFfi _BorrowedFieldsWithBounds_from_foo_and_strings(ffi.Pointer<ffi.Opaque> foo, _SliceUtf16 dstr16X, _SliceUtf8 utf8StrZ);

--- a/feature_tests/dart/lib/src/BorrowedFieldsWithBounds.g.dart
+++ b/feature_tests/dart/lib/src/BorrowedFieldsWithBounds.g.dart
@@ -88,7 +88,7 @@ final class BorrowedFieldsWithBounds {
   core.List<Object> get _fieldsForLifetimeC => [fieldC];
 }
 
-@meta.ResourceIdentifier('BorrowedFieldsWithBounds_from_foo_and_strings')
+@meta.RecordUse('BorrowedFieldsWithBounds_from_foo_and_strings')
 @ffi.Native<_BorrowedFieldsWithBoundsFfi Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16, _SliceUtf8)>(isLeaf: true, symbol: 'BorrowedFieldsWithBounds_from_foo_and_strings')
 // ignore: non_constant_identifier_names
 external _BorrowedFieldsWithBoundsFfi _BorrowedFieldsWithBounds_from_foo_and_strings(ffi.Pointer<ffi.Opaque> foo, _SliceUtf16 dstr16X, _SliceUtf8 utf8StrZ);

--- a/feature_tests/dart/lib/src/CyclicStructA.g.dart
+++ b/feature_tests/dart/lib/src/CyclicStructA.g.dart
@@ -43,7 +43,7 @@ final class CyclicStructA {
       ]);
 }
 
-@meta.RecordUse('CyclicStructA_get_b')
+@meta.RecordUse()
 @ffi.Native<_CyclicStructBFfi Function()>(isLeaf: true, symbol: 'CyclicStructA_get_b')
 // ignore: non_constant_identifier_names
 external _CyclicStructBFfi _CyclicStructA_get_b();

--- a/feature_tests/dart/lib/src/CyclicStructA.g.dart
+++ b/feature_tests/dart/lib/src/CyclicStructA.g.dart
@@ -43,7 +43,7 @@ final class CyclicStructA {
       ]);
 }
 
-@meta.ResourceIdentifier('CyclicStructA_get_b')
+@meta.RecordUse('CyclicStructA_get_b')
 @ffi.Native<_CyclicStructBFfi Function()>(isLeaf: true, symbol: 'CyclicStructA_get_b')
 // ignore: non_constant_identifier_names
 external _CyclicStructBFfi _CyclicStructA_get_b();

--- a/feature_tests/dart/lib/src/CyclicStructB.g.dart
+++ b/feature_tests/dart/lib/src/CyclicStructB.g.dart
@@ -44,7 +44,7 @@ final class CyclicStructB {
       ]);
 }
 
-@meta.ResourceIdentifier('CyclicStructB_get_a')
+@meta.RecordUse('CyclicStructB_get_a')
 @ffi.Native<_CyclicStructAFfi Function()>(isLeaf: true, symbol: 'CyclicStructB_get_a')
 // ignore: non_constant_identifier_names
 external _CyclicStructAFfi _CyclicStructB_get_a();

--- a/feature_tests/dart/lib/src/CyclicStructB.g.dart
+++ b/feature_tests/dart/lib/src/CyclicStructB.g.dart
@@ -44,7 +44,7 @@ final class CyclicStructB {
       ]);
 }
 
-@meta.RecordUse('CyclicStructB_get_a')
+@meta.RecordUse()
 @ffi.Native<_CyclicStructAFfi Function()>(isLeaf: true, symbol: 'CyclicStructB_get_a')
 // ignore: non_constant_identifier_names
 external _CyclicStructAFfi _CyclicStructB_get_a();

--- a/feature_tests/dart/lib/src/Float64Vec.g.dart
+++ b/feature_tests/dart/lib/src/Float64Vec.g.dart
@@ -102,72 +102,72 @@ final class Float64Vec implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('Float64Vec_destroy')
+@meta.RecordUse('Float64Vec_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Float64Vec_destroy')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('Float64Vec_new_bool')
+@meta.RecordUse('Float64Vec_new_bool')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceBool)>(isLeaf: true, symbol: 'Float64Vec_new_bool')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_bool(_SliceBool v);
 
-@meta.ResourceIdentifier('Float64Vec_new_i16')
+@meta.RecordUse('Float64Vec_new_i16')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceInt16)>(isLeaf: true, symbol: 'Float64Vec_new_i16')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_i16(_SliceInt16 v);
 
-@meta.ResourceIdentifier('Float64Vec_new_u16')
+@meta.RecordUse('Float64Vec_new_u16')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUint16)>(isLeaf: true, symbol: 'Float64Vec_new_u16')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_u16(_SliceUint16 v);
 
-@meta.ResourceIdentifier('Float64Vec_new_isize')
+@meta.RecordUse('Float64Vec_new_isize')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceIsize)>(isLeaf: true, symbol: 'Float64Vec_new_isize')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_isize(_SliceIsize v);
 
-@meta.ResourceIdentifier('Float64Vec_new_usize')
+@meta.RecordUse('Float64Vec_new_usize')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUsize)>(isLeaf: true, symbol: 'Float64Vec_new_usize')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_usize(_SliceUsize v);
 
-@meta.ResourceIdentifier('Float64Vec_new_f64_be_bytes')
+@meta.RecordUse('Float64Vec_new_f64_be_bytes')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUint8)>(isLeaf: true, symbol: 'Float64Vec_new_f64_be_bytes')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_f64_be_bytes(_SliceUint8 v);
 
-@meta.ResourceIdentifier('Float64Vec_new_from_owned')
+@meta.RecordUse('Float64Vec_new_from_owned')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceDouble)>(isLeaf: true, symbol: 'Float64Vec_new_from_owned')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_from_owned(_SliceDouble v);
 
-@meta.ResourceIdentifier('Float64Vec_as_slice')
+@meta.RecordUse('Float64Vec_as_slice')
 @ffi.Native<_SliceDouble Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Float64Vec_as_slice')
 // ignore: non_constant_identifier_names
 external _SliceDouble _Float64Vec_as_slice(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('Float64Vec_fill_slice')
+@meta.RecordUse('Float64Vec_fill_slice')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceDouble)>(isLeaf: true, symbol: 'Float64Vec_fill_slice')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_fill_slice(ffi.Pointer<ffi.Opaque> self, _SliceDouble v);
 
-@meta.ResourceIdentifier('Float64Vec_set_value')
+@meta.RecordUse('Float64Vec_set_value')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceDouble)>(isLeaf: true, symbol: 'Float64Vec_set_value')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_set_value(ffi.Pointer<ffi.Opaque> self, _SliceDouble newSlice);
 
-@meta.ResourceIdentifier('Float64Vec_to_string')
+@meta.RecordUse('Float64Vec_to_string')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Float64Vec_to_string')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_to_string(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@meta.ResourceIdentifier('Float64Vec_borrow')
+@meta.RecordUse('Float64Vec_borrow')
 @ffi.Native<_SliceDouble Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Float64Vec_borrow')
 // ignore: non_constant_identifier_names
 external _SliceDouble _Float64Vec_borrow(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('Float64Vec_get')
+@meta.RecordUse('Float64Vec_get')
 @ffi.Native<_ResultDoubleVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_get')
 // ignore: non_constant_identifier_names
 external _ResultDoubleVoid _Float64Vec_get(ffi.Pointer<ffi.Opaque> self, int i);

--- a/feature_tests/dart/lib/src/Float64Vec.g.dart
+++ b/feature_tests/dart/lib/src/Float64Vec.g.dart
@@ -102,72 +102,72 @@ final class Float64Vec implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('Float64Vec_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Float64Vec_destroy')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('Float64Vec_new_bool')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceBool)>(isLeaf: true, symbol: 'Float64Vec_new_bool')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_bool(_SliceBool v);
 
-@meta.RecordUse('Float64Vec_new_i16')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceInt16)>(isLeaf: true, symbol: 'Float64Vec_new_i16')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_i16(_SliceInt16 v);
 
-@meta.RecordUse('Float64Vec_new_u16')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUint16)>(isLeaf: true, symbol: 'Float64Vec_new_u16')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_u16(_SliceUint16 v);
 
-@meta.RecordUse('Float64Vec_new_isize')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceIsize)>(isLeaf: true, symbol: 'Float64Vec_new_isize')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_isize(_SliceIsize v);
 
-@meta.RecordUse('Float64Vec_new_usize')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUsize)>(isLeaf: true, symbol: 'Float64Vec_new_usize')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_usize(_SliceUsize v);
 
-@meta.RecordUse('Float64Vec_new_f64_be_bytes')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUint8)>(isLeaf: true, symbol: 'Float64Vec_new_f64_be_bytes')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_f64_be_bytes(_SliceUint8 v);
 
-@meta.RecordUse('Float64Vec_new_from_owned')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceDouble)>(isLeaf: true, symbol: 'Float64Vec_new_from_owned')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Float64Vec_new_from_owned(_SliceDouble v);
 
-@meta.RecordUse('Float64Vec_as_slice')
+@meta.RecordUse()
 @ffi.Native<_SliceDouble Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Float64Vec_as_slice')
 // ignore: non_constant_identifier_names
 external _SliceDouble _Float64Vec_as_slice(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('Float64Vec_fill_slice')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceDouble)>(isLeaf: true, symbol: 'Float64Vec_fill_slice')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_fill_slice(ffi.Pointer<ffi.Opaque> self, _SliceDouble v);
 
-@meta.RecordUse('Float64Vec_set_value')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceDouble)>(isLeaf: true, symbol: 'Float64Vec_set_value')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_set_value(ffi.Pointer<ffi.Opaque> self, _SliceDouble newSlice);
 
-@meta.RecordUse('Float64Vec_to_string')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Float64Vec_to_string')
 // ignore: non_constant_identifier_names
 external void _Float64Vec_to_string(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@meta.RecordUse('Float64Vec_borrow')
+@meta.RecordUse()
 @ffi.Native<_SliceDouble Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Float64Vec_borrow')
 // ignore: non_constant_identifier_names
 external _SliceDouble _Float64Vec_borrow(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('Float64Vec_get')
+@meta.RecordUse()
 @ffi.Native<_ResultDoubleVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'Float64Vec_get')
 // ignore: non_constant_identifier_names
 external _ResultDoubleVoid _Float64Vec_get(ffi.Pointer<ffi.Opaque> self, int i);

--- a/feature_tests/dart/lib/src/Foo.g.dart
+++ b/feature_tests/dart/lib/src/Foo.g.dart
@@ -66,32 +66,32 @@ final class Foo implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('Foo_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Foo_destroy')
 // ignore: non_constant_identifier_names
 external void _Foo_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('Foo_new')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'Foo_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_new(_SliceUtf8 x);
 
-@meta.RecordUse('Foo_get_bar')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Foo_get_bar')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_get_bar(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('Foo_as_returning')
+@meta.RecordUse()
 @ffi.Native<_BorrowedFieldsReturningFfi Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Foo_as_returning')
 // ignore: non_constant_identifier_names
 external _BorrowedFieldsReturningFfi _Foo_as_returning(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('Foo_extract_from_fields')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_BorrowedFieldsFfi)>(isLeaf: true, symbol: 'Foo_extract_from_fields')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_extract_from_fields(_BorrowedFieldsFfi fields);
 
-@meta.RecordUse('Foo_extract_from_bounds')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_BorrowedFieldsWithBoundsFfi, _SliceUtf8)>(isLeaf: true, symbol: 'Foo_extract_from_bounds')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_extract_from_bounds(_BorrowedFieldsWithBoundsFfi bounds, _SliceUtf8 anotherString);

--- a/feature_tests/dart/lib/src/Foo.g.dart
+++ b/feature_tests/dart/lib/src/Foo.g.dart
@@ -66,32 +66,32 @@ final class Foo implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('Foo_destroy')
+@meta.RecordUse('Foo_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Foo_destroy')
 // ignore: non_constant_identifier_names
 external void _Foo_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('Foo_new')
+@meta.RecordUse('Foo_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'Foo_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_new(_SliceUtf8 x);
 
-@meta.ResourceIdentifier('Foo_get_bar')
+@meta.RecordUse('Foo_get_bar')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Foo_get_bar')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_get_bar(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('Foo_as_returning')
+@meta.RecordUse('Foo_as_returning')
 @ffi.Native<_BorrowedFieldsReturningFfi Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Foo_as_returning')
 // ignore: non_constant_identifier_names
 external _BorrowedFieldsReturningFfi _Foo_as_returning(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('Foo_extract_from_fields')
+@meta.RecordUse('Foo_extract_from_fields')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_BorrowedFieldsFfi)>(isLeaf: true, symbol: 'Foo_extract_from_fields')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_extract_from_fields(_BorrowedFieldsFfi fields);
 
-@meta.ResourceIdentifier('Foo_extract_from_bounds')
+@meta.RecordUse('Foo_extract_from_bounds')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_BorrowedFieldsWithBoundsFfi, _SliceUtf8)>(isLeaf: true, symbol: 'Foo_extract_from_bounds')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Foo_extract_from_bounds(_BorrowedFieldsWithBoundsFfi bounds, _SliceUtf8 anotherString);

--- a/feature_tests/dart/lib/src/MyEnum.g.dart
+++ b/feature_tests/dart/lib/src/MyEnum.g.dart
@@ -43,12 +43,12 @@ enum MyEnum {
   }
 }
 
-@meta.RecordUse('MyEnum_into_value')
+@meta.RecordUse()
 @ffi.Native<ffi.Int8 Function(ffi.Int32)>(isLeaf: true, symbol: 'MyEnum_into_value')
 // ignore: non_constant_identifier_names
 external int _MyEnum_into_value(int self);
 
-@meta.RecordUse('MyEnum_get_a')
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function()>(isLeaf: true, symbol: 'MyEnum_get_a')
 // ignore: non_constant_identifier_names
 external int _MyEnum_get_a();

--- a/feature_tests/dart/lib/src/MyEnum.g.dart
+++ b/feature_tests/dart/lib/src/MyEnum.g.dart
@@ -43,12 +43,12 @@ enum MyEnum {
   }
 }
 
-@meta.ResourceIdentifier('MyEnum_into_value')
+@meta.RecordUse('MyEnum_into_value')
 @ffi.Native<ffi.Int8 Function(ffi.Int32)>(isLeaf: true, symbol: 'MyEnum_into_value')
 // ignore: non_constant_identifier_names
 external int _MyEnum_into_value(int self);
 
-@meta.ResourceIdentifier('MyEnum_get_a')
+@meta.RecordUse('MyEnum_get_a')
 @ffi.Native<ffi.Int32 Function()>(isLeaf: true, symbol: 'MyEnum_get_a')
 // ignore: non_constant_identifier_names
 external int _MyEnum_get_a();

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -63,42 +63,42 @@ final class MyString implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('MyString_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'MyString_destroy')
 // ignore: non_constant_identifier_names
 external void _MyString_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('MyString_new')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'MyString_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new(_SliceUtf8 v);
 
-@meta.RecordUse('MyString_new_unsafe')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'MyString_new_unsafe')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new_unsafe(_SliceUtf8 v);
 
-@meta.RecordUse('MyString_new_owned')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'MyString_new_owned')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new_owned(_SliceUtf8 v);
 
-@meta.RecordUse('MyString_new_from_first')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceSliceUtf8)>(isLeaf: true, symbol: 'MyString_new_from_first')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new_from_first(_SliceSliceUtf8 v);
 
-@meta.RecordUse('MyString_set_str')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'MyString_set_str')
 // ignore: non_constant_identifier_names
 external void _MyString_set_str(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 newStr);
 
-@meta.RecordUse('MyString_get_str')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_get_str')
 // ignore: non_constant_identifier_names
 external void _MyString_get_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@meta.RecordUse('MyString_string_transform')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_string_transform')
 // ignore: non_constant_identifier_names
 external void _MyString_string_transform(_SliceUtf8 foo, ffi.Pointer<ffi.Opaque> write);

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -63,42 +63,42 @@ final class MyString implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('MyString_destroy')
+@meta.RecordUse('MyString_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'MyString_destroy')
 // ignore: non_constant_identifier_names
 external void _MyString_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('MyString_new')
+@meta.RecordUse('MyString_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'MyString_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new(_SliceUtf8 v);
 
-@meta.ResourceIdentifier('MyString_new_unsafe')
+@meta.RecordUse('MyString_new_unsafe')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'MyString_new_unsafe')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new_unsafe(_SliceUtf8 v);
 
-@meta.ResourceIdentifier('MyString_new_owned')
+@meta.RecordUse('MyString_new_owned')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'MyString_new_owned')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new_owned(_SliceUtf8 v);
 
-@meta.ResourceIdentifier('MyString_new_from_first')
+@meta.RecordUse('MyString_new_from_first')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceSliceUtf8)>(isLeaf: true, symbol: 'MyString_new_from_first')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new_from_first(_SliceSliceUtf8 v);
 
-@meta.ResourceIdentifier('MyString_set_str')
+@meta.RecordUse('MyString_set_str')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'MyString_set_str')
 // ignore: non_constant_identifier_names
 external void _MyString_set_str(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 newStr);
 
-@meta.ResourceIdentifier('MyString_get_str')
+@meta.RecordUse('MyString_get_str')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_get_str')
 // ignore: non_constant_identifier_names
 external void _MyString_get_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@meta.ResourceIdentifier('MyString_string_transform')
+@meta.RecordUse('MyString_string_transform')
 @ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_string_transform')
 // ignore: non_constant_identifier_names
 external void _MyString_string_transform(_SliceUtf8 foo, ffi.Pointer<ffi.Opaque> write);

--- a/feature_tests/dart/lib/src/MyStruct.g.dart
+++ b/feature_tests/dart/lib/src/MyStruct.g.dart
@@ -134,22 +134,22 @@ final class MyStruct {
       ]);
 }
 
-@meta.RecordUse('MyStruct_new')
+@meta.RecordUse()
 @ffi.Native<_MyStructFfi Function()>(isLeaf: true, symbol: 'MyStruct_new')
 // ignore: non_constant_identifier_names
 external _MyStructFfi _MyStruct_new();
 
-@meta.RecordUse('MyStruct_into_a')
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(_MyStructFfi)>(isLeaf: true, symbol: 'MyStruct_into_a')
 // ignore: non_constant_identifier_names
 external int _MyStruct_into_a(_MyStructFfi self);
 
-@meta.RecordUse('MyStruct_returns_zst_result')
+@meta.RecordUse()
 @ffi.Native<_ResultVoidMyZstFfi Function()>(isLeaf: true, symbol: 'MyStruct_returns_zst_result')
 // ignore: non_constant_identifier_names
 external _ResultVoidMyZstFfi _MyStruct_returns_zst_result();
 
-@meta.RecordUse('MyStruct_fails_zst_result')
+@meta.RecordUse()
 @ffi.Native<_ResultVoidMyZstFfi Function()>(isLeaf: true, symbol: 'MyStruct_fails_zst_result')
 // ignore: non_constant_identifier_names
 external _ResultVoidMyZstFfi _MyStruct_fails_zst_result();

--- a/feature_tests/dart/lib/src/MyStruct.g.dart
+++ b/feature_tests/dart/lib/src/MyStruct.g.dart
@@ -134,22 +134,22 @@ final class MyStruct {
       ]);
 }
 
-@meta.ResourceIdentifier('MyStruct_new')
+@meta.RecordUse('MyStruct_new')
 @ffi.Native<_MyStructFfi Function()>(isLeaf: true, symbol: 'MyStruct_new')
 // ignore: non_constant_identifier_names
 external _MyStructFfi _MyStruct_new();
 
-@meta.ResourceIdentifier('MyStruct_into_a')
+@meta.RecordUse('MyStruct_into_a')
 @ffi.Native<ffi.Uint8 Function(_MyStructFfi)>(isLeaf: true, symbol: 'MyStruct_into_a')
 // ignore: non_constant_identifier_names
 external int _MyStruct_into_a(_MyStructFfi self);
 
-@meta.ResourceIdentifier('MyStruct_returns_zst_result')
+@meta.RecordUse('MyStruct_returns_zst_result')
 @ffi.Native<_ResultVoidMyZstFfi Function()>(isLeaf: true, symbol: 'MyStruct_returns_zst_result')
 // ignore: non_constant_identifier_names
 external _ResultVoidMyZstFfi _MyStruct_returns_zst_result();
 
-@meta.ResourceIdentifier('MyStruct_fails_zst_result')
+@meta.RecordUse('MyStruct_fails_zst_result')
 @ffi.Native<_ResultVoidMyZstFfi Function()>(isLeaf: true, symbol: 'MyStruct_fails_zst_result')
 // ignore: non_constant_identifier_names
 external _ResultVoidMyZstFfi _MyStruct_fails_zst_result();

--- a/feature_tests/dart/lib/src/NestedBorrowedFields.g.dart
+++ b/feature_tests/dart/lib/src/NestedBorrowedFields.g.dart
@@ -90,7 +90,7 @@ final class NestedBorrowedFields {
   core.List<Object> get _fieldsForLifetimeZ => [...bounds2._fieldsForLifetimeA, ...bounds2._fieldsForLifetimeB, ...bounds2._fieldsForLifetimeC];
 }
 
-@meta.RecordUse('NestedBorrowedFields_from_bar_and_foo_and_strings')
+@meta.RecordUse()
 @ffi.Native<_NestedBorrowedFieldsFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _SliceUtf16, _SliceUtf16, _SliceUtf8, _SliceUtf8)>(isLeaf: true, symbol: 'NestedBorrowedFields_from_bar_and_foo_and_strings')
 // ignore: non_constant_identifier_names
 external _NestedBorrowedFieldsFfi _NestedBorrowedFields_from_bar_and_foo_and_strings(ffi.Pointer<ffi.Opaque> bar, ffi.Pointer<ffi.Opaque> foo, _SliceUtf16 dstr16X, _SliceUtf16 dstr16Z, _SliceUtf8 utf8StrY, _SliceUtf8 utf8StrZ);

--- a/feature_tests/dart/lib/src/NestedBorrowedFields.g.dart
+++ b/feature_tests/dart/lib/src/NestedBorrowedFields.g.dart
@@ -90,7 +90,7 @@ final class NestedBorrowedFields {
   core.List<Object> get _fieldsForLifetimeZ => [...bounds2._fieldsForLifetimeA, ...bounds2._fieldsForLifetimeB, ...bounds2._fieldsForLifetimeC];
 }
 
-@meta.ResourceIdentifier('NestedBorrowedFields_from_bar_and_foo_and_strings')
+@meta.RecordUse('NestedBorrowedFields_from_bar_and_foo_and_strings')
 @ffi.Native<_NestedBorrowedFieldsFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _SliceUtf16, _SliceUtf16, _SliceUtf8, _SliceUtf8)>(isLeaf: true, symbol: 'NestedBorrowedFields_from_bar_and_foo_and_strings')
 // ignore: non_constant_identifier_names
 external _NestedBorrowedFieldsFfi _NestedBorrowedFields_from_bar_and_foo_and_strings(ffi.Pointer<ffi.Opaque> bar, ffi.Pointer<ffi.Opaque> foo, _SliceUtf16 dstr16X, _SliceUtf16 dstr16Z, _SliceUtf8 utf8StrY, _SliceUtf8 utf8StrZ);

--- a/feature_tests/dart/lib/src/One.g.dart
+++ b/feature_tests/dart/lib/src/One.g.dart
@@ -101,62 +101,62 @@ final class One implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('One_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'One_destroy')
 // ignore: non_constant_identifier_names
 external void _One_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('One_transitivity')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_transitivity')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_transitivity(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.RecordUse('One_cycle')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_cycle')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_cycle(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.RecordUse('One_many_dependents')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_many_dependents')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_many_dependents(ffi.Pointer<ffi.Opaque> a, ffi.Pointer<ffi.Opaque> b, ffi.Pointer<ffi.Opaque> c, ffi.Pointer<ffi.Opaque> d, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.RecordUse('One_return_outlives_param')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_return_outlives_param')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_return_outlives_param(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.RecordUse('One_diamond_top')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_top')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_top(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.RecordUse('One_diamond_left')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_left')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_left(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.RecordUse('One_diamond_right')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_right')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_right(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.RecordUse('One_diamond_bottom')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_bottom')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_bottom(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.RecordUse('One_diamond_and_nested_types')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_and_nested_types')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_and_nested_types(ffi.Pointer<ffi.Opaque> a, ffi.Pointer<ffi.Opaque> b, ffi.Pointer<ffi.Opaque> c, ffi.Pointer<ffi.Opaque> d, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.RecordUse('One_implicit_bounds')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_implicit_bounds')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_implicit_bounds(ffi.Pointer<ffi.Opaque> explicitHold, ffi.Pointer<ffi.Opaque> implicitHold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.RecordUse('One_implicit_bounds_deep')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_implicit_bounds_deep')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_implicit_bounds_deep(ffi.Pointer<ffi.Opaque> explicit, ffi.Pointer<ffi.Opaque> implicit1, ffi.Pointer<ffi.Opaque> implicit2, ffi.Pointer<ffi.Opaque> nohold);

--- a/feature_tests/dart/lib/src/One.g.dart
+++ b/feature_tests/dart/lib/src/One.g.dart
@@ -101,62 +101,62 @@ final class One implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('One_destroy')
+@meta.RecordUse('One_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'One_destroy')
 // ignore: non_constant_identifier_names
 external void _One_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('One_transitivity')
+@meta.RecordUse('One_transitivity')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_transitivity')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_transitivity(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier('One_cycle')
+@meta.RecordUse('One_cycle')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_cycle')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_cycle(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier('One_many_dependents')
+@meta.RecordUse('One_many_dependents')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_many_dependents')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_many_dependents(ffi.Pointer<ffi.Opaque> a, ffi.Pointer<ffi.Opaque> b, ffi.Pointer<ffi.Opaque> c, ffi.Pointer<ffi.Opaque> d, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier('One_return_outlives_param')
+@meta.RecordUse('One_return_outlives_param')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_return_outlives_param')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_return_outlives_param(ffi.Pointer<ffi.Opaque> hold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier('One_diamond_top')
+@meta.RecordUse('One_diamond_top')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_top')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_top(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.ResourceIdentifier('One_diamond_left')
+@meta.RecordUse('One_diamond_left')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_left')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_left(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.ResourceIdentifier('One_diamond_right')
+@meta.RecordUse('One_diamond_right')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_right')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_right(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.ResourceIdentifier('One_diamond_bottom')
+@meta.RecordUse('One_diamond_bottom')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_bottom')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_bottom(ffi.Pointer<ffi.Opaque> top, ffi.Pointer<ffi.Opaque> left, ffi.Pointer<ffi.Opaque> right, ffi.Pointer<ffi.Opaque> bottom);
 
-@meta.ResourceIdentifier('One_diamond_and_nested_types')
+@meta.RecordUse('One_diamond_and_nested_types')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_diamond_and_nested_types')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_diamond_and_nested_types(ffi.Pointer<ffi.Opaque> a, ffi.Pointer<ffi.Opaque> b, ffi.Pointer<ffi.Opaque> c, ffi.Pointer<ffi.Opaque> d, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier('One_implicit_bounds')
+@meta.RecordUse('One_implicit_bounds')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_implicit_bounds')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_implicit_bounds(ffi.Pointer<ffi.Opaque> explicitHold, ffi.Pointer<ffi.Opaque> implicitHold, ffi.Pointer<ffi.Opaque> nohold);
 
-@meta.ResourceIdentifier('One_implicit_bounds_deep')
+@meta.RecordUse('One_implicit_bounds_deep')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'One_implicit_bounds_deep')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _One_implicit_bounds_deep(ffi.Pointer<ffi.Opaque> explicit, ffi.Pointer<ffi.Opaque> implicit1, ffi.Pointer<ffi.Opaque> implicit2, ffi.Pointer<ffi.Opaque> nohold);

--- a/feature_tests/dart/lib/src/Opaque.g.dart
+++ b/feature_tests/dart/lib/src/Opaque.g.dart
@@ -70,47 +70,47 @@ final class Opaque implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('Opaque_destroy')
+@meta.RecordUse('Opaque_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Opaque_destroy')
 // ignore: non_constant_identifier_names
 external void _Opaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('Opaque_new')
+@meta.RecordUse('Opaque_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'Opaque_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Opaque_new();
 
-@meta.ResourceIdentifier('Opaque_try_from_utf8')
+@meta.RecordUse('Opaque_try_from_utf8')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'Opaque_try_from_utf8')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Opaque_try_from_utf8(_SliceUtf8 input);
 
-@meta.ResourceIdentifier('Opaque_from_str')
+@meta.RecordUse('Opaque_from_str')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'Opaque_from_str')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Opaque_from_str(_SliceUtf8 input);
 
-@meta.ResourceIdentifier('Opaque_get_debug_str')
+@meta.RecordUse('Opaque_get_debug_str')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Opaque_get_debug_str')
 // ignore: non_constant_identifier_names
 external void _Opaque_get_debug_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@meta.ResourceIdentifier('Opaque_assert_struct')
+@meta.RecordUse('Opaque_assert_struct')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _MyStructFfi)>(isLeaf: true, symbol: 'Opaque_assert_struct')
 // ignore: non_constant_identifier_names
 external void _Opaque_assert_struct(ffi.Pointer<ffi.Opaque> self, _MyStructFfi s);
 
-@meta.ResourceIdentifier('Opaque_returns_usize')
+@meta.RecordUse('Opaque_returns_usize')
 @ffi.Native<ffi.Size Function()>(isLeaf: true, symbol: 'Opaque_returns_usize')
 // ignore: non_constant_identifier_names
 external int _Opaque_returns_usize();
 
-@meta.ResourceIdentifier('Opaque_returns_imported')
+@meta.RecordUse('Opaque_returns_imported')
 @ffi.Native<_ImportedStructFfi Function()>(isLeaf: true, symbol: 'Opaque_returns_imported')
 // ignore: non_constant_identifier_names
 external _ImportedStructFfi _Opaque_returns_imported();
 
-@meta.ResourceIdentifier('Opaque_cmp')
+@meta.RecordUse('Opaque_cmp')
 @ffi.Native<ffi.Int8 Function()>(isLeaf: true, symbol: 'Opaque_cmp')
 // ignore: non_constant_identifier_names
 external int _Opaque_cmp();

--- a/feature_tests/dart/lib/src/Opaque.g.dart
+++ b/feature_tests/dart/lib/src/Opaque.g.dart
@@ -70,47 +70,47 @@ final class Opaque implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('Opaque_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Opaque_destroy')
 // ignore: non_constant_identifier_names
 external void _Opaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('Opaque_new')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'Opaque_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Opaque_new();
 
-@meta.RecordUse('Opaque_try_from_utf8')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'Opaque_try_from_utf8')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Opaque_try_from_utf8(_SliceUtf8 input);
 
-@meta.RecordUse('Opaque_from_str')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'Opaque_from_str')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Opaque_from_str(_SliceUtf8 input);
 
-@meta.RecordUse('Opaque_get_debug_str')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Opaque_get_debug_str')
 // ignore: non_constant_identifier_names
 external void _Opaque_get_debug_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@meta.RecordUse('Opaque_assert_struct')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _MyStructFfi)>(isLeaf: true, symbol: 'Opaque_assert_struct')
 // ignore: non_constant_identifier_names
 external void _Opaque_assert_struct(ffi.Pointer<ffi.Opaque> self, _MyStructFfi s);
 
-@meta.RecordUse('Opaque_returns_usize')
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function()>(isLeaf: true, symbol: 'Opaque_returns_usize')
 // ignore: non_constant_identifier_names
 external int _Opaque_returns_usize();
 
-@meta.RecordUse('Opaque_returns_imported')
+@meta.RecordUse()
 @ffi.Native<_ImportedStructFfi Function()>(isLeaf: true, symbol: 'Opaque_returns_imported')
 // ignore: non_constant_identifier_names
 external _ImportedStructFfi _Opaque_returns_imported();
 
-@meta.RecordUse('Opaque_cmp')
+@meta.RecordUse()
 @ffi.Native<ffi.Int8 Function()>(isLeaf: true, symbol: 'Opaque_cmp')
 // ignore: non_constant_identifier_names
 external int _Opaque_cmp();

--- a/feature_tests/dart/lib/src/OpaqueMutexedString.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueMutexedString.g.dart
@@ -69,47 +69,47 @@ final class OpaqueMutexedString implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('OpaqueMutexedString_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'OpaqueMutexedString_destroy')
 // ignore: non_constant_identifier_names
 external void _OpaqueMutexedString_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('OpaqueMutexedString_from_usize')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(isLeaf: true, symbol: 'OpaqueMutexedString_from_usize')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_from_usize(int number);
 
-@meta.RecordUse('OpaqueMutexedString_change')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'OpaqueMutexedString_change')
 // ignore: non_constant_identifier_names
 external void _OpaqueMutexedString_change(ffi.Pointer<ffi.Opaque> self, int number);
 
-@meta.RecordUse('OpaqueMutexedString_borrow')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_borrow')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_borrow(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('OpaqueMutexedString_borrow_other')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_borrow_other')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_borrow_other(ffi.Pointer<ffi.Opaque> other);
 
-@meta.RecordUse('OpaqueMutexedString_borrow_self_or_other')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_borrow_self_or_other')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_borrow_self_or_other(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);
 
-@meta.RecordUse('OpaqueMutexedString_get_len_and_add')
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'OpaqueMutexedString_get_len_and_add')
 // ignore: non_constant_identifier_names
 external int _OpaqueMutexedString_get_len_and_add(ffi.Pointer<ffi.Opaque> self, int other);
 
-@meta.RecordUse('OpaqueMutexedString_dummy_str')
+@meta.RecordUse()
 @ffi.Native<_SliceUtf8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_dummy_str')
 // ignore: non_constant_identifier_names
 external _SliceUtf8 _OpaqueMutexedString_dummy_str(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('OpaqueMutexedString_wrapper')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_wrapper')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_wrapper(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/OpaqueMutexedString.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueMutexedString.g.dart
@@ -69,47 +69,47 @@ final class OpaqueMutexedString implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('OpaqueMutexedString_destroy')
+@meta.RecordUse('OpaqueMutexedString_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'OpaqueMutexedString_destroy')
 // ignore: non_constant_identifier_names
 external void _OpaqueMutexedString_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('OpaqueMutexedString_from_usize')
+@meta.RecordUse('OpaqueMutexedString_from_usize')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(isLeaf: true, symbol: 'OpaqueMutexedString_from_usize')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_from_usize(int number);
 
-@meta.ResourceIdentifier('OpaqueMutexedString_change')
+@meta.RecordUse('OpaqueMutexedString_change')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'OpaqueMutexedString_change')
 // ignore: non_constant_identifier_names
 external void _OpaqueMutexedString_change(ffi.Pointer<ffi.Opaque> self, int number);
 
-@meta.ResourceIdentifier('OpaqueMutexedString_borrow')
+@meta.RecordUse('OpaqueMutexedString_borrow')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_borrow')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_borrow(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('OpaqueMutexedString_borrow_other')
+@meta.RecordUse('OpaqueMutexedString_borrow_other')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_borrow_other')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_borrow_other(ffi.Pointer<ffi.Opaque> other);
 
-@meta.ResourceIdentifier('OpaqueMutexedString_borrow_self_or_other')
+@meta.RecordUse('OpaqueMutexedString_borrow_self_or_other')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_borrow_self_or_other')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_borrow_self_or_other(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);
 
-@meta.ResourceIdentifier('OpaqueMutexedString_get_len_and_add')
+@meta.RecordUse('OpaqueMutexedString_get_len_and_add')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'OpaqueMutexedString_get_len_and_add')
 // ignore: non_constant_identifier_names
 external int _OpaqueMutexedString_get_len_and_add(ffi.Pointer<ffi.Opaque> self, int other);
 
-@meta.ResourceIdentifier('OpaqueMutexedString_dummy_str')
+@meta.RecordUse('OpaqueMutexedString_dummy_str')
 @ffi.Native<_SliceUtf8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_dummy_str')
 // ignore: non_constant_identifier_names
 external _SliceUtf8 _OpaqueMutexedString_dummy_str(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('OpaqueMutexedString_wrapper')
+@meta.RecordUse('OpaqueMutexedString_wrapper')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueMutexedString_wrapper')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OpaqueMutexedString_wrapper(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/OptionInputStruct.g.dart
+++ b/feature_tests/dart/lib/src/OptionInputStruct.g.dart
@@ -66,7 +66,7 @@ final class OptionInputStruct {
       ]);
 }
 
-@meta.RecordUse('OptionInputStruct_default_ctor')
+@meta.RecordUse()
 @ffi.Native<_OptionInputStructFfi Function()>(isLeaf: true, symbol: 'OptionInputStruct_default_ctor')
 // ignore: non_constant_identifier_names
 external _OptionInputStructFfi _OptionInputStruct_default_ctor();

--- a/feature_tests/dart/lib/src/OptionInputStruct.g.dart
+++ b/feature_tests/dart/lib/src/OptionInputStruct.g.dart
@@ -66,7 +66,7 @@ final class OptionInputStruct {
       ]);
 }
 
-@meta.ResourceIdentifier('OptionInputStruct_default_ctor')
+@meta.RecordUse('OptionInputStruct_default_ctor')
 @ffi.Native<_OptionInputStructFfi Function()>(isLeaf: true, symbol: 'OptionInputStruct_default_ctor')
 // ignore: non_constant_identifier_names
 external _OptionInputStructFfi _OptionInputStruct_default_ctor();

--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -121,82 +121,82 @@ final class OptionOpaque implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('OptionOpaque_destroy')
+@meta.RecordUse('OptionOpaque_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'OptionOpaque_destroy')
 // ignore: non_constant_identifier_names
 external void _OptionOpaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('OptionOpaque_new')
+@meta.RecordUse('OptionOpaque_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'OptionOpaque_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OptionOpaque_new(int i);
 
-@meta.ResourceIdentifier('OptionOpaque_new_none')
+@meta.RecordUse('OptionOpaque_new_none')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'OptionOpaque_new_none')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OptionOpaque_new_none();
 
-@meta.ResourceIdentifier('OptionOpaque_returns')
+@meta.RecordUse('OptionOpaque_returns')
 @ffi.Native<_ResultOptionStructFfiVoid Function()>(isLeaf: true, symbol: 'OptionOpaque_returns')
 // ignore: non_constant_identifier_names
 external _ResultOptionStructFfiVoid _OptionOpaque_returns();
 
-@meta.ResourceIdentifier('OptionOpaque_option_isize')
+@meta.RecordUse('OptionOpaque_option_isize')
 @ffi.Native<_ResultIntPtrVoid Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_isize')
 // ignore: non_constant_identifier_names
 external _ResultIntPtrVoid _OptionOpaque_option_isize(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('OptionOpaque_option_usize')
+@meta.RecordUse('OptionOpaque_option_usize')
 @ffi.Native<_ResultSizeVoid Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_usize')
 // ignore: non_constant_identifier_names
 external _ResultSizeVoid _OptionOpaque_option_usize(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('OptionOpaque_option_i32')
+@meta.RecordUse('OptionOpaque_option_i32')
 @ffi.Native<_ResultInt32Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_i32')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _OptionOpaque_option_i32(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('OptionOpaque_option_u32')
+@meta.RecordUse('OptionOpaque_option_u32')
 @ffi.Native<_ResultUint32Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_u32')
 // ignore: non_constant_identifier_names
 external _ResultUint32Void _OptionOpaque_option_u32(ffi.Pointer<ffi.Opaque> self);
 
-@meta.ResourceIdentifier('OptionOpaque_new_struct')
+@meta.RecordUse('OptionOpaque_new_struct')
 @ffi.Native<_OptionStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_new_struct')
 // ignore: non_constant_identifier_names
 external _OptionStructFfi _OptionOpaque_new_struct();
 
-@meta.ResourceIdentifier('OptionOpaque_new_struct_nones')
+@meta.RecordUse('OptionOpaque_new_struct_nones')
 @ffi.Native<_OptionStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_new_struct_nones')
 // ignore: non_constant_identifier_names
 external _OptionStructFfi _OptionOpaque_new_struct_nones();
 
-@meta.ResourceIdentifier('OptionOpaque_assert_integer')
+@meta.RecordUse('OptionOpaque_assert_integer')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'OptionOpaque_assert_integer')
 // ignore: non_constant_identifier_names
 external void _OptionOpaque_assert_integer(ffi.Pointer<ffi.Opaque> self, int i);
 
-@meta.ResourceIdentifier('OptionOpaque_option_opaque_argument')
+@meta.RecordUse('OptionOpaque_option_opaque_argument')
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_opaque_argument')
 // ignore: non_constant_identifier_names
 external bool _OptionOpaque_option_opaque_argument(ffi.Pointer<ffi.Opaque> arg);
 
-@meta.ResourceIdentifier('OptionOpaque_accepts_option_u8')
+@meta.RecordUse('OptionOpaque_accepts_option_u8')
 @ffi.Native<_ResultUint8Void Function(_ResultUint8Void)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_u8')
 // ignore: non_constant_identifier_names
 external _ResultUint8Void _OptionOpaque_accepts_option_u8(_ResultUint8Void arg);
 
-@meta.ResourceIdentifier('OptionOpaque_accepts_option_enum')
+@meta.RecordUse('OptionOpaque_accepts_option_enum')
 @ffi.Native<_ResultInt32Void Function(_ResultInt32Void)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_enum')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _OptionOpaque_accepts_option_enum(_ResultInt32Void arg);
 
-@meta.ResourceIdentifier('OptionOpaque_accepts_option_input_struct')
+@meta.RecordUse('OptionOpaque_accepts_option_input_struct')
 @ffi.Native<_ResultOptionInputStructFfiVoid Function(_ResultOptionInputStructFfiVoid)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_input_struct')
 // ignore: non_constant_identifier_names
 external _ResultOptionInputStructFfiVoid _OptionOpaque_accepts_option_input_struct(_ResultOptionInputStructFfiVoid arg);
 
-@meta.ResourceIdentifier('OptionOpaque_returns_option_input_struct')
+@meta.RecordUse('OptionOpaque_returns_option_input_struct')
 @ffi.Native<_OptionInputStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_returns_option_input_struct')
 // ignore: non_constant_identifier_names
 external _OptionInputStructFfi _OptionOpaque_returns_option_input_struct();

--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -121,82 +121,82 @@ final class OptionOpaque implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('OptionOpaque_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'OptionOpaque_destroy')
 // ignore: non_constant_identifier_names
 external void _OptionOpaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('OptionOpaque_new')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'OptionOpaque_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OptionOpaque_new(int i);
 
-@meta.RecordUse('OptionOpaque_new_none')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'OptionOpaque_new_none')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _OptionOpaque_new_none();
 
-@meta.RecordUse('OptionOpaque_returns')
+@meta.RecordUse()
 @ffi.Native<_ResultOptionStructFfiVoid Function()>(isLeaf: true, symbol: 'OptionOpaque_returns')
 // ignore: non_constant_identifier_names
 external _ResultOptionStructFfiVoid _OptionOpaque_returns();
 
-@meta.RecordUse('OptionOpaque_option_isize')
+@meta.RecordUse()
 @ffi.Native<_ResultIntPtrVoid Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_isize')
 // ignore: non_constant_identifier_names
 external _ResultIntPtrVoid _OptionOpaque_option_isize(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('OptionOpaque_option_usize')
+@meta.RecordUse()
 @ffi.Native<_ResultSizeVoid Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_usize')
 // ignore: non_constant_identifier_names
 external _ResultSizeVoid _OptionOpaque_option_usize(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('OptionOpaque_option_i32')
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_i32')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _OptionOpaque_option_i32(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('OptionOpaque_option_u32')
+@meta.RecordUse()
 @ffi.Native<_ResultUint32Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_u32')
 // ignore: non_constant_identifier_names
 external _ResultUint32Void _OptionOpaque_option_u32(ffi.Pointer<ffi.Opaque> self);
 
-@meta.RecordUse('OptionOpaque_new_struct')
+@meta.RecordUse()
 @ffi.Native<_OptionStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_new_struct')
 // ignore: non_constant_identifier_names
 external _OptionStructFfi _OptionOpaque_new_struct();
 
-@meta.RecordUse('OptionOpaque_new_struct_nones')
+@meta.RecordUse()
 @ffi.Native<_OptionStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_new_struct_nones')
 // ignore: non_constant_identifier_names
 external _OptionStructFfi _OptionOpaque_new_struct_nones();
 
-@meta.RecordUse('OptionOpaque_assert_integer')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'OptionOpaque_assert_integer')
 // ignore: non_constant_identifier_names
 external void _OptionOpaque_assert_integer(ffi.Pointer<ffi.Opaque> self, int i);
 
-@meta.RecordUse('OptionOpaque_option_opaque_argument')
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_option_opaque_argument')
 // ignore: non_constant_identifier_names
 external bool _OptionOpaque_option_opaque_argument(ffi.Pointer<ffi.Opaque> arg);
 
-@meta.RecordUse('OptionOpaque_accepts_option_u8')
+@meta.RecordUse()
 @ffi.Native<_ResultUint8Void Function(_ResultUint8Void)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_u8')
 // ignore: non_constant_identifier_names
 external _ResultUint8Void _OptionOpaque_accepts_option_u8(_ResultUint8Void arg);
 
-@meta.RecordUse('OptionOpaque_accepts_option_enum')
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_ResultInt32Void)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_enum')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _OptionOpaque_accepts_option_enum(_ResultInt32Void arg);
 
-@meta.RecordUse('OptionOpaque_accepts_option_input_struct')
+@meta.RecordUse()
 @ffi.Native<_ResultOptionInputStructFfiVoid Function(_ResultOptionInputStructFfiVoid)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_input_struct')
 // ignore: non_constant_identifier_names
 external _ResultOptionInputStructFfiVoid _OptionOpaque_accepts_option_input_struct(_ResultOptionInputStructFfiVoid arg);
 
-@meta.RecordUse('OptionOpaque_returns_option_input_struct')
+@meta.RecordUse()
 @ffi.Native<_OptionInputStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_returns_option_input_struct')
 // ignore: non_constant_identifier_names
 external _OptionInputStructFfi _OptionOpaque_returns_option_input_struct();

--- a/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
@@ -26,12 +26,12 @@ final class OptionOpaqueChar implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('OptionOpaqueChar_destroy')
+@meta.RecordUse('OptionOpaqueChar_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'OptionOpaqueChar_destroy')
 // ignore: non_constant_identifier_names
 external void _OptionOpaqueChar_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('OptionOpaqueChar_assert_char')
+@meta.RecordUse('OptionOpaqueChar_assert_char')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'OptionOpaqueChar_assert_char')
 // ignore: non_constant_identifier_names
 external void _OptionOpaqueChar_assert_char(ffi.Pointer<ffi.Opaque> self, Rune ch);

--- a/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
@@ -26,12 +26,12 @@ final class OptionOpaqueChar implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('OptionOpaqueChar_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'OptionOpaqueChar_destroy')
 // ignore: non_constant_identifier_names
 external void _OptionOpaqueChar_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('OptionOpaqueChar_assert_char')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'OptionOpaqueChar_assert_char')
 // ignore: non_constant_identifier_names
 external void _OptionOpaqueChar_assert_char(ffi.Pointer<ffi.Opaque> self, Rune ch);

--- a/feature_tests/dart/lib/src/RefList.g.dart
+++ b/feature_tests/dart/lib/src/RefList.g.dart
@@ -31,12 +31,12 @@ final class RefList implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('RefList_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'RefList_destroy')
 // ignore: non_constant_identifier_names
 external void _RefList_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('RefList_node')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'RefList_node')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _RefList_node(ffi.Pointer<ffi.Opaque> data);

--- a/feature_tests/dart/lib/src/RefList.g.dart
+++ b/feature_tests/dart/lib/src/RefList.g.dart
@@ -31,12 +31,12 @@ final class RefList implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('RefList_destroy')
+@meta.RecordUse('RefList_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'RefList_destroy')
 // ignore: non_constant_identifier_names
 external void _RefList_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('RefList_node')
+@meta.RecordUse('RefList_node')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'RefList_node')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _RefList_node(ffi.Pointer<ffi.Opaque> data);

--- a/feature_tests/dart/lib/src/RefListParameter.g.dart
+++ b/feature_tests/dart/lib/src/RefListParameter.g.dart
@@ -22,7 +22,7 @@ final class RefListParameter implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_RefListParameter_destroy));
 }
 
-@meta.ResourceIdentifier('RefListParameter_destroy')
+@meta.RecordUse('RefListParameter_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'RefListParameter_destroy')
 // ignore: non_constant_identifier_names
 external void _RefListParameter_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/RefListParameter.g.dart
+++ b/feature_tests/dart/lib/src/RefListParameter.g.dart
@@ -22,7 +22,7 @@ final class RefListParameter implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_RefListParameter_destroy));
 }
 
-@meta.RecordUse('RefListParameter_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'RefListParameter_destroy')
 // ignore: non_constant_identifier_names
 external void _RefListParameter_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/RenamedAttrOpaque2.g.dart
+++ b/feature_tests/dart/lib/src/RenamedAttrOpaque2.g.dart
@@ -22,7 +22,7 @@ final class RenamedAttrOpaque2 implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_AttrOpaque2_destroy));
 }
 
-@meta.RecordUse('namespace_AttrOpaque2_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_AttrOpaque2_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque2_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/RenamedAttrOpaque2.g.dart
+++ b/feature_tests/dart/lib/src/RenamedAttrOpaque2.g.dart
@@ -22,7 +22,7 @@ final class RenamedAttrOpaque2 implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_AttrOpaque2_destroy));
 }
 
-@meta.ResourceIdentifier('namespace_AttrOpaque2_destroy')
+@meta.RecordUse('namespace_AttrOpaque2_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_AttrOpaque2_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_AttrOpaque2_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/RenamedComparable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedComparable.g.dart
@@ -37,17 +37,17 @@ final class RenamedComparable implements ffi.Finalizable, core.Comparable<Rename
   int get hashCode => 42; // Cannot get hash from Rust, so a constant is the only correct impl
 }
 
-@meta.ResourceIdentifier('namespace_Comparable_destroy')
+@meta.RecordUse('namespace_Comparable_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_Comparable_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_Comparable_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('namespace_Comparable_new')
+@meta.RecordUse('namespace_Comparable_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Uint8)>(isLeaf: true, symbol: 'namespace_Comparable_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_Comparable_new(int int);
 
-@meta.ResourceIdentifier('namespace_Comparable_cmp')
+@meta.RecordUse('namespace_Comparable_cmp')
 @ffi.Native<ffi.Int8 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_Comparable_cmp')
 // ignore: non_constant_identifier_names
 external int _namespace_Comparable_cmp(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);

--- a/feature_tests/dart/lib/src/RenamedComparable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedComparable.g.dart
@@ -37,17 +37,17 @@ final class RenamedComparable implements ffi.Finalizable, core.Comparable<Rename
   int get hashCode => 42; // Cannot get hash from Rust, so a constant is the only correct impl
 }
 
-@meta.RecordUse('namespace_Comparable_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_Comparable_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_Comparable_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('namespace_Comparable_new')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Uint8)>(isLeaf: true, symbol: 'namespace_Comparable_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_Comparable_new(int int);
 
-@meta.RecordUse('namespace_Comparable_cmp')
+@meta.RecordUse()
 @ffi.Native<ffi.Int8 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_Comparable_cmp')
 // ignore: non_constant_identifier_names
 external int _namespace_Comparable_cmp(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);

--- a/feature_tests/dart/lib/src/RenamedMyIndexer.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIndexer.g.dart
@@ -32,12 +32,12 @@ final class RenamedMyIndexer implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('namespace_MyIndexer_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_MyIndexer_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_MyIndexer_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('namespace_MyIndexer_get')
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'namespace_MyIndexer_get')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _namespace_MyIndexer_get(ffi.Pointer<ffi.Opaque> self, int i);

--- a/feature_tests/dart/lib/src/RenamedMyIndexer.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIndexer.g.dart
@@ -32,12 +32,12 @@ final class RenamedMyIndexer implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('namespace_MyIndexer_destroy')
+@meta.RecordUse('namespace_MyIndexer_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_MyIndexer_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_MyIndexer_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('namespace_MyIndexer_get')
+@meta.RecordUse('namespace_MyIndexer_get')
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'namespace_MyIndexer_get')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _namespace_MyIndexer_get(ffi.Pointer<ffi.Opaque> self, int i);

--- a/feature_tests/dart/lib/src/RenamedMyIterable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIterable.g.dart
@@ -35,17 +35,17 @@ final class RenamedMyIterable with core.Iterable<int> implements ffi.Finalizable
   }
 }
 
-@meta.RecordUse('namespace_MyIterable_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_MyIterable_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_MyIterable_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('namespace_MyIterable_new')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUint8)>(isLeaf: true, symbol: 'namespace_MyIterable_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_MyIterable_new(_SliceUint8 x);
 
-@meta.RecordUse('namespace_MyIterable_iter')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_MyIterable_iter')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_MyIterable_iter(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/RenamedMyIterable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIterable.g.dart
@@ -35,17 +35,17 @@ final class RenamedMyIterable with core.Iterable<int> implements ffi.Finalizable
   }
 }
 
-@meta.ResourceIdentifier('namespace_MyIterable_destroy')
+@meta.RecordUse('namespace_MyIterable_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_MyIterable_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_MyIterable_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('namespace_MyIterable_new')
+@meta.RecordUse('namespace_MyIterable_new')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUint8)>(isLeaf: true, symbol: 'namespace_MyIterable_new')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_MyIterable_new(_SliceUint8 x);
 
-@meta.ResourceIdentifier('namespace_MyIterable_iter')
+@meta.RecordUse('namespace_MyIterable_iter')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_MyIterable_iter')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_MyIterable_iter(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/RenamedMyIterator.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIterator.g.dart
@@ -41,12 +41,12 @@ final class RenamedMyIterator implements ffi.Finalizable, core.Iterator<int> {
   }
 }
 
-@meta.ResourceIdentifier('namespace_MyIterator_destroy')
+@meta.RecordUse('namespace_MyIterator_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_MyIterator_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_MyIterator_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('namespace_MyIterator_next')
+@meta.RecordUse('namespace_MyIterator_next')
 @ffi.Native<_ResultUint8Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_MyIterator_next')
 // ignore: non_constant_identifier_names
 external _ResultUint8Void _namespace_MyIterator_next(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/RenamedMyIterator.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIterator.g.dart
@@ -41,12 +41,12 @@ final class RenamedMyIterator implements ffi.Finalizable, core.Iterator<int> {
   }
 }
 
-@meta.RecordUse('namespace_MyIterator_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_MyIterator_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_MyIterator_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('namespace_MyIterator_next')
+@meta.RecordUse()
 @ffi.Native<_ResultUint8Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_MyIterator_next')
 // ignore: non_constant_identifier_names
 external _ResultUint8Void _namespace_MyIterator_next(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/RenamedOpaqueIterable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedOpaqueIterable.g.dart
@@ -29,12 +29,12 @@ final class RenamedOpaqueIterable with core.Iterable<AttrOpaque1Renamed> impleme
   }
 }
 
-@meta.ResourceIdentifier('namespace_OpaqueIterable_destroy')
+@meta.RecordUse('namespace_OpaqueIterable_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_OpaqueIterable_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_OpaqueIterable_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('namespace_OpaqueIterable_iter')
+@meta.RecordUse('namespace_OpaqueIterable_iter')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_OpaqueIterable_iter')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_OpaqueIterable_iter(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/RenamedOpaqueIterable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedOpaqueIterable.g.dart
@@ -29,12 +29,12 @@ final class RenamedOpaqueIterable with core.Iterable<AttrOpaque1Renamed> impleme
   }
 }
 
-@meta.RecordUse('namespace_OpaqueIterable_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_OpaqueIterable_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_OpaqueIterable_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('namespace_OpaqueIterable_iter')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_OpaqueIterable_iter')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_OpaqueIterable_iter(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/RenamedOpaqueIterator.g.dart
+++ b/feature_tests/dart/lib/src/RenamedOpaqueIterator.g.dart
@@ -38,12 +38,12 @@ final class RenamedOpaqueIterator implements ffi.Finalizable, core.Iterator<Attr
   }
 }
 
-@meta.ResourceIdentifier('namespace_OpaqueIterator_destroy')
+@meta.RecordUse('namespace_OpaqueIterator_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_OpaqueIterator_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_OpaqueIterator_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('namespace_OpaqueIterator_next')
+@meta.RecordUse('namespace_OpaqueIterator_next')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_OpaqueIterator_next')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_OpaqueIterator_next(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/RenamedOpaqueIterator.g.dart
+++ b/feature_tests/dart/lib/src/RenamedOpaqueIterator.g.dart
@@ -38,12 +38,12 @@ final class RenamedOpaqueIterator implements ffi.Finalizable, core.Iterator<Attr
   }
 }
 
-@meta.RecordUse('namespace_OpaqueIterator_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_OpaqueIterator_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_OpaqueIterator_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('namespace_OpaqueIterator_next')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_OpaqueIterator_next')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_OpaqueIterator_next(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/ResultOpaque.g.dart
+++ b/feature_tests/dart/lib/src/ResultOpaque.g.dart
@@ -108,52 +108,52 @@ final class ResultOpaque implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('ResultOpaque_destroy')
+@meta.RecordUse('ResultOpaque_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'ResultOpaque_destroy')
 // ignore: non_constant_identifier_names
 external void _ResultOpaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('ResultOpaque_new')
+@meta.RecordUse('ResultOpaque_new')
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new(int i);
 
-@meta.ResourceIdentifier('ResultOpaque_new_failing_foo')
+@meta.RecordUse('ResultOpaque_new_failing_foo')
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_foo')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new_failing_foo();
 
-@meta.ResourceIdentifier('ResultOpaque_new_failing_bar')
+@meta.RecordUse('ResultOpaque_new_failing_bar')
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_bar')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new_failing_bar();
 
-@meta.ResourceIdentifier('ResultOpaque_new_failing_unit')
+@meta.RecordUse('ResultOpaque_new_failing_unit')
 @ffi.Native<_ResultOpaqueVoid Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_unit')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueVoid _ResultOpaque_new_failing_unit();
 
-@meta.ResourceIdentifier('ResultOpaque_new_failing_struct')
+@meta.RecordUse('ResultOpaque_new_failing_struct')
 @ffi.Native<_ResultOpaqueErrorStructFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_failing_struct')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueErrorStructFfi _ResultOpaque_new_failing_struct(int i);
 
-@meta.ResourceIdentifier('ResultOpaque_new_in_err')
+@meta.RecordUse('ResultOpaque_new_in_err')
 @ffi.Native<_ResultVoidOpaque Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_in_err')
 // ignore: non_constant_identifier_names
 external _ResultVoidOpaque _ResultOpaque_new_in_err(int i);
 
-@meta.ResourceIdentifier('ResultOpaque_new_int')
+@meta.RecordUse('ResultOpaque_new_int')
 @ffi.Native<_ResultInt32Void Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_int')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _ResultOpaque_new_int(int i);
 
-@meta.ResourceIdentifier('ResultOpaque_new_in_enum_err')
+@meta.RecordUse('ResultOpaque_new_in_enum_err')
 @ffi.Native<_ResultInt32Opaque Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_in_enum_err')
 // ignore: non_constant_identifier_names
 external _ResultInt32Opaque _ResultOpaque_new_in_enum_err(int i);
 
-@meta.ResourceIdentifier('ResultOpaque_assert_integer')
+@meta.RecordUse('ResultOpaque_assert_integer')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_assert_integer')
 // ignore: non_constant_identifier_names
 external void _ResultOpaque_assert_integer(ffi.Pointer<ffi.Opaque> self, int i);

--- a/feature_tests/dart/lib/src/ResultOpaque.g.dart
+++ b/feature_tests/dart/lib/src/ResultOpaque.g.dart
@@ -108,52 +108,52 @@ final class ResultOpaque implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('ResultOpaque_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'ResultOpaque_destroy')
 // ignore: non_constant_identifier_names
 external void _ResultOpaque_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('ResultOpaque_new')
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new(int i);
 
-@meta.RecordUse('ResultOpaque_new_failing_foo')
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_foo')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new_failing_foo();
 
-@meta.RecordUse('ResultOpaque_new_failing_bar')
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_bar')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _ResultOpaque_new_failing_bar();
 
-@meta.RecordUse('ResultOpaque_new_failing_unit')
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueVoid Function()>(isLeaf: true, symbol: 'ResultOpaque_new_failing_unit')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueVoid _ResultOpaque_new_failing_unit();
 
-@meta.RecordUse('ResultOpaque_new_failing_struct')
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueErrorStructFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_failing_struct')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueErrorStructFfi _ResultOpaque_new_failing_struct(int i);
 
-@meta.RecordUse('ResultOpaque_new_in_err')
+@meta.RecordUse()
 @ffi.Native<_ResultVoidOpaque Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_in_err')
 // ignore: non_constant_identifier_names
 external _ResultVoidOpaque _ResultOpaque_new_in_err(int i);
 
-@meta.RecordUse('ResultOpaque_new_int')
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_int')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _ResultOpaque_new_int(int i);
 
-@meta.RecordUse('ResultOpaque_new_in_enum_err')
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Opaque Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_in_enum_err')
 // ignore: non_constant_identifier_names
 external _ResultInt32Opaque _ResultOpaque_new_in_enum_err(int i);
 
-@meta.RecordUse('ResultOpaque_assert_integer')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_assert_integer')
 // ignore: non_constant_identifier_names
 external void _ResultOpaque_assert_integer(ffi.Pointer<ffi.Opaque> self, int i);

--- a/feature_tests/dart/lib/src/Two.g.dart
+++ b/feature_tests/dart/lib/src/Two.g.dart
@@ -26,7 +26,7 @@ final class Two implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Two_destroy));
 }
 
-@meta.RecordUse('Two_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Two_destroy')
 // ignore: non_constant_identifier_names
 external void _Two_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/Two.g.dart
+++ b/feature_tests/dart/lib/src/Two.g.dart
@@ -26,7 +26,7 @@ final class Two implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Two_destroy));
 }
 
-@meta.ResourceIdentifier('Two_destroy')
+@meta.RecordUse('Two_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Two_destroy')
 // ignore: non_constant_identifier_names
 external void _Two_destroy(ffi.Pointer<ffi.Void> self);

--- a/feature_tests/dart/lib/src/Unnamespaced.g.dart
+++ b/feature_tests/dart/lib/src/Unnamespaced.g.dart
@@ -31,17 +31,17 @@ final class Unnamespaced implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('namespace_Unnamespaced_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_Unnamespaced_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_Unnamespaced_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('namespace_Unnamespaced_make')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'namespace_Unnamespaced_make')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_Unnamespaced_make(int e);
 
-@meta.RecordUse('namespace_Unnamespaced_use_namespaced')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_Unnamespaced_use_namespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_Unnamespaced_use_namespaced(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> n);

--- a/feature_tests/dart/lib/src/Unnamespaced.g.dart
+++ b/feature_tests/dart/lib/src/Unnamespaced.g.dart
@@ -31,17 +31,17 @@ final class Unnamespaced implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('namespace_Unnamespaced_destroy')
+@meta.RecordUse('namespace_Unnamespaced_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'namespace_Unnamespaced_destroy')
 // ignore: non_constant_identifier_names
 external void _namespace_Unnamespaced_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('namespace_Unnamespaced_make')
+@meta.RecordUse('namespace_Unnamespaced_make')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'namespace_Unnamespaced_make')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _namespace_Unnamespaced_make(int e);
 
-@meta.ResourceIdentifier('namespace_Unnamespaced_use_namespaced')
+@meta.RecordUse('namespace_Unnamespaced_use_namespaced')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'namespace_Unnamespaced_use_namespaced')
 // ignore: non_constant_identifier_names
 external void _namespace_Unnamespaced_use_namespaced(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> n);

--- a/feature_tests/dart/lib/src/Utf16Wrap.g.dart
+++ b/feature_tests/dart/lib/src/Utf16Wrap.g.dart
@@ -41,22 +41,22 @@ final class Utf16Wrap implements ffi.Finalizable {
   }
 }
 
-@meta.ResourceIdentifier('Utf16Wrap_destroy')
+@meta.RecordUse('Utf16Wrap_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Utf16Wrap_destroy')
 // ignore: non_constant_identifier_names
 external void _Utf16Wrap_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.ResourceIdentifier('Utf16Wrap_from_utf16')
+@meta.RecordUse('Utf16Wrap_from_utf16')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf16)>(isLeaf: true, symbol: 'Utf16Wrap_from_utf16')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Utf16Wrap_from_utf16(_SliceUtf16 input);
 
-@meta.ResourceIdentifier('Utf16Wrap_get_debug_str')
+@meta.RecordUse('Utf16Wrap_get_debug_str')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Utf16Wrap_get_debug_str')
 // ignore: non_constant_identifier_names
 external void _Utf16Wrap_get_debug_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@meta.ResourceIdentifier('Utf16Wrap_borrow_cont')
+@meta.RecordUse('Utf16Wrap_borrow_cont')
 @ffi.Native<_SliceUtf16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Utf16Wrap_borrow_cont')
 // ignore: non_constant_identifier_names
 external _SliceUtf16 _Utf16Wrap_borrow_cont(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/Utf16Wrap.g.dart
+++ b/feature_tests/dart/lib/src/Utf16Wrap.g.dart
@@ -41,22 +41,22 @@ final class Utf16Wrap implements ffi.Finalizable {
   }
 }
 
-@meta.RecordUse('Utf16Wrap_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'Utf16Wrap_destroy')
 // ignore: non_constant_identifier_names
 external void _Utf16Wrap_destroy(ffi.Pointer<ffi.Void> self);
 
-@meta.RecordUse('Utf16Wrap_from_utf16')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf16)>(isLeaf: true, symbol: 'Utf16Wrap_from_utf16')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _Utf16Wrap_from_utf16(_SliceUtf16 input);
 
-@meta.RecordUse('Utf16Wrap_get_debug_str')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Utf16Wrap_get_debug_str')
 // ignore: non_constant_identifier_names
 external void _Utf16Wrap_get_debug_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@meta.RecordUse('Utf16Wrap_borrow_cont')
+@meta.RecordUse()
 @ffi.Native<_SliceUtf16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'Utf16Wrap_borrow_cont')
 // ignore: non_constant_identifier_names
 external _SliceUtf16 _Utf16Wrap_borrow_cont(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -87,12 +87,12 @@ final class _RustAlloc implements ffi.Allocator {
   }
 }
 
-@meta.ResourceIdentifier('diplomat_alloc')
+@meta.RecordUse('diplomat_alloc')
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
-@meta.ResourceIdentifier('diplomat_free')
+@meta.RecordUse('diplomat_free')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);
@@ -1007,22 +1007,22 @@ final class _Write {
   }
 }
 
-@meta.ResourceIdentifier('diplomat_buffer_write_create')
+@meta.RecordUse('diplomat_buffer_write_create')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_write_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_write_create(int len);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_len')
+@meta.RecordUse('diplomat_buffer_write_len')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_write_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_get_bytes')
+@meta.RecordUse('diplomat_buffer_write_get_bytes')
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_write_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_destroy')
+@meta.RecordUse('diplomat_buffer_write_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_write_destroy(ffi.Pointer<ffi.Opaque> ptr);

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -87,12 +87,12 @@ final class _RustAlloc implements ffi.Allocator {
   }
 }
 
-@meta.RecordUse('diplomat_alloc')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
-@meta.RecordUse('diplomat_free')
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);
@@ -1007,22 +1007,22 @@ final class _Write {
   }
 }
 
-@meta.RecordUse('diplomat_buffer_write_create')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_write_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_write_create(int len);
 
-@meta.RecordUse('diplomat_buffer_write_len')
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_write_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.RecordUse('diplomat_buffer_write_get_bytes')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_write_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.RecordUse('diplomat_buffer_write_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_write_destroy(ffi.Pointer<ffi.Opaque> ptr);

--- a/feature_tests/dart/pubspec.lock
+++ b/feature_tests/dart/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "65.0.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.1"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: ac86d3abab0f165e4b8f561280ff4e066bceaac83c424dd19f1ae2c2fcd12ca9
+      sha256: "3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.1"
+    version: "1.8.0"
   crypto:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.1"
   lints:
     dependency: "direct dev"
     description:
@@ -165,26 +165,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.6"
   native_assets_cli:
     dependency: "direct main"
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   pool:
     dependency: transitive
     description:
@@ -253,26 +253,26 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -325,26 +325,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.25.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.6.4"
   typed_data:
     dependency: transitive
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -369,14 +369,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.1"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -397,9 +413,9 @@ packages:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: "1579d4a0340a83cf9e4d580ea51a16329c916973bffd5bd4b45e911b25d46bfd"
+      sha256: e9c1a3543d2da0db3e90270dbb1e4eebc985ee5e3ffe468d83224472b2194a5f
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
 sdks:
   dart: ">=3.4.0-204.0.dev <4.0.0"

--- a/tool/templates/dart/init.dart
+++ b/tool/templates/dart/init.dart
@@ -33,12 +33,12 @@ final class _RustAlloc implements ffi.Allocator {
   }
 }
 
-@meta.RecordUse('diplomat_alloc')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
-@meta.RecordUse('diplomat_free')
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);

--- a/tool/templates/dart/init.dart
+++ b/tool/templates/dart/init.dart
@@ -33,12 +33,12 @@ final class _RustAlloc implements ffi.Allocator {
   }
 }
 
-@meta.ResourceIdentifier('diplomat_alloc')
+@meta.RecordUse('diplomat_alloc')
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
-@meta.ResourceIdentifier('diplomat_free')
+@meta.RecordUse('diplomat_free')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);

--- a/tool/templates/dart/native_method.dart.jinja
+++ b/tool/templates/dart/native_method.dart.jinja
@@ -1,4 +1,4 @@
-@meta.ResourceIdentifier('{{ m.abi_name }}')
+@meta.RecordUse('{{ m.abi_name }}')
 @ffi.Native<{{ m.return_type_ffi }} Function({%- for param in m.param_types_ffi %}
       {%- if !loop.first %}, {% endif -%}
       {{ param }}

--- a/tool/templates/dart/native_method.dart.jinja
+++ b/tool/templates/dart/native_method.dart.jinja
@@ -1,4 +1,4 @@
-@meta.RecordUse('{{ m.abi_name }}')
+@meta.RecordUse()
 @ffi.Native<{{ m.return_type_ffi }} Function({%- for param in m.param_types_ffi %}
       {%- if !loop.first %}, {% endif -%}
       {{ param }}

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -55,7 +55,7 @@ final class {{type_name}}
   {%- endif %}
 }
 
-@meta.ResourceIdentifier('{{destructor}}')
+@meta.RecordUse('{{destructor}}')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: '{{destructor}}')
 // ignore: non_constant_identifier_names
 external void _{{destructor}}(ffi.Pointer<ffi.Void> self);

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -55,7 +55,7 @@ final class {{type_name}}
   {%- endif %}
 }
 
-@meta.RecordUse('{{destructor}}')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: '{{destructor}}')
 // ignore: non_constant_identifier_names
 external void _{{destructor}}(ffi.Pointer<ffi.Void> self);

--- a/tool/templates/dart/write.dart
+++ b/tool/templates/dart/write.dart
@@ -16,22 +16,22 @@ final class _Write {
   }
 }
 
-@meta.RecordUse('diplomat_buffer_write_create')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_write_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_write_create(int len);
 
-@meta.RecordUse('diplomat_buffer_write_len')
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_write_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.RecordUse('diplomat_buffer_write_get_bytes')
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_write_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.RecordUse('diplomat_buffer_write_destroy')
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_write_destroy(ffi.Pointer<ffi.Opaque> ptr);

--- a/tool/templates/dart/write.dart
+++ b/tool/templates/dart/write.dart
@@ -16,22 +16,22 @@ final class _Write {
   }
 }
 
-@meta.ResourceIdentifier('diplomat_buffer_write_create')
+@meta.RecordUse('diplomat_buffer_write_create')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_write_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_write_create(int len);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_len')
+@meta.RecordUse('diplomat_buffer_write_len')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_write_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_get_bytes')
+@meta.RecordUse('diplomat_buffer_write_get_bytes')
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_write_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@meta.ResourceIdentifier('diplomat_buffer_write_destroy')
+@meta.RecordUse('diplomat_buffer_write_destroy')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_write_destroy(ffi.Pointer<ffi.Opaque> ptr);


### PR DESCRIPTION
See https://github.com/unicode-org/icu4x/issues/5570. The annotation was renamed and its metadata parameter removed.

I'm going to merge without review to fix ICU4X's broken CI, but cc @robertbastian for post merge review.