### PR TITLE
Throw an error if an `enum` has a variant with a field

### DIFF
--- a/core/src/ast/enums.rs
+++ b/core/src/ast/enums.rs
@@ -39,6 +39,9 @@ impl Enum {
                 .variants
                 .iter()
                 .map(|v| {
+                    if !matches!(v.fields, syn::Fields::Unit) {
+                        panic!("Enums cannot have fields, we only support C-like enums");
+                    }
                     let new_discriminant = v
                         .discriminant
                         .as_ref()


### PR DESCRIPTION
Fixes https://github.com/rust-diplomat/diplomat/issues/732

Instead of throwing an error in lowering, I actually throw it in the parsing -- this makes more sense, since enum variant fields aren't tracked in the ast::Enum.