### PR TITLE
Add support for making traits `Send`/`Sync` in backends where this is safe

### DIFF
--- a/core/src/ast/traits.rs
+++ b/core/src/ast/traits.rs
@@ -116,19 +116,19 @@ impl Trait {
             {
                 let mut seg_iter = segments.iter();
                 if let Some(syn::PathSegment { ident, .. }) = seg_iter.next() {
-                    if ident.to_string() != "std" {
+                    if *ident != "std" {
                         continue;
                     }
                 }
                 if let Some(syn::PathSegment { ident, .. }) = seg_iter.next() {
-                    if ident.to_string() != "marker" {
+                    if *ident != "marker" {
                         continue;
                     }
                 }
                 if let Some(syn::PathSegment { ident, .. }) = seg_iter.next() {
-                    if ident.to_string() == "Send" {
+                    if *ident == "Send" {
                         is_send = true;
-                    } else if ident.to_string() == "Sync" {
+                    } else if *ident == "Sync" {
                         is_sync = true;
                     }
                 }

--- a/core/src/ast/traits.rs
+++ b/core/src/ast/traits.rs
@@ -12,6 +12,8 @@ pub struct Trait {
     pub methods: Vec<TraitMethod>,
     pub docs: Docs,
     pub attrs: Attrs,
+    pub is_sync: bool,
+    pub is_send: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Debug)]
@@ -105,6 +107,33 @@ impl Trait {
                 });
             }
         }
+        let (mut is_sync, mut is_send) = (false, false);
+        for supertrait in &trt.supertraits {
+            if let syn::TypeParamBound::Trait(syn::TraitBound {
+                path: syn::Path { segments, .. },
+                ..
+            }) = supertrait
+            {
+                let mut seg_iter = segments.iter();
+                if let Some(syn::PathSegment { ident, .. }) = seg_iter.next() {
+                    if ident.to_string() != "std" {
+                        continue;
+                    }
+                }
+                if let Some(syn::PathSegment { ident, .. }) = seg_iter.next() {
+                    if ident.to_string() != "marker" {
+                        continue;
+                    }
+                }
+                if let Some(syn::PathSegment { ident, .. }) = seg_iter.next() {
+                    if ident.to_string() == "Send" {
+                        is_send = true;
+                    } else if ident.to_string() == "Sync" {
+                        is_sync = true;
+                    }
+                }
+            }
+        }
 
         Self {
             name: (&trt.ident).into(),
@@ -112,6 +141,8 @@ impl Trait {
             docs: Docs::from_attrs(&trt.attrs),
             lifetimes: LifetimeEnv::from_trait(trt), // TODO
             attrs,
+            is_send,
+            is_sync,
         }
     }
 }

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -874,6 +874,10 @@ pub struct BackendAttrSupport {
     pub traits: bool,
     /// Marking a user-defined type as being a valid error result type.
     pub custom_errors: bool,
+    /// Traits are safe to Send between threads (safe to mark as std::marker::Send)
+    pub traits_are_send: bool,
+    /// Traits are safe to Sync between threads (safe to mark as std::marker::Sync)
+    pub traits_are_sync: bool,
 }
 
 impl BackendAttrSupport {
@@ -901,6 +905,8 @@ impl BackendAttrSupport {
             callbacks: true,
             traits: true,
             custom_errors: true,
+            traits_are_send: true,
+            traits_are_sync: true,
         }
     }
 }
