### PR TITLE
Adding support for overriding functions in Kotlin

### DIFF
--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
@@ -144,7 +144,7 @@ class Float64Vec internal constructor (
         
     }
     
-    fun toString_(): String {
+    override fun toString(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.Float64Vec_to_string(handle, write);
         

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1188,11 +1188,23 @@ returnVal.option() ?: return null
                     panic!("Can only have one iterable method per opaque struct")
                 }
             }
-            _ => format!(
-                "fun {}({}): {return_ty}",
-                self.formatter.fmt_method_name(method),
-                params
-            ),
+            _ => {
+                let should_be_overridden = self.formatter.method_should_be_overridden(
+                    method,
+                    &params,
+                    &return_ty.to_string(),
+                );
+                format!(
+                    "{}fun {}({}): {return_ty}",
+                    if should_be_overridden {
+                        "override "
+                    } else {
+                        ""
+                    },
+                    self.formatter.fmt_method_name(method, should_be_overridden),
+                    params
+                )
+            }
         };
 
         MethodTpl {


### PR DESCRIPTION
Adding support for `override` for generated kotlin functions that have the compatible signature of the function they should be overriding.
Right now just adding support for overriding `toString`. 
This means that, if a Kotlin function with the signature `fun toString(): String` is generated, `override` is added to it so that it overrides the default toString. 

This is specifically useful for allowing default printing of objects. If a Kotlin `Result` has an error type that overrides `toString`, then that is called to display the error. With this PR, we can customize what's printed here if the Result has a Rust-backed error type.
