### PR TITLE
Add support for passing empty strings from Kotlin to Rust

### DIFF
--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -64,132 +64,175 @@ internal class DiplomatJVMRuntime {
 
 internal object PrimitiveArrayTools {
 
-    fun allocateMemory(size: Long): Memory {
+    fun allocateMemory(size: Long): Memory? {
         // we can't use the Memory constructor for a memory of size 0
-        // so, if the size is zero, then we actually build a Memory of
-        // size 1 and then clear it.
-        val mem = Memory(size + if (size == 0L) 1 else 0)
-        if (size == 0L)
-            mem.clear()
-        return mem
+        // so, if the size is zero, then we return null
+        if (size > 0L)
+            return Memory(size)
+        else
+            return null
     }
 
-    fun native(boolArray: BooleanArray): Pair<Memory, Slice> {
+    fun native(boolArray: BooleanArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(boolArray.size.toLong())
-        val ptr = mem.share(0)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(byteArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(byteArray: ByteArray):  Pair<Memory, Slice> {
+    fun native(byteArray: ByteArray):  Pair<Memory?, Slice> {
         val mem = allocateMemory(byteArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) { 
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(byteArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uByteArray: UByteArray): Pair<Memory, Slice> {
+    fun native(uByteArray: UByteArray): Pair<Memory?, Slice> {
         val byteArray = uByteArray.asByteArray()
         val mem = allocateMemory(byteArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uByteArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(shortArray: ShortArray): Pair<Memory, Slice> {
+    fun native(shortArray: ShortArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(shortArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uShortArray: UShortArray): Pair<Memory, Slice> {
+    fun native(uShortArray: UShortArray): Pair<Memory?, Slice> {
         val shortArray = uShortArray.asShortArray()
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uShortArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(intArray: IntArray): Pair<Memory, Slice> {
+    fun native(intArray: IntArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, intArray, 0, intArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(intArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uIntArray: UIntArray): Pair<Memory, Slice> {
+    fun native(uIntArray: UIntArray): Pair<Memory?, Slice> {
         val intArray = uIntArray.asIntArray()
         val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, intArray, 0, intArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uIntArray.size.toLong())
         return Pair(mem, slice)
     }
 
 
-    fun native(longArray: LongArray): Pair<Memory, Slice> {
+    fun native(longArray: LongArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Long.SIZE_BYTES * longArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, longArray, 0, longArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, longArray, 0, longArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(longArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uLongArray: ULongArray): Pair<Memory, Slice> {
+    fun native(uLongArray: ULongArray): Pair<Memory?, Slice> {
         val shortArray = uLongArray.asLongArray()
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uLongArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(floatArray: FloatArray): Pair<Memory, Slice> {
+    fun native(floatArray: FloatArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Float.SIZE_BYTES * floatArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, floatArray, 0, floatArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, floatArray, 0, floatArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(floatArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(doubleArray: DoubleArray): Pair<Memory, Slice> {
+    fun native(doubleArray: DoubleArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, doubleArray, 0, doubleArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, doubleArray, 0, doubleArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(doubleArray.size.toLong())
         return Pair(mem, slice)
     }
@@ -238,12 +281,12 @@ internal object PrimitiveArrayTools {
         return slice.data.getDoubleArray(0, slice.len.toInt())
     }
 
-    fun readUtf8(str: String): Pair<Memory, Slice> {
+    fun readUtf8(str: String): Pair<Memory?, Slice> {
         return native(str.toByteArray())
     }
 
     @ExperimentalUnsignedTypes
-    fun readUtf16(str: String): Pair<Memory, Slice> {
+    fun readUtf16(str: String): Pair<Memory?, Slice> {
         return native(str.map {it.code.toUShort()}.toUShortArray())
     }
 
@@ -260,11 +303,15 @@ internal object PrimitiveArrayTools {
         return charArray
     }
 
-    fun readUtf8s(array: Array<String>): Pair<List<Memory>, Slice> {
+    fun readUtf8s(array: Array<String>): Pair<List<Memory?>, Slice> {
         val sliceSize = Slice.SIZE
         val mem = allocateMemory(sliceSize * array.size.toLong())
-        val ptr = mem.share(0)
-        val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
+        val ptr = if (mem != null) {
+            mem.share(0)
+        } else {
+            Pointer(0)
+        }
+        val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf8(str)
             ptr.setPointer(idx * sliceSize, slice.data)
             ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
@@ -276,11 +323,15 @@ internal object PrimitiveArrayTools {
         return Pair(mems + mem, slice)
     }
 
-    fun readUtf16s(array: Array<String>): Pair<List<Memory>, Slice> {
+    fun readUtf16s(array: Array<String>): Pair<List<Memory?>, Slice> {
         val sliceSize = Slice.SIZE
         val mem = allocateMemory(sliceSize * array.size.toLong())
-        val ptr = mem.share(0)
-        val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
+        val ptr = if (mem != null) {
+            mem.share(0)
+        } else {
+            Pointer(0)
+        }
+        val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf16(str)
             ptr.setPointer(idx * sliceSize, slice.data)
             ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -64,8 +64,18 @@ internal class DiplomatJVMRuntime {
 
 internal object PrimitiveArrayTools {
 
+    fun allocateMemory(size: Long): Memory {
+        // we can't use the Memory constructor for a memory of size 0
+        // so, if the size is zero, then we actually build a Memory of
+        // size 1 and then clear it.
+        val mem = Memory(size + if (size == 0L) 1 else 0)
+        if (size == 0L)
+            mem.clear()
+        return mem
+    }
+
     fun native(boolArray: BooleanArray): Pair<Memory, Slice> {
-        val mem = Memory(boolArray.size.toLong())
+        val mem = allocateMemory(boolArray.size.toLong())
         val ptr = mem.share(0)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         ptr.write(0, byteArray, 0, byteArray.size)
@@ -75,8 +85,8 @@ internal object PrimitiveArrayTools {
         return Pair(mem, slice)
     }
 
-    fun native(byteArray: ByteArray):  Pair<Memory, Slice>{
-        val mem = Memory(byteArray.size.toLong())
+    fun native(byteArray: ByteArray):  Pair<Memory, Slice> {
+        val mem = allocateMemory(byteArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
@@ -88,7 +98,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uByteArray: UByteArray): Pair<Memory, Slice> {
         val byteArray = uByteArray.asByteArray()
-        val mem = Memory(byteArray.size.toLong())
+        val mem = allocateMemory(byteArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
@@ -98,7 +108,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(shortArray: ShortArray): Pair<Memory, Slice> {
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -110,7 +120,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uShortArray: UShortArray): Pair<Memory, Slice> {
         val shortArray = uShortArray.asShortArray()
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -120,7 +130,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(intArray: IntArray): Pair<Memory, Slice> {
-        val mem = Memory(Int.SIZE_BYTES * intArray.size.toLong())
+        val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
@@ -132,7 +142,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uIntArray: UIntArray): Pair<Memory, Slice> {
         val intArray = uIntArray.asIntArray()
-        val mem = Memory(Int.SIZE_BYTES * intArray.size.toLong())
+        val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
@@ -143,7 +153,7 @@ internal object PrimitiveArrayTools {
 
 
     fun native(longArray: LongArray): Pair<Memory, Slice> {
-        val mem = Memory(Long.SIZE_BYTES * longArray.size.toLong())
+        val mem = allocateMemory(Long.SIZE_BYTES * longArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, longArray, 0, longArray.size)
         val slice = Slice()
@@ -155,7 +165,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uLongArray: ULongArray): Pair<Memory, Slice> {
         val shortArray = uLongArray.asLongArray()
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -165,7 +175,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(floatArray: FloatArray): Pair<Memory, Slice> {
-        val mem = Memory(Float.SIZE_BYTES * floatArray.size.toLong())
+        val mem = allocateMemory(Float.SIZE_BYTES * floatArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, floatArray, 0, floatArray.size)
         val slice = Slice()
@@ -175,7 +185,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(doubleArray: DoubleArray): Pair<Memory, Slice> {
-        val mem = Memory(Double.SIZE_BYTES * doubleArray.size.toLong())
+        val mem = allocateMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, doubleArray, 0, doubleArray.size)
         val slice = Slice()
@@ -252,7 +262,7 @@ internal object PrimitiveArrayTools {
 
     fun readUtf8s(array: Array<String>): Pair<List<Memory>, Slice> {
         val sliceSize = Slice.SIZE
-        val mem = Memory(sliceSize * array.size.toLong())
+        val mem = allocateMemory(sliceSize * array.size.toLong())
         val ptr = mem.share(0)
         val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf8(str)
@@ -268,7 +278,7 @@ internal object PrimitiveArrayTools {
 
     fun readUtf16s(array: Array<String>): Pair<List<Memory>, Slice> {
         val sliceSize = Slice.SIZE
-        val mem = Memory(sliceSize * array.size.toLong())
+        val mem = allocateMemory(sliceSize * array.size.toLong())
         val ptr = mem.share(0)
         val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf16(str)

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Locale.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Locale.kt
@@ -41,7 +41,7 @@ class Locale internal constructor (
             val handle = returnVal 
             val returnOpaque = Locale(handle, selfEdges)
             CLEANER.register(returnOpaque, Locale.LocaleCleaner(handle, Locale.lib));
-            nameMem.close()
+            if (nameMem != null) nameMem.close()
             return returnOpaque
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Bar.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Bar.kt
@@ -16,8 +16,8 @@ class Bar internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val bEdges: List<Any>,
-    internal val aEdges: List<Any>,
+    internal val bEdges: List<Any?>,
+    internal val aEdges: List<Any?>,
 )  {
 
     internal class BarCleaner(val handle: Pointer, val lib: BarLib) : Runnable {
@@ -35,7 +35,7 @@ class Bar internal constructor (
         
         val returnVal = lib.Bar_foo(handle);
         val selfEdges: List<Any> = listOf(this)
-        val aEdges: List<Any> = listOf(this)
+        val aEdges: List<Any?> = listOf(this)
         val handle = returnVal 
         val returnOpaque = Foo(handle, selfEdges, aEdges)
         return returnOpaque

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFields.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFields.kt
@@ -26,7 +26,7 @@ internal class BorrowedFieldsNative: Structure(), Structure.ByValue {
 
 class BorrowedFields internal constructor (
     internal val nativeStruct: BorrowedFieldsNative,
-    internal val aEdges: List<Any>
+    internal val aEdges: List<Any?>
     ) {
     val a: String = PrimitiveArrayTools.getUtf16(nativeStruct.a)
     val b: String = PrimitiveArrayTools.getUtf8(nativeStruct.b)
@@ -43,7 +43,7 @@ class BorrowedFields internal constructor (
             
             val returnVal = lib.BorrowedFields_from_bar_and_strings(bar.handle, dstr16Slice, utf8StrSlice);
             
-            val xEdges: List<Any> = listOf(bar) + listOf(dstr16Mem) + listOf(utf8StrMem)
+            val xEdges: List<Any?> = listOf(bar) + listOf(dstr16Mem) + listOf(utf8StrMem)
             val returnStruct = BorrowedFields(returnVal, xEdges)
             return returnStruct
         }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsReturning.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsReturning.kt
@@ -21,7 +21,7 @@ internal class BorrowedFieldsReturningNative: Structure(), Structure.ByValue {
 
 class BorrowedFieldsReturning internal constructor (
     internal val nativeStruct: BorrowedFieldsReturningNative,
-    internal val aEdges: List<Any>
+    internal val aEdges: List<Any?>
     ) {
     val bytes: String = PrimitiveArrayTools.getUtf8(nativeStruct.bytes)
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsWithBounds.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsWithBounds.kt
@@ -26,9 +26,9 @@ internal class BorrowedFieldsWithBoundsNative: Structure(), Structure.ByValue {
 
 class BorrowedFieldsWithBounds internal constructor (
     internal val nativeStruct: BorrowedFieldsWithBoundsNative,
-    internal val aEdges: List<Any>,
-    internal val bEdges: List<Any>,
-    internal val cEdges: List<Any>
+    internal val aEdges: List<Any?>,
+    internal val bEdges: List<Any?>,
+    internal val cEdges: List<Any?>
     ) {
     val fieldA: String = PrimitiveArrayTools.getUtf16(nativeStruct.fieldA)
     val fieldB: String = PrimitiveArrayTools.getUtf8(nativeStruct.fieldB)
@@ -45,9 +45,9 @@ class BorrowedFieldsWithBounds internal constructor (
             
             val returnVal = lib.BorrowedFieldsWithBounds_from_foo_and_strings(foo.handle, dstr16XSlice, utf8StrZSlice);
             
-            val xEdges: List<Any> = listOf(foo) + listOf(dstr16XMem) + listOf(utf8StrZMem)
-            val yEdges: List<Any> = listOf(foo) + listOf(utf8StrZMem)
-            val zEdges: List<Any> = listOf(utf8StrZMem)
+            val xEdges: List<Any?> = listOf(foo) + listOf(dstr16XMem) + listOf(utf8StrZMem)
+            val yEdges: List<Any?> = listOf(foo) + listOf(utf8StrZMem)
+            val zEdges: List<Any?> = listOf(utf8StrZMem)
             val returnStruct = BorrowedFieldsWithBounds(returnVal, xEdges, yEdges, zEdges)
             return returnStruct
         }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
@@ -48,7 +48,7 @@ class Float64Vec internal constructor (
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            vMem.close()
+            if (vMem != null) vMem.close()
             return returnOpaque
         }
         
@@ -60,7 +60,7 @@ class Float64Vec internal constructor (
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            vMem.close()
+            if (vMem != null) vMem.close()
             return returnOpaque
         }
         
@@ -72,7 +72,7 @@ class Float64Vec internal constructor (
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            vMem.close()
+            if (vMem != null) vMem.close()
             return returnOpaque
         }
         
@@ -84,7 +84,7 @@ class Float64Vec internal constructor (
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            vMem.close()
+            if (vMem != null) vMem.close()
             return returnOpaque
         }
         
@@ -96,7 +96,7 @@ class Float64Vec internal constructor (
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            vMem.close()
+            if (vMem != null) vMem.close()
             return returnOpaque
         }
         
@@ -108,7 +108,7 @@ class Float64Vec internal constructor (
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            vMem.close()
+            if (vMem != null) vMem.close()
             return returnOpaque
         }
         

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Foo.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Foo.kt
@@ -21,7 +21,7 @@ class Foo internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val aEdges: List<Any>,
+    internal val aEdges: List<Any?>,
 )  {
 
     internal class FooCleaner(val handle: Pointer, val lib: FooLib) : Runnable {
@@ -39,7 +39,7 @@ class Foo internal constructor (
             
             val returnVal = lib.Foo_new(xSlice);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = listOf(xMem)
+            val aEdges: List<Any?> = listOf(xMem)
             val handle = returnVal 
             val returnOpaque = Foo(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, Foo.FooCleaner(handle, Foo.lib));
@@ -51,11 +51,11 @@ class Foo internal constructor (
             
             val returnVal = lib.Foo_new_static(xSlice);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = listOf()
+            val aEdges: List<Any?> = listOf()
             val handle = returnVal 
             val returnOpaque = Foo(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, Foo.FooCleaner(handle, Foo.lib));
-            xMem.close()
+            if (xMem != null) xMem.close()
             return returnOpaque
         }
         
@@ -63,7 +63,7 @@ class Foo internal constructor (
             
             val returnVal = lib.Foo_extract_from_fields(fields.nativeStruct);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = fields.aEdges
+            val aEdges: List<Any?> = fields.aEdges
             val handle = returnVal 
             val returnOpaque = Foo(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, Foo.FooCleaner(handle, Foo.lib));
@@ -77,7 +77,7 @@ class Foo internal constructor (
             
             val returnVal = lib.Foo_extract_from_bounds(bounds.nativeStruct, anotherStringSlice);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = bounds.bEdges + bounds.cEdges + listOf(anotherStringMem)
+            val aEdges: List<Any?> = bounds.bEdges + bounds.cEdges + listOf(anotherStringMem)
             val handle = returnVal 
             val returnOpaque = Foo(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, Foo.FooCleaner(handle, Foo.lib));
@@ -89,8 +89,8 @@ class Foo internal constructor (
         
         val returnVal = lib.Foo_get_bar(handle);
         val selfEdges: List<Any> = listOf()
-        val bEdges: List<Any> = listOf(this)
-        val aEdges: List<Any> = listOf(this)
+        val bEdges: List<Any?> = listOf(this)
+        val aEdges: List<Any?> = listOf(this)
         val handle = returnVal 
         val returnOpaque = Bar(handle, selfEdges, bEdges, aEdges)
         CLEANER.register(returnOpaque, Bar.BarCleaner(handle, Bar.lib));
@@ -101,7 +101,7 @@ class Foo internal constructor (
         
         val returnVal = lib.Foo_as_returning(handle);
         
-        val aEdges: List<Any> = listOf(this)
+        val aEdges: List<Any?> = listOf(this)
         val returnStruct = BorrowedFieldsReturning(returnVal, aEdges)
         return returnStruct
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -64,132 +64,175 @@ internal class DiplomatJVMRuntime {
 
 internal object PrimitiveArrayTools {
 
-    fun allocateMemory(size: Long): Memory {
+    fun allocateMemory(size: Long): Memory? {
         // we can't use the Memory constructor for a memory of size 0
-        // so, if the size is zero, then we actually build a Memory of
-        // size 1 and then clear it.
-        val mem = Memory(size + if (size == 0L) 1 else 0)
-        if (size == 0L)
-            mem.clear()
-        return mem
+        // so, if the size is zero, then we return null
+        if (size > 0L)
+            return Memory(size)
+        else
+            return null
     }
 
-    fun native(boolArray: BooleanArray): Pair<Memory, Slice> {
+    fun native(boolArray: BooleanArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(boolArray.size.toLong())
-        val ptr = mem.share(0)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(byteArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(byteArray: ByteArray):  Pair<Memory, Slice> {
+    fun native(byteArray: ByteArray):  Pair<Memory?, Slice> {
         val mem = allocateMemory(byteArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) { 
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(byteArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uByteArray: UByteArray): Pair<Memory, Slice> {
+    fun native(uByteArray: UByteArray): Pair<Memory?, Slice> {
         val byteArray = uByteArray.asByteArray()
         val mem = allocateMemory(byteArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uByteArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(shortArray: ShortArray): Pair<Memory, Slice> {
+    fun native(shortArray: ShortArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(shortArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uShortArray: UShortArray): Pair<Memory, Slice> {
+    fun native(uShortArray: UShortArray): Pair<Memory?, Slice> {
         val shortArray = uShortArray.asShortArray()
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uShortArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(intArray: IntArray): Pair<Memory, Slice> {
+    fun native(intArray: IntArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, intArray, 0, intArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(intArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uIntArray: UIntArray): Pair<Memory, Slice> {
+    fun native(uIntArray: UIntArray): Pair<Memory?, Slice> {
         val intArray = uIntArray.asIntArray()
         val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, intArray, 0, intArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uIntArray.size.toLong())
         return Pair(mem, slice)
     }
 
 
-    fun native(longArray: LongArray): Pair<Memory, Slice> {
+    fun native(longArray: LongArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Long.SIZE_BYTES * longArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, longArray, 0, longArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, longArray, 0, longArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(longArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uLongArray: ULongArray): Pair<Memory, Slice> {
+    fun native(uLongArray: ULongArray): Pair<Memory?, Slice> {
         val shortArray = uLongArray.asLongArray()
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uLongArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(floatArray: FloatArray): Pair<Memory, Slice> {
+    fun native(floatArray: FloatArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Float.SIZE_BYTES * floatArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, floatArray, 0, floatArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, floatArray, 0, floatArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(floatArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(doubleArray: DoubleArray): Pair<Memory, Slice> {
+    fun native(doubleArray: DoubleArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, doubleArray, 0, doubleArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, doubleArray, 0, doubleArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(doubleArray.size.toLong())
         return Pair(mem, slice)
     }
@@ -238,12 +281,12 @@ internal object PrimitiveArrayTools {
         return slice.data.getDoubleArray(0, slice.len.toInt())
     }
 
-    fun readUtf8(str: String): Pair<Memory, Slice> {
+    fun readUtf8(str: String): Pair<Memory?, Slice> {
         return native(str.toByteArray())
     }
 
     @ExperimentalUnsignedTypes
-    fun readUtf16(str: String): Pair<Memory, Slice> {
+    fun readUtf16(str: String): Pair<Memory?, Slice> {
         return native(str.map {it.code.toUShort()}.toUShortArray())
     }
 
@@ -260,11 +303,15 @@ internal object PrimitiveArrayTools {
         return charArray
     }
 
-    fun readUtf8s(array: Array<String>): Pair<List<Memory>, Slice> {
+    fun readUtf8s(array: Array<String>): Pair<List<Memory?>, Slice> {
         val sliceSize = Slice.SIZE
         val mem = allocateMemory(sliceSize * array.size.toLong())
-        val ptr = mem.share(0)
-        val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
+        val ptr = if (mem != null) {
+            mem.share(0)
+        } else {
+            Pointer(0)
+        }
+        val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf8(str)
             ptr.setPointer(idx * sliceSize, slice.data)
             ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
@@ -276,11 +323,15 @@ internal object PrimitiveArrayTools {
         return Pair(mems + mem, slice)
     }
 
-    fun readUtf16s(array: Array<String>): Pair<List<Memory>, Slice> {
+    fun readUtf16s(array: Array<String>): Pair<List<Memory?>, Slice> {
         val sliceSize = Slice.SIZE
         val mem = allocateMemory(sliceSize * array.size.toLong())
-        val ptr = mem.share(0)
-        val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
+        val ptr = if (mem != null) {
+            mem.share(0)
+        } else {
+            Pointer(0)
+        }
+        val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf16(str)
             ptr.setPointer(idx * sliceSize, slice.data)
             ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -64,8 +64,18 @@ internal class DiplomatJVMRuntime {
 
 internal object PrimitiveArrayTools {
 
+    fun allocateMemory(size: Long): Memory {
+        // we can't use the Memory constructor for a memory of size 0
+        // so, if the size is zero, then we actually build a Memory of
+        // size 1 and then clear it.
+        val mem = Memory(size + if (size == 0L) 1 else 0)
+        if (size == 0L)
+            mem.clear()
+        return mem
+    }
+
     fun native(boolArray: BooleanArray): Pair<Memory, Slice> {
-        val mem = Memory(boolArray.size.toLong())
+        val mem = allocateMemory(boolArray.size.toLong())
         val ptr = mem.share(0)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         ptr.write(0, byteArray, 0, byteArray.size)
@@ -75,8 +85,8 @@ internal object PrimitiveArrayTools {
         return Pair(mem, slice)
     }
 
-    fun native(byteArray: ByteArray):  Pair<Memory, Slice>{
-        val mem = Memory(byteArray.size.toLong())
+    fun native(byteArray: ByteArray):  Pair<Memory, Slice> {
+        val mem = allocateMemory(byteArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
@@ -88,7 +98,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uByteArray: UByteArray): Pair<Memory, Slice> {
         val byteArray = uByteArray.asByteArray()
-        val mem = Memory(byteArray.size.toLong())
+        val mem = allocateMemory(byteArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
@@ -98,7 +108,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(shortArray: ShortArray): Pair<Memory, Slice> {
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -110,7 +120,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uShortArray: UShortArray): Pair<Memory, Slice> {
         val shortArray = uShortArray.asShortArray()
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -120,7 +130,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(intArray: IntArray): Pair<Memory, Slice> {
-        val mem = Memory(Int.SIZE_BYTES * intArray.size.toLong())
+        val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
@@ -132,7 +142,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uIntArray: UIntArray): Pair<Memory, Slice> {
         val intArray = uIntArray.asIntArray()
-        val mem = Memory(Int.SIZE_BYTES * intArray.size.toLong())
+        val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
@@ -143,7 +153,7 @@ internal object PrimitiveArrayTools {
 
 
     fun native(longArray: LongArray): Pair<Memory, Slice> {
-        val mem = Memory(Long.SIZE_BYTES * longArray.size.toLong())
+        val mem = allocateMemory(Long.SIZE_BYTES * longArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, longArray, 0, longArray.size)
         val slice = Slice()
@@ -155,7 +165,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uLongArray: ULongArray): Pair<Memory, Slice> {
         val shortArray = uLongArray.asLongArray()
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -165,7 +175,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(floatArray: FloatArray): Pair<Memory, Slice> {
-        val mem = Memory(Float.SIZE_BYTES * floatArray.size.toLong())
+        val mem = allocateMemory(Float.SIZE_BYTES * floatArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, floatArray, 0, floatArray.size)
         val slice = Slice()
@@ -175,7 +185,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(doubleArray: DoubleArray): Pair<Memory, Slice> {
-        val mem = Memory(Double.SIZE_BYTES * doubleArray.size.toLong())
+        val mem = allocateMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, doubleArray, 0, doubleArray.size)
         val slice = Slice()
@@ -252,7 +262,7 @@ internal object PrimitiveArrayTools {
 
     fun readUtf8s(array: Array<String>): Pair<List<Memory>, Slice> {
         val sliceSize = Slice.SIZE
-        val mem = Memory(sliceSize * array.size.toLong())
+        val mem = allocateMemory(sliceSize * array.size.toLong())
         val ptr = mem.share(0)
         val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf8(str)
@@ -268,7 +278,7 @@ internal object PrimitiveArrayTools {
 
     fun readUtf16s(array: Array<String>): Pair<List<Memory>, Slice> {
         val sliceSize = Slice.SIZE
-        val mem = Memory(sliceSize * array.size.toLong())
+        val mem = allocateMemory(sliceSize * array.size.toLong())
         val ptr = mem.share(0)
         val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf16(str)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterable.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterable.kt
@@ -37,7 +37,7 @@ class MyIterable internal constructor (
             val handle = returnVal 
             val returnOpaque = MyIterable(handle, selfEdges)
             CLEANER.register(returnOpaque, MyIterable.MyIterableCleaner(handle, MyIterable.lib));
-            xMem.close()
+            if (xMem != null) xMem.close()
             return returnOpaque
         }
     }
@@ -46,7 +46,7 @@ class MyIterable internal constructor (
         
         val returnVal = lib.namespace_MyIterable_iter(handle);
         val selfEdges: List<Any> = listOf()
-        val aEdges: List<Any> = listOf(this)
+        val aEdges: List<Any?> = listOf(this)
         val handle = returnVal 
         val returnOpaque = MyIterator(handle, selfEdges, aEdges)
         CLEANER.register(returnOpaque, MyIterator.MyIteratorCleaner(handle, MyIterator.lib));

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterator.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterator.kt
@@ -17,7 +17,7 @@ class MyIterator internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val aEdges: List<Any>,
+    internal val aEdges: List<Any?>,
 ): Iterator<UByte> {
 
     internal class MyIteratorCleaner(val handle: Pointer, val lib: MyIteratorLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
@@ -43,7 +43,7 @@ class MyString internal constructor (
             val handle = returnVal 
             val returnOpaque = MyString(handle, selfEdges)
             CLEANER.register(returnOpaque, MyString.MyStringCleaner(handle, MyString.lib));
-            vMem.close()
+            if (vMem != null) vMem.close()
             return returnOpaque
         }
         
@@ -55,7 +55,7 @@ class MyString internal constructor (
             val handle = returnVal 
             val returnOpaque = MyString(handle, selfEdges)
             CLEANER.register(returnOpaque, MyString.MyStringCleaner(handle, MyString.lib));
-            vMem.close()
+            if (vMem != null) vMem.close()
             return returnOpaque
         }
         
@@ -78,7 +78,7 @@ class MyString internal constructor (
             val handle = returnVal 
             val returnOpaque = MyString(handle, selfEdges)
             CLEANER.register(returnOpaque, MyString.MyStringCleaner(handle, MyString.lib));
-            vMem.forEach {it.close()}
+            vMem.forEach {if (it != null) it.close()}
             return returnOpaque
         }
         

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/NestedBorrowedFields.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/NestedBorrowedFields.kt
@@ -26,9 +26,9 @@ internal class NestedBorrowedFieldsNative: Structure(), Structure.ByValue {
 
 class NestedBorrowedFields internal constructor (
     internal val nativeStruct: NestedBorrowedFieldsNative,
-    internal val xEdges: List<Any>,
-    internal val yEdges: List<Any>,
-    internal val zEdges: List<Any>
+    internal val xEdges: List<Any?>,
+    internal val yEdges: List<Any?>,
+    internal val zEdges: List<Any?>
     ) {
     val fields: BorrowedFields = BorrowedFields(nativeStruct.fields, xEdges)
     val bounds: BorrowedFieldsWithBounds = BorrowedFieldsWithBounds(nativeStruct.bounds, xEdges, yEdges, yEdges)
@@ -47,9 +47,9 @@ class NestedBorrowedFields internal constructor (
             
             val returnVal = lib.NestedBorrowedFields_from_bar_and_foo_and_strings(bar.handle, foo.handle, dstr16XSlice, dstr16ZSlice, utf8StrYSlice, utf8StrZSlice);
             
-            val xEdges: List<Any> = listOf(bar) + listOf(dstr16XMem) + listOf(utf8StrYMem)
-            val yEdges: List<Any> = listOf(bar) + listOf(utf8StrYMem)
-            val zEdges: List<Any> = listOf(foo) + listOf(dstr16ZMem) + listOf(utf8StrZMem)
+            val xEdges: List<Any?> = listOf(bar) + listOf(dstr16XMem) + listOf(utf8StrYMem)
+            val yEdges: List<Any?> = listOf(bar) + listOf(utf8StrYMem)
+            val zEdges: List<Any?> = listOf(foo) + listOf(dstr16ZMem) + listOf(utf8StrZMem)
             val returnStruct = NestedBorrowedFields(returnVal, xEdges, yEdges, zEdges)
             return returnStruct
         }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/One.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/One.kt
@@ -26,7 +26,7 @@ class One internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val aEdges: List<Any>,
+    internal val aEdges: List<Any?>,
 )  {
 
     internal class OneCleaner(val handle: Pointer, val lib: OneLib) : Runnable {
@@ -43,7 +43,7 @@ class One internal constructor (
             
             val returnVal = lib.One_transitivity(hold.handle, nohold.handle);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = listOf(hold)
+            val aEdges: List<Any?> = listOf(hold)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -54,7 +54,7 @@ class One internal constructor (
             
             val returnVal = lib.One_cycle(hold.handle, nohold.handle);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = listOf(hold)
+            val aEdges: List<Any?> = listOf(hold)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -65,7 +65,7 @@ class One internal constructor (
             
             val returnVal = lib.One_many_dependents(a.handle, b.handle, c.handle, d.handle, nohold.handle);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = listOf(a) + listOf(b) + listOf(c) + listOf(d)
+            val aEdges: List<Any?> = listOf(a) + listOf(b) + listOf(c) + listOf(d)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -76,7 +76,7 @@ class One internal constructor (
             
             val returnVal = lib.One_return_outlives_param(hold.handle, nohold.handle);
             val selfEdges: List<Any> = listOf()
-            val longEdges: List<Any> = listOf(hold)
+            val longEdges: List<Any?> = listOf(hold)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, longEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -87,7 +87,7 @@ class One internal constructor (
             
             val returnVal = lib.One_diamond_top(top.handle, left.handle, right.handle, bottom.handle);
             val selfEdges: List<Any> = listOf()
-            val topEdges: List<Any> = listOf(top) + listOf(left) + listOf(right) + listOf(bottom)
+            val topEdges: List<Any?> = listOf(top) + listOf(left) + listOf(right) + listOf(bottom)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, topEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -98,7 +98,7 @@ class One internal constructor (
             
             val returnVal = lib.One_diamond_left(top.handle, left.handle, right.handle, bottom.handle);
             val selfEdges: List<Any> = listOf()
-            val leftEdges: List<Any> = listOf(left) + listOf(bottom)
+            val leftEdges: List<Any?> = listOf(left) + listOf(bottom)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, leftEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -109,7 +109,7 @@ class One internal constructor (
             
             val returnVal = lib.One_diamond_right(top.handle, left.handle, right.handle, bottom.handle);
             val selfEdges: List<Any> = listOf()
-            val rightEdges: List<Any> = listOf(right) + listOf(bottom)
+            val rightEdges: List<Any?> = listOf(right) + listOf(bottom)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, rightEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -120,7 +120,7 @@ class One internal constructor (
             
             val returnVal = lib.One_diamond_bottom(top.handle, left.handle, right.handle, bottom.handle);
             val selfEdges: List<Any> = listOf()
-            val bottomEdges: List<Any> = listOf(bottom)
+            val bottomEdges: List<Any?> = listOf(bottom)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, bottomEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -131,7 +131,7 @@ class One internal constructor (
             
             val returnVal = lib.One_diamond_and_nested_types(a.handle, b.handle, c.handle, d.handle, nohold.handle);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = listOf(a) + listOf(b) + listOf(c) + listOf(d)
+            val aEdges: List<Any?> = listOf(a) + listOf(b) + listOf(c) + listOf(d)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -142,7 +142,7 @@ class One internal constructor (
             
             val returnVal = lib.One_implicit_bounds(explicitHold.handle, implicitHold.handle, nohold.handle);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = listOf(explicitHold) + listOf(implicitHold)
+            val aEdges: List<Any?> = listOf(explicitHold) + listOf(implicitHold)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
@@ -153,7 +153,7 @@ class One internal constructor (
             
             val returnVal = lib.One_implicit_bounds_deep(explicit.handle, implicit1.handle, implicit2.handle, nohold.handle);
             val selfEdges: List<Any> = listOf()
-            val aEdges: List<Any> = listOf(explicit) + listOf(implicit1) + listOf(implicit2)
+            val aEdges: List<Any?> = listOf(explicit) + listOf(implicit1) + listOf(implicit2)
             val handle = returnVal 
             val returnOpaque = One(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
@@ -53,7 +53,7 @@ class Opaque internal constructor (
             val handle = returnVal ?: return null
             val returnOpaque = Opaque(handle, selfEdges)
             CLEANER.register(returnOpaque, Opaque.OpaqueCleaner(handle, Opaque.lib));
-            inputMem.close()
+            if (inputMem != null) inputMem.close()
             return returnOpaque
         }
         
@@ -65,7 +65,7 @@ class Opaque internal constructor (
             val handle = returnVal 
             val returnOpaque = Opaque(handle, selfEdges)
             CLEANER.register(returnOpaque, Opaque.OpaqueCleaner(handle, Opaque.lib));
-            inputMem.close()
+            if (inputMem != null) inputMem.close()
             return returnOpaque
         }
         

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueIterable.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueIterable.kt
@@ -33,7 +33,7 @@ class OpaqueIterable internal constructor (
         
         val returnVal = lib.namespace_OpaqueIterable_iter(handle);
         val selfEdges: List<Any> = listOf()
-        val aEdges: List<Any> = listOf(this)
+        val aEdges: List<Any?> = listOf(this)
         val handle = returnVal 
         val returnOpaque = OpaqueIterator(handle, selfEdges, aEdges)
         CLEANER.register(returnOpaque, OpaqueIterator.OpaqueIteratorCleaner(handle, OpaqueIterator.lib));

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueIterator.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueIterator.kt
@@ -17,7 +17,7 @@ class OpaqueIterator internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val aEdges: List<Any>,
+    internal val aEdges: List<Any?>,
 ): Iterator<AttrOpaque1?> {
 
     internal class OpaqueIteratorCleaner(val handle: Pointer, val lib: OpaqueIteratorLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
@@ -38,7 +38,7 @@ class OptionString internal constructor (
             val handle = returnVal ?: return null
             val returnOpaque = OptionString(handle, selfEdges)
             CLEANER.register(returnOpaque, OptionString.OptionStringCleaner(handle, OptionString.lib));
-            diplomatStrMem.close()
+            if (diplomatStrMem != null) diplomatStrMem.close()
             return returnOpaque
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/RefList.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/RefList.kt
@@ -16,7 +16,7 @@ class RefList internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val aEdges: List<Any>,
+    internal val aEdges: List<Any?>,
 )  {
 
     internal class RefListCleaner(val handle: Pointer, val lib: RefListLib) : Runnable {
@@ -33,7 +33,7 @@ class RefList internal constructor (
             
             val returnVal = lib.RefList_node(data.handle);
             val selfEdges: List<Any> = listOf()
-            val bEdges: List<Any> = listOf(data)
+            val bEdges: List<Any?> = listOf(data)
             val handle = returnVal 
             val returnOpaque = RefList(handle, selfEdges, bEdges)
             CLEANER.register(returnOpaque, RefList.RefListCleaner(handle, RefList.lib));

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Two.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Two.kt
@@ -15,8 +15,8 @@ class Two internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val aEdges: List<Any>,
-    internal val bEdges: List<Any>,
+    internal val aEdges: List<Any?>,
+    internal val bEdges: List<Any?>,
 )  {
 
     internal class TwoCleaner(val handle: Pointer, val lib: TwoLib) : Runnable {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Utf16Wrap.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Utf16Wrap.kt
@@ -38,7 +38,7 @@ class Utf16Wrap internal constructor (
             val handle = returnVal 
             val returnOpaque = Utf16Wrap(handle, selfEdges)
             CLEANER.register(returnOpaque, Utf16Wrap.Utf16WrapCleaner(handle, Utf16Wrap.lib));
-            inputMem.close()
+            if (inputMem != null) inputMem.close()
             return returnOpaque
         }
     }

--- a/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/MyIteratorTest.kt
+++ b/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/MyIteratorTest.kt
@@ -18,4 +18,18 @@ class MyIteratorTest {
         assertEquals(mutableList.toList(), list)
 
     }
+
+    @Test
+    fun testEmptyIterator() {
+        val list: List<Int> = listOf()
+        val array = list.map { it.toByte().toUByte()}.toUByteArray()
+
+        val myIterable = MyIterable.new_(array)
+        val mutableList : MutableList<Int> = mutableListOf()
+        val myIterator = myIterable.iterator()
+        for (it in myIterator) {
+            mutableList.add(it.toInt())
+        }
+        assertEquals(mutableList.toList(), list)
+    }
 }

--- a/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/MyStringTest.kt
+++ b/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/MyStringTest.kt
@@ -7,6 +7,7 @@ class MyStringTest {
 
     val javaStr = "下面是一句中文"
     val ukrainian = "І це українською мовою"
+    val emptyString = ""
     // this should be ancient egyptian for "his brother elder"
     // transcribed from the wikipedia article on "a tale of two brothers
     // used to verify correct function of codepoints beyond U+FFFF
@@ -27,5 +28,11 @@ class MyStringTest {
         val myString = MyString.newFromFirst(javaStrs)
 
         assertEquals(ancientEgyptian, myString.getStr())
+    }
+
+    @Test
+    fun testEmptyString() {
+        val myString = MyString.new_(emptyString)
+        assertEquals(myString.getStr(), "")
     }
 }

--- a/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/NativeTest.kt
+++ b/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/NativeTest.kt
@@ -13,7 +13,7 @@ class NativeTest {
             val array = random.nextBytes(1000)
             val (mem, slice) = PrimitiveArrayTools.native(array)
             val got = slice.data.getByteArray(0, array.size)
-            mem.close()
+            if (mem != null) mem.close()
             assertEquals(got.toList(), array.toList())
         }
 
@@ -22,7 +22,7 @@ class NativeTest {
             val uByteArray = array.map { it.toUByte()}.toUByteArray()
             val (mem, slice) = PrimitiveArrayTools.native(array)
             val got = slice.data.getByteArray(0, array.size).asUByteArray()
-            mem.close()
+            if (mem != null) mem.close()
             assertEquals(got.map { it.toUByte()}, uByteArray.toList())
         }
 
@@ -32,7 +32,7 @@ class NativeTest {
             val intArray = (0..size).map { random.nextInt() }.toIntArray()
             val (mem, slice) = PrimitiveArrayTools.native(intArray)
             val got = slice.data.getIntArray(0, intArray.size)
-            mem.close()
+            if (mem != null) mem.close()
             assertEquals(got.toList(), intArray.toList())
         }
 
@@ -41,7 +41,7 @@ class NativeTest {
             val intArray = (0..size).map { random.nextInt().toUInt() }.toUIntArray()
             val (mem, slice) = PrimitiveArrayTools.native(intArray)
             val got = slice.data.getIntArray(0, intArray.size).asUIntArray()
-            mem.close()
+            if (mem != null) mem.close()
             assertEquals(got.toList(), intArray.toList())
         }
 

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -980,11 +980,17 @@ returnVal.option() ?: return null
 
     fn gen_cleanup(&self, param_name: Cow<'cx, str>, slice: Slice) -> Option<Cow<'cx, str>> {
         match slice {
-            Slice::Str(Some(_), _) => Some(format!("{param_name}Mem.close()").into()),
+            Slice::Str(Some(_), _) => {
+                Some(format!("if ({param_name}Mem != null) {param_name}Mem.close()").into())
+            }
             Slice::Str(_, _) => None,
-            Slice::Primitive(Some(_), _) => Some(format!("{param_name}Mem.close()").into()),
+            Slice::Primitive(Some(_), _) => {
+                Some(format!("if ({param_name}Mem != null) {param_name}Mem.close()").into())
+            }
             Slice::Primitive(_, _) => None,
-            Slice::Strs(_) => Some(format!("{param_name}Mem.forEach {{it.close()}}").into()),
+            Slice::Strs(_) => {
+                Some(format!("{param_name}Mem.forEach {{if (it != null) it.close()}}").into())
+            }
             _ => todo!(),
         }
     }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2352
+assertion_line: 2361
 expression: result
 ---
 package dev.gigapixel.somelib;
@@ -20,8 +20,8 @@ class BorrowWrapper internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val aEdges: List<Any>,
-    internal val bEdges: List<Any>,
+    internal val aEdges: List<Any?>,
+    internal val bEdges: List<Any?>,
 )  {
 
     internal class BorrowWrapperCleaner(val handle: Pointer, val lib: BorrowWrapperLib) : Runnable {

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_multiple_ref_args.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_multiple_ref_args.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2243
+assertion_line: 2252
 expression: result
 ---
 package dev.gigapixel.somelib;
@@ -43,8 +43,8 @@ class AnotherOpaque internal constructor (
         val handle = returnVal 
         val returnOpaque = RustOwnedBytes(handle, selfEdges)
         CLEANER.register(returnOpaque, RustOwnedBytes.RustOwnedBytesCleaner(handle, RustOwnedBytes.lib));
-        aMem.close()
-        bMem.close()
+        if (aMem != null) aMem.close()
+        if (bMem != null) bMem.close()
         return returnOpaque
     }
 

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2403
+assertion_line: 2412
 expression: result
 ---
 package dev.gigapixel.somelib;
@@ -22,7 +22,7 @@ class MyOpaqueStruct internal constructor (
     // These ensure that anything that is borrowed is kept alive and not cleaned
     // up by the garbage collector.
     internal val selfEdges: List<Any>,
-    internal val bEdges: List<Any>,
+    internal val bEdges: List<Any?>,
     internal var finalizer_registered: Boolean = false,
 )  {
     fun registerFinalizer() {

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -111,7 +111,7 @@ internal class DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatC
 */
 class MyNativeStruct internal constructor (
     internal val nativeStruct: MyNativeStructNative,
-    internal val bEdges: List<Any>
+    internal val bEdges: List<Any?>
     ) {
     val a: Boolean = nativeStruct.a > 0
     val b: Byte = nativeStruct.b
@@ -137,7 +137,7 @@ class MyNativeStruct internal constructor (
             
             val returnVal = lib.MyNativeStruct_new();
             
-            val bEdges: List<Any> = listOf()
+            val bEdges: List<Any?> = listOf()
             val returnStruct = MyNativeStruct(returnVal, bEdges)
             return returnStruct
         }

--- a/tool/templates/kotlin/Opaque.kt.jinja
+++ b/tool/templates/kotlin/Opaque.kt.jinja
@@ -35,7 +35,7 @@ class {{type_name}} internal constructor (
     internal val selfEdges: List<Any>,
     {%- if !lifetimes.is_empty() %}
     {%- for lt in lifetimes %}
-    internal val {{lt}}Edges: List<Any>,
+    internal val {{lt}}Edges: List<Any?>,
     {%- endfor %}
     {%- endif %}
     {%- if use_finalizers_not_cleaners %}

--- a/tool/templates/kotlin/OpaqueReturn.kt.jinja
+++ b/tool/templates/kotlin/OpaqueReturn.kt.jinja
@@ -4,7 +4,7 @@ listOf()
 {%- for self_edge in self_edges %}{%- if !loop.first %} + {% endif -%}{{self_edge}}{%- endfor %}
 {%- endif %}
 {%- for borrow in borrows %}
-val {{borrow.lt}}Edges: List<Any> = {% if borrow.params.is_empty() -%}
+val {{borrow.lt}}Edges: List<Any?> = {% if borrow.params.is_empty() -%}
 listOf()
 {%- else -%}
 {% for param in borrow.params %}{%- if !loop.first %} + {% endif -%}{{param}}{%- endfor %}

--- a/tool/templates/kotlin/Struct.kt.jinja
+++ b/tool/templates/kotlin/Struct.kt.jinja
@@ -47,7 +47,7 @@ class {{type_name}} internal constructor (
     internal val nativeStruct: {{type_name}}Native{% if !lifetimes.is_empty() %},{% endif %}{% endif -%}
     {% if !lifetimes.is_empty() %}
     {%- for lt in lifetimes %}
-    internal val {{lt}}Edges: List<Any>{% if !loop.last%},{% endif %}
+    internal val {{lt}}Edges: List<Any?>{% if !loop.last%},{% endif %}
     {%- endfor %}
     {% endif -%}
     ){%- if is_custom_error %}: Exception("Rust error result for {{type_name}}") {%- endif %} {

--- a/tool/templates/kotlin/StructReturn.kt.jinja
+++ b/tool/templates/kotlin/StructReturn.kt.jinja
@@ -1,5 +1,5 @@
 {%- for borrow in borrows %}
-val {{borrow.lt}}Edges: List<Any> = {% if borrow.params.is_empty() -%}
+val {{borrow.lt}}Edges: List<Any?> = {% if borrow.params.is_empty() -%}
 listOf()
 {%- else -%}
 {%- for param in borrow.params %}{%- if !loop.first %} + {% endif -%}{{param}}{%- endfor %}

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -66,8 +66,18 @@ internal class DiplomatJVMRuntime {
 
 internal object PrimitiveArrayTools {
 
+    fun allocateMemory(size: Long): Memory {
+        // we can't use the Memory constructor for a memory of size 0
+        // so, if the size is zero, then we actually build a Memory of
+        // size 1 and then clear it.
+        val mem = Memory(size + if (size == 0L) 1 else 0)
+        if (size == 0L)
+            mem.clear()
+        return mem
+    }
+
     fun native(boolArray: BooleanArray): Pair<Memory, Slice> {
-        val mem = Memory(boolArray.size.toLong())
+        val mem = allocateMemory(boolArray.size.toLong())
         val ptr = mem.share(0)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         ptr.write(0, byteArray, 0, byteArray.size)
@@ -77,8 +87,8 @@ internal object PrimitiveArrayTools {
         return Pair(mem, slice)
     }
 
-    fun native(byteArray: ByteArray):  Pair<Memory, Slice>{
-        val mem = Memory(byteArray.size.toLong())
+    fun native(byteArray: ByteArray):  Pair<Memory, Slice> {
+        val mem = allocateMemory(byteArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
@@ -90,7 +100,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uByteArray: UByteArray): Pair<Memory, Slice> {
         val byteArray = uByteArray.asByteArray()
-        val mem = Memory(byteArray.size.toLong())
+        val mem = allocateMemory(byteArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
@@ -100,7 +110,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(shortArray: ShortArray): Pair<Memory, Slice> {
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -112,7 +122,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uShortArray: UShortArray): Pair<Memory, Slice> {
         val shortArray = uShortArray.asShortArray()
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -122,7 +132,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(intArray: IntArray): Pair<Memory, Slice> {
-        val mem = Memory(Int.SIZE_BYTES * intArray.size.toLong())
+        val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
@@ -134,7 +144,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uIntArray: UIntArray): Pair<Memory, Slice> {
         val intArray = uIntArray.asIntArray()
-        val mem = Memory(Int.SIZE_BYTES * intArray.size.toLong())
+        val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
@@ -145,7 +155,7 @@ internal object PrimitiveArrayTools {
 
 
     fun native(longArray: LongArray): Pair<Memory, Slice> {
-        val mem = Memory(Long.SIZE_BYTES * longArray.size.toLong())
+        val mem = allocateMemory(Long.SIZE_BYTES * longArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, longArray, 0, longArray.size)
         val slice = Slice()
@@ -157,7 +167,7 @@ internal object PrimitiveArrayTools {
     @ExperimentalUnsignedTypes
     fun native(uLongArray: ULongArray): Pair<Memory, Slice> {
         val shortArray = uLongArray.asLongArray()
-        val mem = Memory(Short.SIZE_BYTES * shortArray.size.toLong())
+        val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
@@ -167,7 +177,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(floatArray: FloatArray): Pair<Memory, Slice> {
-        val mem = Memory(Float.SIZE_BYTES * floatArray.size.toLong())
+        val mem = allocateMemory(Float.SIZE_BYTES * floatArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, floatArray, 0, floatArray.size)
         val slice = Slice()
@@ -177,7 +187,7 @@ internal object PrimitiveArrayTools {
     }
 
     fun native(doubleArray: DoubleArray): Pair<Memory, Slice> {
-        val mem = Memory(Double.SIZE_BYTES * doubleArray.size.toLong())
+        val mem = allocateMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
         val ptr = mem.share(0)
         ptr.write(0, doubleArray, 0, doubleArray.size)
         val slice = Slice()
@@ -254,7 +264,7 @@ internal object PrimitiveArrayTools {
 
     fun readUtf8s(array: Array<String>): Pair<List<Memory>, Slice> {
         val sliceSize = Slice.SIZE
-        val mem = Memory(sliceSize * array.size.toLong())
+        val mem = allocateMemory(sliceSize * array.size.toLong())
         val ptr = mem.share(0)
         val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf8(str)
@@ -270,7 +280,7 @@ internal object PrimitiveArrayTools {
 
     fun readUtf16s(array: Array<String>): Pair<List<Memory>, Slice> {
         val sliceSize = Slice.SIZE
-        val mem = Memory(sliceSize * array.size.toLong())
+        val mem = allocateMemory(sliceSize * array.size.toLong())
         val ptr = mem.share(0)
         val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf16(str)

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -66,132 +66,175 @@ internal class DiplomatJVMRuntime {
 
 internal object PrimitiveArrayTools {
 
-    fun allocateMemory(size: Long): Memory {
+    fun allocateMemory(size: Long): Memory? {
         // we can't use the Memory constructor for a memory of size 0
-        // so, if the size is zero, then we actually build a Memory of
-        // size 1 and then clear it.
-        val mem = Memory(size + if (size == 0L) 1 else 0)
-        if (size == 0L)
-            mem.clear()
-        return mem
+        // so, if the size is zero, then we return null
+        if (size > 0L)
+            return Memory(size)
+        else
+            return null
     }
 
-    fun native(boolArray: BooleanArray): Pair<Memory, Slice> {
+    fun native(boolArray: BooleanArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(boolArray.size.toLong())
-        val ptr = mem.share(0)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(byteArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(byteArray: ByteArray):  Pair<Memory, Slice> {
+    fun native(byteArray: ByteArray):  Pair<Memory?, Slice> {
         val mem = allocateMemory(byteArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) { 
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(byteArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uByteArray: UByteArray): Pair<Memory, Slice> {
+    fun native(uByteArray: UByteArray): Pair<Memory?, Slice> {
         val byteArray = uByteArray.asByteArray()
         val mem = allocateMemory(byteArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, byteArray, 0, byteArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, byteArray, 0, byteArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uByteArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(shortArray: ShortArray): Pair<Memory, Slice> {
+    fun native(shortArray: ShortArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(shortArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uShortArray: UShortArray): Pair<Memory, Slice> {
+    fun native(uShortArray: UShortArray): Pair<Memory?, Slice> {
         val shortArray = uShortArray.asShortArray()
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uShortArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(intArray: IntArray): Pair<Memory, Slice> {
+    fun native(intArray: IntArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, intArray, 0, intArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(intArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uIntArray: UIntArray): Pair<Memory, Slice> {
+    fun native(uIntArray: UIntArray): Pair<Memory?, Slice> {
         val intArray = uIntArray.asIntArray()
         val mem = allocateMemory(Int.SIZE_BYTES * intArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, intArray, 0, intArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, intArray, 0, intArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uIntArray.size.toLong())
         return Pair(mem, slice)
     }
 
 
-    fun native(longArray: LongArray): Pair<Memory, Slice> {
+    fun native(longArray: LongArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Long.SIZE_BYTES * longArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, longArray, 0, longArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, longArray, 0, longArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(longArray.size.toLong())
         return Pair(mem, slice)
     }
 
     @ExperimentalUnsignedTypes
-    fun native(uLongArray: ULongArray): Pair<Memory, Slice> {
+    fun native(uLongArray: ULongArray): Pair<Memory?, Slice> {
         val shortArray = uLongArray.asLongArray()
         val mem = allocateMemory(Short.SIZE_BYTES * shortArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, shortArray, 0, shortArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, shortArray, 0, shortArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(uLongArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(floatArray: FloatArray): Pair<Memory, Slice> {
+    fun native(floatArray: FloatArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Float.SIZE_BYTES * floatArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, floatArray, 0, floatArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, floatArray, 0, floatArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(floatArray.size.toLong())
         return Pair(mem, slice)
     }
 
-    fun native(doubleArray: DoubleArray): Pair<Memory, Slice> {
+    fun native(doubleArray: DoubleArray): Pair<Memory?, Slice> {
         val mem = allocateMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
-        val ptr = mem.share(0)
-        ptr.write(0, doubleArray, 0, doubleArray.size)
         val slice = Slice()
-        slice.data = ptr
+        slice.data = if (mem != null) {
+            val ptr = mem.share(0)
+            ptr.write(0, doubleArray, 0, doubleArray.size)
+            ptr
+        } else {
+            Pointer(0)
+        }
         slice.len = size_t(doubleArray.size.toLong())
         return Pair(mem, slice)
     }
@@ -240,12 +283,12 @@ internal object PrimitiveArrayTools {
         return slice.data.getDoubleArray(0, slice.len.toInt())
     }
 
-    fun readUtf8(str: String): Pair<Memory, Slice> {
+    fun readUtf8(str: String): Pair<Memory?, Slice> {
         return native(str.toByteArray())
     }
 
     @ExperimentalUnsignedTypes
-    fun readUtf16(str: String): Pair<Memory, Slice> {
+    fun readUtf16(str: String): Pair<Memory?, Slice> {
         return native(str.map {it.code.toUShort()}.toUShortArray())
     }
 
@@ -262,11 +305,15 @@ internal object PrimitiveArrayTools {
         return charArray
     }
 
-    fun readUtf8s(array: Array<String>): Pair<List<Memory>, Slice> {
+    fun readUtf8s(array: Array<String>): Pair<List<Memory?>, Slice> {
         val sliceSize = Slice.SIZE
         val mem = allocateMemory(sliceSize * array.size.toLong())
-        val ptr = mem.share(0)
-        val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
+        val ptr = if (mem != null) {
+            mem.share(0)
+        } else {
+            Pointer(0)
+        }
+        val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf8(str)
             ptr.setPointer(idx * sliceSize, slice.data)
             ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
@@ -278,11 +325,15 @@ internal object PrimitiveArrayTools {
         return Pair(mems + mem, slice)
     }
 
-    fun readUtf16s(array: Array<String>): Pair<List<Memory>, Slice> {
+    fun readUtf16s(array: Array<String>): Pair<List<Memory?>, Slice> {
         val sliceSize = Slice.SIZE
         val mem = allocateMemory(sliceSize * array.size.toLong())
-        val ptr = mem.share(0)
-        val mems: List<Memory> = array.zip(0..array.size.toLong()).map { (str, idx) ->
+        val ptr = if (mem != null) {
+            mem.share(0)
+        } else {
+            Pointer(0)
+        }
+        val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
             val (mem, slice) = readUtf16(str)
             ptr.setPointer(idx * sliceSize, slice.data)
             ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())


### PR DESCRIPTION
Previously, we couldn't pass empty strings from Kotlin to Rust. This is because string passing from Kotlin to Rust involves the allocation of a JNA `Memory` object, which can't be creating with a size of zero, so passing an empty string results in a runtime exception.

In this PR, we add support for passing empty strings from Kotlin to Rust. This is done by casing out `Memory` allocation so that if the allocated size is zero we actually allocate a size of 1, and then clear it.

Fixes https://github.com/rust-diplomat/diplomat/issues/749