### PR TITLE
Kotlin `Throwable` primitives and non-opaque enums (if marked as `attr(auto, error)`)

### DIFF
--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DataProvider.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DataProvider.kt
@@ -52,7 +52,7 @@ class DataProvider internal constructor (
             if (returnVal.isOk == 1.toByte()) {
                 return Unit.ok()
             } else {
-                return Unit.primitive_err()
+                return UnitError().err()
             }
         }
     }

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimal.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimal.kt
@@ -66,7 +66,7 @@ class FixedDecimal internal constructor (
             val returnString = DW.writeToString(write)
             return returnString.ok()
         } else {
-            return Unit.primitive_err()
+            return UnitError().err()
         }
     }
 

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatter.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatter.kt
@@ -46,7 +46,7 @@ class FixedDecimalFormatter internal constructor (
                 CLEANER.register(returnOpaque, FixedDecimalFormatter.FixedDecimalFormatterCleaner(handle, FixedDecimalFormatter.lib));
                 return returnOpaque.ok()
             } else {
-                return Unit.primitive_err()
+                return UnitError().err()
             }
         }
     }

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -331,14 +331,112 @@ internal fun <T> T.ok(): Result<T> {
     return Result.success(this)
 }
 
-internal fun <T, E> E.primitive_err(): Result<T> {
-    return Result.failure(RuntimeException("Received error $this"))
-}
-
 internal fun <T> Throwable.err(): Result<T> {
     return Result.failure(this)
 }
 
+class UByteError internal constructor(internal val value: UByte): Exception("Rust error result for UByte") {
+    override fun toString(): String {
+        return "UByte error with value " + value
+    }
+
+    fun getValue(): UByte = value
+}
+
+class ByteError internal constructor(internal val value: Byte): Exception("Rust error result for Byte") {
+    override fun toString(): String {
+        return "Byte error with value " + value
+    }
+
+    fun getValue(): Byte = value
+}
+
+class UShortError internal constructor(internal val value: UShort): Exception("Rust error result for UShort") {
+    override fun toString(): String {
+        return "UShort error with value " + value
+    }
+
+    fun getValue(): UShort = value
+}
+
+class ShortError internal constructor(internal val value: Short): Exception("Rust error result for Short") {
+    override fun toString(): String {
+        return "Short error with value " + value
+    }
+
+    fun getValue(): Short = value
+}
+
+class UIntError internal constructor(internal val value: UInt): Exception("Rust error result for UInt") {
+    override fun toString(): String {
+        return "UInt error with value " + value
+    }
+
+    fun getValue(): UInt = value
+}
+
+class IntError internal constructor(internal val value: Int): Exception("Rust error result for Int") {
+    override fun toString(): String {
+        return "Int error with value " + value
+    }
+
+    fun getValue(): Int = value
+}
+
+class ULongError internal constructor(internal val value: ULong): Exception("Rust error result for ULong") {
+    override fun toString(): String {
+        return "ULong error with value " + value
+    }
+
+    fun getValue(): ULong = value
+}
+
+class LongError internal constructor(internal val value: Long): Exception("Rust error result for Long") {
+    override fun toString(): String {
+        return "Long error with value " + value
+    }
+
+    fun getValue(): Long = value
+}
+
+class FloatError internal constructor(internal val value: Float): Exception("Rust error result for Float") {
+    override fun toString(): String {
+        return "Float error with value " + value
+    }
+
+    fun getValue(): Float = value
+}
+
+class DoubleError internal constructor(internal val value: Double): Exception("Rust error result for Double") {
+    override fun toString(): String {
+        return "Double error with value " + value
+    }
+
+    fun getValue(): Double = value
+}
+
+class CharError internal constructor(internal val value: Char): Exception("Rust error result for Char") {
+    override fun toString(): String {
+        return "Char error with value " + value
+    }
+
+    fun getValue(): Char = value
+}
+
+class BooleanError internal constructor(internal val value: Boolean): Exception("Rust error result for Boolean") {
+    override fun toString(): String {
+        return "Boolean error with value " + value
+    }
+
+    fun getValue(): Boolean = value
+}
+
+class UnitError internal constructor(): Exception("Rust error result for Unit") {
+    override fun toString(): String {
+        return "Unit error"
+    }
+}
+           
 internal class ResultPointerUnitUnion: Union() {
     @JvmField
     internal var ok: Pointer = Pointer(0)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ErrorEnum.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ErrorEnum.kt
@@ -29,3 +29,10 @@ enum class ErrorEnum {
         }
     }
 }
