### PR TITLE
fix js str decode

### DIFF
--- a/feature_tests/c/include/MyString.h
+++ b/feature_tests/c/include/MyString.h
@@ -29,6 +29,8 @@ void MyString_get_str(const MyString* self, DiplomatWrite* write);
 
 void MyString_string_transform(DiplomatStringView foo, DiplomatWrite* write);
 
+DiplomatStringView MyString_borrow(const MyString* self);
+
 
 void MyString_destroy(MyString* self);
 

--- a/feature_tests/cpp/include/MyString.d.hpp
+++ b/feature_tests/cpp/include/MyString.d.hpp
@@ -31,6 +31,8 @@ public:
 
   inline static diplomat::result<std::string, diplomat::Utf8Error> string_transform(std::string_view foo);
 
+  inline std::string_view borrow() const;
+
   inline const diplomat::capi::MyString* AsFFI() const;
   inline diplomat::capi::MyString* AsFFI();
   inline static const MyString* FromFFI(const diplomat::capi::MyString* ptr);

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -28,6 +28,8 @@ namespace capi {
     
     void MyString_string_transform(diplomat::capi::DiplomatStringView foo, diplomat::capi::DiplomatWrite* write);
     
+    diplomat::capi::DiplomatStringView MyString_borrow(const diplomat::capi::MyString* self);
+    
     
     void MyString_destroy(MyString* self);
     
@@ -75,6 +77,11 @@ inline diplomat::result<std::string, diplomat::Utf8Error> MyString::string_trans
   diplomat::capi::MyString_string_transform({foo.data(), foo.size()},
     &write);
   return diplomat::Ok<std::string>(std::move(output));
+}
+
+inline std::string_view MyString::borrow() const {
+  auto result = diplomat::capi::MyString_borrow(this->AsFFI());
+  return std::string_view(result.data, result.len);
 }
 
 inline const diplomat::capi::MyString* MyString::AsFFI() const {

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -61,6 +61,13 @@ final class MyString implements ffi.Finalizable {
     _MyString_string_transform(foo._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
+
+  String borrow() {
+    // This lifetime edge depends on lifetimes: 'a
+    core.List<Object> aEdges = [this];
+    final result = _MyString_borrow(_ffi);
+    return result._toDart(aEdges);
+  }
 }
 
 @meta.RecordUse()
@@ -102,3 +109,8 @@ external void _MyString_get_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Op
 @ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_string_transform')
 // ignore: non_constant_identifier_names
 external void _MyString_string_transform(_SliceUtf8 foo, ffi.Pointer<ffi.Opaque> write);
+
+@meta.RecordUse()
+@ffi.Native<_SliceUtf8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_borrow')
+// ignore: non_constant_identifier_names
+external _SliceUtf8 _MyString_borrow(ffi.Pointer<ffi.Opaque> self);

--- a/feature_tests/js/api/BorrowedFields.mjs
+++ b/feature_tests/js/api/BorrowedFields.mjs
@@ -83,11 +83,11 @@ export class BorrowedFields {
         }
         var structObj = {};
         const aDeref = ptr;
-        structObj.a = new diplomatRuntime.DiplomatSliceStr(wasm, aDeref,  "string16", aEdges);
+        structObj.a = new diplomatRuntime.DiplomatSliceStr(wasm, aDeref,  "string16", aEdges).getValue();
         const bDeref = ptr + 8;
-        structObj.b = new diplomatRuntime.DiplomatSliceStr(wasm, bDeref,  "string8", aEdges);
+        structObj.b = new diplomatRuntime.DiplomatSliceStr(wasm, bDeref,  "string8", aEdges).getValue();
         const cDeref = ptr + 16;
-        structObj.c = new diplomatRuntime.DiplomatSliceStr(wasm, cDeref,  "string8", aEdges);
+        structObj.c = new diplomatRuntime.DiplomatSliceStr(wasm, cDeref,  "string8", aEdges).getValue();
 
         return new BorrowedFields(structObj, internalConstructor);
     }

--- a/feature_tests/js/api/BorrowedFieldsReturning.mjs
+++ b/feature_tests/js/api/BorrowedFieldsReturning.mjs
@@ -52,7 +52,7 @@ export class BorrowedFieldsReturning {
         }
         var structObj = {};
         const bytesDeref = ptr;
-        structObj.bytes = new diplomatRuntime.DiplomatSliceStr(wasm, bytesDeref,  "string8", aEdges);
+        structObj.bytes = new diplomatRuntime.DiplomatSliceStr(wasm, bytesDeref,  "string8", aEdges).getValue();
 
         return new BorrowedFieldsReturning(structObj, internalConstructor);
     }

