### PR TITLE
Register finalizer for Kotlin Opaque

### DIFF
--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DataProvider.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DataProvider.kt
@@ -16,7 +16,7 @@ class DataProvider internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class DataProviderCleaner(val handle: Pointer, val lib: DataProviderLib) : Runnable {

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimal.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimal.kt
@@ -17,7 +17,7 @@ class FixedDecimal internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class FixedDecimalCleaner(val handle: Pointer, val lib: FixedDecimalLib) : Runnable {

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatter.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatter.kt
@@ -16,7 +16,7 @@ class FixedDecimalFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class FixedDecimalFormatterCleaner(val handle: Pointer, val lib: FixedDecimalFormatterLib) : Runnable {

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Locale.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Locale.kt
@@ -15,7 +15,7 @@ class Locale internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class LocaleCleaner(val handle: Pointer, val lib: LocaleLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
@@ -19,7 +19,7 @@ class AttrOpaque1 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class AttrOpaque1Cleaner(val handle: Pointer, val lib: AttrOpaque1Lib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque2.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque2.kt
@@ -14,7 +14,7 @@ class AttrOpaque2 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class AttrOpaque2Cleaner(val handle: Pointer, val lib: AttrOpaque2Lib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
@@ -27,7 +27,7 @@ class Float64Vec internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class Float64VecCleaner(val handle: Pointer, val lib: Float64VecLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIndexer.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIndexer.kt
@@ -15,7 +15,7 @@ class MyIndexer internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class MyIndexerCleaner(val handle: Pointer, val lib: MyIndexerLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterable.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterable.kt
@@ -16,7 +16,7 @@ class MyIterable internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 ): Iterable<MyIteratorIteratorItem> {
 
     internal class MyIterableCleaner(val handle: Pointer, val lib: MyIterableLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
@@ -21,7 +21,7 @@ class MyString internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class MyStringCleaner(val handle: Pointer, val lib: MyStringLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
@@ -22,7 +22,7 @@ class Opaque internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class OpaqueCleaner(val handle: Pointer, val lib: OpaqueLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueIterable.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueIterable.kt
@@ -15,7 +15,7 @@ class OpaqueIterable internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 ): Iterable<OpaqueIteratorIteratorItem> {
 
     internal class OpaqueIterableCleaner(val handle: Pointer, val lib: OpaqueIterableLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
@@ -22,7 +22,7 @@ class OpaqueMutexedString internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class OpaqueMutexedStringCleaner(val handle: Pointer, val lib: OpaqueMutexedStringLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
@@ -25,7 +25,7 @@ class OptionOpaque internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class OptionOpaqueCleaner(val handle: Pointer, val lib: OptionOpaqueLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaqueChar.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaqueChar.kt
@@ -15,7 +15,7 @@ class OptionOpaqueChar internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class OptionOpaqueCharCleaner(val handle: Pointer, val lib: OptionOpaqueCharLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
@@ -17,7 +17,7 @@ class OptionString internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class OptionStringCleaner(val handle: Pointer, val lib: OptionStringLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/RefListParameter.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/RefListParameter.kt
@@ -14,7 +14,7 @@ class RefListParameter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class RefListParameterCleaner(val handle: Pointer, val lib: RefListParameterLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
@@ -23,7 +23,7 @@ class ResultOpaque internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class ResultOpaqueCleaner(val handle: Pointer, val lib: ResultOpaqueLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Unnamespaced.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Unnamespaced.kt
@@ -16,7 +16,7 @@ class Unnamespaced internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class UnnamespacedCleaner(val handle: Pointer, val lib: UnnamespacedLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Utf16Wrap.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Utf16Wrap.kt
@@ -17,7 +17,7 @@ class Utf16Wrap internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class Utf16WrapCleaner(val handle: Pointer, val lib: Utf16WrapLib) : Runnable {

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_multiple_ref_args.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_multiple_ref_args.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2099
+assertion_line: 2174
 expression: result
 ---
 package dev.gigapixel.somelib;
@@ -20,7 +20,7 @@ class AnotherOpaque internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>
+    internal val selfEdges: List<Any>,
 )  {
 
     internal class AnotherOpaqueCleaner(val handle: Pointer, val lib: AnotherOpaqueLib) : Runnable {

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2261
+assertion_line: 2328
 expression: result
 ---
 package dev.gigapixel.somelib;
@@ -23,11 +23,17 @@ class MyOpaqueStruct internal constructor (
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
     internal val bEdges: List<Any>,
+    internal var finalizer_registered: Boolean = false,
 )  {
+    fun registerFinalizer() {
+        this.finalizer_registered = true
+    }
+
     @Override
     @SuppressWarnings("Finalize")
     fun finalize() {
-        lib.MyOpaqueStruct_destroy(handle)
+        if (finalizer_registered)
+            lib.MyOpaqueStruct_destroy(handle)
     }
 
     companion object {

--- a/tool/templates/kotlin/Opaque.kt.jinja
+++ b/tool/templates/kotlin/Opaque.kt.jinja
@@ -29,10 +29,14 @@ class {{type_name}} internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
-    internal val selfEdges: List<Any>{% if !lifetimes.is_empty() %},
+    internal val selfEdges: List<Any>,
+    {%- if !lifetimes.is_empty() %}
     {%- for lt in lifetimes %}
     internal val {{lt}}Edges: List<Any>,
     {%- endfor %}
+    {%- endif %}
+    {%- if use_finalizers_not_cleaners %}
+    internal var finalizer_registered: Boolean = false,
     {%- endif %}
 )
 {%- if special_methods.interfaces.is_empty() %} {% else %}: {% for interface in special_methods.interfaces %}
@@ -48,10 +52,15 @@ class {{type_name}} internal constructor (
         }
     }
     {%- else %}
+    fun registerFinalizer() {
+        this.finalizer_registered = true
+    }
+
     @Override
     @SuppressWarnings("Finalize")
     fun finalize() {
-        lib.{{dtor_abi_name}}(handle)
+        if (finalizer_registered)
+            lib.{{dtor_abi_name}}(handle)
     }
     {%- endif %}
 

--- a/tool/templates/kotlin/OpaqueReturn.kt.jinja
+++ b/tool/templates/kotlin/OpaqueReturn.kt.jinja
@@ -15,6 +15,8 @@ val returnOpaque = {{return_type_name}}(handle, selfEdges{%- if !borrows.is_empt
 {%- if is_owned %}
 {%- if !use_finalizers_not_cleaners %}
 CLEANER.register(returnOpaque, {{return_type_name}}.{{return_type_name}}Cleaner(handle, {{return_type_name}}.lib));
+{%- else %}
+returnOpaque.registerFinalizer()
 {%- endif %}
 {%- else -%}
 {%- endif %}


### PR DESCRIPTION
Register the finalizer for opaques so the Rust memory cleanup is only called if Rust has passed a `Box<Opaque>` back to Kotlin (and so Kotlin owns the handler and is responsible for telling Rust that the memory should be cleaned up). This is done with Cleaners already.