### PR TITLE
Fixing the trait struct cookie assignment in Kotlin

### DIFF
--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
@@ -109,7 +109,7 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             vtable.run_testStructTraitFn_callback = testStructTraitFn;
             val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
             native_wrapper.vtable = vtable;
-            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);
+            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(native_wrapper as Object);
             return DiplomatTrait_TesterTrait_Wrapper(native_wrapper);
         }
     }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
@@ -165,7 +165,7 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             vtable.run_testEnumReturn_callback = testEnumReturn;
             val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
             native_wrapper.vtable = vtable;
-            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);
+            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(native_wrapper as Object);
             return DiplomatTrait_TesterTrait_Wrapper(native_wrapper);
         }
     }

--- a/tool/templates/kotlin/Trait.kt.jinja
+++ b/tool/templates/kotlin/Trait.kt.jinja
@@ -93,7 +93,7 @@ internal class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
             {% endif -%}
             val native_wrapper = DiplomatTrait_{{trait_name}}_Wrapper_Native();
             native_wrapper.vtable = vtable;
-            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(vtable as Object);
+            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(native_wrapper as Object);
             return DiplomatTrait_{{trait_name}}_Wrapper(native_wrapper);
         }
     }


### PR DESCRIPTION
The `data` pointer passed to Rust for the trait struct objects in Kotlin corresponded to the vtable, but it should actually be the struct object itself. This bug crashed the JVM on GC.