+class ErrorEnumError internal constructor(internal val value: ErrorEnum): Exception("Rust error result for ErrorEnum") {
+    override fun toString(): String {
+        return "ErrorEnum error with value " + value
+    }
+
+    fun getValue(): ErrorEnum = value
+}

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -331,14 +331,112 @@ internal fun <T> T.ok(): Result<T> {
     return Result.success(this)
 }
 
-internal fun <T, E> E.primitive_err(): Result<T> {
-    return Result.failure(RuntimeException("Received error $this"))
-}
-
 internal fun <T> Throwable.err(): Result<T> {
     return Result.failure(this)
 }
 
+class UByteError internal constructor(internal val value: UByte): Exception("Rust error result for UByte") {
+    override fun toString(): String {
+        return "UByte error with value " + value
+    }
+
+    fun getValue(): UByte = value
+}
+
+class ByteError internal constructor(internal val value: Byte): Exception("Rust error result for Byte") {
+    override fun toString(): String {
+        return "Byte error with value " + value
+    }
+
+    fun getValue(): Byte = value
+}
+
+class UShortError internal constructor(internal val value: UShort): Exception("Rust error result for UShort") {
+    override fun toString(): String {
+        return "UShort error with value " + value
+    }
+
+    fun getValue(): UShort = value
+}
+
+class ShortError internal constructor(internal val value: Short): Exception("Rust error result for Short") {
+    override fun toString(): String {
+        return "Short error with value " + value
+    }
+
+    fun getValue(): Short = value
+}
+
+class UIntError internal constructor(internal val value: UInt): Exception("Rust error result for UInt") {
+    override fun toString(): String {
+        return "UInt error with value " + value
+    }
+
+    fun getValue(): UInt = value
+}
+
+class IntError internal constructor(internal val value: Int): Exception("Rust error result for Int") {
+    override fun toString(): String {
+        return "Int error with value " + value
+    }
+
+    fun getValue(): Int = value
+}
+
+class ULongError internal constructor(internal val value: ULong): Exception("Rust error result for ULong") {
+    override fun toString(): String {
+        return "ULong error with value " + value
+    }
+
+    fun getValue(): ULong = value
+}
+
+class LongError internal constructor(internal val value: Long): Exception("Rust error result for Long") {
+    override fun toString(): String {
+        return "Long error with value " + value
+    }
+
+    fun getValue(): Long = value
+}
+
+class FloatError internal constructor(internal val value: Float): Exception("Rust error result for Float") {
+    override fun toString(): String {
+        return "Float error with value " + value
+    }
+
+    fun getValue(): Float = value
+}
+
+class DoubleError internal constructor(internal val value: Double): Exception("Rust error result for Double") {
+    override fun toString(): String {
+        return "Double error with value " + value
+    }
+
+    fun getValue(): Double = value
+}
+
+class CharError internal constructor(internal val value: Char): Exception("Rust error result for Char") {
+    override fun toString(): String {
+        return "Char error with value " + value
+    }
+
+    fun getValue(): Char = value
+}
+
+class BooleanError internal constructor(internal val value: Boolean): Exception("Rust error result for Boolean") {
+    override fun toString(): String {
+        return "Boolean error with value " + value
+    }
+
+    fun getValue(): Boolean = value
+}
+
+class UnitError internal constructor(): Exception("Rust error result for Unit") {
+    override fun toString(): String {
+        return "Unit error"
+    }
+}
+           
 internal class ResultIntUnitUnion: Union() {
     @JvmField
     internal var ok: Int = 0
@@ -421,6 +519,23 @@ internal class ResultPointerUnitUnion: Union() {
 class ResultPointerUnit: Structure(), Structure.ByValue  {
     @JvmField
     internal var union: ResultPointerUnitUnion = ResultPointerUnitUnion()
+
+    @JvmField
+    internal var isOk: Byte = 0
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("union", "isOk")
+    }
+}
+internal class ResultUnitIntUnion: Union() {
+    @JvmField
+    internal var err: Int = 0
+}
+
+class ResultUnitInt: Structure(), Structure.ByValue  {
+    @JvmField
+    internal var union: ResultUnitIntUnion = ResultUnitIntUnion()
 
     @JvmField
     internal var isOk: Byte = 0

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyEnum.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyEnum.kt
@@ -45,7 +45,7 @@ enum class MyEnum(val inner: Int) {
         fun getA(): MyEnum {
             
             val returnVal = lib.MyEnum_get_a();
-            return MyEnum.fromNative(returnVal)
+            return (MyEnum.fromNative(returnVal))
         }
     }
     

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
@@ -51,7 +51,7 @@ class OptionString internal constructor (
             val returnString = DW.writeToString(write)
             return returnString.ok()
         } else {
-            return Unit.primitive_err()
+            return UnitError().err()
         }
     }
     

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
@@ -15,6 +15,7 @@ internal interface ResultOpaqueLib: Library {
     fun ResultOpaque_new_failing_struct(i: Int): ResultPointerErrorStructNative
     fun ResultOpaque_new_in_err(i: Int): ResultUnitPointer
     fun ResultOpaque_new_int(i: Int): ResultIntUnit
+    fun ResultOpaque_new_failing_int(i: Int): ResultUnitInt
     fun ResultOpaque_new_in_enum_err(i: Int): ResultIntPointer
     fun ResultOpaque_assert_integer(handle: Pointer, i: Int): Unit
 }
@@ -46,7 +47,7 @@ class ResultOpaque internal constructor (
                 CLEANER.register(returnOpaque, ResultOpaque.ResultOpaqueCleaner(handle, ResultOpaque.lib));
                 return returnOpaque.ok()
             } else {
-                return ErrorEnum.fromNative(returnVal.union.err).primitive_err()
+                return ErrorEnumError(ErrorEnum.fromNative(returnVal.union.err)).err()
             }
         }
         
