### PR TITLE
Fix slice args for traits and callbacks

### DIFF
--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1061,6 +1061,13 @@ returnVal.option() ?: return null
                                     format!("{}: {}Native", in_name, in_ty),
                                 )
                             }
+                            Type::Slice(_) => {
+                                // slices need to be passed as Slice type
+                                (
+                                    format!("PrimitiveArrayTools.get{}({})", in_ty, in_name),
+                                    format!("{}: Slice", in_name),
+                                )
+                            }
                             _ => (in_name.clone(), format!("{}: {}", in_name, in_ty)),
                         })
                         .unzip();
@@ -1497,6 +1504,13 @@ returnVal.option() ?: return null
                         (
                             format!("{}({})", in_ty, in_name),
                             format!("{}: {}Native", in_name, in_ty),
+                        )
+                    }
+                    Type::Slice(_) => {
+                        // slices need to be passed as Slice type
+                        (
+                            format!("PrimitiveArrayTools.get{}({})", in_ty, in_name),
+                            format!("{}: Slice", in_name),
                         )
                     }
                     _ => (in_name.clone(), format!("{}: {}", in_name, in_ty)),
@@ -2282,6 +2296,7 @@ mod test {
                     fn test_trait_fn(&self, x: i32, y: i32, z: u8) -> i32;
                     fn test_void_trait_fn(&self);
                     fn test_struct_trait_fn(&self, s: TraitTestingStruct) -> i32;
+                    fn test_with_slices(&mut self, a: &[u8], b: &[i16]) -> i32;
                 }
                 pub struct Wrapper {
                     cant_be_empty: bool,

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1061,12 +1061,16 @@ returnVal.option() ?: return null
                                     format!("{}: {}Native", in_name, in_ty),
                                 )
                             }
-                            Type::Slice(_) => {
+                            Type::Slice(Slice::Primitive(_, _)) => {
                                 // slices need to be passed as Slice type
+                                // and only primitive slices are allowed
                                 (
                                     format!("PrimitiveArrayTools.get{}({})", in_ty, in_name),
                                     format!("{}: Slice", in_name),
                                 )
+                            }
+                            Type::Slice(_) => {
+                                panic!("Non-primitive slices are not allowed as callback args")
                             }
                             _ => (in_name.clone(), format!("{}: {}", in_name, in_ty)),
                         })
@@ -1506,12 +1510,15 @@ returnVal.option() ?: return null
                             format!("{}: {}Native", in_name, in_ty),
                         )
                     }
-                    Type::Slice(_) => {
+                    Type::Slice(Slice::Primitive(_, _)) => {
                         // slices need to be passed as Slice type
                         (
                             format!("PrimitiveArrayTools.get{}({})", in_ty, in_name),
                             format!("{}: Slice", in_name),
                         )
+                    }
+                    Type::Slice(_) => {
+                        panic!("Non-primitive slices are not allowed as callback args")
                     }
                     _ => (in_name.clone(), format!("{}: {}", in_name, in_ty)),
                 })

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2320
+assertion_line: 2335
 expression: result
 ---
 package dev.gigapixel.somelib
@@ -15,6 +15,7 @@ interface TesterTrait {
     fun testTraitFn(x: Int, y: Int, z: UByte): Int;
     fun testVoidTraitFn(): Unit;
     fun testStructTraitFn(s: TraitTestingStruct): Int;
+    fun testWithSlices(a: UByteArray, b: ShortArray): Int;
 }
 
 
@@ -26,6 +27,9 @@ internal interface Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn: Callb
 }
 internal interface Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn: Callback {
     fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int
+}
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testWithSlices: Callback {
+    fun invoke(ignored: Pointer?, a: Slice, b: Slice ): Int
 }
 
 internal object TesterTrait_VTable_destructor: Callback {
@@ -63,9 +67,16 @@ internal class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.B
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
+    @JvmField
+    internal var run_testWithSlices_callback: Runner_DiplomatTraitMethod_TesterTrait_testWithSlices
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testWithSlices {
+                override fun invoke(ignored: Pointer?, a: Slice, b: Slice ): Int {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
-        return listOf("destructor", "size", "alignment", "run_testTraitFn_callback", "run_testVoidTraitFn_callback", "run_testStructTraitFn_callback")
+        return listOf("destructor", "size", "alignment", "run_testTraitFn_callback", "run_testVoidTraitFn_callback", "run_testStructTraitFn_callback", "run_testWithSlices_callback")
     }
 }
 
@@ -112,6 +123,12 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
                 }
             }
             vtable.run_testStructTraitFn_callback = testStructTraitFn;
+            val testWithSlices: Runner_DiplomatTraitMethod_TesterTrait_testWithSlices = object :  Runner_DiplomatTraitMethod_TesterTrait_testWithSlices {
+                override fun invoke(ignored: Pointer?, a: Slice, b: Slice ): Int {
+                    return trt_obj.testWithSlices(PrimitiveArrayTools.getUByteArray(a), PrimitiveArrayTools.getShortArray(b));
+                }
+            }
+            vtable.run_testWithSlices_callback = testWithSlices;
             val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
             native_wrapper.vtable = vtable;
             native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);


### PR DESCRIPTION
Slice args for callbacks and traits need to be converted to the expected Kotlin array type, from the `Slice` type.