### PR TITLE
Kotlin result

### DIFF
--- a/example/kotlin/somelib/src/jmh/kotlin/dev/diplomattest/somelib/ICU4XFixedDecimalFormatter.kt
+++ b/example/kotlin/somelib/src/jmh/kotlin/dev/diplomattest/somelib/ICU4XFixedDecimalFormatter.kt
@@ -8,35 +8,35 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Benchmark)
 internal open class ICU4XFixedDecimalFormatterBench {
-    private val locale = ICU4XLocale.new_("en")
-    private val provider = ICU4XDataProvider.newStatic()
-    private val options = ICU4XFixedDecimalFormatterOptions.default_()
-    private val formatter = ICU4XFixedDecimalFormatter.tryNew(locale, provider, options).wrapErrAndThrow()
-    private val decimal = ICU4XFixedDecimal.new_(123)
+    private val locale = Locale.new_("en")
+    private val provider = DataProvider.newStatic()
+    private val options = FixedDecimalFormatterOptions.default_()
+    private val formatter = FixedDecimalFormatter.tryNew(locale, provider, options).getOrThrow()
+    private val decimal = FixedDecimal.new_(123)
 
     @Benchmark
     fun benchLocale(bh: Blackhole) {
-        bh.consume(ICU4XLocale.new_("en"))
+        bh.consume(Locale.new_("en"))
     }
 
     @Benchmark
     fun benchProvider(bh: Blackhole) {
-        bh.consume(ICU4XDataProvider.newStatic())
+        bh.consume(DataProvider.newStatic())
     }
 
     @Benchmark
     fun benchOptions(bh: Blackhole) {
-        bh.consume(ICU4XFixedDecimalFormatterOptions.default_())
+        bh.consume(FixedDecimalFormatterOptions.default_())
     }
 
     @Benchmark
     fun benchDecimal(bh: Blackhole) {
-        bh.consume(ICU4XFixedDecimal.new_(123))
+        bh.consume(FixedDecimal.new_(123))
     }
 
     @Benchmark
     fun benchFormatter(bh: Blackhole) {
-        bh.consume(ICU4XFixedDecimalFormatter.tryNew(locale, provider, options).wrapErrAndThrow())
+        bh.consume(FixedDecimalFormatter.tryNew(locale, provider, options).getOrThrow())
     }
 
     @Benchmark

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DataProvider.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DataProvider.kt
@@ -46,13 +46,13 @@ class DataProvider internal constructor (
         
         /** This exists as a regression test for https://github.com/rust-diplomat/diplomat/issues/155
         */
-        fun returnsResult(): Res<Unit, Unit> {
+        fun returnsResult(): Result<Unit> {
             
             val returnVal = lib.icu4x_DataProvider_returns_result_mv1();
             if (returnVal.isOk == 1.toByte()) {
                 return Unit.ok()
             } else {
-                return Err(Unit)
+                return Unit.err()
             }
         }
     }

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimal.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimal.kt
@@ -58,7 +58,7 @@ class FixedDecimal internal constructor (
     *
     *See the [Rust documentation for `write_to`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.write_to) for more information.
     */
-    fun toString_(): Res<String, Unit> {
+    fun toString_(): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_FixedDecimal_to_string_mv1(handle, write);
         if (returnVal.isOk == 1.toByte()) {
@@ -66,7 +66,7 @@ class FixedDecimal internal constructor (
             val returnString = DW.writeToString(write)
             return returnString.ok()
         } else {
-            return Err(Unit)
+            return Unit.err()
         }
     }
 

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatter.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatter.kt
@@ -36,7 +36,7 @@ class FixedDecimalFormatter internal constructor (
         *
         *See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new) for more information.
         */
-        fun tryNew(locale: Locale, provider: DataProvider, options: FixedDecimalFormatterOptions): Res<FixedDecimalFormatter, Unit> {
+        fun tryNew(locale: Locale, provider: DataProvider, options: FixedDecimalFormatterOptions): Result<FixedDecimalFormatter> {
             
             val returnVal = lib.icu4x_FixedDecimalFormatter_try_new_mv1(locale.handle, provider.handle, options.nativeStruct);
             if (returnVal.isOk == 1.toByte()) {
@@ -46,7 +46,7 @@ class FixedDecimalFormatter internal constructor (
                 CLEANER.register(returnOpaque, FixedDecimalFormatter.FixedDecimalFormatterCleaner(handle, FixedDecimalFormatter.lib));
                 return returnOpaque.ok()
             } else {
-                return Err(Unit)
+                return Unit.err()
             }
         }
     }

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -339,12 +339,12 @@ fun <T, E> Res<T, E>.wrapErrAndThrow(): T {
     }
 }
 
-fun <T, E> T.ok(): Res<T, E> {
-    return Ok(this)
+fun <T> T.ok(): Result<T> {
+    return Result.success(this)
 }
 
-fun <T, E> E.err(): Res<T, E> {
-    return Err(this)
+fun <T, E> E.err(): Result<T> {
+    return Result.failure(RuntimeException("Received error $this"))
 }
 
 internal class ResultPointerUnitUnion: Union() {

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -320,30 +320,12 @@ class Slice: Structure(), Structure.ByValue {
     }
 }
 
-sealed interface Res<T, E>
-class Ok<T, E>(val inner: T) : Res<T, E>
-class Err<T, E>(val inner: E) : Res<T, E>
 
-
-fun <T> Res<T, Throwable>.reThrow(): T {
-    return when (this) {
-        is Ok -> this.inner
-        is Err -> throw this.inner
-    }
-}
-
-fun <T, E> Res<T, E>.wrapErrAndThrow(): T {
-    return when (this) {
-        is Ok -> this.inner
-        is Err -> throw RuntimeException("Received error ${this.inner}")
-    }
-}
-
-fun <T> T.ok(): Result<T> {
+internal fun <T> T.ok(): Result<T> {
     return Result.success(this)
 }
 
-fun <T, E> E.err(): Result<T> {
+internal fun <T, E> E.err(): Result<T> {
     return Result.failure(RuntimeException("Received error $this"))
 }
 

--- a/example/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/ICU4XFixedDecimalFormatterTest.kt
+++ b/example/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/ICU4XFixedDecimalFormatterTest.kt
@@ -9,7 +9,7 @@ class ICU4XFixedDecimalFormatterTest {
         val locale = Locale.new_("en")
         val provider = DataProvider.newStatic()
         val options = FixedDecimalFormatterOptions.default_()
-        val formatter = FixedDecimalFormatter.tryNew(locale, provider, options).wrapErrAndThrow()
+        val formatter = FixedDecimalFormatter.tryNew(locale, provider, options).getOrThrow()
         val decimal: FixedDecimal = FixedDecimal.new_(123)
         val formatted = formatter.formatWrite(decimal)
         assertEquals(formatted, "123")

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -339,12 +339,12 @@ fun <T, E> Res<T, E>.wrapErrAndThrow(): T {
     }
 }
 
-fun <T, E> T.ok(): Res<T, E> {
-    return Ok(this)
+fun <T> T.ok(): Result<T> {
+    return Result.success(this)
 }
 
-fun <T, E> E.err(): Res<T, E> {
-    return Err(this)
+fun <T, E> E.err(): Result<T> {
+    return Result.failure(RuntimeException("Received error $this"))
 }
 
 internal class ResultIntUnitUnion: Union() {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -320,30 +320,12 @@ class Slice: Structure(), Structure.ByValue {
     }
 }
 
-sealed interface Res<T, E>
-class Ok<T, E>(val inner: T) : Res<T, E>
-class Err<T, E>(val inner: E) : Res<T, E>
 
-
-fun <T> Res<T, Throwable>.reThrow(): T {
-    return when (this) {
-        is Ok -> this.inner
-        is Err -> throw this.inner
-    }
-}
-
-fun <T, E> Res<T, E>.wrapErrAndThrow(): T {
-    return when (this) {
-        is Ok -> this.inner
-        is Err -> throw RuntimeException("Received error ${this.inner}")
-    }
-}
-
-fun <T> T.ok(): Result<T> {
+internal fun <T> T.ok(): Result<T> {
     return Result.success(this)
 }
 
-fun <T, E> E.err(): Result<T> {
+internal fun <T, E> E.err(): Result<T> {
     return Result.failure(RuntimeException("Received error $this"))
 }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
@@ -58,7 +58,7 @@ class MyStruct internal constructor (
             return returnStruct
         }
         
-        fun returnsZstResult(): Res<Unit, MyZst> {
+        fun returnsZstResult(): Result<Unit> {
             
             val returnVal = lib.MyStruct_returns_zst_result();
             if (returnVal.isOk == 1.toByte()) {
@@ -68,7 +68,7 @@ class MyStruct internal constructor (
             }
         }
         
-        fun failsZstResult(): Res<Unit, MyZst> {
+        fun failsZstResult(): Result<Unit> {
             
             val returnVal = lib.MyStruct_fails_zst_result();
             if (returnVal.isOk == 1.toByte()) {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
@@ -43,7 +43,7 @@ class OptionString internal constructor (
         }
     }
     
-    fun write(): Res<String, Unit> {
+    fun write(): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.OptionString_write(handle, write);
         if (returnVal.isOk == 1.toByte()) {
@@ -51,7 +51,7 @@ class OptionString internal constructor (
             val returnString = DW.writeToString(write)
             return returnString.ok()
         } else {
-            return Err(Unit)
+            return Unit.err()
         }
     }
     

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
@@ -36,7 +36,7 @@ class ResultOpaque internal constructor (
         internal val libClass: Class<ResultOpaqueLib> = ResultOpaqueLib::class.java
         internal val lib: ResultOpaqueLib = Native.load("somelib", libClass)
         
-        fun new_(i: Int): Res<ResultOpaque, ErrorEnum> {
+        fun new_(i: Int): Result<ResultOpaque> {
             
             val returnVal = lib.ResultOpaque_new(i);
             if (returnVal.isOk == 1.toByte()) {
@@ -50,7 +50,7 @@ class ResultOpaque internal constructor (
             }
         }
         
-        fun newFailingFoo(): Res<ResultOpaque, ErrorEnum> {
+        fun newFailingFoo(): Result<ResultOpaque> {
             
             val returnVal = lib.ResultOpaque_new_failing_foo();
             if (returnVal.isOk == 1.toByte()) {
@@ -64,7 +64,7 @@ class ResultOpaque internal constructor (
             }
         }
         
-        fun newFailingBar(): Res<ResultOpaque, ErrorEnum> {
+        fun newFailingBar(): Result<ResultOpaque> {
             
             val returnVal = lib.ResultOpaque_new_failing_bar();
             if (returnVal.isOk == 1.toByte()) {
@@ -78,7 +78,7 @@ class ResultOpaque internal constructor (
             }
         }
         
-        fun newFailingUnit(): Res<ResultOpaque, Unit> {
+        fun newFailingUnit(): Result<ResultOpaque> {
             
             val returnVal = lib.ResultOpaque_new_failing_unit();
             if (returnVal.isOk == 1.toByte()) {
@@ -88,11 +88,11 @@ class ResultOpaque internal constructor (
                 CLEANER.register(returnOpaque, ResultOpaque.ResultOpaqueCleaner(handle, ResultOpaque.lib));
                 return returnOpaque.ok()
             } else {
-                return Err(Unit)
+                return Unit.err()
             }
         }
         
-        fun newFailingStruct(i: Int): Res<ResultOpaque, ErrorStruct> {
+        fun newFailingStruct(i: Int): Result<ResultOpaque> {
             
             val returnVal = lib.ResultOpaque_new_failing_struct(i);
             if (returnVal.isOk == 1.toByte()) {
@@ -108,7 +108,7 @@ class ResultOpaque internal constructor (
             }
         }
         
-        fun newInErr(i: Int): Res<Unit, ResultOpaque> {
+        fun newInErr(i: Int): Result<Unit> {
             
             val returnVal = lib.ResultOpaque_new_in_err(i);
             if (returnVal.isOk == 1.toByte()) {
@@ -122,17 +122,17 @@ class ResultOpaque internal constructor (
             }
         }
         
-        fun newInt(i: Int): Res<Int, Unit> {
+        fun newInt(i: Int): Result<Int> {
             
             val returnVal = lib.ResultOpaque_new_int(i);
             if (returnVal.isOk == 1.toByte()) {
                 return (returnVal.union.ok).ok()
             } else {
-                return Err(Unit)
+                return Unit.err()
             }
         }
         
-        fun newInEnumErr(i: Int): Res<ErrorEnum, ResultOpaque> {
+        fun newInEnumErr(i: Int): Result<ErrorEnum> {
             
             val returnVal = lib.ResultOpaque_new_in_enum_err(i);
             if (returnVal.isOk == 1.toByte()) {

--- a/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/ResultOpaqueTest.kt
+++ b/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/ResultOpaqueTest.kt
@@ -9,28 +9,29 @@ class ResultOpaqueTest {
     @Test
     fun testOpaqueResult() {
         val result = ResultOpaque.new_(10)
-        val success = result.wrapErrAndThrow()
+        val success = result.getOrThrow()
         success.assertInteger(10)
 
-        val result2 = ResultOpaque.newFailingBar()
-        when (result2) {
-            is Ok -> assert(false)
-            is Err -> assertEquals(result2.inner, ErrorEnum.Bar)
-        }
+        val resultOpaque2 = ResultOpaque.newFailingBar()
+        assert(resultOpaque2.isFailure)
+
+        val result2 = resultOpaque2.exceptionOrNull()?.message
+        val shouldRes: Result<ResultOpaque> = ErrorEnum.Bar.err()
+
+        assertEquals(result2, shouldRes.exceptionOrNull()?.message)
 
 
-        val result3 = ResultOpaque.newFailingFoo()
+        val resultOpaque3 = ResultOpaque.newFailingFoo()
+        assert(resultOpaque3.isFailure)
+        val result3 = resultOpaque3.exceptionOrNull()?.message
+        val shouldRes3: Result<ResultOpaque> = ErrorEnum.Foo.err()
+        assertEquals(result3, shouldRes3.exceptionOrNull()?.message)
 
-        when (result3) {
-            is Ok -> assert(false)
-            is Err -> assertEquals(result3.inner, ErrorEnum.Foo)
-        }
-
-        val result4 = ResultOpaque.newInErr(8)
-
-        when (result4) {
-            is Ok -> assert(false)
-            is Err -> result4.inner.assertInteger(8)
-        }
+        val resultOpaque4 = ResultOpaque.newInErr(8)
+        assert(resultOpaque4.isFailure)
+        val result4 = resultOpaque4.exceptionOrNull()?.message
+        val assertion = result4?.startsWith("Received error dev.diplomattest.somelib.ResultOpaque", true)
+        assert(assertion == true)
     }
+
 }

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -273,12 +273,8 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
     fn gen_return_type_name(&self, result_ty: &ReturnType) -> Cow<'cx, str> {
         match *result_ty {
             ReturnType::Infallible(ref success) => self.gen_infallible_return_type_name(success),
-            ReturnType::Fallible(ref ok, ref err) => {
+            ReturnType::Fallible(ref ok, _) => {
                 let ok_type = self.gen_infallible_return_type_name(ok);
-                let err_type = err
-                    .as_ref()
-                    .map(|err| self.gen_type_name(err, None))
-                    .unwrap_or_else(|| "Unit".into());
                 format!("Result<{ok_type}>").into()
             }
             ReturnType::Nullable(ref success) => self

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -279,7 +279,7 @@ impl<'a, 'cx> TyGenContext<'a, 'cx> {
                     .as_ref()
                     .map(|err| self.gen_type_name(err, None))
                     .unwrap_or_else(|| "Unit".into());
-                format!("Res<{ok_type}, {err_type}>").into()
+                format!("Result<{ok_type}>").into()
             }
             ReturnType::Nullable(ref success) => self
                 .formatter
@@ -864,7 +864,7 @@ val intermediateOption = {val_name}.option() ?: return null
                             use_finalizers_not_cleaners,
                         )
                     })
-                    .unwrap_or_else(|| "return Err(Unit)".into());
+                    .unwrap_or_else(|| "return Unit.err()".into());
 
                 #[derive(Template)]
                 #[template(path = "kotlin/ResultReturn.kt.jinja", escape = "none")]

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -1,6 +1,5 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2150
 expression: struct_code
 ---
 package dev.gigapixel.somelib
@@ -154,23 +153,23 @@ class MyNativeStruct internal constructor (
                 return PrimitiveArrayTools.getUByteArray(returnVal)
         }
         
-        fun booleanResult(): Res<Boolean, Unit> {
+        fun booleanResult(): Result<Boolean> {
             
             val returnVal = lib.MyNativeStruct_boolean_result();
             if (returnVal.isOk == 1.toByte()) {
                 return (returnVal.union.ok > 0).ok()
             } else {
-                return Err(Unit)
+                return Unit.err()
             }
         }
         
-        fun ubyteResult(): Res<UByte, Unit> {
+        fun ubyteResult(): Result<UByte> {
             
             val returnVal = lib.MyNativeStruct_ubyte_result();
             if (returnVal.isOk == 1.toByte()) {
                 return (returnVal.union.ok.toUByte()).ok()
             } else {
-                return Err(Unit)
+                return Unit.err()
             }
         }
     }

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -341,12 +341,12 @@ fun <T, E> Res<T, E>.wrapErrAndThrow(): T {
     }
 }
 
-fun <T, E> T.ok(): Res<T, E> {
-    return Ok(this)
+fun <T> T.ok(): Result<T> {
+    return Result.success(this)
 }
 
-fun <T, E> E.err(): Res<T, E> {
-    return Err(this)
+fun <T, E> E.err(): Result<T> {
+    return Result.failure(RuntimeException("Received error $this"))
 }
 
 {% for native_result in native_results -%}

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -322,30 +322,12 @@ class Slice: Structure(), Structure.ByValue {
     }
 }
 
-sealed interface Res<T, E>
-class Ok<T, E>(val inner: T) : Res<T, E>
-class Err<T, E>(val inner: E) : Res<T, E>
 
-
-fun <T> Res<T, Throwable>.reThrow(): T {
-    return when (this) {
-        is Ok -> this.inner
-        is Err -> throw this.inner
-    }
-}
-
-fun <T, E> Res<T, E>.wrapErrAndThrow(): T {
-    return when (this) {
-        is Ok -> this.inner
-        is Err -> throw RuntimeException("Received error ${this.inner}")
-    }
-}
-
-fun <T> T.ok(): Result<T> {
+internal fun <T> T.ok(): Result<T> {
     return Result.success(this)
 }
 
-fun <T, E> E.err(): Result<T> {
+internal fun <T, E> E.err(): Result<T> {
     return Result.failure(RuntimeException("Received error $this"))
 }
 


### PR DESCRIPTION
Uses kotlin result. An attempt to address #697.  I have to admit I'm not a big fan. On the plus side it is more ergonomic, but a big minus is we completely erase the type of the error. Unfortunately as per the discussion in the issue we can't make a generic wrapping class. Instead we would have to change the error type to extend Throwable. Let me know what y'all think of this.