### PR TITLE
Fix kotlin trait method and cb struct and enum returns

### DIFF
--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2335
+assertion_line: 2380
 expression: result
 ---
 package dev.gigapixel.somelib
@@ -16,6 +16,8 @@ interface TesterTrait {
     fun testVoidTraitFn(): Unit;
     fun testStructTraitFn(s: TraitTestingStruct): Int;
     fun testWithSlices(a: UByteArray, b: ShortArray): Int;
+    fun testStructReturn(): TraitTestingStruct;
+    fun testEnumReturn(): TraitTestingEnum;
 }
 
 
@@ -30,6 +32,12 @@ internal interface Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn: Cal
 }
 internal interface Runner_DiplomatTraitMethod_TesterTrait_testWithSlices: Callback {
     fun invoke(ignored: Pointer?, a: Slice, b: Slice ): Int
+}
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testStructReturn: Callback {
+    fun invoke(ignored: Pointer?): TraitTestingStructNative
+}
+internal interface Runner_DiplomatTraitMethod_TesterTrait_testEnumReturn: Callback {
+    fun invoke(ignored: Pointer?): Int
 }
 
 internal object TesterTrait_VTable_destructor: Callback {
@@ -74,9 +82,23 @@ internal class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.B
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
+    @JvmField
+    internal var run_testStructReturn_callback: Runner_DiplomatTraitMethod_TesterTrait_testStructReturn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructReturn {
+                override fun invoke(ignored: Pointer?): TraitTestingStructNative {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
+    @JvmField
+    internal var run_testEnumReturn_callback: Runner_DiplomatTraitMethod_TesterTrait_testEnumReturn
+        = object :  Runner_DiplomatTraitMethod_TesterTrait_testEnumReturn {
+                override fun invoke(ignored: Pointer?): Int {
+                    throw Exception("ERROR NOT IMPLEMENTED")
+                }
+            }
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
-        return listOf("destructor", "size", "alignment", "run_testTraitFn_callback", "run_testVoidTraitFn_callback", "run_testStructTraitFn_callback", "run_testWithSlices_callback")
+        return listOf("destructor", "size", "alignment", "run_testTraitFn_callback", "run_testVoidTraitFn_callback", "run_testStructTraitFn_callback", "run_testWithSlices_callback", "run_testStructReturn_callback", "run_testEnumReturn_callback")
     }
 }
 
@@ -129,6 +151,18 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
                 }
             }
             vtable.run_testWithSlices_callback = testWithSlices;
+            val testStructReturn: Runner_DiplomatTraitMethod_TesterTrait_testStructReturn = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructReturn {
+                override fun invoke(ignored: Pointer?): TraitTestingStructNative {
+                    return trt_obj.testStructReturn().nativeStruct;
+                }
+            }
+            vtable.run_testStructReturn_callback = testStructReturn;
+            val testEnumReturn: Runner_DiplomatTraitMethod_TesterTrait_testEnumReturn = object :  Runner_DiplomatTraitMethod_TesterTrait_testEnumReturn {
+                override fun invoke(ignored: Pointer?): Int {
+                    return trt_obj.testEnumReturn().toNative();
+                }
+            }
+            vtable.run_testEnumReturn_callback = testEnumReturn;
             val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
             native_wrapper.vtable = vtable;
             native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);

--- a/tool/templates/kotlin/Callback.kt.jinja
+++ b/tool/templates/kotlin/Callback.kt.jinja
@@ -1,6 +1,6 @@
 
 internal interface Runner_{{name}}: Callback {
-    fun invoke(lang_specific_context: Pointer?{% if native_input_params_and_types != "" %}, {{native_input_params_and_types}} {% endif %}): {{output_type}}
+    fun invoke(lang_specific_context: Pointer?{% if native_input_params_and_types != "" %}, {{native_input_params_and_types}} {% endif %}): {{native_output_type}}
 }
 
 internal class {{name}}_Native: Structure(), Structure.ByValue {
@@ -9,7 +9,7 @@ internal class {{name}}_Native: Structure(), Structure.ByValue {
     @JvmField
     internal var run_callback: Runner_{{name}}
         = object :  Runner_{{name}} {
-                override fun invoke(lang_specific_context: Pointer?{% if input_types != "" %}, {{native_input_params_and_types}} {% endif %}): {{output_type}} {
+                override fun invoke(lang_specific_context: Pointer?{% if input_types != "" %}, {{native_input_params_and_types}} {% endif %}): {{native_output_type}} {
                     throw Exception("Default callback runner -- should be replaced.")
                 }
             }
@@ -37,8 +37,8 @@ internal class {{name}} internal constructor (
         
         fun fromCallback(cb: ({{input_types}})->{{output_type}}): {{name}} {
             val callback: Runner_{{name}} = object :  Runner_{{name}} {
-                override fun invoke(lang_specific_context: Pointer?{% if input_types != "" %}, {{native_input_params_and_types}} {% endif %}): {{output_type}} {
-                    return cb({{native_input_names}});
+                override fun invoke(lang_specific_context: Pointer?{% if input_types != "" %}, {{native_input_params_and_types}} {% endif %}): {{native_output_type}} {
+                    return cb({{native_input_names}}){{return_modification}};
                 }
             }
             val cb_wrap = {{name}}_Native()

--- a/tool/templates/kotlin/Trait.kt.jinja
+++ b/tool/templates/kotlin/Trait.kt.jinja
@@ -21,7 +21,7 @@ interface {{trait_name}} {
 {% if !trait_methods.is_empty() -%}
     {%- for trait_method in trait_methods %}
 internal interface Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}}: Callback {
-    fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.output_type}}
+    fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.native_output_type}}
 }
     {%- endfor %}
 {%- endif %}
@@ -44,7 +44,7 @@ internal class DiplomatTrait_{{trait_name}}_VTable_Native: Structure(), Structur
     @JvmField
     internal var run_{{trait_method.name}}_callback: Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}}
         = object :  Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}} {
-                override fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.output_type}} {
+                override fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.native_output_type}} {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
@@ -84,8 +84,8 @@ internal class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
             {% if !trait_methods.is_empty() -%}
                 {%- for trait_method in trait_methods %}
             val {{trait_method.name}}: Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}} = object :  Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}} {
-                override fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.output_type}} {
-                    return trt_obj.{{trait_method.name}}({{trait_method.input_params}});
+                override fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.native_output_type}} {
+                    return trt_obj.{{trait_method.name}}({{trait_method.input_params}}){{trait_method.return_modification}};
                 }
             }
             vtable.run_{{trait_method.name}}_callback = {{trait_method.name}};


### PR DESCRIPTION
The Kotlin code generation for callback and trait methods that return enums and structs were missing the conversion code to transform the values into the Rust versions.