--- a/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
+++ b/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
@@ -85,11 +85,11 @@ export class BorrowedFieldsWithBounds {
         }
         var structObj = {};
         const fieldADeref = ptr;
-        structObj.fieldA = new diplomatRuntime.DiplomatSliceStr(wasm, fieldADeref,  "string16", aEdges);
+        structObj.fieldA = new diplomatRuntime.DiplomatSliceStr(wasm, fieldADeref,  "string16", aEdges).getValue();
         const fieldBDeref = ptr + 8;
-        structObj.fieldB = new diplomatRuntime.DiplomatSliceStr(wasm, fieldBDeref,  "string8", bEdges);
+        structObj.fieldB = new diplomatRuntime.DiplomatSliceStr(wasm, fieldBDeref,  "string8", bEdges).getValue();
         const fieldCDeref = ptr + 16;
-        structObj.fieldC = new diplomatRuntime.DiplomatSliceStr(wasm, fieldCDeref,  "string8", cEdges);
+        structObj.fieldC = new diplomatRuntime.DiplomatSliceStr(wasm, fieldCDeref,  "string8", cEdges).getValue();
 
         return new BorrowedFieldsWithBounds(structObj, internalConstructor);
     }

--- a/feature_tests/js/api/MyString.d.ts
+++ b/feature_tests/js/api/MyString.d.ts
@@ -19,4 +19,6 @@ export class MyString {
     get str(): string;
 
     static stringTransform(foo: string): string;
+
+    borrow(): string;
 }

--- a/feature_tests/js/api/MyString.mjs
+++ b/feature_tests/js/api/MyString.mjs
@@ -141,4 +141,21 @@ export class MyString {
             write.free();
         }
     }
+
+    borrow() {
+        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 8, 4, false);
+        
+        // This lifetime edge depends on lifetimes 'a
+        let aEdges = [this];
+        
+        const result = wasm.MyString_borrow(diplomatReceive.buffer, this.ffiValue);
+    
+        try {
+            return new diplomatRuntime.DiplomatSliceStr(wasm, diplomatReceive.buffer,  "string8", aEdges).getValue();
+        }
+        
+        finally {
+            diplomatReceive.free();
+        }
+    }
 }

