### PR TITLE
Demo Gen Organized Output

### DIFF
--- a/example/demo_gen/demo/FixedDecimal.d.ts
+++ b/example/demo_gen/demo/FixedDecimal.d.ts
@@ -1,2 +1,2 @@
 import { FixedDecimal } from "../../js/lib/api/index.mjs"
-export function toString(v: number);
+export function toString(fixedDecimalV: number);

--- a/example/demo_gen/demo/FixedDecimal.mjs
+++ b/example/demo_gen/demo/FixedDecimal.mjs
@@ -1,14 +1,10 @@
 import { FixedDecimal } from "../../js/lib/api/index.mjs"
 export function toString(v) {
-    return (function (...args) { return args[0].toString(...args.slice(1)) }).apply(
-        null,
-        [
-            (function (...args) { return new FixedDecimal(...args) } ).apply(
-                null,
-                [
-                    v
-                ]
-            )
-        ]
-    );
+    
+    let self = new FixedDecimal(v);
+    
+    let out = self.toString();
+    
+
+    return out;
 }

--- a/example/demo_gen/demo/FixedDecimal.mjs
+++ b/example/demo_gen/demo/FixedDecimal.mjs
@@ -1,9 +1,9 @@
 import { FixedDecimal } from "../../js/lib/api/index.mjs"
