### PR TITLE
Fix cookie creation for trait struct in Kotlin

### DIFF
--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
@@ -109,8 +109,9 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             vtable.run_testStructTraitFn_callback = testStructTraitFn;
             val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
             native_wrapper.vtable = vtable;
-            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(native_wrapper as Object);
-            return DiplomatTrait_TesterTrait_Wrapper(native_wrapper);
+            val ret_val = DiplomatTrait_TesterTrait_Wrapper(native_wrapper);
+            ret_val.nativeStruct.data_ = DiplomatJVMRuntime.buildRustCookie(ret_val as Object);
+            return ret_val;
         }
     }
 }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2424
+assertion_line: 2422
 expression: result
 ---
 package dev.gigapixel.somelib
@@ -168,8 +168,9 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             vtable.run_testEnumReturn_callback = testEnumReturn;
             val native_wrapper = DiplomatTrait_TesterTrait_Wrapper_Native();
             native_wrapper.vtable = vtable;
-            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(native_wrapper as Object);
-            return DiplomatTrait_TesterTrait_Wrapper(native_wrapper);
+            val ret_val = DiplomatTrait_TesterTrait_Wrapper(native_wrapper);
+            ret_val.nativeStruct.data_ = DiplomatJVMRuntime.buildRustCookie(ret_val as Object);
+            return ret_val;
         }
     }
 }

--- a/tool/templates/kotlin/Trait.kt.jinja
+++ b/tool/templates/kotlin/Trait.kt.jinja
@@ -100,8 +100,9 @@ internal class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
             {% endif -%}
             val native_wrapper = DiplomatTrait_{{trait_name}}_Wrapper_Native();
             native_wrapper.vtable = vtable;
-            native_wrapper.data_ = DiplomatJVMRuntime.buildRustCookie(native_wrapper as Object);
-            return DiplomatTrait_{{trait_name}}_Wrapper(native_wrapper);
+            val ret_val = DiplomatTrait_{{trait_name}}_Wrapper(native_wrapper);
+            ret_val.nativeStruct.data_ = DiplomatJVMRuntime.buildRustCookie(ret_val as Object);
+            return ret_val;
         }
     }
 }


### PR DESCRIPTION
Cookie creating was previously done on an object passed by value to native code -- this didn't cause a crash previously, because the validity of the JObject `GlobalRef::new(..)` was being called on was not being checked, however it wasn't working properly. This does result in a crash on Android, where the JObject is actually checked.

This PR fixes this issue, and sets the cookie to a real JObject (the trait object itself, instead of the underlying native struct).