### PR TITLE
Avoid demo parameter collisions in function definitions

### DIFF
--- a/example/demo_gen/demo/FixedDecimal.mjs
+++ b/example/demo_gen/demo/FixedDecimal.mjs
@@ -1,5 +1,5 @@
 import { FixedDecimal } from "../../js/lib/api/index.mjs"
-export function toString() {
+export function toString(v) {
     var terminusArgs = arguments;
     return (function (...args) { return args[0].toString(...args.slice(1)) }).apply(
         null,

--- a/example/demo_gen/demo/FixedDecimal.mjs
+++ b/example/demo_gen/demo/FixedDecimal.mjs
@@ -1,13 +1,12 @@
 import { FixedDecimal } from "../../js/lib/api/index.mjs"
 export function toString(v) {
-    var terminusArgs = arguments;
     return (function (...args) { return args[0].toString(...args.slice(1)) }).apply(
         null,
         [
             FixedDecimal.new_.apply(
                 null,
                 [
-                    terminusArgs[0]
+                    v
                 ]
             )
         ]

--- a/example/demo_gen/demo/FixedDecimalFormatter.mjs
+++ b/example/demo_gen/demo/FixedDecimalFormatter.mjs
@@ -3,7 +3,7 @@ import { FixedDecimal } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
-export function formatWrite() {
+export function formatWrite(name, grouping_strategy, some_other_config, v) {
     var terminusArgs = arguments;
     return (function (...args) { return args[0].formatWrite(...args.slice(1)) }).apply(
         null,

--- a/example/demo_gen/demo/FixedDecimalFormatter.mjs
+++ b/example/demo_gen/demo/FixedDecimalFormatter.mjs
@@ -4,7 +4,6 @@ import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
 export function formatWrite(name, grouping_strategy, some_other_config, v) {
-    var terminusArgs = arguments;
     return (function (...args) { return args[0].formatWrite(...args.slice(1)) }).apply(
         null,
         [
@@ -14,7 +13,7 @@ export function formatWrite(name, grouping_strategy, some_other_config, v) {
                     Locale.new_.apply(
                         null,
                         [
-                            terminusArgs[0]
+                            name
                         ]
                     ),
                     DataProvider.newStatic.apply(
@@ -27,8 +26,8 @@ export function formatWrite(name, grouping_strategy, some_other_config, v) {
                     }).apply(
                         null,
                         [
-                            terminusArgs[1],
-                            terminusArgs[2]
+                            grouping_strategy,
+                            some_other_config
                         ]
                     )
                 ]
@@ -36,7 +35,7 @@ export function formatWrite(name, grouping_strategy, some_other_config, v) {
             FixedDecimal.new_.apply(
                 null,
                 [
-                    terminusArgs[3]
+                    v
                 ]
             )
         ]

--- a/feature_tests/demo_gen/demo/Float64Vec.mjs
+++ b/feature_tests/demo_gen/demo/Float64Vec.mjs
@@ -1,13 +1,12 @@
 import { Float64Vec } from "../../js/api/index.mjs"
 export function toString(v) {
-    var terminusArgs = arguments;
     return (function (...args) { return args[0].toString(...args.slice(1)) }).apply(
         null,
         [
             Float64Vec.newFromOwned.apply(
                 null,
                 [
-                    terminusArgs[0]
+                    v
                 ]
             )
         ]

--- a/feature_tests/demo_gen/demo/Float64Vec.mjs
+++ b/feature_tests/demo_gen/demo/Float64Vec.mjs
@@ -1,5 +1,5 @@
 import { Float64Vec } from "../../js/api/index.mjs"
-export function toString() {
+export function toString(v) {
     var terminusArgs = arguments;
     return (function (...args) { return args[0].toString(...args.slice(1)) }).apply(
         null,

--- a/feature_tests/demo_gen/demo/MyString.mjs
+++ b/feature_tests/demo_gen/demo/MyString.mjs
@@ -1,24 +1,22 @@
 import { MyString } from "../../js/api/index.mjs"
 export function getStr(v) {
-    var terminusArgs = arguments;
     return (function (...args) { return args[0].getStr }).apply(
         null,
         [
             MyString.new_.apply(
                 null,
                 [
-                    terminusArgs[0]
+                    v
                 ]
             )
         ]
     );
 }
 export function stringTransform(foo) {
-    var terminusArgs = arguments;
     return MyString.stringTransform.apply(
         null,
         [
-            terminusArgs[0]
+            foo
         ]
     );
 }

--- a/feature_tests/demo_gen/demo/MyString.mjs
+++ b/feature_tests/demo_gen/demo/MyString.mjs
@@ -1,5 +1,5 @@
 import { MyString } from "../../js/api/index.mjs"
-export function getStr() {
+export function getStr(v) {
     var terminusArgs = arguments;
     return (function (...args) { return args[0].getStr }).apply(
         null,
@@ -13,7 +13,7 @@ export function getStr() {
         ]
     );
 }
-export function stringTransform() {
+export function stringTransform(foo) {
     var terminusArgs = arguments;
     return MyString.stringTransform.apply(
         null,

--- a/feature_tests/demo_gen/demo/Opaque.mjs
+++ b/feature_tests/demo_gen/demo/Opaque.mjs
@@ -1,6 +1,5 @@
 import { Opaque } from "../../js/api/index.mjs"
 export function getDebugStr() {
-    var terminusArgs = arguments;
     return (function (...args) { return args[0].getDebugStr(...args.slice(1)) }).apply(
         null,
         [

--- a/feature_tests/demo_gen/demo/OptionString.mjs
+++ b/feature_tests/demo_gen/demo/OptionString.mjs
@@ -1,5 +1,5 @@
 import { OptionString } from "../../js/api/index.mjs"
-export function write() {
+export function write(diplomatStr) {
     var terminusArgs = arguments;
     return (function (...args) { return args[0].write(...args.slice(1)) }).apply(
         null,

--- a/feature_tests/demo_gen/demo/OptionString.mjs
+++ b/feature_tests/demo_gen/demo/OptionString.mjs
@@ -1,13 +1,12 @@
 import { OptionString } from "../../js/api/index.mjs"
 export function write(diplomatStr) {
-    var terminusArgs = arguments;
     return (function (...args) { return args[0].write(...args.slice(1)) }).apply(
         null,
         [
             OptionString.new_.apply(
                 null,
                 [
-                    terminusArgs[0]
+                    diplomatStr
                 ]
             )
         ]

--- a/feature_tests/demo_gen/demo/Utf16Wrap.mjs
+++ b/feature_tests/demo_gen/demo/Utf16Wrap.mjs
@@ -1,13 +1,12 @@
 import { Utf16Wrap } from "../../js/api/index.mjs"
 export function getDebugStr(input) {
-    var terminusArgs = arguments;
     return (function (...args) { return args[0].getDebugStr(...args.slice(1)) }).apply(
         null,
         [
             Utf16Wrap.fromUtf16.apply(
                 null,
                 [
-                    terminusArgs[0]
+                    input
                 ]
             )
         ]

--- a/feature_tests/demo_gen/demo/Utf16Wrap.mjs
+++ b/feature_tests/demo_gen/demo/Utf16Wrap.mjs
@@ -1,5 +1,5 @@
 import { Utf16Wrap } from "../../js/api/index.mjs"
-export function getDebugStr() {
+export function getDebugStr(input) {
     var terminusArgs = arguments;
     return (function (...args) { return args[0].getDebugStr(...args.slice(1)) }).apply(
         null,

--- a/tool/src/demo_gen/mod.rs
+++ b/tool/src/demo_gen/mod.rs
@@ -3,7 +3,10 @@
 //! Designed to work in conjunction with the JS backend.
 //!
 //! See docs/demo_gen.md for more.
-use std::{collections::{BTreeSet, HashMap}, fmt::Write};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt::Write,
+};
 
 use askama::{self, Template};
 use diplomat_core::hir::{BackendAttrSupport, TypeContext};

--- a/tool/src/demo_gen/mod.rs
+++ b/tool/src/demo_gen/mod.rs
@@ -3,7 +3,7 @@
 //! Designed to work in conjunction with the JS backend.
 //!
 //! See docs/demo_gen.md for more.
-use std::{collections::BTreeSet, fmt::Write};
+use std::{collections::{BTreeSet, HashMap}, fmt::Write};
 
 use askama::{self, Template};
 use diplomat_core::hir::{BackendAttrSupport, TypeContext};
@@ -200,6 +200,8 @@ pub(crate) fn run<'tcx>(
 
                         imports: BTreeSet::new(),
                     },
+
+                    out_param_collision: HashMap::new(),
 
                     relative_import_path: import_path.clone(),
                     module_name: module_name.clone(),

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use diplomat_core::hir::{
     self, DemoInfo, Method, OpaqueDef, StructDef, StructPath, TyPosition, Type, TypeContext,
@@ -171,6 +171,20 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
             self.module_name.clone(),
             self.relative_import_path.clone(),
         );
+
+        let mut param_collision_dict : HashMap<String, i32> = HashMap::new();
+
+        for out_param in &mut self.terminus_info.out_params {
+            if param_collision_dict.contains_key(&out_param.param_name) {
+                let num = param_collision_dict.get(&out_param.param_name).unwrap();
+                
+                out_param.param_name = format!("{}_{}", out_param.param_name, num);
+
+                param_collision_dict.insert(out_param.param_name.clone(), num + 1);
+            } else {
+                param_collision_dict.insert(out_param.param_name.clone(), 1);
+            }
+        }
 
         self.terminus_info.imports.insert(format);
     }

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -250,7 +250,7 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
         self.out_param_collision.insert(param_name, n);
 
         let out_param = OutParam {
-            param_name: p,
+            param_name: p.clone(),
             label,
             type_name: type_name.clone(),
             type_use,
@@ -261,7 +261,7 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
 
         let param_info = ParamInfo {
             // Grab arguments without having to name them
-            js: format!("terminusArgs[{}]", self.terminus_info.out_params.len() - 1),
+            js: p,
         };
 
         node.params.push(param_info);

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -260,7 +260,6 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
         self.terminus_info.out_params.push(out_param);
 
         let param_info = ParamInfo {
-            // Grab arguments without having to name them
             js: p,
         };
 

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -55,7 +55,7 @@ pub(super) struct RenderTerminusContext<'ctx, 'tcx> {
     pub terminus_info: TerminusInfo,
 
     /// To avoid similar parameter names while we're collecting [`OutParam`]s.
-    pub out_param_collision : HashMap<String, i32>,
+    pub out_param_collision: HashMap<String, i32>,
 
     pub relative_import_path: String,
     pub module_name: String,
@@ -242,7 +242,7 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
         let (p, n) = if self.out_param_collision.contains_key(&param_name) {
             let n = self.out_param_collision.get(&param_name).unwrap();
 
-            (format!("{param_name}_{n}"), n+1)
+            (format!("{param_name}_{n}"), n + 1)
         } else {
             (param_name.clone(), 1)
         };

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -259,9 +259,7 @@ impl<'ctx, 'tcx> RenderTerminusContext<'ctx, 'tcx> {
 
         self.terminus_info.out_params.push(out_param);
 
-        let param_info = ParamInfo {
-            js: p,
-        };
+        let param_info = ParamInfo { js: p };
 
         node.params.push(param_info);
     }

--- a/tool/templates/demo_gen/terminus.js.jinja
+++ b/tool/templates/demo_gen/terminus.js.jinja
@@ -3,7 +3,6 @@ export function {{function_name}}(
     {{param.param_name}}{% if typescript %}: {{param.type_name}}{% endif %}{% if !loop.last %}, {% endif %}
     {%- endfor -%}
 ){% if typescript %};{% else %} {
-    var terminusArgs = arguments;
     return {{node_call_stack|indent(4)}};
 }
 {%- endif %}

--- a/tool/templates/demo_gen/terminus.js.jinja
+++ b/tool/templates/demo_gen/terminus.js.jinja
@@ -1,7 +1,7 @@
 export function {{function_name}}(
-    {%- if typescript %}{%- for param in out_params -%}
+    {%- for param in out_params -%}
     {{param.param_name}}{% if typescript %}: {{param.type_name}}{% endif %}{% if !loop.last %}, {% endif %}
-    {%- endfor -%}{% endif -%}
+    {%- endfor -%}
 ){% if typescript %};{% else %} {
     var terminusArgs = arguments;
     return {{node_call_stack|indent(4)}};


### PR DESCRIPTION
Fixes #612, and removes `terminusArgs`, since now we can access parameter names directly.