### PR TITLE
Demo Owning Type Arguments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,4 @@ feature_tests/js/api/** linguist-generated=true
 feature_tests/js/docs/source/** linguist-generated=true
 feature_tests/kotlin/somelib/** linguist-generated=true
 feature_tests/js/api/** linguist-generated=true
+feature_tests/demo_gen/demo/** linguist-generated=true

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -20,7 +20,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "OptionString:DiplomatStr",
+                name: "Self:DiplomatStr",
                 type: "string",
                 typeUse: "string"
             }
@@ -35,7 +35,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Float64Vec:V",
+                name: "Self:V",
                 type: "Array<number>",
                 typeUse: "Array<number>"
             }
@@ -50,7 +50,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "MyString:V",
+                name: "Self:V",
                 type: "string",
                 typeUse: "string"
             }
@@ -65,7 +65,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "MyString:Foo",
+                name: "Foo",
                 type: "string",
                 typeUse: "string"
             }
@@ -89,7 +89,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Utf16Wrap:Input",
+                name: "Self:Input",
                 type: "string",
                 typeUse: "string"
             }

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -20,7 +20,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "DiplomatStr",
+                name: "OptionString:DiplomatStr",
                 type: "string",
                 typeUse: "string"
             }
@@ -35,7 +35,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "V",
+                name: "Float64Vec:V",
                 type: "Array<number>",
                 typeUse: "Array<number>"
             }
@@ -50,7 +50,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "V",
+                name: "MyString:V",
                 type: "string",
                 typeUse: "string"
             }
@@ -65,7 +65,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Foo",
+                name: "MyString:Foo",
                 type: "string",
                 typeUse: "string"
             }
@@ -89,7 +89,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Input",
+                name: "Utf16Wrap:Input",
                 type: "string",
                 typeUse: "string"
             }

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -159,10 +159,8 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
 
         // Not making this as part of the RenderTerminusContext because we want each evaluation to have a specific node,
         // which I find easier easier to represent as a parameter to each function than something like an updating the current node in the struct.
-        let mut root = MethodDependency::new(
-            self.get_constructor_js(type_name.clone(), method),
-            None,
-        );
+        let mut root =
+            MethodDependency::new(self.get_constructor_js(type_name.clone(), method), None);
 
         // And then we just treat the terminus as a regular constructor method:
         self.terminus_info.node_call_stack = self.evaluate_constructor(method, &mut root);
@@ -195,9 +193,11 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
         let attrs_default = attrs.unwrap_or_default();
         // This only works for enums, since otherwise we break the type into its component parts.
         let label = if attrs_default.input_cfg.label.is_empty() {
-            let owning_str = node.owning_param.as_ref().map(|p| {
-                format!("{}:", heck::AsUpperCamelCase(p))
-            }).unwrap_or_default();
+            let owning_str = node
+                .owning_param
+                .as_ref()
+                .map(|p| format!("{}:", heck::AsUpperCamelCase(p)))
+                .unwrap_or_default();
             format!(
                 "{}{}",
                 owning_str,
@@ -356,7 +356,7 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
         &mut self,
         op: &OpaqueDef,
         type_name: String,
-        param_name : String,
+        param_name: String,
         node: &mut MethodDependency,
     ) {
         let mut usable_constructor = false;

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -45,7 +45,7 @@ struct MethodDependency {
     params: Vec<ParamInfo>,
 
     /// The type name that this method belongs to. Currently used by [`OutParam`] for better default parameter names.
-    owning_type : String,
+    owning_type: String,
 }
 
 pub(super) struct RenderTerminusContext<'ctx, 'tcx> {
@@ -63,7 +63,7 @@ impl MethodDependency {
         MethodDependency {
             method_js,
             params: Vec::new(),
-            owning_type
+            owning_type,
         }
     }
 }
@@ -159,8 +159,10 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
 
         // Not making this as part of the RenderTerminusContext because we want each evaluation to have a specific node,
         // which I find easier easier to represent as a parameter to each function than something like an updating the current node in the struct.
-        let mut root =
-            MethodDependency::new(self.get_constructor_js(type_name.clone(), method), type_name.clone());
+        let mut root = MethodDependency::new(
+            self.get_constructor_js(type_name.clone(), method),
+            type_name.clone(),
+        );
 
         // And then we just treat the terminus as a regular constructor method:
         self.terminus_info.node_call_stack = self.evaluate_constructor(method, &mut root);
@@ -193,7 +195,12 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
         let attrs_default = attrs.unwrap_or_default();
         // This only works for enums, since otherwise we break the type into its component parts.
         let label = if attrs_default.input_cfg.label.is_empty() {
-            format!("{}:{}", heck::AsUpperCamelCase(node.owning_type.clone()), heck::AsUpperCamelCase(param_name.clone())).to_string()
+            format!(
+                "{}:{}",
+                heck::AsUpperCamelCase(node.owning_type.clone()),
+                heck::AsUpperCamelCase(param_name.clone())
+            )
+            .to_string()
         } else {
             attrs_default.input_cfg.label
         };
@@ -371,8 +378,10 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
                         self.relative_import_path.clone(),
                     ));
 
-                let mut child =
-                    MethodDependency::new(self.get_constructor_js(type_name.to_string(), method), type_name);
+                let mut child = MethodDependency::new(
+                    self.get_constructor_js(type_name.to_string(), method),
+                    type_name,
+                );
 
                 let call = self.evaluate_constructor(method, &mut child);
                 node.params.push(ParamInfo { js: call });

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -193,7 +193,7 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
         let attrs_default = attrs.unwrap_or_default();
         // This only works for enums, since otherwise we break the type into its component parts.
         let label = if attrs_default.input_cfg.label.is_empty() {
-            heck::AsUpperCamelCase(format!("{}:{}", node.owning_type, param_name.clone())).to_string()
+            format!("{}:{}", heck::AsUpperCamelCase(node.owning_type.clone()), heck::AsUpperCamelCase(param_name.clone())).to_string()
         } else {
             attrs_default.input_cfg.label
         };


### PR DESCRIPTION
Adds `FunctionOwningType:ParameterType` as a default way of labeling parameters.

Fixes #713, intended to fix #611 as well.