@@ -60,7 +61,7 @@ class ResultOpaque internal constructor (
                 CLEANER.register(returnOpaque, ResultOpaque.ResultOpaqueCleaner(handle, ResultOpaque.lib));
                 return returnOpaque.ok()
             } else {
-                return ErrorEnum.fromNative(returnVal.union.err).primitive_err()
+                return ErrorEnumError(ErrorEnum.fromNative(returnVal.union.err)).err()
             }
         }
         
@@ -74,7 +75,7 @@ class ResultOpaque internal constructor (
                 CLEANER.register(returnOpaque, ResultOpaque.ResultOpaqueCleaner(handle, ResultOpaque.lib));
                 return returnOpaque.ok()
             } else {
-                return ErrorEnum.fromNative(returnVal.union.err).primitive_err()
+                return ErrorEnumError(ErrorEnum.fromNative(returnVal.union.err)).err()
             }
         }
         
@@ -88,7 +89,7 @@ class ResultOpaque internal constructor (
                 CLEANER.register(returnOpaque, ResultOpaque.ResultOpaqueCleaner(handle, ResultOpaque.lib));
                 return returnOpaque.ok()
             } else {
-                return Unit.primitive_err()
+                return UnitError().err()
             }
         }
         
@@ -128,7 +129,17 @@ class ResultOpaque internal constructor (
             if (returnVal.isOk == 1.toByte()) {
                 return (returnVal.union.ok).ok()
             } else {
-                return Unit.primitive_err()
+                return UnitError().err()
+            }
+        }
+        
+        fun newFailingInt(i: Int): Result<Unit> {
+            
+            val returnVal = lib.ResultOpaque_new_failing_int(i);
+            if (returnVal.isOk == 1.toByte()) {
+                return Unit.ok()
+            } else {
+                return IntError(returnVal.union.err).err()
             }
         }
         
