### PR TITLE
Kotlin unsigned types proper support

### DIFF
--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -84,7 +84,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong())
+        slice.len = size_t(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -98,7 +98,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong())
+        slice.len = size_t(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -114,7 +114,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uByteArray.size.toLong())
+        slice.len = size_t(uByteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -128,7 +128,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(shortArray.size.toLong())
+        slice.len = size_t(shortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -144,7 +144,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uShortArray.size.toLong())
+        slice.len = size_t(uShortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -158,7 +158,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(intArray.size.toLong())
+        slice.len = size_t(intArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -174,7 +174,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uIntArray.size.toLong())
+        slice.len = size_t(uIntArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -189,7 +189,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(longArray.size.toLong())
+        slice.len = size_t(longArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -205,7 +205,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uLongArray.size.toLong())
+        slice.len = size_t(uLongArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -219,7 +219,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(floatArray.size.toLong())
+        slice.len = size_t(floatArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -233,7 +233,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(doubleArray.size.toLong())
+        slice.len = size_t(doubleArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -319,7 +319,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong())
+        slice.len = size_t(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -339,7 +339,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong())
+        slice.len = size_t(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -349,7 +349,7 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen)
+            thisSlice.len = size_t(thisLen.toULong())
             getUtf16(thisSlice)
         }
     }
@@ -360,16 +360,56 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen)
+            thisSlice.len = size_t(thisLen.toULong())
             getUtf8(thisSlice)
         }
     }
 }
 
-class size_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
-    override fun toByte(): Byte = value.toByte()
-    override fun toChar(): Char = value.toInt().toChar()
-    override fun toShort(): Short = value.toShort()
+class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toULong(): ULong = this.toLong().toULong()
+    constructor(): this(0u)
+}
+
+class isize_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+}
+
+class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUByte(): UByte = this.toByte().toUByte()
+    constructor(): this(0u)
+}
+
+class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUShort(): UShort = this.toShort().toUShort()
+    constructor(): this(0u)
+}
+
+class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUInt(): UInt = this.toInt().toUInt()
+    constructor(): this(0u)
+}
+
+class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toULong(): ULong = this.toLong().toULong()
+    constructor(): this(0u)
 }
 
 class Slice: Structure(), Structure.ByValue {

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -84,7 +84,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong().toULong())
+        slice.len = FFISizet(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -98,7 +98,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong().toULong())
+        slice.len = FFISizet(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -114,7 +114,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uByteArray.size.toLong().toULong())
+        slice.len = FFISizet(uByteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -128,7 +128,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(shortArray.size.toLong().toULong())
+        slice.len = FFISizet(shortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -144,7 +144,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uShortArray.size.toLong().toULong())
+        slice.len = FFISizet(uShortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -158,7 +158,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(intArray.size.toLong().toULong())
+        slice.len = FFISizet(intArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -174,7 +174,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uIntArray.size.toLong().toULong())
+        slice.len = FFISizet(uIntArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -189,7 +189,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(longArray.size.toLong().toULong())
+        slice.len = FFISizet(longArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -205,7 +205,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uLongArray.size.toLong().toULong())
+        slice.len = FFISizet(uLongArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -219,7 +219,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(floatArray.size.toLong().toULong())
+        slice.len = FFISizet(floatArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -233,7 +233,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(doubleArray.size.toLong().toULong())
+        slice.len = FFISizet(doubleArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -319,7 +319,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong().toULong())
+        slice.len = FFISizet(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -339,7 +339,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong().toULong())
+        slice.len = FFISizet(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -349,7 +349,7 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen.toULong())
+            thisSlice.len = FFISizet(thisLen.toULong())
             getUtf16(thisSlice)
         }
     }
@@ -360,13 +360,13 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen.toULong())
+            thisSlice.len = FFISizet(thisLen.toULong())
             getUtf8(thisSlice)
         }
     }
 }
 
-class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
+class FFISizet(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -374,13 +374,13 @@ class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE,
     constructor(): this(0u)
 }
 
-class isize_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
+class FFIIsizet(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
 }
 
-class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
+class FFIUint8(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -388,7 +388,7 @@ class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().t
     constructor(): this(0u)
 }
 
