### PR TITLE
Fixing error with multi-arg callbacks and trait methods in Kotlin

### DIFF
--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2058
+assertion_line: 2064
 expression: struct_code
 ---
 package dev.gigapixel.somelib
@@ -57,7 +57,7 @@ internal class MyNativeStructNative: Structure(), Structure.ByValue {
 
 
 internal interface Runner_DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f: Callback {
-    fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int
+    fun invoke(lang_specific_context: Pointer?, arg0: Int, arg1: Int, arg2: Int ): Int
 }
 
 internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native: Structure(), Structure.ByValue {
@@ -66,7 +66,7 @@ internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatC
     @JvmField
     internal var run_callback: Runner_DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f
         = object :  Runner_DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f {
-                override fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Int, arg1: Int, arg2: Int ): Int {
                     throw Exception("Default callback runner -- should be replaced.")
                 }
             }
@@ -92,10 +92,10 @@ internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatC
     companion object {
         val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native::class.java).toLong()
         
-        fun fromCallback(cb: (Int)->Int): DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f {
+        fun fromCallback(cb: (Int, Int, Int)->Int): DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f {
             val callback: Runner_DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f = object :  Runner_DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f {
-                override fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int {
-                    return cb(arg0);
+                override fun invoke(lang_specific_context: Pointer?, arg0: Int, arg1: Int, arg2: Int ): Int {
+                    return cb(arg0, arg1, arg2);
                 }
             }
             val cb_wrap = DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native()
@@ -138,7 +138,7 @@ class MyNativeStruct internal constructor (
             return returnStruct
         }
         
-        fun testMultiArgCallback(f: (Int)->Int, x: Int): Int {
+        fun testMultiArgCallback(f: (Int, Int, Int)->Int, x: Int): Int {
             
             val returnVal = lib.MyNativeStruct_test_multi_arg_callback(DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f.fromCallback(f).nativeStruct, x);
             return (returnVal)

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2256
+assertion_line: 2320
 expression: result
 ---
 package dev.gigapixel.somelib
@@ -12,14 +12,14 @@ import com.sun.jna.Pointer
 import com.sun.jna.Structure
 
 interface TesterTrait {
-    fun testTraitFn(x: Int): Int;
+    fun testTraitFn(x: Int, y: Int, z: UByte): Int;
     fun testVoidTraitFn(): Unit;
     fun testStructTraitFn(s: TraitTestingStruct): Int;
 }
 
 
 internal interface Runner_DiplomatTraitMethod_TesterTrait_testTraitFn: Callback {
-    fun invoke(ignored: Pointer?, x: Int ): Int
+    fun invoke(ignored: Pointer?, x: Int, y: Int, z: UByte ): Int
 }
 internal interface Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn: Callback {
     fun invoke(ignored: Pointer?): Unit
@@ -45,7 +45,7 @@ internal class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.B
     @JvmField
     internal var run_testTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn
         = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
-                override fun invoke(ignored: Pointer?, x: Int ): Int {
+                override fun invoke(ignored: Pointer?, x: Int, y: Int, z: UByte ): Int {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
@@ -95,8 +95,8 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             
             
             val testTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
-                override fun invoke(ignored: Pointer?, x: Int ): Int {
-                    return trt_obj.testTraitFn(x);
+                override fun invoke(ignored: Pointer?, x: Int, y: Int, z: UByte ): Int {
+                    return trt_obj.testTraitFn(x, y, z);
                 }
             }
             vtable.run_testTraitFn_callback = testTraitFn;


### PR DESCRIPTION
There was an error where mutli-arg callbacks and trait methods had the args concatenated together with no commas in between in the generated Kotlin code. This PR fixes this bug.