### PR TITLE
Update to strck 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
  "quote",
  "serde",
  "smallvec",
- "strck_ident",
+ "strck",
  "syn",
 ]
 
@@ -1361,17 +1361,10 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strck"
-version = "0.1.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be91090ded9d8f979d9fe921777342d37e769e0b6b7296843a7a38247240e917"
-
-[[package]]
-name = "strck_ident"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c3802b169b3858a44667f221c9a0b3136e6019936ea926fc97fbad8af77202"
+checksum = "42316e70da376f3d113a68d138a60d8a9883c604fe97942721ec2068dab13a9f"
 dependencies = [
- "strck",
  "unicode-ident",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,7 +32,7 @@ proc-macro2 = "1.0.27"
 serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 displaydoc = { version = "0.2", optional = true }
 smallvec = "1.9.0"
-strck_ident = { version = "0.1", features = ["rust"] }
+strck = { version = "1.0", features = ["ident"] }
 either = {version = "1.9.0", optional = true, default-features = false}
 
 [dev-dependencies]

--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -430,7 +430,7 @@ impl LifetimeLowerer for &ast::LifetimeEnv {
 
 #[cfg(test)]
 mod tests {
-    use strck_ident::IntoCk;
+    use strck::IntoCk;
 
     /// Convert a syntax tree into a [`TypeContext`].
     macro_rules! tcx {

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::ast::attrs::AttrInheritContext;
 use crate::{ast, Env};
 use core::fmt;
-use strck_ident::IntoCk;
+use strck::IntoCk;
 
 /// An error from lowering the AST to the HIR.
 #[derive(Debug)]

--- a/core/src/hir/mod.rs
+++ b/core/src/hir/mod.rs
@@ -28,4 +28,4 @@ pub use types::*;
 pub use lowering::{ErrorAndContext, ErrorContext, LoweringError};
 
 pub use crate::ast::{Docs, DocsUrlGenerator};
-pub use strck_ident::rust::{Ident, IdentBuf};
+pub use strck::ident::rust::{Ident, IdentBuf};


### PR DESCRIPTION
Quinn helpfully released a new version of strck that doesn't pull in an extra `strck_ident` crate, instead using feature flags internally. Reduces ICU4X's dep count.