-class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
+class FFIUint16(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -396,7 +396,7 @@ class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort(
     constructor(): this(0u)
 }
 
-class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
+class FFIUint32(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -404,7 +404,7 @@ class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLo
     constructor(): this(0u)
 }
 
-class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
+class FFIUint64(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -415,7 +415,7 @@ class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), 
 class Slice: Structure(), Structure.ByValue {
 
     @JvmField var data: Pointer = Pointer(0)// Pointer to const char
-    @JvmField var len: size_t = size_t() // size_t of 0
+    @JvmField var len: FFISizet = FFISizet() // FFISizet of 0
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
@@ -9,8 +9,8 @@ import com.sun.jna.Structure
 internal interface AttrOpaque1Lib: Library {
     fun namespace_AttrOpaque1_destroy(handle: Pointer)
     fun namespace_AttrOpaque1_new(): Pointer
-    fun namespace_AttrOpaque1_method(handle: Pointer): u_byte
-    fun renamed_on_abi_only(handle: Pointer): u_byte
+    fun namespace_AttrOpaque1_method(handle: Pointer): FFIUint8
+    fun renamed_on_abi_only(handle: Pointer): FFIUint8
     fun namespace_AttrOpaque1_use_unnamespaced(handle: Pointer, un: Pointer): Unit
     fun namespace_AttrOpaque1_use_namespaced(handle: Pointer, n: Int): Unit
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
@@ -9,8 +9,8 @@ import com.sun.jna.Structure
 internal interface AttrOpaque1Lib: Library {
     fun namespace_AttrOpaque1_destroy(handle: Pointer)
     fun namespace_AttrOpaque1_new(): Pointer
-    fun namespace_AttrOpaque1_method(handle: Pointer): Byte
-    fun renamed_on_abi_only(handle: Pointer): Byte
+    fun namespace_AttrOpaque1_method(handle: Pointer): u_byte
+    fun renamed_on_abi_only(handle: Pointer): u_byte
     fun namespace_AttrOpaque1_use_unnamespaced(handle: Pointer, un: Pointer): Unit
     fun namespace_AttrOpaque1_use_namespaced(handle: Pointer, n: Int): Unit
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructB.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructB.kt
@@ -13,7 +13,7 @@ internal interface CyclicStructBLib: Library {
 
 internal class CyclicStructBNative: Structure(), Structure.ByValue {
     @JvmField
-    internal var field: u_byte = u_byte();
+    internal var field: FFIUint8 = FFIUint8();
   
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructB.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructB.kt
@@ -13,7 +13,7 @@ internal interface CyclicStructBLib: Library {
 
 internal class CyclicStructBNative: Structure(), Structure.ByValue {
     @JvmField
-    internal var field: Byte = 0;
+    internal var field: u_byte = u_byte();
   
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
@@ -20,7 +20,7 @@ internal interface Float64VecLib: Library {
     fun Float64Vec_set_value(handle: Pointer, newSlice: Slice): Unit
     fun Float64Vec_to_string(handle: Pointer, write: Pointer): Unit
     fun Float64Vec_borrow(handle: Pointer): Slice
-    fun Float64Vec_get(handle: Pointer, i: size_t): OptionDouble
+    fun Float64Vec_get(handle: Pointer, i: FFISizet): OptionDouble
 }
 
 class Float64Vec internal constructor (
@@ -160,7 +160,7 @@ class Float64Vec internal constructor (
     
     internal fun getInternal(i: ULong): Double? {
         
-        val returnVal = lib.Float64Vec_get(handle, size_t(i));
+        val returnVal = lib.Float64Vec_get(handle, FFISizet(i));
         return returnVal.option()
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
@@ -20,7 +20,7 @@ internal interface Float64VecLib: Library {
     fun Float64Vec_set_value(handle: Pointer, newSlice: Slice): Unit
     fun Float64Vec_to_string(handle: Pointer, write: Pointer): Unit
     fun Float64Vec_borrow(handle: Pointer): Slice
-    fun Float64Vec_get(handle: Pointer, i: Long): OptionDouble
+    fun Float64Vec_get(handle: Pointer, i: size_t): OptionDouble
 }
 
 class Float64Vec internal constructor (
@@ -160,7 +160,7 @@ class Float64Vec internal constructor (
     
     internal fun getInternal(i: ULong): Double? {
         
-        val returnVal = lib.Float64Vec_get(handle, i.toLong());
+        val returnVal = lib.Float64Vec_get(handle, size_t(i));
         return returnVal.option()
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ImportedStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ImportedStruct.kt
@@ -13,7 +13,7 @@ internal class ImportedStructNative: Structure(), Structure.ByValue {
     @JvmField
     internal var foo: Int = UnimportedEnum.default().toNative();
     @JvmField
-    internal var count: Byte = 0;
+    internal var count: u_byte = u_byte();
   
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ImportedStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ImportedStruct.kt
@@ -13,7 +13,7 @@ internal class ImportedStructNative: Structure(), Structure.ByValue {
     @JvmField
     internal var foo: Int = UnimportedEnum.default().toNative();
     @JvmField
-    internal var count: u_byte = u_byte();
+    internal var count: FFIUint8 = FFIUint8();
   
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -84,7 +84,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong().toULong())
+        slice.len = FFISizet(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -98,7 +98,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong().toULong())
+        slice.len = FFISizet(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -114,7 +114,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uByteArray.size.toLong().toULong())
+        slice.len = FFISizet(uByteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -128,7 +128,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(shortArray.size.toLong().toULong())
+        slice.len = FFISizet(shortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -144,7 +144,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uShortArray.size.toLong().toULong())
+        slice.len = FFISizet(uShortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -158,7 +158,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(intArray.size.toLong().toULong())
+        slice.len = FFISizet(intArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -174,7 +174,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uIntArray.size.toLong().toULong())
+        slice.len = FFISizet(uIntArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -189,7 +189,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(longArray.size.toLong().toULong())
+        slice.len = FFISizet(longArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -205,7 +205,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uLongArray.size.toLong().toULong())
+        slice.len = FFISizet(uLongArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -219,7 +219,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(floatArray.size.toLong().toULong())
+        slice.len = FFISizet(floatArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -233,7 +233,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(doubleArray.size.toLong().toULong())
+        slice.len = FFISizet(doubleArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -319,7 +319,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong().toULong())
+        slice.len = FFISizet(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -339,7 +339,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong().toULong())
+        slice.len = FFISizet(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -349,7 +349,7 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen.toULong())
+            thisSlice.len = FFISizet(thisLen.toULong())
             getUtf16(thisSlice)
         }
     }
@@ -360,13 +360,13 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen.toULong())
+            thisSlice.len = FFISizet(thisLen.toULong())
             getUtf8(thisSlice)
         }
     }
 }
 
-class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
+class FFISizet(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -374,13 +374,13 @@ class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE,
     constructor(): this(0u)
 }
 
-class isize_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
+class FFIIsizet(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
 }
 
-class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
+class FFIUint8(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -388,7 +388,7 @@ class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().t
     constructor(): this(0u)
 }
 
-class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
+class FFIUint16(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -396,7 +396,7 @@ class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort(
     constructor(): this(0u)
 }
 
-class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
+class FFIUint32(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -404,7 +404,7 @@ class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLo
     constructor(): this(0u)
 }
 
-class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
+class FFIUint64(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -415,7 +415,7 @@ class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), 
 class Slice: Structure(), Structure.ByValue {
 
     @JvmField var data: Pointer = Pointer(0)// Pointer to const char
-    @JvmField var len: size_t = size_t() // size_t of 0
+    @JvmField var len: FFISizet = FFISizet() // FFISizet of 0
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {
@@ -735,6 +735,86 @@ internal class OptionDouble: Structure(), Structure.ByValue  {
         }
     }
 }
+internal class OptionFFIIsizet: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var value: FFIIsizet = FFIIsizet()
+    
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("value", "isOk")
+    }
+
+    internal fun option(): FFIIsizet? {
+        if (isOk == 1.toByte()) {
+            return value
+        } else {
+            return null
+        }
+    }
+}
+internal class OptionFFISizet: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var value: FFISizet = FFISizet()
+    
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("value", "isOk")
+    }
+
+    internal fun option(): FFISizet? {
+        if (isOk == 1.toByte()) {
+            return value
+        } else {
+            return null
+        }
+    }
+}
+internal class OptionFFIUint32: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var value: FFIUint32 = FFIUint32()
+    
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("value", "isOk")
+    }
+
+    internal fun option(): FFIUint32? {
+        if (isOk == 1.toByte()) {
+            return value
+        } else {
+            return null
+        }
+    }
+}
+internal class OptionFFIUint8: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var value: FFIUint8 = FFIUint8()
+    
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("value", "isOk")
+    }
+
+    internal fun option(): FFIUint8? {
+        if (isOk == 1.toByte()) {
+            return value
+        } else {
+            return null
+        }
+    }
+}
 internal class OptionInt: Structure(), Structure.ByValue  {
     @JvmField
     internal var value: Int = 0
@@ -788,86 +868,6 @@ internal class OptionSlice: Structure(), Structure.ByValue  {
     }
 
     internal fun option(): Slice? {
-        if (isOk == 1.toByte()) {
-            return value
-        } else {
-            return null
-        }
-    }
-}
-internal class Optionisize_t: Structure(), Structure.ByValue  {
-    @JvmField
-    internal var value: isize_t = isize_t()
-    
-    @JvmField
-    internal var isOk: Byte = 0
-
-    // Define the fields of the struct
-    override fun getFieldOrder(): List<String> {
-        return listOf("value", "isOk")
-    }
-
-    internal fun option(): isize_t? {
-        if (isOk == 1.toByte()) {
-            return value
-        } else {
-            return null
-        }
-    }
-}
-internal class Optionsize_t: Structure(), Structure.ByValue  {
-    @JvmField
-    internal var value: size_t = size_t()
-    
-    @JvmField
-    internal var isOk: Byte = 0
-
-    // Define the fields of the struct
-    override fun getFieldOrder(): List<String> {
-        return listOf("value", "isOk")
-    }
-
-    internal fun option(): size_t? {
-        if (isOk == 1.toByte()) {
-            return value
-        } else {
-            return null
-        }
-    }
-}
-internal class Optionu_byte: Structure(), Structure.ByValue  {
-    @JvmField
-    internal var value: u_byte = u_byte()
-    
-    @JvmField
-    internal var isOk: Byte = 0
-
-    // Define the fields of the struct
-    override fun getFieldOrder(): List<String> {
-        return listOf("value", "isOk")
-    }
-
-    internal fun option(): u_byte? {
-        if (isOk == 1.toByte()) {
-            return value
-        } else {
-            return null
-        }
-    }
-}
-internal class Optionu_int: Structure(), Structure.ByValue  {
-    @JvmField
-    internal var value: u_int = u_int()
-    
-    @JvmField
-    internal var isOk: Byte = 0
-
-    // Define the fields of the struct
-    override fun getFieldOrder(): List<String> {
-        return listOf("value", "isOk")
-    }
-
-    internal fun option(): u_int? {
         if (isOk == 1.toByte()) {
             return value
         } else {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -84,7 +84,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong())
+        slice.len = size_t(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -98,7 +98,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong())
+        slice.len = size_t(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -114,7 +114,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uByteArray.size.toLong())
+        slice.len = size_t(uByteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -128,7 +128,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(shortArray.size.toLong())
+        slice.len = size_t(shortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -144,7 +144,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uShortArray.size.toLong())
+        slice.len = size_t(uShortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -158,7 +158,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(intArray.size.toLong())
+        slice.len = size_t(intArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -174,7 +174,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uIntArray.size.toLong())
+        slice.len = size_t(uIntArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -189,7 +189,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(longArray.size.toLong())
+        slice.len = size_t(longArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -205,7 +205,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uLongArray.size.toLong())
+        slice.len = size_t(uLongArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -219,7 +219,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(floatArray.size.toLong())
+        slice.len = size_t(floatArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -233,7 +233,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(doubleArray.size.toLong())
+        slice.len = size_t(doubleArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -319,7 +319,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong())
+        slice.len = size_t(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -339,7 +339,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong())
+        slice.len = size_t(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -349,7 +349,7 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen)
+            thisSlice.len = size_t(thisLen.toULong())
             getUtf16(thisSlice)
         }
     }
@@ -360,16 +360,56 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen)
+            thisSlice.len = size_t(thisLen.toULong())
             getUtf8(thisSlice)
         }
     }
 }
 
-class size_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
-    override fun toByte(): Byte = value.toByte()
-    override fun toChar(): Char = value.toInt().toChar()
-    override fun toShort(): Short = value.toShort()
+class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toULong(): ULong = this.toLong().toULong()
+    constructor(): this(0u)
+}
+
+class isize_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+}
+
+class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUByte(): UByte = this.toByte().toUByte()
+    constructor(): this(0u)
+}
+
+class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUShort(): UShort = this.toShort().toUShort()
+    constructor(): this(0u)
+}
+
+class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUInt(): UInt = this.toInt().toUInt()
+    constructor(): this(0u)
+}
+
+class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toULong(): ULong = this.toLong().toULong()
+    constructor(): this(0u)
 }
 
 class Slice: Structure(), Structure.ByValue {
@@ -655,26 +695,6 @@ class ResultUnitUnit: Structure(), Structure.ByValue  {
 }
 
 
-internal class OptionByte: Structure(), Structure.ByValue  {
-    @JvmField
-    internal var value: Byte = 0
-    
-    @JvmField
-    internal var isOk: Byte = 0
-
-    // Define the fields of the struct
-    override fun getFieldOrder(): List<String> {
-        return listOf("value", "isOk")
-    }
-
-    internal fun option(): Byte? {
-        if (isOk == 1.toByte()) {
-            return value
-        } else {
-            return null
-        }
-    }
-}
 internal class OptionCyclicStructANative: Structure(), Structure.ByValue  {
     @JvmField
     internal var value: CyclicStructANative = CyclicStructANative()
@@ -735,26 +755,6 @@ internal class OptionInt: Structure(), Structure.ByValue  {
         }
     }
 }
-internal class OptionLong: Structure(), Structure.ByValue  {
-    @JvmField
-    internal var value: Long = 0
-    
-    @JvmField
-    internal var isOk: Byte = 0
-
-    // Define the fields of the struct
-    override fun getFieldOrder(): List<String> {
-        return listOf("value", "isOk")
-    }
-
-    internal fun option(): Long? {
-        if (isOk == 1.toByte()) {
-            return value
-        } else {
-            return null
-        }
-    }
-}
 internal class OptionOptionStructNative: Structure(), Structure.ByValue  {
     @JvmField
     internal var value: OptionStructNative = OptionStructNative()
@@ -788,6 +788,86 @@ internal class OptionSlice: Structure(), Structure.ByValue  {
     }
 
     internal fun option(): Slice? {
+        if (isOk == 1.toByte()) {
+            return value
+        } else {
+            return null
+        }
+    }
+}
+internal class Optionisize_t: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var value: isize_t = isize_t()
+    
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("value", "isOk")
+    }
+
+    internal fun option(): isize_t? {
+        if (isOk == 1.toByte()) {
+            return value
+        } else {
+            return null
+        }
+    }
+}
+internal class Optionsize_t: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var value: size_t = size_t()
+    
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("value", "isOk")
+    }
+
+    internal fun option(): size_t? {
+        if (isOk == 1.toByte()) {
+            return value
+        } else {
+            return null
+        }
+    }
+}
+internal class Optionu_byte: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var value: u_byte = u_byte()
+    
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("value", "isOk")
+    }
+
+    internal fun option(): u_byte? {
+        if (isOk == 1.toByte()) {
+            return value
+        } else {
+            return null
+        }
+    }
+}
+internal class Optionu_int: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var value: u_int = u_int()
+    
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("value", "isOk")
+    }
+
+    internal fun option(): u_int? {
         if (isOk == 1.toByte()) {
             return value
         } else {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIndexer.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIndexer.kt
@@ -8,7 +8,7 @@ import com.sun.jna.Structure
 
 internal interface MyIndexerLib: Library {
     fun namespace_MyIndexer_destroy(handle: Pointer)
-    fun namespace_MyIndexer_get(handle: Pointer, i: size_t): OptionSlice
+    fun namespace_MyIndexer_get(handle: Pointer, i: FFISizet): OptionSlice
 }
 
 class MyIndexer internal constructor (
@@ -31,7 +31,7 @@ class MyIndexer internal constructor (
     
     internal fun getInternal(i: ULong): String? {
         
-        val returnVal = lib.namespace_MyIndexer_get(handle, size_t(i));
+        val returnVal = lib.namespace_MyIndexer_get(handle, FFISizet(i));
         
         val intermediateOption = returnVal.option() ?: return null
             return PrimitiveArrayTools.getUtf8(intermediateOption)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIndexer.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIndexer.kt
@@ -8,7 +8,7 @@ import com.sun.jna.Structure
 
 internal interface MyIndexerLib: Library {
     fun namespace_MyIndexer_destroy(handle: Pointer)
-    fun namespace_MyIndexer_get(handle: Pointer, i: Long): OptionSlice
+    fun namespace_MyIndexer_get(handle: Pointer, i: size_t): OptionSlice
 }
 
 class MyIndexer internal constructor (
@@ -31,7 +31,7 @@ class MyIndexer internal constructor (
     
     internal fun getInternal(i: ULong): String? {
         
-        val returnVal = lib.namespace_MyIndexer_get(handle, i.toLong());
+        val returnVal = lib.namespace_MyIndexer_get(handle, size_t(i));
         
         val intermediateOption = returnVal.option() ?: return null
             return PrimitiveArrayTools.getUtf8(intermediateOption)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterator.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterator.kt
@@ -8,7 +8,7 @@ import com.sun.jna.Structure
 
 internal interface MyIteratorLib: Library {
     fun namespace_MyIterator_destroy(handle: Pointer)
-    fun namespace_MyIterator_next(handle: Pointer): OptionByte
+    fun namespace_MyIterator_next(handle: Pointer): Optionu_byte
 }
 typealias MyIteratorIteratorItem = UByte
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterator.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterator.kt
@@ -8,7 +8,7 @@ import com.sun.jna.Structure
 
 internal interface MyIteratorLib: Library {
     fun namespace_MyIterator_destroy(handle: Pointer)
-    fun namespace_MyIterator_next(handle: Pointer): Optionu_byte
+    fun namespace_MyIterator_next(handle: Pointer): OptionFFIUint8
 }
 typealias MyIteratorIteratorItem = UByte
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
@@ -8,20 +8,20 @@ import com.sun.jna.Structure
 
 internal interface MyStructLib: Library {
     fun MyStruct_new(): MyStructNative
-    fun MyStruct_into_a(nativeStruct: MyStructNative): u_byte
+    fun MyStruct_into_a(nativeStruct: MyStructNative): FFIUint8
     fun MyStruct_returns_zst_result(): ResultUnitMyZstNative
     fun MyStruct_fails_zst_result(): ResultUnitMyZstNative
 }
 
 internal class MyStructNative: Structure(), Structure.ByValue {
     @JvmField
-    internal var a: u_byte = u_byte();
+    internal var a: FFIUint8 = FFIUint8();
     @JvmField
     internal var b: Byte = 0;
     @JvmField
-    internal var c: u_byte = u_byte();
+    internal var c: FFIUint8 = FFIUint8();
     @JvmField
-    internal var d: u_long = u_long();
+    internal var d: FFIUint64 = FFIUint64();
     @JvmField
     internal var e: Int = 0;
     @JvmField

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
@@ -8,20 +8,20 @@ import com.sun.jna.Structure
 
 internal interface MyStructLib: Library {
     fun MyStruct_new(): MyStructNative
-    fun MyStruct_into_a(nativeStruct: MyStructNative): Byte
+    fun MyStruct_into_a(nativeStruct: MyStructNative): u_byte
     fun MyStruct_returns_zst_result(): ResultUnitMyZstNative
     fun MyStruct_fails_zst_result(): ResultUnitMyZstNative
 }
 
 internal class MyStructNative: Structure(), Structure.ByValue {
     @JvmField
-    internal var a: Byte = 0;
+    internal var a: u_byte = u_byte();
     @JvmField
     internal var b: Byte = 0;
     @JvmField
-    internal var c: Byte = 0;
+    internal var c: u_byte = u_byte();
     @JvmField
-    internal var d: Long = 0;
+    internal var d: u_long = u_long();
     @JvmField
     internal var e: Int = 0;
     @JvmField

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
@@ -13,7 +13,7 @@ internal interface OpaqueLib: Library {
     fun Opaque_from_str(input: Slice): Pointer
     fun Opaque_get_debug_str(handle: Pointer, write: Pointer): Unit
     fun Opaque_assert_struct(handle: Pointer, s: MyStructNative): Unit
-    fun Opaque_returns_usize(): size_t
+    fun Opaque_returns_usize(): FFISizet
     fun Opaque_returns_imported(): ImportedStructNative
     fun Opaque_cmp(): Byte
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
@@ -13,7 +13,7 @@ internal interface OpaqueLib: Library {
     fun Opaque_from_str(input: Slice): Pointer
     fun Opaque_get_debug_str(handle: Pointer, write: Pointer): Unit
     fun Opaque_assert_struct(handle: Pointer, s: MyStructNative): Unit
-    fun Opaque_returns_usize(): Long
+    fun Opaque_returns_usize(): size_t
     fun Opaque_returns_imported(): ImportedStructNative
     fun Opaque_cmp(): Byte
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
@@ -8,15 +8,15 @@ import com.sun.jna.Structure
 
 internal interface OpaqueMutexedStringLib: Library {
     fun OpaqueMutexedString_destroy(handle: Pointer)
-    fun OpaqueMutexedString_from_usize(number: size_t): Pointer
-    fun OpaqueMutexedString_change(handle: Pointer, number: size_t): Unit
+    fun OpaqueMutexedString_from_usize(number: FFISizet): Pointer
+    fun OpaqueMutexedString_change(handle: Pointer, number: FFISizet): Unit
     fun OpaqueMutexedString_borrow(handle: Pointer): Pointer
     fun OpaqueMutexedString_borrow_other(other: Pointer): Pointer
     fun OpaqueMutexedString_borrow_self_or_other(handle: Pointer, other: Pointer): Pointer
-    fun OpaqueMutexedString_get_len_and_add(handle: Pointer, other: size_t): size_t
+    fun OpaqueMutexedString_get_len_and_add(handle: Pointer, other: FFISizet): FFISizet
     fun OpaqueMutexedString_dummy_str(handle: Pointer): Slice
     fun OpaqueMutexedString_wrapper(handle: Pointer): Pointer
-    fun OpaqueMutexedString_to_unsigned_from_unsigned(handle: Pointer, input: u_short): u_short
+    fun OpaqueMutexedString_to_unsigned_from_unsigned(handle: Pointer, input: FFIUint16): FFIUint16
 }
 
 class OpaqueMutexedString internal constructor (
@@ -38,7 +38,7 @@ class OpaqueMutexedString internal constructor (
         
         fun fromUsize(number: ULong): OpaqueMutexedString {
             
-            val returnVal = lib.OpaqueMutexedString_from_usize(size_t(number));
+            val returnVal = lib.OpaqueMutexedString_from_usize(FFISizet(number));
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = OpaqueMutexedString(handle, selfEdges)
@@ -58,7 +58,7 @@ class OpaqueMutexedString internal constructor (
     
     fun change(number: ULong): Unit {
         
-        val returnVal = lib.OpaqueMutexedString_change(handle, size_t(number));
+        val returnVal = lib.OpaqueMutexedString_change(handle, FFISizet(number));
         
     }
     
@@ -82,7 +82,7 @@ class OpaqueMutexedString internal constructor (
     
     fun getLenAndAdd(other: ULong): ULong {
         
-        val returnVal = lib.OpaqueMutexedString_get_len_and_add(handle, size_t(other));
+        val returnVal = lib.OpaqueMutexedString_get_len_and_add(handle, FFISizet(other));
         return (returnVal.toULong())
     }
     
@@ -104,7 +104,7 @@ class OpaqueMutexedString internal constructor (
     
     fun toUnsignedFromUnsigned(input: UShort): UShort {
         
-        val returnVal = lib.OpaqueMutexedString_to_unsigned_from_unsigned(handle, u_short(input));
+        val returnVal = lib.OpaqueMutexedString_to_unsigned_from_unsigned(handle, FFIUint16(input));
         return (returnVal.toUShort())
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
@@ -8,15 +8,15 @@ import com.sun.jna.Structure
 
 internal interface OpaqueMutexedStringLib: Library {
     fun OpaqueMutexedString_destroy(handle: Pointer)
-    fun OpaqueMutexedString_from_usize(number: Long): Pointer
-    fun OpaqueMutexedString_change(handle: Pointer, number: Long): Unit
+    fun OpaqueMutexedString_from_usize(number: size_t): Pointer
+    fun OpaqueMutexedString_change(handle: Pointer, number: size_t): Unit
     fun OpaqueMutexedString_borrow(handle: Pointer): Pointer
     fun OpaqueMutexedString_borrow_other(other: Pointer): Pointer
     fun OpaqueMutexedString_borrow_self_or_other(handle: Pointer, other: Pointer): Pointer
-    fun OpaqueMutexedString_get_len_and_add(handle: Pointer, other: Long): Long
+    fun OpaqueMutexedString_get_len_and_add(handle: Pointer, other: size_t): size_t
     fun OpaqueMutexedString_dummy_str(handle: Pointer): Slice
     fun OpaqueMutexedString_wrapper(handle: Pointer): Pointer
-    fun OpaqueMutexedString_to_unsigned_from_unsigned(handle: Pointer, input: Short): Short
+    fun OpaqueMutexedString_to_unsigned_from_unsigned(handle: Pointer, input: u_short): u_short
 }
 
 class OpaqueMutexedString internal constructor (
@@ -38,7 +38,7 @@ class OpaqueMutexedString internal constructor (
         
         fun fromUsize(number: ULong): OpaqueMutexedString {
             
-            val returnVal = lib.OpaqueMutexedString_from_usize(number.toLong());
+            val returnVal = lib.OpaqueMutexedString_from_usize(size_t(number));
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = OpaqueMutexedString(handle, selfEdges)
@@ -58,7 +58,7 @@ class OpaqueMutexedString internal constructor (
     
     fun change(number: ULong): Unit {
         
-        val returnVal = lib.OpaqueMutexedString_change(handle, number.toLong());
+        val returnVal = lib.OpaqueMutexedString_change(handle, size_t(number));
         
     }
     
@@ -82,7 +82,7 @@ class OpaqueMutexedString internal constructor (
     
     fun getLenAndAdd(other: ULong): ULong {
         
-        val returnVal = lib.OpaqueMutexedString_get_len_and_add(handle, other.toLong());
+        val returnVal = lib.OpaqueMutexedString_get_len_and_add(handle, size_t(other));
         return (returnVal.toULong())
     }
     
@@ -104,7 +104,7 @@ class OpaqueMutexedString internal constructor (
     
     fun toUnsignedFromUnsigned(input: UShort): UShort {
         
-        val returnVal = lib.OpaqueMutexedString_to_unsigned_from_unsigned(handle, input.toShort());
+        val returnVal = lib.OpaqueMutexedString_to_unsigned_from_unsigned(handle, u_short(input));
         return (returnVal.toUShort())
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
@@ -11,10 +11,10 @@ internal interface OptionOpaqueLib: Library {
     fun OptionOpaque_new(i: Int): Pointer?
     fun OptionOpaque_new_none(): Pointer?
     fun OptionOpaque_returns(): OptionOptionStructNative
-    fun OptionOpaque_option_isize(handle: Pointer): OptionLong
-    fun OptionOpaque_option_usize(handle: Pointer): OptionLong
+    fun OptionOpaque_option_isize(handle: Pointer): Optionisize_t
+    fun OptionOpaque_option_usize(handle: Pointer): Optionsize_t
     fun OptionOpaque_option_i32(handle: Pointer): OptionInt
-    fun OptionOpaque_option_u32(handle: Pointer): OptionInt
+    fun OptionOpaque_option_u32(handle: Pointer): Optionu_int
     fun OptionOpaque_new_struct(): OptionStructNative
     fun OptionOpaque_new_struct_nones(): OptionStructNative
     fun OptionOpaque_assert_integer(handle: Pointer, i: Int): Unit
@@ -95,7 +95,7 @@ class OptionOpaque internal constructor (
     fun optionIsize(): Long? {
         
         val returnVal = lib.OptionOpaque_option_isize(handle);
-        return returnVal.option()
+        return returnVal.option()?.toLong()
     }
     
     fun optionUsize(): ULong? {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
@@ -11,10 +11,10 @@ internal interface OptionOpaqueLib: Library {
     fun OptionOpaque_new(i: Int): Pointer?
     fun OptionOpaque_new_none(): Pointer?
     fun OptionOpaque_returns(): OptionOptionStructNative
-    fun OptionOpaque_option_isize(handle: Pointer): Optionisize_t
-    fun OptionOpaque_option_usize(handle: Pointer): Optionsize_t
+    fun OptionOpaque_option_isize(handle: Pointer): OptionFFIIsizet
+    fun OptionOpaque_option_usize(handle: Pointer): OptionFFISizet
     fun OptionOpaque_option_i32(handle: Pointer): OptionInt
-    fun OptionOpaque_option_u32(handle: Pointer): Optionu_int
+    fun OptionOpaque_option_u32(handle: Pointer): OptionFFIUint32
     fun OptionOpaque_new_struct(): OptionStructNative
     fun OptionOpaque_new_struct_nones(): OptionStructNative
     fun OptionOpaque_assert_integer(handle: Pointer, i: Int): Unit

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionStruct.kt
@@ -15,7 +15,7 @@ internal class OptionStructNative: Structure(), Structure.ByValue {
     @JvmField
     internal var b: Pointer? = null;
     @JvmField
-    internal var c: u_int = u_int();
+    internal var c: FFIUint32 = FFIUint32();
     @JvmField
     internal var d: Pointer? = null;
   

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionStruct.kt
@@ -15,7 +15,7 @@ internal class OptionStructNative: Structure(), Structure.ByValue {
     @JvmField
     internal var b: Pointer? = null;
     @JvmField
-    internal var c: Int = 0;
+    internal var c: u_int = u_int();
     @JvmField
     internal var d: Pointer? = null;
   

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
@@ -14,7 +14,7 @@ interface TesterTrait {
 
 
 internal interface Runner_DiplomatTraitMethod_TesterTrait_testTraitFn: Callback {
-    fun invoke(ignored: Pointer?, x: UInt ): UInt
+    fun invoke(ignored: Pointer?, x: UInt ): u_int
 }
 internal interface Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn: Callback {
     fun invoke(ignored: Pointer?): Unit
@@ -40,7 +40,7 @@ internal class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.B
     @JvmField
     internal var run_testTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn
         = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
-                override fun invoke(ignored: Pointer?, x: UInt ): UInt {
+                override fun invoke(ignored: Pointer?, x: UInt ): u_int {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
@@ -90,20 +90,20 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             
             
             val testTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
-                override fun invoke(ignored: Pointer?, x: UInt ): UInt {
-                    return trt_obj.testTraitFn(x);
+                override fun invoke(ignored: Pointer?, x: UInt ): u_int {
+                    return u_int(trt_obj.testTraitFn(x));
                 }
             }
             vtable.run_testTraitFn_callback = testTraitFn;
             val testVoidTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn {
                 override fun invoke(ignored: Pointer?): Unit {
-                    return trt_obj.testVoidTraitFn();
+                    return (trt_obj.testVoidTraitFn());
                 }
             }
             vtable.run_testVoidTraitFn_callback = testVoidTraitFn;
             val testStructTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn {
                 override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
-                    return trt_obj.testStructTraitFn(TraitTestingStruct(s));
+                    return (trt_obj.testStructTraitFn(TraitTestingStruct(s)));
                 }
             }
             vtable.run_testStructTraitFn_callback = testStructTraitFn;

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TesterTrait.kt
@@ -14,7 +14,7 @@ interface TesterTrait {
 
 
 internal interface Runner_DiplomatTraitMethod_TesterTrait_testTraitFn: Callback {
-    fun invoke(ignored: Pointer?, x: UInt ): u_int
+    fun invoke(ignored: Pointer?, x: UInt ): FFIUint32
 }
 internal interface Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn: Callback {
     fun invoke(ignored: Pointer?): Unit
@@ -40,7 +40,7 @@ internal class DiplomatTrait_TesterTrait_VTable_Native: Structure(), Structure.B
     @JvmField
     internal var run_testTraitFn_callback: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn
         = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
-                override fun invoke(ignored: Pointer?, x: UInt ): u_int {
+                override fun invoke(ignored: Pointer?, x: UInt ): FFIUint32 {
                     throw Exception("ERROR NOT IMPLEMENTED")
                 }
             }
@@ -90,8 +90,8 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             
             
             val testTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
-                override fun invoke(ignored: Pointer?, x: UInt ): u_int {
-                    return u_int(trt_obj.testTraitFn(x));
+                override fun invoke(ignored: Pointer?, x: UInt ): FFIUint32 {
+                    return FFIUint32(trt_obj.testTraitFn(x));
                 }
             }
             vtable.run_testTraitFn_callback = testTraitFn;

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -40,12 +40,12 @@ impl<'tcx> KotlinFormatter<'tcx> {
 
     pub fn fmt_primitive_to_native_conversion(&self, name: &str, prim: PrimitiveType) -> String {
         match prim {
-            PrimitiveType::Int(IntType::U8) => format!("u_byte({name})"),
-            PrimitiveType::Int(IntType::U16) => format!("u_short({name})"),
-            PrimitiveType::Int(IntType::U32) => format!("u_int({name})"),
-            PrimitiveType::Int(IntType::U64) => format!("u_long({name})"),
-            PrimitiveType::IntSize(IntSizeType::Usize) => format!("size_t({name})"),
-            PrimitiveType::IntSize(IntSizeType::Isize) => format!("isize_t({name})"),
+            PrimitiveType::Int(IntType::U8) => format!("FFIUint8({name})"),
+            PrimitiveType::Int(IntType::U16) => format!("FFIUint16({name})"),
+            PrimitiveType::Int(IntType::U32) => format!("FFIUint32({name})"),
+            PrimitiveType::Int(IntType::U64) => format!("FFIUint64({name})"),
+            PrimitiveType::IntSize(IntSizeType::Usize) => format!("FFISizet({name})"),
+            PrimitiveType::IntSize(IntSizeType::Isize) => format!("FFIIsizet({name})"),
             PrimitiveType::Int128(_) => panic!("128 bit ints not supported"),
             _ => name.into(),
         }
@@ -78,13 +78,13 @@ impl<'tcx> KotlinFormatter<'tcx> {
             PrimitiveType::Int(IntType::I16) => "Short",
             PrimitiveType::Int(IntType::I32) => "Int",
             PrimitiveType::Int(IntType::I64) => "Long",
-            PrimitiveType::Int(IntType::U8) => "u_byte",
-            PrimitiveType::Int(IntType::U16) => "u_short",
-            PrimitiveType::Int(IntType::U32) => "u_int",
-            PrimitiveType::Int(IntType::U64) => "u_long",
+            PrimitiveType::Int(IntType::U8) => "FFIUint8",
+            PrimitiveType::Int(IntType::U16) => "FFIUint16",
+            PrimitiveType::Int(IntType::U32) => "FFIUint32",
+            PrimitiveType::Int(IntType::U64) => "FFIUint64",
             PrimitiveType::Byte => "Byte",
-            PrimitiveType::IntSize(IntSizeType::Isize) => "isize_t",
-            PrimitiveType::IntSize(IntSizeType::Usize) => "size_t",
+            PrimitiveType::IntSize(IntSizeType::Isize) => "FFIIsizet",
+            PrimitiveType::IntSize(IntSizeType::Usize) => "FFISizet",
             PrimitiveType::Float(FloatType::F32) => "Float",
             PrimitiveType::Float(FloatType::F64) => "Double",
             PrimitiveType::Int128(_) => panic!("i128 not supported in Kotlin"),
@@ -175,24 +175,24 @@ impl<'tcx> KotlinFormatter<'tcx> {
         match prim {
             PrimitiveType::Float(FloatType::F32) => "0.0F",
             PrimitiveType::Float(FloatType::F64) => "0.0",
-            PrimitiveType::Int(IntType::U8) => "u_byte()",
-            PrimitiveType::Int(IntType::U16) => "u_short()",
-            PrimitiveType::Int(IntType::U32) => "u_int()",
-            PrimitiveType::Int(IntType::U64) => "u_long()",
-            PrimitiveType::IntSize(IntSizeType::Usize) => "size_t()",
-            PrimitiveType::IntSize(IntSizeType::Isize) => "isize_t()",
+            PrimitiveType::Int(IntType::U8) => "FFIUint8()",
+            PrimitiveType::Int(IntType::U16) => "FFIUint16()",
+            PrimitiveType::Int(IntType::U32) => "FFIUint32()",
+            PrimitiveType::Int(IntType::U64) => "FFIUint64()",
+            PrimitiveType::IntSize(IntSizeType::Usize) => "FFISizet()",
+            PrimitiveType::IntSize(IntSizeType::Isize) => "FFIIsizet()",
             _ => "0",
         }
     }
 
     pub fn fmt_unsigned_primitive_ffi_cast(&self, prim: &PrimitiveType) -> &'static str {
         match prim {
-            PrimitiveType::Int(IntType::U8) => "u_byte",
-            PrimitiveType::Int(IntType::U16) => "u_short",
-            PrimitiveType::Int(IntType::U32) => "u_int",
-            PrimitiveType::Int(IntType::U64) => "u_long",
-            PrimitiveType::IntSize(IntSizeType::Usize) => "size_t",
-            PrimitiveType::IntSize(IntSizeType::Isize) => "isize_t",
+            PrimitiveType::Int(IntType::U8) => "FFIUint8",
+            PrimitiveType::Int(IntType::U16) => "FFIUint16",
+            PrimitiveType::Int(IntType::U32) => "FFIUint32",
+            PrimitiveType::Int(IntType::U64) => "FFIUint64",
+            PrimitiveType::IntSize(IntSizeType::Usize) => "FFISizet",
+            PrimitiveType::IntSize(IntSizeType::Isize) => "FFIIsizet",
             _ => "",
         }
     }
@@ -380,12 +380,12 @@ impl<'tcx> KotlinFormatter<'tcx> {
     pub fn fmt_primitive_type_native(&self, prim: PrimitiveType) -> &'static str {
         match prim {
             PrimitiveType::Bool => "Byte",
-            PrimitiveType::Int(IntType::U8) => "u_byte",
-            PrimitiveType::Int(IntType::U16) => "u_short",
-            PrimitiveType::Int(IntType::U32) => "u_int",
-            PrimitiveType::Int(IntType::U64) => "u_long",
-            PrimitiveType::IntSize(IntSizeType::Usize) => "size_t",
-            PrimitiveType::IntSize(IntSizeType::Isize) => "isize_t",
+            PrimitiveType::Int(IntType::U8) => "FFIUint8",
+            PrimitiveType::Int(IntType::U16) => "FFIUint16",
+            PrimitiveType::Int(IntType::U32) => "FFIUint32",
+            PrimitiveType::Int(IntType::U64) => "FFIUint64",
+            PrimitiveType::IntSize(IntSizeType::Usize) => "FFISizet",
+            PrimitiveType::IntSize(IntSizeType::Isize) => "FFIIsizet",
             prim => self.fmt_primitive_as_ffi(prim),
         }
     }

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -40,11 +40,12 @@ impl<'tcx> KotlinFormatter<'tcx> {
 
     pub fn fmt_primitive_to_native_conversion(&self, name: &str, prim: PrimitiveType) -> String {
         match prim {
-            PrimitiveType::Int(IntType::U8) => format!("{name}.toByte()"),
-            PrimitiveType::Int(IntType::U16) => format!("{name}.toShort()"),
-            PrimitiveType::Int(IntType::U32) => format!("{name}.toInt()"),
-            PrimitiveType::Int(IntType::U64) => format!("{name}.toLong()"),
-            PrimitiveType::IntSize(IntSizeType::Usize) => format!("{name}.toLong()"),
+            PrimitiveType::Int(IntType::U8) => format!("u_byte({name})"),
+            PrimitiveType::Int(IntType::U16) => format!("u_short({name})"),
+            PrimitiveType::Int(IntType::U32) => format!("u_int({name})"),
+            PrimitiveType::Int(IntType::U64) => format!("u_long({name})"),
+            PrimitiveType::IntSize(IntSizeType::Usize) => format!("size_t({name})"),
+            PrimitiveType::IntSize(IntSizeType::Isize) => format!("isize_t({name})"),
             PrimitiveType::Int128(_) => panic!("128 bit ints not supported"),
             _ => name.into(),
         }
@@ -69,11 +70,7 @@ impl<'tcx> KotlinFormatter<'tcx> {
         "Array<String>"
     }
 
-    pub fn fmt_primitive_as_ffi(
-        &self,
-        prim: PrimitiveType,
-        support_unsigned: bool,
-    ) -> &'static str {
+    pub fn fmt_primitive_as_ffi(&self, prim: PrimitiveType) -> &'static str {
         match prim {
             PrimitiveType::Bool => "Boolean",
             PrimitiveType::Char => "Int",
@@ -81,43 +78,13 @@ impl<'tcx> KotlinFormatter<'tcx> {
             PrimitiveType::Int(IntType::I16) => "Short",
             PrimitiveType::Int(IntType::I32) => "Int",
             PrimitiveType::Int(IntType::I64) => "Long",
-            PrimitiveType::Int(IntType::U8) => {
-                if support_unsigned {
-                    "UByte"
-                } else {
-                    "Byte"
-                }
-            }
-            PrimitiveType::Int(IntType::U16) => {
-                if support_unsigned {
-                    "UShort"
-                } else {
-                    "Short"
-                }
-            }
-            PrimitiveType::Int(IntType::U32) => {
-                if support_unsigned {
-                    "UInt"
-                } else {
-                    "Int"
-                }
-            }
-            PrimitiveType::Int(IntType::U64) => {
-                if support_unsigned {
-                    "ULong"
-                } else {
-                    "Long"
-                }
-            }
+            PrimitiveType::Int(IntType::U8) => "u_byte",
+            PrimitiveType::Int(IntType::U16) => "u_short",
+            PrimitiveType::Int(IntType::U32) => "u_int",
+            PrimitiveType::Int(IntType::U64) => "u_long",
             PrimitiveType::Byte => "Byte",
-            PrimitiveType::IntSize(IntSizeType::Isize) => "Long",
-            PrimitiveType::IntSize(IntSizeType::Usize) => {
-                if support_unsigned {
-                    "ULong"
-                } else {
-                    "Long"
-                }
-            }
+            PrimitiveType::IntSize(IntSizeType::Isize) => "isize_t",
+            PrimitiveType::IntSize(IntSizeType::Usize) => "size_t",
             PrimitiveType::Float(FloatType::F32) => "Float",
             PrimitiveType::Float(FloatType::F64) => "Double",
             PrimitiveType::Int128(_) => panic!("i128 not supported in Kotlin"),
@@ -208,9 +175,28 @@ impl<'tcx> KotlinFormatter<'tcx> {
         match prim {
             PrimitiveType::Float(FloatType::F32) => "0.0F",
             PrimitiveType::Float(FloatType::F64) => "0.0",
+            PrimitiveType::Int(IntType::U8) => "u_byte()",
+            PrimitiveType::Int(IntType::U16) => "u_short()",
+            PrimitiveType::Int(IntType::U32) => "u_int()",
+            PrimitiveType::Int(IntType::U64) => "u_long()",
+            PrimitiveType::IntSize(IntSizeType::Usize) => "size_t()",
+            PrimitiveType::IntSize(IntSizeType::Isize) => "isize_t()",
             _ => "0",
         }
     }
+
+    pub fn fmt_unsigned_primitive_ffi_cast(&self, prim: &PrimitiveType) -> &'static str {
+        match prim {
+            PrimitiveType::Int(IntType::U8) => "u_byte",
+            PrimitiveType::Int(IntType::U16) => "u_short",
+            PrimitiveType::Int(IntType::U32) => "u_int",
+            PrimitiveType::Int(IntType::U64) => "u_long",
+            PrimitiveType::IntSize(IntSizeType::Usize) => "size_t",
+            PrimitiveType::IntSize(IntSizeType::Isize) => "isize_t",
+            _ => "",
+        }
+    }
+
     pub fn fmt_field_default<'a, P: TyPosition>(&'a self, ty: &'a Type<P>) -> Cow<'tcx, str> {
         match ty {
             Type::Primitive(prim) => self.fmt_primitive_default(*prim).into(),
@@ -243,6 +229,9 @@ impl<'tcx> KotlinFormatter<'tcx> {
             PrimitiveType::Int(IntType::U64) => format!("{optional_conversion}.toULong()").into(),
             PrimitiveType::IntSize(IntSizeType::Usize) => {
                 format!("{optional_conversion}.toULong()").into()
+            }
+            PrimitiveType::IntSize(IntSizeType::Isize) => {
+                format!("{optional_conversion}.toLong()").into()
             }
             PrimitiveType::Int128(_) => panic!("Int128 not supported"),
             _ => "".into(),
@@ -391,12 +380,13 @@ impl<'tcx> KotlinFormatter<'tcx> {
     pub fn fmt_primitive_type_native(&self, prim: PrimitiveType) -> &'static str {
         match prim {
             PrimitiveType::Bool => "Byte",
-            PrimitiveType::Int(IntType::U8) => "Byte",
-            PrimitiveType::Int(IntType::U16) => "Short",
-            PrimitiveType::Int(IntType::U32) => "Int",
-            PrimitiveType::Int(IntType::U64) => "Long",
-            PrimitiveType::IntSize(_) => "Long",
-            prim => self.fmt_primitive_as_ffi(prim, false),
+            PrimitiveType::Int(IntType::U8) => "u_byte",
+            PrimitiveType::Int(IntType::U16) => "u_short",
+            PrimitiveType::Int(IntType::U32) => "u_int",
+            PrimitiveType::Int(IntType::U64) => "u_long",
+            PrimitiveType::IntSize(IntSizeType::Usize) => "size_t",
+            PrimitiveType::IntSize(IntSizeType::Isize) => "isize_t",
+            prim => self.fmt_primitive_as_ffi(prim),
         }
     }
 

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1862,10 +1862,7 @@ returnVal.option() ?: return null
         additional_name: Option<String>,
     ) -> Cow<'cx, str> {
         match *ty {
-            Type::Primitive(prim) => self
-                .formatter
-                .fmt_primitive_as_ffi(prim)
-                .into(),
+            Type::Primitive(prim) => self.formatter.fmt_primitive_as_ffi(prim).into(),
             Type::Opaque(ref op) => {
                 let optional = if op.is_optional() { "?" } else { "" };
                 format!("Pointer{optional}").into()

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1635,7 +1635,7 @@ returnVal.option() ?: return null
                 .into(),
                 match ty {
                     Type::Primitive(prim) => {
-                        self.formatter.fmt_unsigned_primitive_ffi_cast(prim).into()
+                        self.formatter.fmt_unsigned_primitive_ffi_cast(prim)
                     }
                     _ => "",
                 }

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1634,9 +1634,7 @@ returnVal.option() ?: return null
                 }
                 .into(),
                 match ty {
-                    Type::Primitive(prim) => {
-                        self.formatter.fmt_unsigned_primitive_ffi_cast(prim)
-                    }
+                    Type::Primitive(prim) => self.formatter.fmt_unsigned_primitive_ffi_cast(prim),
                     _ => "",
                 }
                 .into(),

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
@@ -13,7 +13,7 @@ import com.sun.jna.Structure
 
 internal interface MyOpaqueStructLib: Library {
     fun MyOpaqueStruct_destroy(handle: Pointer)
-    fun MyOpaqueStruct_get_byte(): u_byte
+    fun MyOpaqueStruct_get_byte(): FFIUint8
     fun MyOpaqueStruct_get_string_wrapper(in1: Int): Int
 }
 

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
@@ -13,7 +13,7 @@ import com.sun.jna.Structure
 
 internal interface MyOpaqueStructLib: Library {
     fun MyOpaqueStruct_destroy(handle: Pointer)
-    fun MyOpaqueStruct_get_byte(): Byte
+    fun MyOpaqueStruct_get_byte(): u_byte
     fun MyOpaqueStruct_get_string_wrapper(in1: Int): Int
 }
 

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -16,7 +16,7 @@ internal interface MyNativeStructLib: Library {
     fun MyNativeStruct_test_multi_arg_callback(f: DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native, x: Int): Int
     fun MyNativeStruct_get_u_byte_slice(): Slice
     fun MyNativeStruct_boolean_result(): ResultByteUnit
-    fun MyNativeStruct_ubyte_result(): ResultByteUnit
+    fun MyNativeStruct_ubyte_result(): Resultu_byteUnit
 }
 
 internal class MyNativeStructNative: Structure(), Structure.ByValue {
@@ -25,21 +25,21 @@ internal class MyNativeStructNative: Structure(), Structure.ByValue {
     @JvmField
     internal var b: Byte = 0;
     @JvmField
-    internal var c: Byte = 0;
+    internal var c: u_byte = u_byte();
     @JvmField
     internal var d: Short = 0;
     @JvmField
-    internal var e: Short = 0;
+    internal var e: u_short = u_short();
     @JvmField
     internal var f: Int = 0;
     @JvmField
-    internal var g: Int = 0;
+    internal var g: u_int = u_int();
     @JvmField
     internal var h: Long = 0;
     /** Documentation for the struct field `i`
     */
     @JvmField
-    internal var i: Long = 0;
+    internal var i: u_long = u_long();
     @JvmField
     internal var j: Int = 0;
     @JvmField

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -16,7 +16,7 @@ internal interface MyNativeStructLib: Library {
     fun MyNativeStruct_test_multi_arg_callback(f: DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f_Native, x: Int): Int
     fun MyNativeStruct_get_u_byte_slice(): Slice
     fun MyNativeStruct_boolean_result(): ResultByteUnit
-    fun MyNativeStruct_ubyte_result(): Resultu_byteUnit
+    fun MyNativeStruct_ubyte_result(): ResultFFIUint8Unit
 }
 
 internal class MyNativeStructNative: Structure(), Structure.ByValue {
@@ -25,21 +25,21 @@ internal class MyNativeStructNative: Structure(), Structure.ByValue {
     @JvmField
     internal var b: Byte = 0;
     @JvmField
-    internal var c: u_byte = u_byte();
+    internal var c: FFIUint8 = FFIUint8();
     @JvmField
     internal var d: Short = 0;
     @JvmField
-    internal var e: u_short = u_short();
+    internal var e: FFIUint16 = FFIUint16();
     @JvmField
     internal var f: Int = 0;
     @JvmField
-    internal var g: u_int = u_int();
+    internal var g: FFIUint32 = FFIUint32();
     @JvmField
     internal var h: Long = 0;
     /** Documentation for the struct field `i`
     */
     @JvmField
-    internal var i: u_long = u_long();
+    internal var i: FFIUint64 = FFIUint64();
     @JvmField
     internal var j: Int = 0;
     @JvmField

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__trait_gen.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2422
+assertion_line: 2479
 expression: result
 ---
 package dev.gigapixel.somelib
@@ -132,37 +132,37 @@ internal class DiplomatTrait_TesterTrait_Wrapper internal constructor (
             
             val testTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testTraitFn {
                 override fun invoke(ignored: Pointer?, x: Int, y: Int, z: UByte ): Int {
-                    return trt_obj.testTraitFn(x, y, z);
+                    return (trt_obj.testTraitFn(x, y, z));
                 }
             }
             vtable.run_testTraitFn_callback = testTraitFn;
             val testVoidTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testVoidTraitFn {
                 override fun invoke(ignored: Pointer?): Unit {
-                    return trt_obj.testVoidTraitFn();
+                    return (trt_obj.testVoidTraitFn());
                 }
             }
             vtable.run_testVoidTraitFn_callback = testVoidTraitFn;
             val testStructTraitFn: Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructTraitFn {
                 override fun invoke(ignored: Pointer?, s: TraitTestingStructNative ): Int {
-                    return trt_obj.testStructTraitFn(TraitTestingStruct(s));
+                    return (trt_obj.testStructTraitFn(TraitTestingStruct(s)));
                 }
             }
             vtable.run_testStructTraitFn_callback = testStructTraitFn;
             val testWithSlices: Runner_DiplomatTraitMethod_TesterTrait_testWithSlices = object :  Runner_DiplomatTraitMethod_TesterTrait_testWithSlices {
                 override fun invoke(ignored: Pointer?, a: Slice, b: Slice ): Int {
-                    return trt_obj.testWithSlices(PrimitiveArrayTools.getUByteArray(a), PrimitiveArrayTools.getShortArray(b));
+                    return (trt_obj.testWithSlices(PrimitiveArrayTools.getUByteArray(a), PrimitiveArrayTools.getShortArray(b)));
                 }
             }
             vtable.run_testWithSlices_callback = testWithSlices;
             val testStructReturn: Runner_DiplomatTraitMethod_TesterTrait_testStructReturn = object :  Runner_DiplomatTraitMethod_TesterTrait_testStructReturn {
                 override fun invoke(ignored: Pointer?): TraitTestingStructNative {
-                    return trt_obj.testStructReturn().nativeStruct;
+                    return (trt_obj.testStructReturn()).nativeStruct;
                 }
             }
             vtable.run_testStructReturn_callback = testStructReturn;
             val testEnumReturn: Runner_DiplomatTraitMethod_TesterTrait_testEnumReturn = object :  Runner_DiplomatTraitMethod_TesterTrait_testEnumReturn {
                 override fun invoke(ignored: Pointer?): Int {
-                    return trt_obj.testEnumReturn().toNative();
+                    return (trt_obj.testEnumReturn()).toNative();
                 }
             }
             vtable.run_testEnumReturn_callback = testEnumReturn;

--- a/tool/templates/kotlin/Trait.kt.jinja
+++ b/tool/templates/kotlin/Trait.kt.jinja
@@ -92,7 +92,7 @@ internal class DiplomatTrait_{{trait_name}}_Wrapper internal constructor (
                 {%- for trait_method in trait_methods %}
             val {{trait_method.name}}: Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}} = object :  Runner_DiplomatTraitMethod_{{trait_name}}_{{trait_method.name}} {
                 override fun invoke(ignored: Pointer?{% if trait_method.input_params_and_types != "" %}, {{trait_method.input_params_and_types}} {% endif %}): {{trait_method.native_output_type}} {
-                    return trt_obj.{{trait_method.name}}({{trait_method.input_params}}){{trait_method.return_modification}};
+                    return {{trait_method.return_cast}}(trt_obj.{{trait_method.name}}({{trait_method.input_params}})){{trait_method.return_modification}};
                 }
             }
             vtable.run_{{trait_method.name}}_callback = {{trait_method.name}};

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -86,7 +86,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong())
+        slice.len = size_t(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -100,7 +100,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong())
+        slice.len = size_t(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -116,7 +116,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uByteArray.size.toLong())
+        slice.len = size_t(uByteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -130,7 +130,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(shortArray.size.toLong())
+        slice.len = size_t(shortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -146,7 +146,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uShortArray.size.toLong())
+        slice.len = size_t(uShortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -160,7 +160,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(intArray.size.toLong())
+        slice.len = size_t(intArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -176,7 +176,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uIntArray.size.toLong())
+        slice.len = size_t(uIntArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -191,7 +191,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(longArray.size.toLong())
+        slice.len = size_t(longArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -207,7 +207,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uLongArray.size.toLong())
+        slice.len = size_t(uLongArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -221,7 +221,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(floatArray.size.toLong())
+        slice.len = size_t(floatArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -235,7 +235,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(doubleArray.size.toLong())
+        slice.len = size_t(doubleArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -321,7 +321,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong())
+        slice.len = size_t(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -341,7 +341,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong())
+        slice.len = size_t(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -351,7 +351,7 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen)
+            thisSlice.len = size_t(thisLen.toULong())
             getUtf16(thisSlice)
         }
     }
@@ -362,16 +362,56 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen)
+            thisSlice.len = size_t(thisLen.toULong())
             getUtf8(thisSlice)
         }
     }
 }
 
-class size_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
-    override fun toByte(): Byte = value.toByte()
-    override fun toChar(): Char = value.toInt().toChar()
-    override fun toShort(): Short = value.toShort()
+class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toULong(): ULong = this.toLong().toULong()
+    constructor(): this(0u)
+}
+
+class isize_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+}
+
+class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUByte(): UByte = this.toByte().toUByte()
+    constructor(): this(0u)
+}
+
+class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUShort(): UShort = this.toShort().toUShort()
+    constructor(): this(0u)
+}
+
+class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toUInt(): UInt = this.toInt().toUInt()
+    constructor(): this(0u)
+}
+
+class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
+    override fun toByte(): Byte = this.toLong().toByte()
+    override fun toChar(): Char = this.toLong().toInt().toChar()
+    override fun toShort(): Short = this.toLong().toShort()
+    fun toULong(): ULong = this.toLong().toULong()
+    constructor(): this(0u)
 }
 
 class Slice: Structure(), Structure.ByValue {

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -86,7 +86,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong().toULong())
+        slice.len = FFISizet(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -100,7 +100,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(byteArray.size.toLong().toULong())
+        slice.len = FFISizet(byteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -116,7 +116,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uByteArray.size.toLong().toULong())
+        slice.len = FFISizet(uByteArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -130,7 +130,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(shortArray.size.toLong().toULong())
+        slice.len = FFISizet(shortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -146,7 +146,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uShortArray.size.toLong().toULong())
+        slice.len = FFISizet(uShortArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -160,7 +160,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(intArray.size.toLong().toULong())
+        slice.len = FFISizet(intArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -176,7 +176,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uIntArray.size.toLong().toULong())
+        slice.len = FFISizet(uIntArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -191,7 +191,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(longArray.size.toLong().toULong())
+        slice.len = FFISizet(longArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -207,7 +207,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(uLongArray.size.toLong().toULong())
+        slice.len = FFISizet(uLongArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -221,7 +221,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(floatArray.size.toLong().toULong())
+        slice.len = FFISizet(floatArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -235,7 +235,7 @@ internal object PrimitiveArrayTools {
         } else {
             Pointer(0)
         }
-        slice.len = size_t(doubleArray.size.toLong().toULong())
+        slice.len = FFISizet(doubleArray.size.toLong().toULong())
         return Pair(mem, slice)
     }
 
@@ -321,7 +321,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong().toULong())
+        slice.len = FFISizet(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -341,7 +341,7 @@ internal object PrimitiveArrayTools {
         }
         val slice = Slice()
         slice.data = ptr
-        slice.len = size_t(array.size.toLong().toULong())
+        slice.len = FFISizet(array.size.toLong().toULong())
         return Pair(mems + mem, slice)
     }
 
@@ -351,7 +351,7 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen.toULong())
+            thisSlice.len = FFISizet(thisLen.toULong())
             getUtf16(thisSlice)
         }
     }
@@ -362,13 +362,13 @@ internal object PrimitiveArrayTools {
             val thisPtr = Pointer(slice.data.getLong(idx * Slice.SIZE))
             val thisLen = slice.data.getLong(idx * Slice.SIZE + Long.SIZE_BYTES)
             thisSlice.data = thisPtr
-            thisSlice.len = size_t(thisLen.toULong())
+            thisSlice.len = FFISizet(thisLen.toULong())
             getUtf8(thisSlice)
         }
     }
 }
 
-class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
+class FFISizet(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value.toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -376,13 +376,13 @@ class size_t(val value: ULong = 0u): com.sun.jna.IntegerType(Native.SIZE_T_SIZE,
     constructor(): this(0u)
 }
 
-class isize_t(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
+class FFIIsizet(val value: Long = 0): com.sun.jna.IntegerType(Native.SIZE_T_SIZE, value, true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
 }
 
-class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
+class FFIUint8(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -390,7 +390,7 @@ class u_byte(val value: UByte = 0u): com.sun.jna.IntegerType(1, value.toByte().t
     constructor(): this(0u)
 }
 
-class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
+class FFIUint16(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -398,7 +398,7 @@ class u_short(val value: UShort = 0u): com.sun.jna.IntegerType(2, value.toShort(
     constructor(): this(0u)
 }
 
-class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
+class FFIUint32(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -406,7 +406,7 @@ class u_int(val value: UInt = 0u): com.sun.jna.IntegerType(4, value.toInt().toLo
     constructor(): this(0u)
 }
 
-class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
+class FFIUint64(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), true)  {
     override fun toByte(): Byte = this.toLong().toByte()
     override fun toChar(): Char = this.toLong().toInt().toChar()
     override fun toShort(): Short = this.toLong().toShort()
@@ -417,7 +417,7 @@ class u_long(val value: ULong = 0u): com.sun.jna.IntegerType(8, value.toLong(), 
 class Slice: Structure(), Structure.ByValue {
 
     @JvmField var data: Pointer = Pointer(0)// Pointer to const char
-    @JvmField var len: size_t = size_t() // size_t of 0
+    @JvmField var len: FFISizet = FFISizet() // FFISizet of 0
 
     // Define the fields of the struct
     override fun getFieldOrder(): List<String> {


### PR DESCRIPTION
Instead of converting to/from unsigned types when passing unsigned values across/back from the FFI boundary from Kotlin to Rust, we should actually be building a JNA compatible representation of unsigned types (subclassing the JNA `IntegerType`) and using this instead.

This PR adds this support, with new types for `u_int`, `u_long`, `u_short`, and `u_byte`. This PR also adds proper representation for `isize`: like `usize`, it shouldn't just be `Long`, it should be dependent on the size_t size on the machine.

Fixing https://github.com/rust-diplomat/diplomat/issues/748