@@ -1034,6 +1040,8 @@ impl AttributeValidator for BasicAttributeValidator {
                 callbacks,
                 traits,
                 custom_errors,
+                traits_are_send,
+                traits_are_sync,
             } = self.support;
             match value {
                 "namespacing" => namespacing,
@@ -1057,6 +1065,8 @@ impl AttributeValidator for BasicAttributeValidator {
                 "callbacks" => callbacks,
                 "traits" => traits,
                 "custom_errors" => custom_errors,
+                "traits_are_send" => traits_are_send,
+                "traits_are_sync" => traits_are_sync,
                 _ => {
                     return Err(LoweringError::Other(format!(
                         "Unknown supports = value found: {value}"

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -402,6 +402,17 @@ impl<'ast> LoweringContext<'ast> {
             &mut self.errors,
         );
 
+        if ast_trait.is_send && !self.attr_validator.attrs_supported().traits_are_send {
+            self.errors.push(LoweringError::Other(
+                "Traits are not safe to std::marker::Send in this backend".into(),
+            ));
+        }
+        if ast_trait.is_sync && !self.attr_validator.attrs_supported().traits_are_sync {
+            self.errors.push(LoweringError::Other(
+                "Traits are not safe to std::marker::Send in this backend".into(),
+            ));
+        }
+
         let fcts = if attrs.disable {
             Vec::new()
         } else {

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -23,7 +23,3 @@ proc-macro2 = "1.0.27"
 [dev-dependencies]
 insta = "1.7.1"
 tempfile = "3.2.0"
-
-[features]
-traits_are_send = []
-traits_are_sync = []

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -23,3 +23,7 @@ proc-macro2 = "1.0.27"
 [dev-dependencies]
 insta = "1.7.1"
 tempfile = "3.2.0"
+
+[features]
+traits_are_send = []
+traits_are_sync = []

--- a/macro/src/snapshots/diplomat__tests__traits.snap
+++ b/macro/src/snapshots/diplomat__tests__traits.snap
@@ -1,7 +1,7 @@
 ---
 source: macro/src/lib.rs
-assertion_line: 1059
-expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                pub struct TestingStruct { x: i32, y: i32, } pub trait\n                                TesterTrait\n                                {\n                                    fn test_trait_fn(&self, x: i32) -> i32; fn\n                                    test_void_trait_fn(&self); fn\n                                    test_struct_trait_fn(&self, s: TestingStruct) -> i32; fn\n                                    test_slice_trait_fn(&self, s: &[u8]) -> i32;\n                                } pub struct Wrapper { cant_be_empty: bool, } impl Wrapper\n                                {\n                                    pub fn test_with_trait(t: impl TesterTrait, x: i32) -> i32\n                                    { t.test_void_trait_fn(); t.test_trait_fn(x) } pub fn\n                                    test_trait_with_struct(t: impl TesterTrait) -> i32\n                                    {\n                                        let arg = TestingStruct { x: 1, y: 5, };\n                                        t.test_struct_trait_fn(arg)\n                                    }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+assertion_line: 1069
+expression: "rustfmt_code(&gen_bridge(parse_quote! {\n                            mod ffi\n                            {\n                                pub struct TestingStruct { x: i32, y: i32, } pub trait\n                                TesterTrait: std::marker::Send\n                                {\n                                    fn test_trait_fn(&self, x: i32) -> i32; fn\n                                    test_void_trait_fn(&self); fn\n                                    test_struct_trait_fn(&self, s: TestingStruct) -> i32; fn\n                                    test_slice_trait_fn(&self, s: &[u8]) -> i32;\n                                } pub struct Wrapper { cant_be_empty: bool, } impl Wrapper\n                                {\n                                    pub fn test_with_trait(t: impl TesterTrait, x: i32) -> i32\n                                    { t.test_void_trait_fn(); t.test_trait_fn(x) } pub fn\n                                    test_trait_with_struct(t: impl TesterTrait) -> i32\n                                    {\n                                        let arg = TestingStruct { x: 1, y: 5, };\n                                        t.test_struct_trait_fn(arg)\n                                    }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
 ---
 mod ffi {
     #[repr(C)]
@@ -9,7 +9,7 @@ mod ffi {
         x: i32,
         y: i32,
     }
-    pub trait TesterTrait {
+    pub trait TesterTrait: std::marker::Send {
         fn test_trait_fn(&self, x: i32) -> i32;
         fn test_void_trait_fn(&self);
         fn test_struct_trait_fn(&self, s: TestingStruct) -> i32;
@@ -56,6 +56,7 @@ mod ffi {
         data: *const c_void,
         pub vtable: TesterTrait_VTable,
     }
+    unsafe impl std::marker::Send for DiplomatTraitStruct_TesterTrait {}
     impl TesterTrait for DiplomatTraitStruct_TesterTrait {
         fn test_trait_fn(&self, x: i32) -> i32 {
             unsafe { ((self.vtable).run_test_trait_fn_callback)(self.data, x) }

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -35,6 +35,8 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.callbacks = true;
     a.traits = true;
     a.custom_errors = false;
+    a.traits_are_send = false;
+    a.traits_are_sync = false;
 
     a
 }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -31,6 +31,8 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.callbacks = false;
     a.traits = false;
     a.custom_errors = false;
+    a.traits_are_send = false;
+    a.traits_are_sync = false;
 
     a
 }

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -42,6 +42,8 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.option = true;
     a.callbacks = false;
     a.traits = false;
+    a.traits_are_send = false;
+    a.traits_are_sync = false;
 
     a
 }

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -57,6 +57,8 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.option = true;
     a.traits = false;
     a.custom_errors = false; // TODO
+    a.traits_are_send = false;
+    a.traits_are_sync = false;
 
     a
 }

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -44,6 +44,8 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.callbacks = true;
     a.traits = true;
     a.custom_errors = true;
+    a.traits_are_send = true;
+    a.traits_are_sync = true;
 
     a
 }


### PR DESCRIPTION
https://github.com/rust-diplomat/diplomat/issues/703

This PR adds support for automatically generating an `impl Send`/`impl Sync` for the VTable of a trait that is marked as `Send` or `Sync` (resp). This means the user doesn't have to add the `impl` to the VTable themselves, which is cumbersome and confusing as the VTable is generated by the macro and is meant to be hidden.

Not all backends support safely sending traits across the language boundary. As discussed in https://github.com/rust-diplomat/diplomat/issues/703, we've determined it is safe for Kotlin. Right now, the rest of the backends are marked as not having safe support for `Send`/`Sync` on traits (this really only affects C, since we didn't build trait support for the other backends yet).
If a trait is marked as `Send`/`Sync` but the corresponding config flag to show that this is safe is set to false, then an error will be thrown during lowering.