-export function toString(v) {
+export function toString(fixedDecimalV) {
     
-    let self = new FixedDecimal(v);
+    let fixedDecimal = new FixedDecimal(fixedDecimalV);
     
-    let out = self.toString();
+    let out = fixedDecimal.toString();
     
 
     return out;

--- a/example/demo_gen/demo/FixedDecimalFormatter.d.ts
+++ b/example/demo_gen/demo/FixedDecimalFormatter.d.ts
@@ -3,4 +3,4 @@ import { FixedDecimal } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
-export function formatWrite(name: string, grouping_strategy: FixedDecimalGroupingStrategy, some_other_config: boolean, v: number);
+export function formatWrite(fixedDecimalFormatterFixedDecimalFormatterLocaleName: string, fixedDecimalFormatterGroupingStrategy: FixedDecimalGroupingStrategy, fixedDecimalFormatterSomeOtherConfig: boolean, valueV: number);

--- a/example/demo_gen/demo/FixedDecimalFormatter.d.ts
+++ b/example/demo_gen/demo/FixedDecimalFormatter.d.ts
@@ -3,4 +3,4 @@ import { FixedDecimal } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
-export function formatWrite(fixedDecimalFormatterFixedDecimalFormatterLocaleName: string, fixedDecimalFormatterGroupingStrategy: FixedDecimalGroupingStrategy, fixedDecimalFormatterSomeOtherConfig: boolean, valueV: number);
+export function formatWrite(fixedDecimalFormatterLocaleName: string, fixedDecimalFormatterOptionsFixedDecimalFormatterGroupingStrategy: FixedDecimalGroupingStrategy, fixedDecimalFormatterOptionsFixedDecimalFormatterSomeOtherConfig: boolean, valueV: number);

--- a/example/demo_gen/demo/FixedDecimalFormatter.d.ts
+++ b/example/demo_gen/demo/FixedDecimalFormatter.d.ts
@@ -3,4 +3,4 @@ import { FixedDecimal } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
-export function formatWrite(fixedDecimalFormatterLocaleName: string, fixedDecimalFormatterOptionsFixedDecimalFormatterGroupingStrategy: FixedDecimalGroupingStrategy, fixedDecimalFormatterOptionsFixedDecimalFormatterSomeOtherConfig: boolean, valueV: number);
+export function formatWrite(fixedDecimalFormatterLocaleName: string, fixedDecimalFormatterOptionsGroupingStrategy: FixedDecimalGroupingStrategy, fixedDecimalFormatterOptionsSomeOtherConfig: boolean, valueV: number);

--- a/example/demo_gen/demo/FixedDecimalFormatter.mjs
+++ b/example/demo_gen/demo/FixedDecimalFormatter.mjs
@@ -3,22 +3,22 @@ import { FixedDecimal } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
-export function formatWrite(name, grouping_strategy, some_other_config, v) {
+export function formatWrite(fixedDecimalFormatterFixedDecimalFormatterLocaleName, fixedDecimalFormatterGroupingStrategy, fixedDecimalFormatterSomeOtherConfig, valueV) {
     
-    let locale = new Locale(name);
+    let fixedDecimalFormatterLocale = new Locale(fixedDecimalFormatterFixedDecimalFormatterLocaleName);
     
-    let provider = DataProvider.newStatic();
+    let fixedDecimalFormatterProvider = DataProvider.newStatic();
     
-    let options = FixedDecimalFormatterOptions.fromFields({
-        groupingStrategy: grouping_strategy,
-        someOtherConfig: some_other_config
+    let fixedDecimalFormatterOptions = FixedDecimalFormatterOptions.fromFields({
+        groupingStrategy: fixedDecimalFormatterGroupingStrategy,
+        someOtherConfig: fixedDecimalFormatterSomeOtherConfig
     });
     
-    let self = FixedDecimalFormatter.tryNew(locale,provider,options);
+    let fixedDecimalFormatter = FixedDecimalFormatter.tryNew(fixedDecimalFormatterLocale,fixedDecimalFormatterProvider,fixedDecimalFormatterOptions);
     
-    let value = new FixedDecimal(v);
+    let value = new FixedDecimal(valueV);
     
-    let out = self.formatWrite(value);
+    let out = fixedDecimalFormatter.formatWrite(value);
     
 
     return out;

--- a/example/demo_gen/demo/FixedDecimalFormatter.mjs
+++ b/example/demo_gen/demo/FixedDecimalFormatter.mjs
@@ -4,42 +4,22 @@ import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
 export function formatWrite(name, grouping_strategy, some_other_config, v) {
-    return (function (...args) { return args[0].formatWrite(...args.slice(1)) }).apply(
-        null,
-        [
-            FixedDecimalFormatter.tryNew.apply(
-                null,
-                [
-                    (function (...args) { return new Locale(...args) } ).apply(
-                        null,
-                        [
-                            name
-                        ]
-                    ),
-                    DataProvider.newStatic.apply(
-                        null,
-                        [
-                        ]
-                    ),
-                    (function (...args) {
-                        return FixedDecimalFormatterOptions.fromFields({
-                            groupingStrategy: args[0],
-                            someOtherConfig: args[1]});
-                    }).apply(
-                        null,
-                        [
-                            grouping_strategy,
-                            some_other_config
-                        ]
-                    )
-                ]
-            ),
-            (function (...args) { return new FixedDecimal(...args) } ).apply(
-                null,
-                [
-                    v
-                ]
-            )
-        ]
-    );
+    
+    let locale = new Locale(name);
+    
+    let provider = DataProvider.newStatic();
+    
+    let options = FixedDecimalFormatterOptions.fromFields({
+        groupingStrategy: grouping_strategy,
+        someOtherConfig: some_other_config
+    });
+    
+    let self = FixedDecimalFormatter.tryNew(locale,provider,options);
+    
+    let value = new FixedDecimal(v);
+    
+    let out = self.formatWrite(value);
+    
+
+    return out;
 }

--- a/example/demo_gen/demo/FixedDecimalFormatter.mjs
+++ b/example/demo_gen/demo/FixedDecimalFormatter.mjs
@@ -3,15 +3,15 @@ import { FixedDecimal } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
-export function formatWrite(fixedDecimalFormatterLocaleName, fixedDecimalFormatterOptionsFixedDecimalFormatterGroupingStrategy, fixedDecimalFormatterOptionsFixedDecimalFormatterSomeOtherConfig, valueV) {
+export function formatWrite(fixedDecimalFormatterLocaleName, fixedDecimalFormatterOptionsGroupingStrategy, fixedDecimalFormatterOptionsSomeOtherConfig, valueV) {
     
     let fixedDecimalFormatterLocale = new Locale(fixedDecimalFormatterLocaleName);
     
     let fixedDecimalFormatterProvider = DataProvider.newStatic();
     
     let fixedDecimalFormatterOptions = FixedDecimalFormatterOptions.fromFields({
-        groupingStrategy: fixedDecimalFormatterOptionsFixedDecimalFormatterGroupingStrategy,
-        someOtherConfig: fixedDecimalFormatterOptionsFixedDecimalFormatterSomeOtherConfig
+        groupingStrategy: fixedDecimalFormatterOptionsGroupingStrategy,
+        someOtherConfig: fixedDecimalFormatterOptionsSomeOtherConfig
     });
     
     let fixedDecimalFormatter = FixedDecimalFormatter.tryNew(fixedDecimalFormatterLocale,fixedDecimalFormatterProvider,fixedDecimalFormatterOptions);

--- a/example/demo_gen/demo/FixedDecimalFormatter.mjs
+++ b/example/demo_gen/demo/FixedDecimalFormatter.mjs
@@ -3,18 +3,18 @@ import { FixedDecimal } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatter } from "../../js/lib/api/index.mjs"
 import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
-export function formatWrite(fixedDecimalFormatterFixedDecimalFormatterLocaleName, fixedDecimalFormatterGroupingStrategy, fixedDecimalFormatterSomeOtherConfig, valueV) {
+export function formatWrite(fixedDecimalFormatterLocaleName, fixedDecimalFormatterOptionsFixedDecimalFormatterGroupingStrategy, fixedDecimalFormatterOptionsFixedDecimalFormatterSomeOtherConfig, valueV) {
     
-    let fixedDecimalFormatterLocale = new Locale(fixedDecimalFormatterFixedDecimalFormatterLocaleName);
+    let locale = new Locale(fixedDecimalFormatterLocaleName);
     
-    let fixedDecimalFormatterProvider = DataProvider.newStatic();
+    let provider = DataProvider.newStatic();
     
-    let fixedDecimalFormatterOptions = FixedDecimalFormatterOptions.fromFields({
-        groupingStrategy: fixedDecimalFormatterGroupingStrategy,
-        someOtherConfig: fixedDecimalFormatterSomeOtherConfig
+    let options = FixedDecimalFormatterOptions.fromFields({
+        groupingStrategy: fixedDecimalFormatterOptionsFixedDecimalFormatterGroupingStrategy,
+        someOtherConfig: fixedDecimalFormatterOptionsFixedDecimalFormatterSomeOtherConfig
     });
     
-    let fixedDecimalFormatter = FixedDecimalFormatter.tryNew(fixedDecimalFormatterLocale,fixedDecimalFormatterProvider,fixedDecimalFormatterOptions);
+    let fixedDecimalFormatter = FixedDecimalFormatter.tryNew(locale,provider,options);
     
     let value = new FixedDecimal(valueV);
     

--- a/example/demo_gen/demo/FixedDecimalFormatter.mjs
+++ b/example/demo_gen/demo/FixedDecimalFormatter.mjs
@@ -5,16 +5,16 @@ import { FixedDecimalFormatterOptions } from "../../js/lib/api/index.mjs"
 import { Locale } from "../../js/lib/api/index.mjs"
 export function formatWrite(fixedDecimalFormatterLocaleName, fixedDecimalFormatterOptionsFixedDecimalFormatterGroupingStrategy, fixedDecimalFormatterOptionsFixedDecimalFormatterSomeOtherConfig, valueV) {
     
-    let locale = new Locale(fixedDecimalFormatterLocaleName);
+    let fixedDecimalFormatterLocale = new Locale(fixedDecimalFormatterLocaleName);
     
-    let provider = DataProvider.newStatic();
+    let fixedDecimalFormatterProvider = DataProvider.newStatic();
     
-    let options = FixedDecimalFormatterOptions.fromFields({
+    let fixedDecimalFormatterOptions = FixedDecimalFormatterOptions.fromFields({
         groupingStrategy: fixedDecimalFormatterOptionsFixedDecimalFormatterGroupingStrategy,
         someOtherConfig: fixedDecimalFormatterOptionsFixedDecimalFormatterSomeOtherConfig
     });
     
-    let fixedDecimalFormatter = FixedDecimalFormatter.tryNew(locale,provider,options);
+    let fixedDecimalFormatter = FixedDecimalFormatter.tryNew(fixedDecimalFormatterLocale,fixedDecimalFormatterProvider,fixedDecimalFormatterOptions);
     
     let value = new FixedDecimal(valueV);
     

--- a/example/demo_gen/demo/index.mjs
+++ b/example/demo_gen/demo/index.mjs
@@ -15,7 +15,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Locale Name",
+                name: "FixedDecimalFormatter:Locale:Name",
                 type: "string",
                 typeUse: "string"
             },

--- a/example/demo_gen/test/test-demo.mjs
+++ b/example/demo_gen/test/test-demo.mjs
@@ -14,3 +14,8 @@ test("Test FixedDecimalFormatter", (t) => {
 test("Custom Function", (t) => {
 	t.is(RenderInfo.termini["FixedDecimal.multiplyPow10"].func(3), "10000");
 });
+
+test("Variable Names", (t) => {
+	// Can't exactly check variable names without reading the file, but RenderInfo re-uses the same info, so we check that instead.
+	t.is(RenderInfo.termini["FixedDecimalFormatter.formatWrite"].parameters[0].name, "FixedDecimalFormatter:Locale:Name");
+});

--- a/example/src/locale.rs
+++ b/example/src/locale.rs
@@ -11,7 +11,7 @@ pub mod ffi {
         /// Construct an [`Locale`] from a locale identifier represented as a string.
         #[diplomat::attr(auto, constructor)]
         pub fn new(
-            #[diplomat::demo(input(label = "Locale Name"))] name: &DiplomatStr,
+            name: &DiplomatStr,
         ) -> Box<Locale> {
             Box::new(Locale(icu::locid::Locale::try_from_bytes(name).unwrap()))
         }

--- a/example/src/locale.rs
+++ b/example/src/locale.rs
@@ -10,9 +10,7 @@ pub mod ffi {
     impl Locale {
         /// Construct an [`Locale`] from a locale identifier represented as a string.
         #[diplomat::attr(auto, constructor)]
-        pub fn new(
-            name: &DiplomatStr,
-        ) -> Box<Locale> {
+        pub fn new(name: &DiplomatStr) -> Box<Locale> {
             Box::new(Locale(icu::locid::Locale::try_from_bytes(name).unwrap()))
         }
     }

--- a/feature_tests/c/include/CyclicStructA.h
+++ b/feature_tests/c/include/CyclicStructA.h
@@ -20,6 +20,8 @@ CyclicStructB CyclicStructA_get_b(void);
 
 void CyclicStructA_cyclic_out(CyclicStructA self, DiplomatWrite* write);
 
+void CyclicStructA_double_cyclic_out(CyclicStructA self, CyclicStructA cyclic_struct_a, DiplomatWrite* write);
+
 
 
 

--- a/feature_tests/c/include/CyclicStructA.h
+++ b/feature_tests/c/include/CyclicStructA.h
@@ -22,6 +22,8 @@ void CyclicStructA_cyclic_out(CyclicStructA self, DiplomatWrite* write);
 
 void CyclicStructA_double_cyclic_out(CyclicStructA self, CyclicStructA cyclic_struct_a, DiplomatWrite* write);
 
+void CyclicStructA_getter_out(CyclicStructA self, DiplomatWrite* write);
+
 
 
 

--- a/feature_tests/cpp/include/CyclicStructA.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.d.hpp
@@ -33,6 +33,8 @@ struct CyclicStructA {
 
   inline std::string double_cyclic_out(CyclicStructA cyclic_struct_a);
 
+  inline std::string getter_out();
+
   inline diplomat::capi::CyclicStructA AsFFI() const;
   inline static CyclicStructA FromFFI(diplomat::capi::CyclicStructA c_struct);
 };

--- a/feature_tests/cpp/include/CyclicStructA.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.d.hpp
@@ -31,6 +31,8 @@ struct CyclicStructA {
 
   inline std::string cyclic_out();
 
+  inline std::string double_cyclic_out(CyclicStructA cyclic_struct_a);
+
   inline diplomat::capi::CyclicStructA AsFFI() const;
   inline static CyclicStructA FromFFI(diplomat::capi::CyclicStructA c_struct);
 };

--- a/feature_tests/cpp/include/CyclicStructA.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.hpp
@@ -23,6 +23,8 @@ namespace capi {
     
     void CyclicStructA_double_cyclic_out(diplomat::capi::CyclicStructA self, diplomat::capi::CyclicStructA cyclic_struct_a, diplomat::capi::DiplomatWrite* write);
     
+    void CyclicStructA_getter_out(diplomat::capi::CyclicStructA self, diplomat::capi::DiplomatWrite* write);
+    
     
     } // extern "C"
 } // namespace capi
@@ -46,6 +48,14 @@ inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   diplomat::capi::CyclicStructA_double_cyclic_out(this->AsFFI(),
     cyclic_struct_a.AsFFI(),
+    &write);
+  return output;
+}
+
+inline std::string CyclicStructA::getter_out() {
+  std::string output;
+  diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  diplomat::capi::CyclicStructA_getter_out(this->AsFFI(),
     &write);
   return output;
 }

--- a/feature_tests/cpp/include/CyclicStructA.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.hpp
@@ -21,6 +21,8 @@ namespace capi {
     
     void CyclicStructA_cyclic_out(diplomat::capi::CyclicStructA self, diplomat::capi::DiplomatWrite* write);
     
+    void CyclicStructA_double_cyclic_out(diplomat::capi::CyclicStructA self, diplomat::capi::CyclicStructA cyclic_struct_a, diplomat::capi::DiplomatWrite* write);
+    
     
     } // extern "C"
 } // namespace capi
@@ -35,6 +37,15 @@ inline std::string CyclicStructA::cyclic_out() {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   diplomat::capi::CyclicStructA_cyclic_out(this->AsFFI(),
+    &write);
+  return output;
+}
+
+inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_a) {
+  std::string output;
+  diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  diplomat::capi::CyclicStructA_double_cyclic_out(this->AsFFI(),
+    cyclic_struct_a.AsFFI(),
     &write);
   return output;
 }

--- a/feature_tests/dart/lib/src/CyclicStructA.g.dart
+++ b/feature_tests/dart/lib/src/CyclicStructA.g.dart
@@ -46,6 +46,13 @@ final class CyclicStructA {
     return write.finalize();
   }
 
+  String get getterOut {
+    final temp = _FinalizedArena();
+    final write = _Write();
+    _CyclicStructA_getter_out(_toFfi(temp.arena), write._ffi);
+    return write.finalize();
+  }
+
   @override
   bool operator ==(Object other) =>
       other is CyclicStructA &&
@@ -71,3 +78,8 @@ external void _CyclicStructA_cyclic_out(_CyclicStructAFfi self, ffi.Pointer<ffi.
 @ffi.Native<ffi.Void Function(_CyclicStructAFfi, _CyclicStructAFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'CyclicStructA_double_cyclic_out')
 // ignore: non_constant_identifier_names
 external void _CyclicStructA_double_cyclic_out(_CyclicStructAFfi self, _CyclicStructAFfi cyclicStructA, ffi.Pointer<ffi.Opaque> write);
+
+@meta.RecordUse()
+@ffi.Native<ffi.Void Function(_CyclicStructAFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'CyclicStructA_getter_out')
+// ignore: non_constant_identifier_names
+external void _CyclicStructA_getter_out(_CyclicStructAFfi self, ffi.Pointer<ffi.Opaque> write);

--- a/feature_tests/dart/lib/src/CyclicStructA.g.dart
+++ b/feature_tests/dart/lib/src/CyclicStructA.g.dart
@@ -39,6 +39,13 @@ final class CyclicStructA {
     return write.finalize();
   }
 
+  String doubleCyclicOut(CyclicStructA cyclicStructA) {
+    final temp = _FinalizedArena();
+    final write = _Write();
+    _CyclicStructA_double_cyclic_out(_toFfi(temp.arena), cyclicStructA._toFfi(temp.arena), write._ffi);
+    return write.finalize();
+  }
+
   @override
   bool operator ==(Object other) =>
       other is CyclicStructA &&
@@ -59,3 +66,8 @@ external _CyclicStructBFfi _CyclicStructA_get_b();
 @ffi.Native<ffi.Void Function(_CyclicStructAFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'CyclicStructA_cyclic_out')
 // ignore: non_constant_identifier_names
 external void _CyclicStructA_cyclic_out(_CyclicStructAFfi self, ffi.Pointer<ffi.Opaque> write);
+
+@meta.RecordUse()
+@ffi.Native<ffi.Void Function(_CyclicStructAFfi, _CyclicStructAFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'CyclicStructA_double_cyclic_out')
+// ignore: non_constant_identifier_names
+external void _CyclicStructA_double_cyclic_out(_CyclicStructAFfi self, _CyclicStructAFfi cyclicStructA, ffi.Pointer<ffi.Opaque> write);

--- a/feature_tests/demo_gen/demo/CyclicStructA.d.ts
+++ b/feature_tests/demo_gen/demo/CyclicStructA.d.ts
@@ -1,3 +1,3 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
-export function cyclicOut(cyclicStructAField: number);
+export function cyclicOut(cyclicStructAACyclicStructAField: number);

--- a/feature_tests/demo_gen/demo/CyclicStructA.d.ts
+++ b/feature_tests/demo_gen/demo/CyclicStructA.d.ts
@@ -1,3 +1,3 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
-export function cyclicOut(cyclicStructAACyclicStructAField: number);
+export function cyclicOut(cyclicStructAAField: number);

--- a/feature_tests/demo_gen/demo/CyclicStructA.d.ts
+++ b/feature_tests/demo_gen/demo/CyclicStructA.d.ts
@@ -1,3 +1,3 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
-export function cyclicOut(field: number);
+export function cyclicOut(cyclicStructAField: number);

--- a/feature_tests/demo_gen/demo/CyclicStructA.d.ts
+++ b/feature_tests/demo_gen/demo/CyclicStructA.d.ts
@@ -2,3 +2,4 @@ import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 export function cyclicOut(cyclicStructAAField: number);
 export function doubleCyclicOut(cyclicStructAAField: number, cyclicStructAAField_1: number);
+export function getterOut(cyclicStructAAField: number);

--- a/feature_tests/demo_gen/demo/CyclicStructA.d.ts
+++ b/feature_tests/demo_gen/demo/CyclicStructA.d.ts
@@ -1,3 +1,4 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 export function cyclicOut(cyclicStructAAField: number);
+export function doubleCyclicOut(cyclicStructAAField: number, cyclicStructAAField_1: number);

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -2,15 +2,15 @@ import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 export function cyclicOut(cyclicStructAACyclicStructAField) {
     
-    let a = CyclicStructB.fromFields({
+    let cyclicStructAA = CyclicStructB.fromFields({
         field: cyclicStructAACyclicStructAField
     });
     
-    let CyclicStructA = CyclicStructA.fromFields({
-        a: a
+    let cyclicStructA = CyclicStructA.fromFields({
+        a: cyclicStructAA
     });
     
-    let out = CyclicStructA.cyclicOut();
+    let out = cyclicStructA.cyclicOut();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -1,9 +1,9 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
-export function cyclicOut(cyclicStructAField) {
+export function cyclicOut(cyclicStructAACyclicStructAField) {
     
     let a = CyclicStructB.fromFields({
-        field: cyclicStructAField
+        field: cyclicStructAACyclicStructAField
     });
     
     let CyclicStructA = CyclicStructA.fromFields({

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -1,26 +1,17 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 export function cyclicOut(field) {
-    return (function (...args) { return args[0].cyclicOut(...args.slice(1)) }).apply(
-        null,
-        [
-            (function (...args) {
-                return CyclicStructA.fromFields({
-                    a: args[0]});
-            }).apply(
-                null,
-                [
-                    (function (...args) {
-                        return CyclicStructB.fromFields({
-                            field: args[0]});
-                    }).apply(
-                        null,
-                        [
-                            field
-                        ]
-                    )
-                ]
-            )
-        ]
-    );
+    
+    let a = CyclicStructB.fromFields({
+        field: field
+    });
+    
+    let self = CyclicStructA.fromFields({
+        a: a
+    });
+    
+    let out = self.cyclicOut();
+    
+
+    return out;
 }

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -1,9 +1,9 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
-export function cyclicOut(cyclicStructAACyclicStructAField) {
+export function cyclicOut(cyclicStructAAField) {
     
     let cyclicStructAA = CyclicStructB.fromFields({
-        field: cyclicStructAACyclicStructAField
+        field: cyclicStructAAField
     });
     
     let cyclicStructA = CyclicStructA.fromFields({

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -48,7 +48,7 @@ export function getterOut(cyclicStructAAField) {
         a: cyclicStructAA
     });
     
-    let out = cyclicStructA.getterOut();
+    let out = cyclicStructA.getterOut;
     
 
     return out;

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -15,3 +15,26 @@ export function cyclicOut(cyclicStructAAField) {
 
     return out;
 }
+export function doubleCyclicOut(cyclicStructAAField, cyclicStructAAField_1) {
+    
+    let cyclicStructAA = CyclicStructB.fromFields({
+        field: cyclicStructAAField
+    });
+    
+    let cyclicStructA = CyclicStructA.fromFields({
+        a: cyclicStructAA
+    });
+    
+    let cyclicStructAA = CyclicStructB.fromFields({
+        field: cyclicStructAAField_1
+    });
+    
+    let cyclicStructA = CyclicStructA.fromFields({
+        a: cyclicStructAA
+    });
+    
+    let out = cyclicStructA.doubleCyclicOut(cyclicStructA);
+    
+
+    return out;
+}

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -1,16 +1,16 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
-export function cyclicOut(field) {
+export function cyclicOut(cyclicStructAField) {
     
     let a = CyclicStructB.fromFields({
-        field: field
+        field: cyclicStructAField
     });
     
-    let self = CyclicStructA.fromFields({
+    let CyclicStructA = CyclicStructA.fromFields({
         a: a
     });
     
-    let out = self.cyclicOut();
+    let out = CyclicStructA.cyclicOut();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -38,3 +38,18 @@ export function doubleCyclicOut(cyclicStructAAField, cyclicStructAAField_1) {
 
     return out;
 }
+export function getterOut(cyclicStructAAField) {
+    
+    let cyclicStructAA = CyclicStructB.fromFields({
+        field: cyclicStructAAField
+    });
+    
+    let cyclicStructA = CyclicStructA.fromFields({
+        a: cyclicStructAA
+    });
+    
+    let out = cyclicStructA.getterOut();
+    
+
+    return out;
+}

--- a/feature_tests/demo_gen/demo/CyclicStructA.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructA.mjs
@@ -25,15 +25,15 @@ export function doubleCyclicOut(cyclicStructAAField, cyclicStructAAField_1) {
         a: cyclicStructAA
     });
     
-    let cyclicStructAA = CyclicStructB.fromFields({
+    let cyclicStructAA_1 = CyclicStructB.fromFields({
         field: cyclicStructAAField_1
     });
     
-    let cyclicStructA = CyclicStructA.fromFields({
-        a: cyclicStructAA
+    let cyclicStructA_1 = CyclicStructA.fromFields({
+        a: cyclicStructAA_1
     });
     
-    let out = cyclicStructA.doubleCyclicOut(cyclicStructA);
+    let out = cyclicStructA.doubleCyclicOut(cyclicStructA_1);
     
 
     return out;

--- a/feature_tests/demo_gen/demo/CyclicStructC.d.ts
+++ b/feature_tests/demo_gen/demo/CyclicStructC.d.ts
@@ -1,4 +1,4 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 import { CyclicStructC } from "../../js/api/index.mjs"
-export function cyclicOut(field: number);
+export function cyclicOut(cyclicStructCAField: number);

--- a/feature_tests/demo_gen/demo/CyclicStructC.d.ts
+++ b/feature_tests/demo_gen/demo/CyclicStructC.d.ts
@@ -1,4 +1,4 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 import { CyclicStructC } from "../../js/api/index.mjs"
-export function cyclicOut(cyclicStructCAField: number);
+export function cyclicOut(cyclicStructCACyclicStructCaCyclicStructCaField: number);

--- a/feature_tests/demo_gen/demo/CyclicStructC.d.ts
+++ b/feature_tests/demo_gen/demo/CyclicStructC.d.ts
@@ -1,4 +1,4 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 import { CyclicStructC } from "../../js/api/index.mjs"
-export function cyclicOut(cyclicStructCACyclicStructCaCyclicStructCaField: number);
+export function cyclicOut(cyclicStructCAAField: number);

--- a/feature_tests/demo_gen/demo/CyclicStructC.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructC.mjs
@@ -1,21 +1,21 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 import { CyclicStructC } from "../../js/api/index.mjs"
-export function cyclicOut(field) {
+export function cyclicOut(cyclicStructCAField) {
     
-    let a = CyclicStructB.fromFields({
-        field: field
+    let cyclicStructCA = CyclicStructB.fromFields({
+        field: cyclicStructCAField
     });
     
     let a = CyclicStructA.fromFields({
+        a: cyclicStructCA
+    });
+    
+    let CyclicStructC = CyclicStructC.fromFields({
         a: a
     });
     
-    let self = CyclicStructC.fromFields({
-        a: a
-    });
-    
-    let out = self.cyclicOut();
+    let out = CyclicStructC.cyclicOut();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/CyclicStructC.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructC.mjs
@@ -1,10 +1,10 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 import { CyclicStructC } from "../../js/api/index.mjs"
-export function cyclicOut(cyclicStructCAField) {
+export function cyclicOut(cyclicStructCACyclicStructCaCyclicStructCaField) {
     
     let cyclicStructCA = CyclicStructB.fromFields({
-        field: cyclicStructCAField
+        field: cyclicStructCACyclicStructCaCyclicStructCaField
     });
     
     let a = CyclicStructA.fromFields({

--- a/feature_tests/demo_gen/demo/CyclicStructC.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructC.mjs
@@ -2,34 +2,21 @@ import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 import { CyclicStructC } from "../../js/api/index.mjs"
 export function cyclicOut(field) {
-    return (function (...args) { return args[0].cyclicOut(...args.slice(1)) }).apply(
-        null,
-        [
-            (function (...args) {
-                return CyclicStructC.fromFields({
-                    a: args[0]});
-            }).apply(
-                null,
-                [
-                    (function (...args) {
-                        return CyclicStructA.fromFields({
-                            a: args[0]});
-                    }).apply(
-                        null,
-                        [
-                            (function (...args) {
-                                return CyclicStructB.fromFields({
-                                    field: args[0]});
-                            }).apply(
-                                null,
-                                [
-                                    field
-                                ]
-                            )
-                        ]
-                    )
-                ]
-            )
-        ]
-    );
+    
+    let a = CyclicStructB.fromFields({
+        field: field
+    });
+    
+    let a = CyclicStructA.fromFields({
+        a: a
+    });
+    
+    let self = CyclicStructC.fromFields({
+        a: a
+    });
+    
+    let out = self.cyclicOut();
+    
+
+    return out;
 }

--- a/feature_tests/demo_gen/demo/CyclicStructC.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructC.mjs
@@ -1,14 +1,14 @@
 import { CyclicStructA } from "../../js/api/index.mjs"
 import { CyclicStructB } from "../../js/api/index.mjs"
 import { CyclicStructC } from "../../js/api/index.mjs"
-export function cyclicOut(cyclicStructCACyclicStructCaCyclicStructCaField) {
+export function cyclicOut(cyclicStructCAAField) {
     
-    let cyclicStructCACyclicStructCa = CyclicStructB.fromFields({
-        field: cyclicStructCACyclicStructCaCyclicStructCaField
+    let cyclicStructCAA = CyclicStructB.fromFields({
+        field: cyclicStructCAAField
     });
     
     let cyclicStructCA = CyclicStructA.fromFields({
-        a: cyclicStructCACyclicStructCa
+        a: cyclicStructCAA
     });
     
     let cyclicStructC = CyclicStructC.fromFields({

--- a/feature_tests/demo_gen/demo/CyclicStructC.mjs
+++ b/feature_tests/demo_gen/demo/CyclicStructC.mjs
@@ -3,19 +3,19 @@ import { CyclicStructB } from "../../js/api/index.mjs"
 import { CyclicStructC } from "../../js/api/index.mjs"
 export function cyclicOut(cyclicStructCACyclicStructCaCyclicStructCaField) {
     
-    let cyclicStructCA = CyclicStructB.fromFields({
+    let cyclicStructCACyclicStructCa = CyclicStructB.fromFields({
         field: cyclicStructCACyclicStructCaCyclicStructCaField
     });
     
-    let a = CyclicStructA.fromFields({
+    let cyclicStructCA = CyclicStructA.fromFields({
+        a: cyclicStructCACyclicStructCa
+    });
+    
+    let cyclicStructC = CyclicStructC.fromFields({
         a: cyclicStructCA
     });
     
-    let CyclicStructC = CyclicStructC.fromFields({
-        a: a
-    });
-    
-    let out = CyclicStructC.cyclicOut();
+    let out = cyclicStructC.cyclicOut();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/Float64Vec.d.ts
+++ b/feature_tests/demo_gen/demo/Float64Vec.d.ts
@@ -1,2 +1,2 @@
 import { Float64Vec } from "../../js/api/index.mjs"
-export function toString(v: Array<number>);
+export function toString(float64VecV: Array<number>);

--- a/feature_tests/demo_gen/demo/Float64Vec.mjs
+++ b/feature_tests/demo_gen/demo/Float64Vec.mjs
@@ -1,9 +1,9 @@
 import { Float64Vec } from "../../js/api/index.mjs"
-export function toString(v) {
+export function toString(float64VecV) {
     
-    let self = new Float64Vec(v);
+    let float64Vec = new Float64Vec(float64VecV);
     
-    let out = self.toString();
+    let out = float64Vec.toString();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/Float64Vec.mjs
+++ b/feature_tests/demo_gen/demo/Float64Vec.mjs
@@ -1,14 +1,10 @@
 import { Float64Vec } from "../../js/api/index.mjs"
 export function toString(v) {
-    return (function (...args) { return args[0].toString(...args.slice(1)) }).apply(
-        null,
-        [
-            (function (...args) { return new Float64Vec(...args) } ).apply(
-                null,
-                [
-                    v
-                ]
-            )
-        ]
-    );
+    
+    let self = new Float64Vec(v);
+    
+    let out = self.toString();
+    
+
+    return out;
 }

--- a/feature_tests/demo_gen/demo/MyOpaqueEnum.mjs
+++ b/feature_tests/demo_gen/demo/MyOpaqueEnum.mjs
@@ -1,9 +1,9 @@
 import { MyOpaqueEnum } from "../../js/api/index.mjs"
 export function toString() {
     
-    let self = MyOpaqueEnum.new_();
+    let myOpaqueEnum = MyOpaqueEnum.new_();
     
-    let out = self.toString();
+    let out = myOpaqueEnum.toString();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/MyOpaqueEnum.mjs
+++ b/feature_tests/demo_gen/demo/MyOpaqueEnum.mjs
@@ -1,13 +1,10 @@
 import { MyOpaqueEnum } from "../../js/api/index.mjs"
 export function toString() {
-    return (function (...args) { return args[0].toString(...args.slice(1)) }).apply(
-        null,
-        [
-            MyOpaqueEnum.new_.apply(
-                null,
-                [
-                ]
-            )
-        ]
-    );
+    
+    let self = MyOpaqueEnum.new_();
+    
+    let out = self.toString();
+    
+
+    return out;
 }

--- a/feature_tests/demo_gen/demo/MyString.d.ts
+++ b/feature_tests/demo_gen/demo/MyString.d.ts
@@ -1,3 +1,3 @@
 import { MyString } from "../../js/api/index.mjs"
-export function getStr(v: string);
+export function getStr(myStringV: string);
 export function stringTransform(foo: string);

--- a/feature_tests/demo_gen/demo/MyString.mjs
+++ b/feature_tests/demo_gen/demo/MyString.mjs
@@ -1,9 +1,9 @@
 import { MyString } from "../../js/api/index.mjs"
-export function getStr(v) {
+export function getStr(myStringV) {
     
-    let self = new MyString(v);
+    let myString = new MyString(myStringV);
     
-    let out = self.getStr();
+    let out = myString.getStr();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/MyString.mjs
+++ b/feature_tests/demo_gen/demo/MyString.mjs
@@ -1,22 +1,17 @@
 import { MyString } from "../../js/api/index.mjs"
 export function getStr(v) {
-    return (function (...args) { return args[0].getStr }).apply(
-        null,
-        [
-            (function (...args) { return new MyString(...args) } ).apply(
-                null,
-                [
-                    v
-                ]
-            )
-        ]
-    );
+    
+    let self = new MyString(v);
+    
+    let out = self.getStr();
+    
+
+    return out;
 }
 export function stringTransform(foo) {
-    return MyString.stringTransform.apply(
-        null,
-        [
-            foo
-        ]
-    );
+    
+    let out = MyString.stringTransform(foo);
+    
+
+    return out;
 }

--- a/feature_tests/demo_gen/demo/MyString.mjs
+++ b/feature_tests/demo_gen/demo/MyString.mjs
@@ -3,7 +3,7 @@ export function getStr(myStringV) {
     
     let myString = new MyString(myStringV);
     
-    let out = myString.getStr();
+    let out = myString.getStr;
     
 
     return out;

--- a/feature_tests/demo_gen/demo/Opaque.mjs
+++ b/feature_tests/demo_gen/demo/Opaque.mjs
@@ -1,13 +1,10 @@
 import { Opaque } from "../../js/api/index.mjs"
 export function getDebugStr() {
-    return (function (...args) { return args[0].getDebugStr(...args.slice(1)) }).apply(
-        null,
-        [
-            (function (...args) { return new Opaque(...args) } ).apply(
-                null,
-                [
-                ]
-            )
-        ]
-    );
+    
+    let self = new Opaque();
+    
+    let out = self.getDebugStr();
+    
+
+    return out;
 }

--- a/feature_tests/demo_gen/demo/Opaque.mjs
+++ b/feature_tests/demo_gen/demo/Opaque.mjs
@@ -1,9 +1,9 @@
 import { Opaque } from "../../js/api/index.mjs"
 export function getDebugStr() {
     
-    let self = new Opaque();
+    let opaque = new Opaque();
     
-    let out = self.getDebugStr();
+    let out = opaque.getDebugStr();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/OptionString.d.ts
+++ b/feature_tests/demo_gen/demo/OptionString.d.ts
@@ -1,2 +1,2 @@
 import { OptionString } from "../../js/api/index.mjs"
-export function write(diplomatStr: string);
+export function write(optionStringDiplomatStr: string);

--- a/feature_tests/demo_gen/demo/OptionString.mjs
+++ b/feature_tests/demo_gen/demo/OptionString.mjs
@@ -1,9 +1,9 @@
 import { OptionString } from "../../js/api/index.mjs"
-export function write(diplomatStr) {
+export function write(optionStringDiplomatStr) {
     
-    let self = OptionString.new_(diplomatStr);
+    let optionString = OptionString.new_(optionStringDiplomatStr);
     
-    let out = self.write();
+    let out = optionString.write();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/OptionString.mjs
+++ b/feature_tests/demo_gen/demo/OptionString.mjs
@@ -1,14 +1,10 @@
 import { OptionString } from "../../js/api/index.mjs"
 export function write(diplomatStr) {
-    return (function (...args) { return args[0].write(...args.slice(1)) }).apply(
-        null,
-        [
-            OptionString.new_.apply(
-                null,
-                [
-                    diplomatStr
-                ]
-            )
-        ]
-    );
+    
+    let self = OptionString.new_(diplomatStr);
+    
+    let out = self.write();
+    
+
+    return out;
 }

--- a/feature_tests/demo_gen/demo/Utf16Wrap.d.ts
+++ b/feature_tests/demo_gen/demo/Utf16Wrap.d.ts
@@ -1,2 +1,2 @@
 import { Utf16Wrap } from "../../js/api/index.mjs"
-export function getDebugStr(input: string);
+export function getDebugStr(utf16WrapInput: string);

--- a/feature_tests/demo_gen/demo/Utf16Wrap.mjs
+++ b/feature_tests/demo_gen/demo/Utf16Wrap.mjs
@@ -1,9 +1,9 @@
 import { Utf16Wrap } from "../../js/api/index.mjs"
-export function getDebugStr(input) {
+export function getDebugStr(utf16WrapInput) {
     
-    let self = new Utf16Wrap(input);
+    let utf16Wrap = new Utf16Wrap(utf16WrapInput);
     
-    let out = self.getDebugStr();
+    let out = utf16Wrap.getDebugStr();
     
 
     return out;

--- a/feature_tests/demo_gen/demo/Utf16Wrap.mjs
+++ b/feature_tests/demo_gen/demo/Utf16Wrap.mjs
@@ -1,14 +1,10 @@
 import { Utf16Wrap } from "../../js/api/index.mjs"
 export function getDebugStr(input) {
-    return (function (...args) { return args[0].getDebugStr(...args.slice(1)) }).apply(
-        null,
-        [
-            (function (...args) { return new Utf16Wrap(...args) } ).apply(
-                null,
-                [
-                    input
-                ]
-            )
-        ]
-    );
+    
+    let self = new Utf16Wrap(input);
+    
+    let out = self.getDebugStr();
+    
+
+    return out;
 }

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -55,6 +55,21 @@ let termini = Object.assign({
         ]
     },
 
+    "CyclicStructA.getterOut": {
+        func: CyclicStructADemo.getterOut,
+        // For avoiding webpacking minifying issues:
+        funcName: "CyclicStructA.getterOut",
+        parameters: [
+            
+            {
+                name: "CyclicStructA:A:Field",
+                type: "number",
+                typeUse: "number"
+            }
+            
+        ]
+    },
+
     "CyclicStructC.cyclicOut": {
         func: CyclicStructCDemo.cyclicOut,
         // For avoiding webpacking minifying issues:

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -34,6 +34,27 @@ let termini = Object.assign({
         ]
     },
 
+    "CyclicStructA.doubleCyclicOut": {
+        func: CyclicStructADemo.doubleCyclicOut,
+        // For avoiding webpacking minifying issues:
+        funcName: "CyclicStructA.doubleCyclicOut",
+        parameters: [
+            
+            {
+                name: "CyclicStructA:A:Field",
+                type: "number",
+                typeUse: "number"
+            },
+            
+            {
+                name: "CyclicStructA:A:Field",
+                type: "number",
+                typeUse: "number"
+            }
+            
+        ]
+    },
+
     "CyclicStructC.cyclicOut": {
         func: CyclicStructCDemo.cyclicOut,
         // For avoiding webpacking minifying issues:

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -56,7 +56,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "OptionString:OptionStringDiplomatStr",
+                name: "OptionString:DiplomatStr",
                 type: "string",
                 typeUse: "string"
             }
@@ -71,7 +71,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Float64Vec:Float64VecV",
+                name: "Float64Vec:V",
                 type: "Array<number>",
                 typeUse: "Array<number>"
             }
@@ -86,7 +86,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "MyString:MyStringV",
+                name: "MyString:V",
                 type: "string",
                 typeUse: "string"
             }
@@ -134,7 +134,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Utf16Wrap:Utf16WrapInput",
+                name: "Utf16Wrap:Input",
                 type: "string",
                 typeUse: "string"
             }

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -26,7 +26,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "CyclicStructA:A:CyclicStructAField",
+                name: "CyclicStructA:A:Field",
                 type: "number",
                 typeUse: "number"
             }
@@ -41,7 +41,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "CyclicStructC:A:CyclicStructCa:CyclicStructCaField",
+                name: "CyclicStructC:A:A:Field",
                 type: "number",
                 typeUse: "number"
             }

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -26,7 +26,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Self:A:Field",
+                name: "CyclicStructA:A:CyclicStructAField",
                 type: "number",
                 typeUse: "number"
             }
@@ -41,7 +41,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Self:A:A:Field",
+                name: "CyclicStructC:A:CyclicStructCa:CyclicStructCaField",
                 type: "number",
                 typeUse: "number"
             }
@@ -56,7 +56,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Self:DiplomatStr",
+                name: "OptionString:OptionStringDiplomatStr",
                 type: "string",
                 typeUse: "string"
             }
@@ -71,7 +71,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Self:V",
+                name: "Float64Vec:Float64VecV",
                 type: "Array<number>",
                 typeUse: "Array<number>"
             }
@@ -86,7 +86,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Self:V",
+                name: "MyString:MyStringV",
                 type: "string",
                 typeUse: "string"
             }
@@ -134,7 +134,7 @@ let termini = Object.assign({
         parameters: [
             
             {
-                name: "Self:Input",
+                name: "Utf16Wrap:Utf16WrapInput",
                 type: "string",
                 typeUse: "string"
             }

--- a/feature_tests/demo_gen/test/test.mjs
+++ b/feature_tests/demo_gen/test/test.mjs
@@ -7,7 +7,7 @@ test("My String", (t) => {
 
 test("Cyclic Parameters", (t) => {
 	t.is(RenderInfo.termini["CyclicStructA.cyclicOut"].parameters[0].name, "CyclicStructA:A:Field");
-	t.is(RenderInfo.termini["CyclicStructC.cyclicOut"].parameters[0].name, "CyclicStructA:A:A:Field");
+	t.is(RenderInfo.termini["CyclicStructC.cyclicOut"].parameters[0].name, "CyclicStructC:A:A:Field");
 	t.is(CyclicStructADemo.cyclicOut(10), "10");
 	t.is(CyclicStructCDemo.cyclicOut(15), "15");
 });

--- a/feature_tests/demo_gen/test/test.mjs
+++ b/feature_tests/demo_gen/test/test.mjs
@@ -20,3 +20,7 @@ test("Variable Name Collisions", (t) => {
 
 	t.is(CyclicStructADemo.doubleCyclicOut(10, 20), "10 20");
 });
+
+test("Getter", (t) => {
+	t.is(CyclicStructADemo.getterOut(10), "10");
+});

--- a/feature_tests/demo_gen/test/test.mjs
+++ b/feature_tests/demo_gen/test/test.mjs
@@ -11,3 +11,10 @@ test("Cyclic Parameters", (t) => {
 	t.is(CyclicStructADemo.cyclicOut(10), "10");
 	t.is(CyclicStructCDemo.cyclicOut(15), "15");
 });
+
+test("Variable Name Collisions", (t) => {
+	// Make sure that the names for the parameters are the same so that we're assured some collisions.
+	// As long as this test passes and the Javascript compiles, we should be good to go.
+	t.is(RenderInfo.termini["CyclicStructA.doubleCyclicOut"].parameters[0].name, "CyclicStructA:A:Field");
+	t.is(RenderInfo.termini["CyclicStructA.doubleCyclicOut"].parameters[1].name, "CyclicStructA:A:Field");
+});

--- a/feature_tests/demo_gen/test/test.mjs
+++ b/feature_tests/demo_gen/test/test.mjs
@@ -6,8 +6,8 @@ test("My String", (t) => {
 })
 
 test("Cyclic Parameters", (t) => {
-	t.is(RenderInfo.termini["CyclicStructA.cyclicOut"].parameters[0].name, "Self:A:Field");
-	t.is(RenderInfo.termini["CyclicStructC.cyclicOut"].parameters[0].name, "Self:A:A:Field");
+	t.is(RenderInfo.termini["CyclicStructA.cyclicOut"].parameters[0].name, "CyclicStructA:A:Field");
+	t.is(RenderInfo.termini["CyclicStructC.cyclicOut"].parameters[0].name, "CyclicStructA:A:A:Field");
 	t.is(CyclicStructADemo.cyclicOut(10), "10");
 	t.is(CyclicStructCDemo.cyclicOut(15), "15");
 });

--- a/feature_tests/demo_gen/test/test.mjs
+++ b/feature_tests/demo_gen/test/test.mjs
@@ -17,4 +17,6 @@ test("Variable Name Collisions", (t) => {
 	// As long as this test passes and the Javascript compiles, we should be good to go.
 	t.is(RenderInfo.termini["CyclicStructA.doubleCyclicOut"].parameters[0].name, "CyclicStructA:A:Field");
 	t.is(RenderInfo.termini["CyclicStructA.doubleCyclicOut"].parameters[1].name, "CyclicStructA:A:Field");
+
+	t.is(CyclicStructADemo.doubleCyclicOut(10, 20), "10 20");
 });

--- a/feature_tests/js/api/CyclicStructA.d.ts
+++ b/feature_tests/js/api/CyclicStructA.d.ts
@@ -24,5 +24,7 @@ export class CyclicStructA {
 
     cyclicOut(): string;
 
+    doubleCyclicOut(cyclicStructA: CyclicStructA_obj): string;
+
     constructor(structObj : CyclicStructA_obj);
 }

--- a/feature_tests/js/api/CyclicStructA.d.ts
+++ b/feature_tests/js/api/CyclicStructA.d.ts
@@ -26,5 +26,7 @@ export class CyclicStructA {
 
     doubleCyclicOut(cyclicStructA: CyclicStructA_obj): string;
 
+    get getterOut(): string;
+
     constructor(structObj : CyclicStructA_obj);
 }

--- a/feature_tests/js/api/CyclicStructA.mjs
+++ b/feature_tests/js/api/CyclicStructA.mjs
@@ -128,6 +128,23 @@ export class CyclicStructA {
         }
     }
 
+    get getterOut() {
+        let functionCleanupArena = new diplomatRuntime.CleanupArena();
+        
+        const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
+        wasm.CyclicStructA_getter_out(...this._intoFFI(), write.buffer);
+    
+        try {
+            return write.readString8();
+        }
+        
+        finally {
+            functionCleanupArena.free();
+        
+            write.free();
+        }
+    }
+
     constructor(structObj) {
         return this.#internalConstructor(...arguments)
     }

--- a/feature_tests/js/api/CyclicStructA.mjs
+++ b/feature_tests/js/api/CyclicStructA.mjs
@@ -111,6 +111,23 @@ export class CyclicStructA {
         }
     }
 
+    doubleCyclicOut(cyclicStructA) {
+        let functionCleanupArena = new diplomatRuntime.CleanupArena();
+        
+        const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
+        wasm.CyclicStructA_double_cyclic_out(...this._intoFFI(), ...CyclicStructA._fromSuppliedValue(diplomatRuntime.internalConstructor, cyclicStructA)._intoFFI(functionCleanupArena, {}), write.buffer);
+    
+        try {
+            return write.readString8();
+        }
+        
+        finally {
+            functionCleanupArena.free();
+        
+            write.free();
+        }
+    }
+
     constructor(structObj) {
         return this.#internalConstructor(...arguments)
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructA.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructA.kt
@@ -10,6 +10,7 @@ internal interface CyclicStructALib: Library {
     fun CyclicStructA_get_b(): CyclicStructBNative
     fun CyclicStructA_cyclic_out(nativeStruct: CyclicStructANative, write: Pointer): Unit
     fun CyclicStructA_double_cyclic_out(nativeStruct: CyclicStructANative, cyclicStructA: CyclicStructANative, write: Pointer): Unit
+    fun CyclicStructA_getter_out(nativeStruct: CyclicStructANative, write: Pointer): Unit
 }
 
 internal class CyclicStructANative: Structure(), Structure.ByValue {
@@ -51,6 +52,14 @@ class CyclicStructA internal constructor (
     fun doubleCyclicOut(cyclicStructA: CyclicStructA): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.CyclicStructA_double_cyclic_out(nativeStruct, cyclicStructA.nativeStruct, write);
+        
+        val returnString = DW.writeToString(write)
+        return returnString
+    }
+    
+    fun getterOut(): String {
+        val write = DW.lib.diplomat_buffer_write_create(0)
+        val returnVal = lib.CyclicStructA_getter_out(nativeStruct, write);
         
         val returnString = DW.writeToString(write)
         return returnString

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructA.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructA.kt
@@ -9,6 +9,7 @@ import com.sun.jna.Structure
 internal interface CyclicStructALib: Library {
     fun CyclicStructA_get_b(): CyclicStructBNative
     fun CyclicStructA_cyclic_out(nativeStruct: CyclicStructANative, write: Pointer): Unit
+    fun CyclicStructA_double_cyclic_out(nativeStruct: CyclicStructANative, cyclicStructA: CyclicStructANative, write: Pointer): Unit
 }
 
 internal class CyclicStructANative: Structure(), Structure.ByValue {
@@ -42,6 +43,14 @@ class CyclicStructA internal constructor (
     fun cyclicOut(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.CyclicStructA_cyclic_out(nativeStruct, write);
+        
+        val returnString = DW.writeToString(write)
+        return returnString
+    }
+    
+    fun doubleCyclicOut(cyclicStructA: CyclicStructA): String {
+        val write = DW.lib.diplomat_buffer_write_create(0)
+        val returnVal = lib.CyclicStructA_double_cyclic_out(nativeStruct, cyclicStructA.nativeStruct, write);
         
         val returnString = DW.writeToString(write)
         return returnString

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -269,8 +269,12 @@ pub mod ffi {
         }
 
         // For demo gen: tests having the same variables in the namespace
-        pub fn double_cyclic_out(self, cyclic_struct_a : Self, out : &mut DiplomatWrite) {
-            out.write_fmt(format_args!("{} {}", &self.a.field, cyclic_struct_a.a.field)).unwrap();
+        pub fn double_cyclic_out(self, cyclic_struct_a: Self, out: &mut DiplomatWrite) {
+            out.write_fmt(format_args!(
+                "{} {}",
+                &self.a.field, cyclic_struct_a.a.field
+            ))
+            .unwrap();
         }
     }
 

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -276,6 +276,11 @@ pub mod ffi {
             ))
             .unwrap();
         }
+
+        #[diplomat::attr(auto, getter)]
+        pub fn getter_out(self, out: &mut DiplomatWrite) {
+            out.write_str(&self.a.field.to_string()).unwrap();
+        }
     }
 
     impl CyclicStructB {

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -267,6 +267,11 @@ pub mod ffi {
         pub fn cyclic_out(self, out: &mut DiplomatWrite) {
             out.write_str(&self.a.field.to_string()).unwrap();
         }
+
+        // For demo gen: tests having the same variables in the namespace
+        pub fn double_cyclic_out(self, cyclic_struct_a : Self, out : &mut DiplomatWrite) {
+            out.write_fmt(format_args!("{} {}", &self.a.field, cyclic_struct_a.a.field)).unwrap();
+        }
     }
 
     impl CyclicStructB {

--- a/tool/src/demo_gen/mod.rs
+++ b/tool/src/demo_gen/mod.rs
@@ -196,7 +196,7 @@ pub(crate) fn run<'tcx>(
 
                         js_file_name: js_file_name.clone(),
 
-                        node_call_stack: String::default(),
+                        node_call_stack: Vec::default(),
 
                         // We set this in the init function of WebDemoGenerationContext.
                         typescript: false,

--- a/tool/src/demo_gen/mod.rs
+++ b/tool/src/demo_gen/mod.rs
@@ -204,7 +204,7 @@ pub(crate) fn run<'tcx>(
                         imports: BTreeSet::new(),
                     },
 
-                    out_param_collision: HashMap::new(),
+                    name_collision: HashMap::new(),
 
                     relative_import_path: import_path.clone(),
                     module_name: module_name.clone(),

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -408,16 +408,16 @@ impl RenderTerminusContext<'_, '_> {
                         self.relative_import_path.clone(),
                     ));
 
-                let var_name = heck::AsLowerCamelCase(param_name.clone()).to_string();
-
                 let owned_type = format!(
                     "{}{}",
                     node.owning_param
                         .as_ref()
                         .map(|o| { format!("{o}:") })
                         .unwrap_or_default(),
-                    heck::AsUpperCamelCase(param_name)
+                    heck::AsUpperCamelCase(param_name.clone())
                 );
+                
+                let var_name = heck::AsLowerCamelCase(owned_type.clone()).to_string();
 
                 let mut child = MethodDependency::new(
                     self.get_constructor_js(type_name.to_string(), method),
@@ -474,9 +474,11 @@ impl RenderTerminusContext<'_, '_> {
             heck::AsUpperCamelCase(param_name.clone())
         );
 
+        let var_name = heck::AsLowerCamelCase(owned_type.clone()).to_string();
+
         let mut child = MethodDependency::new(
             format!("{type_name}.fromFields"),
-            param_name.clone(),
+            var_name.clone(),
             Some(owned_type),
         );
 
@@ -518,7 +520,7 @@ impl RenderTerminusContext<'_, '_> {
             .node_call_stack
             .push(child.render().unwrap());
 
-        param_name
+        var_name
     }
 
     /// Read a constructor that will be created by our terminus, and add any parameters we might need.

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -139,6 +139,7 @@ pub(super) struct TerminusInfo {
     pub js_file_name: String,
 
     /// Final result of recursively calling [`RenderTerminusContext::evaluate_constructor`] on [`MethodDependency`]
+    /// TODO: Replace with actually appending results of [`RenderTerminusContext::evaluate_constructor`] to this (like a stack).
     pub node_call_stack: String,
 
     /// Are we a typescript file? Set by [`super::WebDemoGenerationContext::init`]

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -536,6 +536,7 @@ impl RenderTerminusContext<'_, '_> {
         }
 
         for param in method.params.iter() {
+            // TODO: Check FixedDecimalFormatter.mjs, this is creating a weird variable name
             let param_name : String = heck::AsLowerCamelCase(
                 format!("{}{}", owning_param, param.name)
             ).to_string();

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -42,14 +42,14 @@ struct MethodDependency {
     method_js: String,
 
     /// The variable name to assign to this method.
-    variable_name : String,
+    variable_name: String,
 
     /// Parameters names to pass into the method.
     /// TODO: Global parameter name collisions?
     params: Vec<String>,
 
     /// Parameter that calls this method.
-    self_param : Option<String>,
+    self_param: Option<String>,
 
     /// The Rust parameter that we're attempting to construct with this method. Currently used by [`OutParam`] for better default parameter names.
     owning_param: Option<String>,
@@ -69,7 +69,7 @@ pub(super) struct RenderTerminusContext<'ctx, 'tcx> {
 }
 
 impl MethodDependency {
-    pub fn new(method_js: String, variable_name : String, owning_param: Option<String>) -> Self {
+    pub fn new(method_js: String, variable_name: String, owning_param: Option<String>) -> Self {
         MethodDependency {
             method_js,
             variable_name,
@@ -171,8 +171,11 @@ impl RenderTerminusContext<'_, '_> {
 
         // Not making this as part of the RenderTerminusContext because we want each evaluation to have a specific node,
         // which I find easier easier to represent as a parameter to each function than something like an updating the current node in the struct.
-        let mut root =
-            MethodDependency::new(self.get_constructor_js(type_name.clone(), method), "out".into(), None);
+        let mut root = MethodDependency::new(
+            self.get_constructor_js(type_name.clone(), method),
+            "out".into(),
+            None,
+        );
 
         // And then we just treat the terminus as a regular constructor method:
         self.evaluate_constructor(method, &mut root);
@@ -274,7 +277,7 @@ impl RenderTerminusContext<'_, '_> {
     /// 2. Go a step deeper and look at its possible constructors to call evaluate_param on.
     ///
     /// `node` - Represents the current function of the parameter we're evaluating. See [`MethodDependency`] for more on its purpose.
-    /// 
+    ///
     /// Returns the name of the parameter that has been added to the [`TerminusInfo::node_call_stack`].
     fn evaluate_param<P: TyPosition<StructPath = StructPath>>(
         &mut self,
@@ -469,11 +472,15 @@ impl RenderTerminusContext<'_, '_> {
             heck::AsUpperCamelCase(param_name.clone())
         );
 
-        let mut child = MethodDependency::new(format!("{type_name}.fromFields"), param_name.clone(), Some(owned_type));
+        let mut child = MethodDependency::new(
+            format!("{type_name}.fromFields"),
+            param_name.clone(),
+            Some(owned_type),
+        );
 
         struct FieldInfo {
             field_name: String,
-            param_name : String,
+            param_name: String,
         }
 
         #[derive(Template)]
@@ -492,13 +499,15 @@ impl RenderTerminusContext<'_, '_> {
                     field.name.to_string(),
                     &mut child,
                     field.attrs.demo_attrs.clone(),
-                )
+                ),
             });
         }
 
         child.params.push(StructInfo { fields }.render().unwrap());
 
-        self.terminus_info.node_call_stack.push(child.render().unwrap());
+        self.terminus_info
+            .node_call_stack
+            .push(child.render().unwrap());
 
         param_name
     }
@@ -512,7 +521,8 @@ impl RenderTerminusContext<'_, '_> {
 
             let ty = s.ty.clone().into();
 
-            let self_param = self.evaluate_param(&ty, "self".into(), node, s.attrs.demo_attrs.clone());
+            let self_param =
+                self.evaluate_param(&ty, "self".into(), node, s.attrs.demo_attrs.clone());
             node.self_param.replace(self_param);
         }
 
@@ -527,6 +537,8 @@ impl RenderTerminusContext<'_, '_> {
         }
 
         // Add this method to the call stack:
-        self.terminus_info.node_call_stack.push(node.render().unwrap());
+        self.terminus_info
+            .node_call_stack
+            .push(node.render().unwrap());
     }
 }

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -117,7 +117,7 @@ impl MethodDependency {
 /// export function formatWrite(fixedDecimalFormatterLocaleName, fixedDecimalFormatterOptionsGroupingStrategy, fixedDecimalFormatterOptionsSomeOtherConfig, valueV) {
 ///
 ///     let fixedDecimalFormatterLocale = new Locale(fixedDecimalFormatterLocaleName);
-/// 
+///
 ///     let fixedDecimalFormatterProvider = DataProvider.newStatic();
 ///     
 ///     let fixedDecimalFormatterOptions = FixedDecimalFormatterOptions.fromFields({
@@ -126,11 +126,11 @@ impl MethodDependency {
 ///     });
 ///     
 ///     let fixedDecimalFormatter = FixedDecimalFormatter.tryNew(fixedDecimalFormatterLocale,fixedDecimalFormatterProvider,fixedDecimalFormatterOptions);
-/// 
+///
 ///     let value = new FixedDecimal(valueV);
-/// 
+///
 ///     let out = fixedDecimalFormatter.formatWrite(value);
-/// 
+///
 ///     return out;
 /// }
 /// ```

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -535,7 +535,6 @@ impl RenderTerminusContext<'_, '_> {
                 self.evaluate_param(&ty, type_name.to_string(), node, s.attrs.demo_attrs.clone());
             node.self_param.replace(self_param);
 
-            
             let is_getter = matches!(
                 method.attrs.special_method,
                 Some(hir::SpecialMethod::Getter(_))

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -44,8 +44,8 @@ struct MethodDependency {
     /// The variable name to assign to this method.
     variable_name : String,
 
-    /// Parameters to pass into the method.
-    params: Vec<ParamInfo>,
+    /// Parameters names to pass into the method.
+    params: Vec<String>,
 
     /// The Rust parameter that we're attempting to construct with this method. Currently used by [`OutParam`] for better default parameter names.
     owning_param: Option<String>,

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -114,23 +114,24 @@ impl MethodDependency {
 ///
 /// The final render looks something like this:
 /// ```typescript
-/// function formatWrite(locale : Locale, provider : DataProvider, options : FixedDecimalFormatterOptions, v : number) {
-///     return function(...args) { let self = args[0]; self.formatWrite(...args.slice(1)); }
-///     .apply(
-///         null,
-///         [
-///             FixedDecimalFormatter.tryNew.apply(
-///                 null,
-///                 [locale,
-///                 provider,
-///                 options]
-///             ),
-///             FixedDecimal.new_.apply(
-///                 null,
-///                 [v]
-///             ),
-///         ]
-///     );
+/// export function formatWrite(fixedDecimalFormatterLocaleName, fixedDecimalFormatterOptionsGroupingStrategy, fixedDecimalFormatterOptionsSomeOtherConfig, valueV) {
+///
+///     let fixedDecimalFormatterLocale = new Locale(fixedDecimalFormatterLocaleName);
+/// 
+///     let fixedDecimalFormatterProvider = DataProvider.newStatic();
+///     
+///     let fixedDecimalFormatterOptions = FixedDecimalFormatterOptions.fromFields({
+///         groupingStrategy: fixedDecimalFormatterOptionsGroupingStrategy,
+///         someOtherConfig: fixedDecimalFormatterOptionsSomeOtherConfig
+///     });
+///     
+///     let fixedDecimalFormatter = FixedDecimalFormatter.tryNew(fixedDecimalFormatterLocale,fixedDecimalFormatterProvider,fixedDecimalFormatterOptions);
+/// 
+///     let value = new FixedDecimal(valueV);
+/// 
+///     let out = fixedDecimalFormatter.formatWrite(value);
+/// 
+///     return out;
 /// }
 /// ```
 #[derive(Template)]

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -210,16 +210,16 @@ impl RenderTerminusContext<'_, '_> {
         let attrs_default = attrs.unwrap_or_default();
 
         let owning_str = node
-                .owning_param
-                .as_ref()
-                .map(|p| format!("{}:", p))
-                .unwrap_or_default();
+            .owning_param
+            .as_ref()
+            .map(|p| format!("{}:", p))
+            .unwrap_or_default();
         let owned_full_name = format!(
-                "{}{}",
-                owning_str,
-                heck::AsUpperCamelCase(param_name.clone())
-            )
-            .to_string();
+            "{}{}",
+            owning_str,
+            heck::AsUpperCamelCase(param_name.clone())
+        )
+        .to_string();
         // This only works for enums, since otherwise we break the type into its component parts.
         let label = if attrs_default.input_cfg.label.is_empty() {
             owned_full_name.clone()
@@ -538,18 +538,18 @@ impl RenderTerminusContext<'_, '_> {
 
             let type_name = self.formatter.fmt_type_name(ty.id().unwrap());
 
-            let self_param = self.evaluate_param(
-                &ty,
-                type_name.to_string(),
-                node,
-                s.attrs.demo_attrs.clone(),
-            );
+            let self_param =
+                self.evaluate_param(&ty, type_name.to_string(), node, s.attrs.demo_attrs.clone());
             node.self_param.replace(self_param);
         }
 
         for param in method.params.iter() {
-            let new_param =
-                self.evaluate_param(&param.ty, param.name.to_string(), node, param.attrs.demo_attrs.clone());
+            let new_param = self.evaluate_param(
+                &param.ty,
+                param.name.to_string(),
+                node,
+                param.attrs.demo_attrs.clone(),
+            );
             node.params.push(new_param);
         }
 

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -495,19 +495,12 @@ impl RenderTerminusContext<'_, '_> {
 
         let mut fields = Vec::new();
 
-        let owning_param = node
-            .owning_param
-            .clone()
-            .map(|s| format!("{s}:"))
-            .unwrap_or_default();
-
         for field in st.fields.iter() {
             fields.push(FieldInfo {
                 field_name: self.formatter.fmt_param_name(field.name.as_ref()).into(),
                 param_name: self.evaluate_param(
                     &field.ty,
-                    heck::AsLowerCamelCase(format!("{}{}", owning_param, field.name.clone()))
-                        .to_string(),
+                    field.name.to_string(),
                     &mut child,
                     field.attrs.demo_attrs.clone(),
                 ),

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -198,7 +198,7 @@ impl RenderTerminusContext<'_, '_> {
 
     /// Helper function for quickly passing a parameter to both our node and the render terminus.
     /// Appends to [TerminusInfo::out_params]
-    /// 
+    ///
     /// Returns the name of the parameter attached to the render terminus.
     fn append_out_param<P: TyPosition<StructPath = StructPath>>(
         &mut self,
@@ -322,7 +322,12 @@ impl RenderTerminusContext<'_, '_> {
                 }
 
                 if all_attrs.demo_attrs.external {
-                    return self.append_out_param(param_name.clone(), param_type, node, Some(param_attrs));
+                    return self.append_out_param(
+                        param_name.clone(),
+                        param_type,
+                        node,
+                        Some(param_attrs),
+                    );
                 }
 
                 self.evaluate_op_constructors(op, type_name.to_string(), param_name, node)
@@ -490,16 +495,19 @@ impl RenderTerminusContext<'_, '_> {
 
         let mut fields = Vec::new();
 
-        let owning_param = node.owning_param.clone().map(|s| {
-            format!("{s}_")
-        }).unwrap_or_default();
+        let owning_param = node
+            .owning_param
+            .clone()
+            .map(|s| format!("{s}_"))
+            .unwrap_or_default();
 
         for field in st.fields.iter() {
             fields.push(FieldInfo {
                 field_name: self.formatter.fmt_param_name(field.name.as_ref()).into(),
                 param_name: self.evaluate_param(
                     &field.ty,
-                    heck::AsLowerCamelCase(format!("{}{}", owning_param, field.name.clone())).to_string(),
+                    heck::AsLowerCamelCase(format!("{}{}", owning_param, field.name.clone()))
+                        .to_string(),
                     &mut child,
                     field.attrs.demo_attrs.clone(),
                 ),
@@ -519,34 +527,35 @@ impl RenderTerminusContext<'_, '_> {
     fn evaluate_constructor(&mut self, method: &Method, node: &mut MethodDependency) {
         let param_self = method.param_self.as_ref();
 
-        let owning_param = node.owning_param.clone().map(|s| {
-            format!("{s}_")
-        }).unwrap_or_default();
+        let owning_param = node
+            .owning_param
+            .clone()
+            .map(|s| format!("{s}_"))
+            .unwrap_or_default();
 
         if param_self.is_some() {
             let s = param_self.unwrap();
 
-            let ty : Type = s.ty.clone().into();
+            let ty: Type = s.ty.clone().into();
 
             let type_name = self.formatter.fmt_type_name(ty.id().unwrap());
 
-            let self_param =
-                self.evaluate_param(&ty, format!("{owning_param}{type_name}"), node, s.attrs.demo_attrs.clone());
+            let self_param = self.evaluate_param(
+                &ty,
+                format!("{owning_param}{type_name}"),
+                node,
+                s.attrs.demo_attrs.clone(),
+            );
             node.self_param.replace(self_param);
         }
 
         for param in method.params.iter() {
             // TODO: Check FixedDecimalFormatter.mjs, this is creating a weird variable name
-            let param_name : String = heck::AsLowerCamelCase(
-                format!("{}{}", owning_param, param.name)
-            ).to_string();
+            let param_name: String =
+                heck::AsLowerCamelCase(format!("{}{}", owning_param, param.name)).to_string();
 
-            let new_param = self.evaluate_param(
-                &param.ty,
-                param_name,
-                node,
-                param.attrs.demo_attrs.clone(),
-            );
+            let new_param =
+                self.evaluate_param(&param.ty, param_name, node, param.attrs.demo_attrs.clone());
             node.params.push(new_param);
         }
 

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -63,7 +63,12 @@ pub(super) struct RenderTerminusContext<'ctx, 'tcx> {
 }
 
 impl MethodDependency {
-    pub fn new(ctx : &mut RenderTerminusContext, method_js: String, variable_name: String, owning_param: Option<String>) -> Self {
+    pub fn new(
+        ctx: &mut RenderTerminusContext,
+        method_js: String,
+        variable_name: String,
+        owning_param: Option<String>,
+    ) -> Self {
         let (var_name, n) = if ctx.name_collision.contains_key(&variable_name) {
             let n = ctx.name_collision.get(&variable_name).unwrap();
 

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -8,12 +8,6 @@ use crate::{js::formatter::JSFormatter, ErrorStore};
 
 use askama::{self, Template};
 
-#[derive(Clone)]
-pub struct ParamInfo {
-    /// The javascript that represents this parameter.
-    pub js: String,
-}
-
 pub struct OutParam {
     /// Param JS representation (i.e., `arg_1`)
     pub param_name: String,

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -416,7 +416,7 @@ impl RenderTerminusContext<'_, '_> {
                         .unwrap_or_default(),
                     heck::AsUpperCamelCase(param_name.clone())
                 );
-                
+
                 let var_name = heck::AsLowerCamelCase(owned_type.clone()).to_string();
 
                 let mut child = MethodDependency::new(

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -45,6 +45,7 @@ struct MethodDependency {
     variable_name : String,
 
     /// Parameters names to pass into the method.
+    /// TODO: Global parameter name collisions?
     params: Vec<String>,
 
     /// The Rust parameter that we're attempting to construct with this method. Currently used by [`OutParam`] for better default parameter names.

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -42,7 +42,6 @@ struct MethodDependency {
     variable_name: String,
 
     /// Parameters names to pass into the method.
-    /// TODO: Global parameter name collisions?
     params: Vec<String>,
 
     /// Parameter that calls this method.
@@ -178,10 +177,6 @@ impl RenderTerminusContext<'_, '_> {
     /// Create a Render Terminus .js file from a method.
     /// We define this (for now) as any function that outputs [`hir::SuccessType::Write`]
     pub fn evaluate(&mut self, type_name: String, method: &Method) {
-        // TODO: I think it would be nice to have a stack of the current namespace a given parameter.
-        // For instance, ICU4XFixedDecimalFormatter.formatWrite() needs a constructed ICU4XFixedDecimal, which takes an i32 called v as input.
-        // Someone just trying to read the .d.ts file will only see function formatWrite(v: number); which doesn't really help them figure out where that's from or why it's there.
-
         // Not making this as part of the RenderTerminusContext because we want each evaluation to have a specific node,
         // which I find easier easier to represent as a parameter to each function than something like an updating the current node in the struct.
         let mut root = MethodDependency::new(
@@ -307,9 +302,6 @@ impl RenderTerminusContext<'_, '_> {
         node: &mut MethodDependency,
         param_attrs: DemoInfo,
     ) -> String {
-        // TODO: I think we need to check for struct and opaque types as to whether or not these have attributes that label them as provided as a parameter.
-
-        // TODO: Instead of flat returning param_name, need to add info based on the node's parameters (and all other variables) to avoid collisions.
         match param_type {
             // Types we can easily coerce into out parameters (i.e., get easy user input from):
             Type::Primitive(..) => {

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -48,6 +48,9 @@ struct MethodDependency {
     /// TODO: Global parameter name collisions?
     params: Vec<String>,
 
+    /// Parameter that calls this method.
+    self_param : Option<String>,
+
     /// The Rust parameter that we're attempting to construct with this method. Currently used by [`OutParam`] for better default parameter names.
     owning_param: Option<String>,
 }
@@ -71,6 +74,7 @@ impl MethodDependency {
             method_js,
             variable_name,
             params: Vec::new(),
+            self_param: None,
             owning_param,
         }
     }
@@ -351,19 +355,18 @@ impl RenderTerminusContext<'_, '_> {
     /// `method` - The method we're trying to call.
     fn get_constructor_js(&self, owner_type_name: String, method: &Method) -> String {
         let method_name = self.formatter.fmt_method_name(method);
+
+        // TODO: Add support for getters back in.
         if method.param_self.is_some() {
             // We represent as function () instead of () => since closures ignore the `this` args applied to them for whatever reason.
 
             // TODO: Currently haven't run into other methods that require special syntax to be called in this way, but this might change.
-            let is_getter = matches!(
-                method.attrs.special_method,
-                Some(hir::SpecialMethod::Getter(_))
-            );
+            // let is_getter = matches!(
+            //     method.attrs.special_method,
+            //     Some(hir::SpecialMethod::Getter(_))
+            // );
 
-            format!(
-                "(function (...args) {{ return args[0].{method_name}{} }})",
-                if !is_getter { "(...args.slice(1))" } else { "" }
-            )
+            method_name
         } else if let Some(hir::SpecialMethod::Constructor) = method.attrs.special_method {
             format!("new {owner_type_name}")
         } else {
@@ -507,8 +510,7 @@ impl RenderTerminusContext<'_, '_> {
             let ty = s.ty.clone().into();
 
             let self_param = self.evaluate_param(&ty, "self".into(), node, s.attrs.demo_attrs.clone());
-            // TODO: Add "self_param"
-            node.params.push(self_param);
+            node.self_param.replace(self_param);
         }
 
         for param in method.params.iter() {

--- a/tool/templates/demo_gen/method_dependency.js.jinja
+++ b/tool/templates/demo_gen/method_dependency.js.jinja
@@ -1,4 +1,4 @@
-let {{variable_name}} = {{ method_js }}(
+let {{variable_name}} = {% if let Some(s) = self_param -%} {{s}}. {%- endif -%} {{ method_js }}(
     {%- for param in params -%}
     {{ param }}{% if !loop.last %},{% endif -%}
     {%- endfor -%}

--- a/tool/templates/demo_gen/method_dependency.js.jinja
+++ b/tool/templates/demo_gen/method_dependency.js.jinja
@@ -1,5 +1,5 @@
 let {{variable_name}} = {{ method_js }}(
     {%- for param in params -%}
-    {{ param.js }}{% if !loop.last %},{% endif -%}
+    {{ param }}{% if !loop.last %},{% endif -%}
     {%- endfor -%}
 );

--- a/tool/templates/demo_gen/method_dependency.js.jinja
+++ b/tool/templates/demo_gen/method_dependency.js.jinja
@@ -2,4 +2,4 @@ let {{variable_name}} = {{ method_js }}(
     {%- for param in params -%}
     {{ param }}{% if !loop.last %},{% endif -%}
     {%- endfor -%}
-);
+)

--- a/tool/templates/demo_gen/method_dependency.js.jinja
+++ b/tool/templates/demo_gen/method_dependency.js.jinja
@@ -1,5 +1,5 @@
-let {{variable_name}} = {% if let Some(s) = self_param -%} {{s}}. {%- endif -%} {{ method_js }}(
+let {{variable_name}} = {% if let Some(s) = self_param -%} {{s}}. {%- endif -%} {{ method_js }} {%- if !is_getter -%} (
     {%- for param in params -%}
     {{ param }}{% if !loop.last %},{% endif -%}
     {%- endfor -%}
-)
+) {%- endif %}

--- a/tool/templates/demo_gen/method_dependency.js.jinja
+++ b/tool/templates/demo_gen/method_dependency.js.jinja
@@ -1,8 +1,5 @@
-{{ method_js }}.apply(
-    null,
-    [
-        {%- for param in params %}
-        {{ param.js|indent(8) }}{% if !loop.last %},{% endif -%}
-        {% endfor %}
-    ]
-)
+let {{variable_name}} = {{ method_js }}(
+    {%- for param in params -%}
+    {{ param.js }}{% if !loop.last %},{% endif -%}
+    {%- endfor -%}
+);

--- a/tool/templates/demo_gen/struct.js.jinja
+++ b/tool/templates/demo_gen/struct.js.jinja
@@ -1,7 +1,5 @@
-(function (...args) {
-    return {{type_name}}.fromFields({
-        {%- for field in fields %}
-        {{field}}: args[{{loop.index0}}]{% if !loop.last %},{% endif %}
-        {%- endfor -%}
-    });
-})
+{
+    {%- for field in fields %}
+    {{field.field_name}}: {{field.param_name}}{% if !loop.last %},{% endif %}
+    {%- endfor %}
+}

--- a/tool/templates/demo_gen/terminus.js.jinja
+++ b/tool/templates/demo_gen/terminus.js.jinja
@@ -3,6 +3,10 @@ export function {{function_name}}(
     {{param.param_name}}{% if typescript %}: {{param.type_name}}{% endif %}{% if !loop.last %}, {% endif %}
     {%- endfor -%}
 ){% if typescript %};{% else %} {
-    return {{node_call_stack|indent(4)}};
+    {% for method in node_call_stack %}
+    {{ method|indent(4) }};
+    {% endfor %}
+
+    return out;
 }
 {%- endif %}


### PR DESCRIPTION
Fixes #609.

Looks much more human readable now, with output like:

```js
export function formatWrite(name, grouping_strategy, some_other_config, v) {
    
    let locale = new Locale(name);
    
    let provider = DataProvider.newStatic();
    
    let options = FixedDecimalFormatterOptions.fromFields({
        groupingStrategy: grouping_strategy,
        someOtherConfig: some_other_config
    });
    
    let self = FixedDecimalFormatter.tryNew(locale,provider,options);
    
    let value = new FixedDecimal(v);
    
    let out = self.formatWrite(value);
    

    return out;
}
```

Quite a few TODOs with this one:

- [x] Global variable name collision avoidance
  - [x] Tests
- [x] Recursive variable name (based on the variable it will be used for)
  - [x] Tests 
- [x] Rename all `self` parameters to something based on the type name
- [x] Calling a getter
  - [x] Tests
- [x] Remove all associated TODOs from `terminus.rs` (once these are checked off)
- [x] Update `docs/demo_gen.md`