--- a/feature_tests/js/api/OpaqueMutexedString.mjs
+++ b/feature_tests/js/api/OpaqueMutexedString.mjs
@@ -109,7 +109,7 @@ export class OpaqueMutexedString {
         const result = wasm.OpaqueMutexedString_dummy_str(diplomatReceive.buffer, this.ffiValue);
     
         try {
-            return new diplomatRuntime.DiplomatSliceStr(wasm, diplomatReceive.buffer,  "string8", aEdges);
+            return new diplomatRuntime.DiplomatSliceStr(wasm, diplomatReceive.buffer,  "string8", aEdges).getValue();
         }
         
         finally {

--- a/feature_tests/js/api/OptionString.mjs
+++ b/feature_tests/js/api/OptionString.mjs
@@ -75,7 +75,7 @@ export class OptionString {
             if (!diplomatReceive.resultFlag) {
                 return null;
             }
-            return new diplomatRuntime.DiplomatSliceStr(wasm, diplomatReceive.buffer,  "string8", aEdges);
+            return new diplomatRuntime.DiplomatSliceStr(wasm, diplomatReceive.buffer,  "string8", aEdges).getValue();
         }
         
         finally {

--- a/feature_tests/js/api/Utf16Wrap.mjs
+++ b/feature_tests/js/api/Utf16Wrap.mjs
@@ -71,7 +71,7 @@ export class Utf16Wrap {
         const result = wasm.Utf16Wrap_borrow_cont(diplomatReceive.buffer, this.ffiValue);
     
         try {
-            return new diplomatRuntime.DiplomatSliceStr(wasm, diplomatReceive.buffer,  "string16", aEdges);
+            return new diplomatRuntime.DiplomatSliceStr(wasm, diplomatReceive.buffer,  "string16", aEdges).getValue();
         }
         
         finally {

--- a/feature_tests/js/test/slices-ts.mjs
+++ b/feature_tests/js/test/slices-ts.mjs
@@ -8,6 +8,10 @@ test("String List", (t) => {
     let str = MyString.newFromFirst(["This", "is", "a", "test."]);
     t.is(str.str, "This");
 });
+test("MyString borrow", (t) => {
+    let str = MyString.new_("This is a test.");
+    t.is(str.borrow(), "This is a test.");
+});
 test("Float64Vec", (t) => {
     let input = [1, 2, 3, 4, 5];
     let data = Float64Vec.newIsize(input);

--- a/feature_tests/js/test/slices-ts.mts
+++ b/feature_tests/js/test/slices-ts.mts
@@ -12,6 +12,11 @@ test("String List", (t) => {
   t.is(str.str, "This");
 });
 
+test("MyString borrow", (t) => {
+  let str = MyString.new_("This is a test.");
+  t.is(str.borrow(), "This is a test.");
+});
+
 test("Float64Vec", (t) => {
   let input = [1, 2, 3, 4, 5];
   let data = Float64Vec.newIsize(input);

--- a/feature_tests/js/test/slices.mjs
+++ b/feature_tests/js/test/slices.mjs
@@ -1,18 +1,23 @@
-import test from 'ava';
-import { MyString, Float64Vec} from "diplomat-wasm-js-feature-tests";
+import test from "ava";
+import { MyString, Float64Vec } from "diplomat-wasm-js-feature-tests";
 
 test("MyString functionality", (t) => {
-    let str = MyString.new_("This is a test value.");
-    t.is(str.str, "This is a test value.");
+  let str = MyString.new_("This is a test value.");
+  t.is(str.str, "This is a test value.");
 });
 
 test("String List", (t) => {
-	let str = MyString.newFromFirst(["This", "is", "a", "test."]);
-	t.is(str.str, "This");
+  let str = MyString.newFromFirst(["This", "is", "a", "test."]);
+  t.is(str.str, "This");
+});
+
+test("MyString borrow", (t) => {
+  let str = MyString.new_("This is a test.");
+  t.is(str.borrow(), "This is a test.");
 });
 
 test("Float64Vec", (t) => {
-    let input = [1, 2, 3, 4, 5];
-    let data = Float64Vec.newIsize(input);
-    t.deepEqual(data.borrow(), input);
+  let input = [1, 2, 3, 4, 5];
+  let data = Float64Vec.newIsize(input);
+  t.deepEqual(data.borrow(), input);
 });

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
@@ -15,6 +15,7 @@ internal interface MyStringLib: Library {
     fun MyString_set_str(handle: Pointer, newStr: Slice): Unit
     fun MyString_get_str(handle: Pointer, write: Pointer): Unit
     fun MyString_string_transform(foo: Slice, write: Pointer): Unit
+    fun MyString_borrow(handle: Pointer): Slice
 }
 
 class MyString internal constructor (
@@ -104,6 +105,12 @@ class MyString internal constructor (
         
         val returnString = DW.writeToString(write)
         return returnString
+    }
+    
+    fun borrow(): String {
+        
+        val returnVal = lib.MyString_borrow(handle);
+            return PrimitiveArrayTools.getUtf8(returnVal)
     }
 
 }

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -40,6 +40,10 @@ mod ffi {
             let _ = foo;
             let _ = write;
         }
+
+        pub fn borrow<'a>(&'a self) -> DiplomatStrSlice<'a> {
+            AsRef::<[u8]>::as_ref(&self.0).into()
+        }
     }
 
     #[diplomat::opaque]

--- a/tool/src/js/converter.rs
+++ b/tool/src/js/converter.rs
@@ -244,7 +244,7 @@ impl<'jsctx, 'tcx> TyGenContext<'jsctx, 'tcx> {
                     )
                     .into(),
                     hir::Slice::Str(_, encoding) => format!(
-                        r#"new diplomatRuntime.DiplomatSliceStr(wasm, {variable_name},  "string{}", {edges})"#,
+                        r#"new diplomatRuntime.DiplomatSliceStr(wasm, {variable_name},  "string{}", {edges}).getValue()"#,
                         match encoding {
                             hir::StringEncoding::Utf8 | hir::StringEncoding::UnvalidatedUtf8 => 8,
                             hir::StringEncoding::UnvalidatedUtf16 => 16,
@@ -257,7 +257,7 @@ impl<'jsctx, 'tcx> TyGenContext<'jsctx, 'tcx> {
                         // We basically iterate through and read each string into the array.
                         // TODO: Need a test for this.
                         format!(
-                            r#"new diplomatRuntime.DiplomatSliceStrings(wasm, {variable_name}, "string{}", {edges})"#,
+                            r#"new diplomatRuntime.DiplomatSliceStrings(wasm, {variable_name}, "string{}", {edges}).getValue()"#,
                             match encoding {
                                 hir::StringEncoding::Utf8
                                 | hir::StringEncoding::UnvalidatedUtf8 => 8,


### PR DESCRIPTION
I uncovered another bug in the js backend, while I was working on a library using diplomat. 
The bug is that methods returning string slices return `DiplomatStrSlice` class instead of a js `string`. It's the same issue that affected #722 , and the fix is the same.