@@ -136,7 +147,7 @@ class ResultOpaque internal constructor (
             
             val returnVal = lib.ResultOpaque_new_in_enum_err(i);
             if (returnVal.isOk == 1.toByte()) {
-                return ErrorEnum.fromNative(returnVal.union.ok).ok()
+                return (ErrorEnum.fromNative(returnVal.union.ok)).ok()
             } else {
                 val selfEdges: List<Any> = listOf()
                 val handle = returnVal.union.err 

--- a/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/ResultOpaqueTest.kt
+++ b/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/ResultOpaqueTest.kt
@@ -16,7 +16,7 @@ class ResultOpaqueTest {
         assert(resultOpaque2.isFailure)
 
         val result2 = resultOpaque2.exceptionOrNull()?.message
-        val shouldRes: Result<ResultOpaque> = ErrorEnum.Bar.primitive_err()
+        val shouldRes: Result<ResultOpaque> = ErrorEnumError(ErrorEnum.Bar).err()
 
         assertEquals(result2, shouldRes.exceptionOrNull()?.message)
 
@@ -24,7 +24,7 @@ class ResultOpaqueTest {
         val resultOpaque3 = ResultOpaque.newFailingFoo()
         assert(resultOpaque3.isFailure)
         val result3 = resultOpaque3.exceptionOrNull()?.message
-        val shouldRes3: Result<ResultOpaque> = ErrorEnum.Foo.primitive_err()
+        val shouldRes3: Result<ResultOpaque> = ErrorEnumError(ErrorEnum.Foo).err()
         assertEquals(result3, shouldRes3.exceptionOrNull()?.message)
 
         val resultOpaque4 = ResultOpaque.newInErr(8)
@@ -32,6 +32,15 @@ class ResultOpaqueTest {
         val result4 = resultOpaque4.exceptionOrNull()?.message
         val assertion = result4?.startsWith("Rust error result for ResultOpaque", true)
         assert(assertion == true)
+
+        val resultOpaque5 = ResultOpaque.newFailingInt(5)
+        assert(resultOpaque5.isFailure)
+        try {
+            resultOpaque5.getOrThrow()
+            assert(false == true) // should not reach here
+        } catch(ie: IntError) {
+            assertEquals(ie.getValue(), 5)
+        }
     }
 
 }

--- a/feature_tests/src/result.rs
+++ b/feature_tests/src/result.rs
@@ -53,6 +53,7 @@ pub mod ffi {
             Ok(i)
         }
 
+        #[diplomat::attr(not(supports = custom_errors), disable)]
         pub fn new_failing_int(i: i32) -> Result<(), i32> {
             Err(i)
         }

--- a/feature_tests/src/result.rs
+++ b/feature_tests/src/result.rs
@@ -6,6 +6,7 @@ pub mod ffi {
     pub struct ResultOpaque(i32);
 
     #[derive(PartialEq, Eq, Debug)]
+    #[diplomat::attr(auto, error)]
     pub enum ErrorEnum {
         Foo,
         Bar,
@@ -50,6 +51,10 @@ pub mod ffi {
 
         pub fn new_int(i: i32) -> Result<i32, ()> {
             Ok(i)
+        }
+
+        pub fn new_failing_int(i: i32) -> Result<(), i32> {
+            Err(i)
         }
 
         pub fn new_in_enum_err(i: i32) -> Result<ErrorEnum, Box<ResultOpaque>> {

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -249,6 +249,27 @@ impl<'tcx> KotlinFormatter<'tcx> {
         }
     }
 
+    pub fn fmt_primitive_error_type(&self, prim: PrimitiveType) -> Cow<str> {
+        match prim {
+            PrimitiveType::Bool => "BoolError".into(),
+            PrimitiveType::Int(IntType::U8) => "UByteError".into(),
+            PrimitiveType::Int(IntType::I8) => "ByteError".into(),
+            PrimitiveType::Int(IntType::U16) => "UShortError".into(),
+            PrimitiveType::Int(IntType::I16) => "ShortError".into(),
+            PrimitiveType::Int(IntType::U32) => "UIntError".into(),
+            PrimitiveType::Int(IntType::I32) => "IntError".into(),
+            PrimitiveType::Int(IntType::U64) => "ULongError".into(),
+            PrimitiveType::Int(IntType::I64) => "LongError".into(),
+            PrimitiveType::Byte => "ByteError".into(),
+            PrimitiveType::IntSize(IntSizeType::Isize) => "LongError".into(),
+            PrimitiveType::IntSize(IntSizeType::Usize) => "ULongError".into(),
+            PrimitiveType::Float(FloatType::F32) => "FloatError".into(),
+            PrimitiveType::Float(FloatType::F64) => "DoubleError".into(),
+            PrimitiveType::Char => "CharError".into(),
+            PrimitiveType::Int128(_) => panic!("i128 not supported in Kotlin"),
+        }
+    }
+
     pub fn fmt_struct_field_native_to_kt<'a, P: TyPosition>(
         &'a self,
         field_name: &'a str,

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/kotlin/mod.rs
-assertion_line: 2191
+assertion_line: 2217
 expression: struct_code
 ---
 package dev.gigapixel.somelib
@@ -160,7 +160,7 @@ class MyNativeStruct internal constructor (
             if (returnVal.isOk == 1.toByte()) {
                 return (returnVal.union.ok > 0).ok()
             } else {
-                return Unit.primitive_err()
+                return UnitError().err()
             }
         }
         
@@ -170,7 +170,7 @@ class MyNativeStruct internal constructor (
             if (returnVal.isOk == 1.toByte()) {
                 return (returnVal.union.ok.toUByte()).ok()
             } else {
-                return Unit.primitive_err()
+                return UnitError().err()
             }
         }
     }

--- a/tool/templates/kotlin/Enum.kt.jinja
+++ b/tool/templates/kotlin/Enum.kt.jinja
@@ -80,3 +80,13 @@ enum class {{type_name}}
     {{m|indent(4)}}
 {%- endfor %}
 }
+
+{%- if is_custom_error %}
+class {{type_name}}Error internal constructor(internal val value: {{type_name}}): Exception("Rust error result for {{type_name}}") {
+    override fun toString(): String {
+        return "{{type_name}} error with value " + value
+    }
+
+    fun getValue(): {{type_name}} = value
+}
+{%- endif %}

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -333,10 +333,6 @@ internal fun <T> T.ok(): Result<T> {
     return Result.success(this)
 }
 
-internal fun <T, E> E.primitive_err(): Result<T> {
-    return Result.failure(RuntimeException("Received error $this"))
-}
-
 internal fun <T> Throwable.err(): Result<T> {
     return Result.failure(this)
 }
@@ -435,6 +431,12 @@ class BooleanError internal constructor(internal val value: Boolean): Exception(
     }
 
     fun getValue(): Boolean = value
+}
+
+class UnitError internal constructor(): Exception("Rust error result for Unit") {
+    override fun toString(): String {
+        return "Unit error"
+    }
 }
            
 {% for native_result in native_results -%}

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -341,6 +341,102 @@ internal fun <T> Throwable.err(): Result<T> {
     return Result.failure(this)
 }
 
+class UByteError internal constructor(internal val value: UByte): Exception("Rust error result for UByte") {
+    override fun toString(): String {
+        return "UByte error with value " + value
+    }
+
+    fun getValue(): UByte = value
+}
+
+class ByteError internal constructor(internal val value: Byte): Exception("Rust error result for Byte") {
+    override fun toString(): String {
+        return "Byte error with value " + value
+    }
+
+    fun getValue(): Byte = value
+}
+
+class UShortError internal constructor(internal val value: UShort): Exception("Rust error result for UShort") {
+    override fun toString(): String {
+        return "UShort error with value " + value
+    }
+
+    fun getValue(): UShort = value
+}
+
+class ShortError internal constructor(internal val value: Short): Exception("Rust error result for Short") {
+    override fun toString(): String {
+        return "Short error with value " + value
+    }
+
+    fun getValue(): Short = value
+}
+
+class UIntError internal constructor(internal val value: UInt): Exception("Rust error result for UInt") {
+    override fun toString(): String {
+        return "UInt error with value " + value
+    }
+
+    fun getValue(): UInt = value
+}
+
+class IntError internal constructor(internal val value: Int): Exception("Rust error result for Int") {
+    override fun toString(): String {
+        return "Int error with value " + value
+    }
+
+    fun getValue(): Int = value
+}
+
+class ULongError internal constructor(internal val value: ULong): Exception("Rust error result for ULong") {
+    override fun toString(): String {
+        return "ULong error with value " + value
+    }
+
+    fun getValue(): ULong = value
+}
+
+class LongError internal constructor(internal val value: Long): Exception("Rust error result for Long") {
+    override fun toString(): String {
+        return "Long error with value " + value
+    }
+
+    fun getValue(): Long = value
+}
+
+class FloatError internal constructor(internal val value: Float): Exception("Rust error result for Float") {
+    override fun toString(): String {
+        return "Float error with value " + value
+    }
+
+    fun getValue(): Float = value
+}
+
+class DoubleError internal constructor(internal val value: Double): Exception("Rust error result for Double") {
+    override fun toString(): String {
+        return "Double error with value " + value
+    }
+
+    fun getValue(): Double = value
+}
+
+class CharError internal constructor(internal val value: Char): Exception("Rust error result for Char") {
+    override fun toString(): String {
+        return "Char error with value " + value
+    }
+
+    fun getValue(): Char = value
+}
+
+class BooleanError internal constructor(internal val value: Boolean): Exception("Rust error result for Boolean") {
+    override fun toString(): String {
+        return "Boolean error with value " + value
+    }
+
+    fun getValue(): Boolean = value
+}
+           
 {% for native_result in native_results -%}
 {{native_result}}
 {% endfor %}


### PR DESCRIPTION
In https://github.com/rust-diplomat/diplomat/pull/741, we added support for throwable custom types for opaques and non-opaque structs that are returned as errors.

In this PR, we add support for returning `Throwable` enums and primitives. This requires creating a `Throwable` wrapper class for every primitive type, and generating one for any enum marked as `attr(auto, error)`.  We also now throw an error during code generation if a user attempts to return a Result of an enum not marked as `attr(auto, error)` (same behaviour as for opaques and non-opaque structs).

Last part of fixing https://github.com/rust-diplomat/diplomat/issues/697