### PR TITLE
Add support for callbacks to C++

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -951,6 +951,11 @@ impl TypeName {
                     if let syn::PathArguments::AngleBracketed(type_args) =
                         &p.path.segments.last().unwrap().arguments
                     {
+                        assert!(
+                            type_args.args.len() > 1,
+                            "Not enough arguments given to Result<T,E>. Are you using a non-std Result type?"
+                        );
+
                         if let (syn::GenericArgument::Type(ok), syn::GenericArgument::Type(err)) =
                             (&type_args.args[0], &type_args.args[1])
                         {

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -921,8 +921,13 @@ impl<'ast> LoweringContext<'ast> {
                     let hir_in_ty = self
                         .lower_out_type(in_ty, ltl, in_path, false, false)
                         .unwrap();
-                    if hir_in_ty.lifetimes().next().is_some() {
-                        self.errors.push(LoweringError::Other("Callback parameters can't be borrowed, and therefore can't have lifetimes".into()));
+
+                    if !matches!(hir_in_ty, super::Type::Slice(super::Slice::Str(_, _)))
+                        && hir_in_ty.lifetimes().next().is_some()
+                    {
+                        self.errors.push(LoweringError::Other(
+                            "Callback parameters can't be borrowed, and therefore can't have lifetimes".into(),
+                        ));
                         return Err(());
                     }
                     params.push(CallbackParam {

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <variant>
 #include <cstdint>
+#include <functional>
 
 #if __cplusplus >= 202002L
 #include <span>
@@ -210,6 +211,61 @@ private:
 };
 
 #endif // __cplusplus >= 202002L
+
+// Interop between std::function & our C Callback wrapper type
+
+template <typename T> struct fn_traits;
+template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
+    using fn_ptr_t = Ret(Args...);
+    using function_t = std::function<fn_ptr_t>;
+    using ret = Ret;
+
+    template <typename T, typename = void>
+    struct as_ffi {
+      using type = T;
+    };
+
+    template <typename T>
+    struct as_ffi<T, std::void_t<decltype(&T::AsFFI)>> {
+      using type = decltype(std::declval<T>().AsFFI());
+    };
+
+    template<typename T>
+    using as_ffi_t = typename as_ffi<T>::type;
+
+    template<typename T>
+    using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+
+    template<typename T>
+    using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+
+    // For a given T, creates a function that take in the C ABI version & return the C++ type.
+    template<typename T>
+    static T replace(replace_fn_t<T> val) {
+        if constexpr(std::is_same_v<T, std::string_view>)   {
+            return std::string_view{val.data, val.len};
+        } else if constexpr(!std::is_same_v<T, as_ffi_t<T>>) {
+            return T::FromFFI(val);
+        }
+        else {
+            return val;
+        }
+    }
+
+    static Ret c_run_callback(const void *cb, replace_fn_t<Args>... args) {
+        return (*reinterpret_cast<const function_t *>(cb))(replace<Args>(args)...);
+    }
+
+    static void c_delete(const void *cb) {
+        delete reinterpret_cast<const function_t *>(cb);
+    }
+
+    fn_traits(function_t) {} // Allows less clunky construction (avoids decltype)
+};
+
+// additional deduction guide required
+template<class T>
+fn_traits(T) -> fn_traits<T>;
 
 } // namespace diplomat
 

--- a/example/cpp/include/icu4x/DataProvider.d.hpp
+++ b/example/cpp/include/icu4x/DataProvider.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/example/cpp/include/icu4x/DataProvider.hpp
+++ b/example/cpp/include/icu4x/DataProvider.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/example/cpp/include/icu4x/FixedDecimal.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimal.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/example/cpp/include/icu4x/FixedDecimal.hpp
+++ b/example/cpp/include/icu4x/FixedDecimal.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/example/cpp/include/icu4x/FixedDecimalFormatter.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatter.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/example/cpp/include/icu4x/FixedDecimalFormatter.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatter.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 #include "DataProvider.hpp"

--- a/example/cpp/include/icu4x/FixedDecimalFormatterOptions.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatterOptions.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 #include "FixedDecimalGroupingStrategy.d.hpp"

--- a/example/cpp/include/icu4x/FixedDecimalFormatterOptions.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatterOptions.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 #include "FixedDecimalGroupingStrategy.hpp"

--- a/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/example/cpp/include/icu4x/Locale.d.hpp
+++ b/example/cpp/include/icu4x/Locale.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/example/cpp/include/icu4x/Locale.hpp
+++ b/example/cpp/include/icu4x/Locale.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/feature_tests/c/include/CallbackWrapper.h
+++ b/feature_tests/c/include/CallbackWrapper.h
@@ -40,6 +40,11 @@ typedef struct DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g {
     int32_t (*run_callback)(const void*, int32_t );
     void (*destructor)(const void*);
 } DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g;
+typedef struct DiplomatCallback_CallbackWrapper_test_str_cb_arg_f {
+    const void* data;
+    int32_t (*run_callback)(const void*, DiplomatStringView );
+    void (*destructor)(const void*);
+} DiplomatCallback_CallbackWrapper_test_str_cb_arg_f;
 
 int32_t CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f f_cb_wrap, int32_t x);
 
@@ -48,6 +53,8 @@ int32_t CallbackWrapper_test_no_args(DiplomatCallback_CallbackWrapper_test_no_ar
 int32_t CallbackWrapper_test_cb_with_struct(DiplomatCallback_CallbackWrapper_test_cb_with_struct_f f_cb_wrap);
 
 int32_t CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_f f_cb_wrap, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g g_cb_wrap);
+
+int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_str_cb_arg_f f_cb_wrap);
 
 
 

--- a/feature_tests/cpp/Makefile
+++ b/feature_tests/cpp/Makefile
@@ -25,8 +25,12 @@ $(ALL_HEADERS):
 ./tests/attrs.out: ../../target/debug/libdiplomat_feature_tests.a $(ALL_HEADERS) ./tests/attrs.cpp
 	$(CXX) -std=c++17 ./tests/attrs.cpp ../../target/debug/libdiplomat_feature_tests.a -ldl -lpthread -lm -g -o ./tests/attrs.out
 
-test: ./tests/structs.out ./tests/result.out ./tests/option.out ./tests/attrs.out
+./tests/callback.out: ../../target/debug/libdiplomat_feature_tests.a $(ALL_HEADERS) ./tests/callback.cpp
+	$(CXX) -std=c++17 ./tests/callback.cpp ../../target/debug/libdiplomat_feature_tests.a -ldl -lpthread -lm -g -o ./tests/callback.out
+
+test: ./tests/structs.out ./tests/result.out ./tests/option.out ./tests/attrs.out ./tests/callback.out
 	./tests/structs.out
 	./tests/result.out
 	./tests/option.out
 	./tests/attrs.out
+	./tests/callback.out

--- a/feature_tests/cpp/include/Bar.d.hpp
+++ b/feature_tests/cpp/include/Bar.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Bar.hpp
+++ b/feature_tests/cpp/include/Bar.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "Foo.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/BorrowedFields.d.hpp
+++ b/feature_tests/cpp/include/BorrowedFields.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/BorrowedFields.hpp
+++ b/feature_tests/cpp/include/BorrowedFields.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "Bar.hpp"
 #include "diplomat_runtime.hpp"
@@ -26,7 +27,7 @@ namespace capi {
 
 inline diplomat::result<BorrowedFields, diplomat::Utf8Error> BorrowedFields::from_bar_and_strings(const Bar& bar, std::u16string_view dstr16, std::string_view utf8_str) {
   if (!diplomat::capi::diplomat_is_str(utf8_str.data(), utf8_str.size())) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
+    return diplomat::Err<diplomat::Utf8Error>();
   }
   auto result = diplomat::capi::BorrowedFields_from_bar_and_strings(bar.AsFFI(),
     {dstr16.data(), dstr16.size()},

--- a/feature_tests/cpp/include/BorrowedFieldsReturning.d.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsReturning.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/BorrowedFieldsReturning.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsReturning.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/BorrowedFieldsWithBounds.d.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsWithBounds.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/BorrowedFieldsWithBounds.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsWithBounds.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "Foo.hpp"
 #include "diplomat_runtime.hpp"
@@ -26,7 +27,7 @@ namespace capi {
 
 inline diplomat::result<BorrowedFieldsWithBounds, diplomat::Utf8Error> BorrowedFieldsWithBounds::from_foo_and_strings(const Foo& foo, std::u16string_view dstr16_x, std::string_view utf8_str_z) {
   if (!diplomat::capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size())) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
+    return diplomat::Err<diplomat::Utf8Error>();
   }
   auto result = diplomat::capi::BorrowedFieldsWithBounds_from_foo_and_strings(foo.AsFFI(),
     {dstr16_x.data(), dstr16_x.size()},

--- a/feature_tests/cpp/include/CallbackTestingStruct.d.hpp
+++ b/feature_tests/cpp/include/CallbackTestingStruct.d.hpp
@@ -1,0 +1,35 @@
+#ifndef CallbackTestingStruct_D_HPP
+#define CallbackTestingStruct_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    struct CallbackTestingStruct {
+      int32_t x;
+      int32_t y;
+    };
+    
+    typedef struct CallbackTestingStruct_option {union { CallbackTestingStruct ok; }; bool is_ok; } CallbackTestingStruct_option;
+} // namespace capi
+} // namespace
+
+
+struct CallbackTestingStruct {
+  int32_t x;
+  int32_t y;
+
+  inline diplomat::capi::CallbackTestingStruct AsFFI() const;
+  inline static CallbackTestingStruct FromFFI(diplomat::capi::CallbackTestingStruct c_struct);
+};
+
+
+#endif // CallbackTestingStruct_D_HPP

--- a/feature_tests/cpp/include/CallbackTestingStruct.hpp
+++ b/feature_tests/cpp/include/CallbackTestingStruct.hpp
@@ -1,0 +1,41 @@
+#ifndef CallbackTestingStruct_HPP
+#define CallbackTestingStruct_HPP
+
+#include "CallbackTestingStruct.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    extern "C" {
+    
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+
+inline diplomat::capi::CallbackTestingStruct CallbackTestingStruct::AsFFI() const {
+  return diplomat::capi::CallbackTestingStruct {
+    /* .x = */ x,
+    /* .y = */ y,
+  };
+}
+
+inline CallbackTestingStruct CallbackTestingStruct::FromFFI(diplomat::capi::CallbackTestingStruct c_struct) {
+  return CallbackTestingStruct {
+    /* .x = */ c_struct.x,
+    /* .y = */ c_struct.y,
+  };
+}
+
+
+#endif // CallbackTestingStruct_HPP

--- a/feature_tests/cpp/include/CallbackWrapper.d.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.d.hpp
@@ -1,0 +1,45 @@
+#ifndef CallbackWrapper_D_HPP
+#define CallbackWrapper_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+struct CallbackTestingStruct;
+
+
+namespace diplomat {
+namespace capi {
+    struct CallbackWrapper {
+      bool cant_be_empty;
+    };
+    
+    typedef struct CallbackWrapper_option {union { CallbackWrapper ok; }; bool is_ok; } CallbackWrapper_option;
+} // namespace capi
+} // namespace
+
+
+struct CallbackWrapper {
+  bool cant_be_empty;
+
+  inline static int32_t test_multi_arg_callback(std::function<int32_t(int32_t)> f, int32_t x);
+
+  inline static int32_t test_no_args(std::function<void()> h);
+
+  inline static int32_t test_cb_with_struct(std::function<int32_t(CallbackTestingStruct)> f);
+
+  inline static int32_t test_multiple_cb_args(std::function<int32_t()> f, std::function<int32_t(int32_t)> g);
+
+  inline static int32_t test_str_cb_arg(std::function<int32_t(std::string_view)> f);
+
+  inline diplomat::capi::CallbackWrapper AsFFI() const;
+  inline static CallbackWrapper FromFFI(diplomat::capi::CallbackWrapper c_struct);
+};
+
+
+#endif // CallbackWrapper_D_HPP

--- a/feature_tests/cpp/include/CallbackWrapper.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.hpp
@@ -1,0 +1,107 @@
+#ifndef CallbackWrapper_HPP
+#define CallbackWrapper_HPP
+
+#include "CallbackWrapper.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "CallbackTestingStruct.hpp"
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    extern "C" {
+    typedef struct DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f {
+        const void* data;
+        int32_t (*run_callback)(const void*, int32_t );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f;
+    typedef struct DiplomatCallback_CallbackWrapper_test_no_args_h {
+        const void* data;
+        void (*run_callback)(const void*);
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_no_args_h;
+    typedef struct DiplomatCallback_CallbackWrapper_test_cb_with_struct_f {
+        const void* data;
+        int32_t (*run_callback)(const void*, diplomat::capi::CallbackTestingStruct );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_cb_with_struct_f;
+    typedef struct DiplomatCallback_CallbackWrapper_test_multiple_cb_args_f {
+        const void* data;
+        int32_t (*run_callback)(const void*);
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_multiple_cb_args_f;
+    typedef struct DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g {
+        const void* data;
+        int32_t (*run_callback)(const void*, int32_t );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g;
+    typedef struct DiplomatCallback_CallbackWrapper_test_str_cb_arg_f {
+        const void* data;
+        int32_t (*run_callback)(const void*, diplomat::capi::DiplomatStringView );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_str_cb_arg_f;
+    
+    int32_t CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f f_cb_wrap, int32_t x);
+    
+    int32_t CallbackWrapper_test_no_args(DiplomatCallback_CallbackWrapper_test_no_args_h h_cb_wrap);
+    
+    int32_t CallbackWrapper_test_cb_with_struct(DiplomatCallback_CallbackWrapper_test_cb_with_struct_f f_cb_wrap);
+    
+    int32_t CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_f f_cb_wrap, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g g_cb_wrap);
+    
+    int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_str_cb_arg_f f_cb_wrap);
+    
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline int32_t CallbackWrapper::test_multi_arg_callback(std::function<int32_t(int32_t)> f, int32_t x) {
+  auto result = diplomat::capi::CallbackWrapper_test_multi_arg_callback({new decltype(f)(f), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete},
+    x);
+  return result;
+}
+
+inline int32_t CallbackWrapper::test_no_args(std::function<void()> h) {
+  auto result = diplomat::capi::CallbackWrapper_test_no_args({new decltype(h)(h), diplomat::fn_traits(h).c_run_callback, diplomat::fn_traits(h).c_delete});
+  return result;
+}
+
+inline int32_t CallbackWrapper::test_cb_with_struct(std::function<int32_t(CallbackTestingStruct)> f) {
+  auto result = diplomat::capi::CallbackWrapper_test_cb_with_struct({new decltype(f)(f), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
+  return result;
+}
+
+inline int32_t CallbackWrapper::test_multiple_cb_args(std::function<int32_t()> f, std::function<int32_t(int32_t)> g) {
+  auto result = diplomat::capi::CallbackWrapper_test_multiple_cb_args({new decltype(f)(f), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete},
+    {new decltype(g)(g), diplomat::fn_traits(g).c_run_callback, diplomat::fn_traits(g).c_delete});
+  return result;
+}
+
+inline int32_t CallbackWrapper::test_str_cb_arg(std::function<int32_t(std::string_view)> f) {
+  auto result = diplomat::capi::CallbackWrapper_test_str_cb_arg({new decltype(f)(f), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
+  return result;
+}
+
+
+inline diplomat::capi::CallbackWrapper CallbackWrapper::AsFFI() const {
+  return diplomat::capi::CallbackWrapper {
+    /* .cant_be_empty = */ cant_be_empty,
+  };
+}
+
+inline CallbackWrapper CallbackWrapper::FromFFI(diplomat::capi::CallbackWrapper c_struct) {
+  return CallbackWrapper {
+    /* .cant_be_empty = */ c_struct.cant_be_empty,
+  };
+}
+
+
+#endif // CallbackWrapper_HPP

--- a/feature_tests/cpp/include/ContiguousEnum.d.hpp
+++ b/feature_tests/cpp/include/ContiguousEnum.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ContiguousEnum.hpp
+++ b/feature_tests/cpp/include/ContiguousEnum.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/CyclicStructA.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "CyclicStructB.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/CyclicStructA.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "CyclicStructB.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/CyclicStructB.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructB.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/CyclicStructB.hpp
+++ b/feature_tests/cpp/include/CyclicStructB.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "CyclicStructA.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/CyclicStructC.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructC.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "CyclicStructA.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/CyclicStructC.hpp
+++ b/feature_tests/cpp/include/CyclicStructC.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "CyclicStructA.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/DefaultEnum.d.hpp
+++ b/feature_tests/cpp/include/DefaultEnum.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/DefaultEnum.hpp
+++ b/feature_tests/cpp/include/DefaultEnum.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ErrorEnum.d.hpp
+++ b/feature_tests/cpp/include/ErrorEnum.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ErrorEnum.hpp
+++ b/feature_tests/cpp/include/ErrorEnum.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ErrorStruct.d.hpp
+++ b/feature_tests/cpp/include/ErrorStruct.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ErrorStruct.hpp
+++ b/feature_tests/cpp/include/ErrorStruct.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp/include/Float64Vec.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Foo.d.hpp
+++ b/feature_tests/cpp/include/Foo.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Foo.hpp
+++ b/feature_tests/cpp/include/Foo.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "Bar.hpp"
 #include "BorrowedFields.hpp"

--- a/feature_tests/cpp/include/ImportedStruct.d.hpp
+++ b/feature_tests/cpp/include/ImportedStruct.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "UnimportedEnum.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/ImportedStruct.hpp
+++ b/feature_tests/cpp/include/ImportedStruct.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "UnimportedEnum.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/MyEnum.d.hpp
+++ b/feature_tests/cpp/include/MyEnum.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/MyEnum.hpp
+++ b/feature_tests/cpp/include/MyEnum.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/MyOpaqueEnum.d.hpp
+++ b/feature_tests/cpp/include/MyOpaqueEnum.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/MyOpaqueEnum.hpp
+++ b/feature_tests/cpp/include/MyOpaqueEnum.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/MyString.d.hpp
+++ b/feature_tests/cpp/include/MyString.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 
@@ -44,7 +45,7 @@ inline std::unique_ptr<MyString> MyString::new_(std::string_view v) {
 
 inline diplomat::result<std::unique_ptr<MyString>, diplomat::Utf8Error> MyString::new_unsafe(std::string_view v) {
   if (!diplomat::capi::diplomat_is_str(v.data(), v.size())) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
+    return diplomat::Err<diplomat::Utf8Error>();
   }
   auto result = diplomat::capi::MyString_new_unsafe({v.data(), v.size()});
   return diplomat::Ok<std::unique_ptr<MyString>>(std::unique_ptr<MyString>(MyString::FromFFI(result)));
@@ -70,7 +71,7 @@ inline std::string MyString::get_str() const {
 
 inline diplomat::result<std::string, diplomat::Utf8Error> MyString::string_transform(std::string_view foo) {
   if (!diplomat::capi::diplomat_is_str(foo.data(), foo.size())) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
+    return diplomat::Err<diplomat::Utf8Error>();
   }
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);

--- a/feature_tests/cpp/include/MyStruct.d.hpp
+++ b/feature_tests/cpp/include/MyStruct.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "MyEnum.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/MyStruct.hpp
+++ b/feature_tests/cpp/include/MyStruct.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "MyEnum.hpp"
 #include "MyZst.hpp"

--- a/feature_tests/cpp/include/MyZst.d.hpp
+++ b/feature_tests/cpp/include/MyZst.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/MyZst.hpp
+++ b/feature_tests/cpp/include/MyZst.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/NestedBorrowedFields.d.hpp
+++ b/feature_tests/cpp/include/NestedBorrowedFields.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "BorrowedFields.d.hpp"
 #include "BorrowedFieldsWithBounds.d.hpp"

--- a/feature_tests/cpp/include/NestedBorrowedFields.hpp
+++ b/feature_tests/cpp/include/NestedBorrowedFields.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "Bar.hpp"
 #include "BorrowedFields.hpp"
@@ -29,10 +30,10 @@ namespace capi {
 
 inline diplomat::result<NestedBorrowedFields, diplomat::Utf8Error> NestedBorrowedFields::from_bar_and_foo_and_strings(const Bar& bar, const Foo& foo, std::u16string_view dstr16_x, std::u16string_view dstr16_z, std::string_view utf8_str_y, std::string_view utf8_str_z) {
   if (!diplomat::capi::diplomat_is_str(utf8_str_y.data(), utf8_str_y.size())) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
+    return diplomat::Err<diplomat::Utf8Error>();
   }
   if (!diplomat::capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size())) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
+    return diplomat::Err<diplomat::Utf8Error>();
   }
   auto result = diplomat::capi::NestedBorrowedFields_from_bar_and_foo_and_strings(bar.AsFFI(),
     foo.AsFFI(),

--- a/feature_tests/cpp/include/One.d.hpp
+++ b/feature_tests/cpp/include/One.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/One.hpp
+++ b/feature_tests/cpp/include/One.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "Two.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/Opaque.d.hpp
+++ b/feature_tests/cpp/include/Opaque.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Opaque.hpp
+++ b/feature_tests/cpp/include/Opaque.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "ImportedStruct.hpp"
 #include "MyStruct.hpp"
@@ -53,7 +54,7 @@ inline std::unique_ptr<Opaque> Opaque::try_from_utf8(std::string_view input) {
 
 inline diplomat::result<std::unique_ptr<Opaque>, diplomat::Utf8Error> Opaque::from_str(std::string_view input) {
   if (!diplomat::capi::diplomat_is_str(input.data(), input.size())) {
-    return diplomat::Err<diplomat::Utf8Error>(diplomat::Utf8Error());
+    return diplomat::Err<diplomat::Utf8Error>();
   }
   auto result = diplomat::capi::Opaque_from_str({input.data(), input.size()});
   return diplomat::Ok<std::unique_ptr<Opaque>>(std::unique_ptr<Opaque>(Opaque::FromFFI(result)));

--- a/feature_tests/cpp/include/OpaqueMutexedString.d.hpp
+++ b/feature_tests/cpp/include/OpaqueMutexedString.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OpaqueMutexedString.hpp
+++ b/feature_tests/cpp/include/OpaqueMutexedString.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "Utf16Wrap.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/OptionEnum.d.hpp
+++ b/feature_tests/cpp/include/OptionEnum.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionEnum.hpp
+++ b/feature_tests/cpp/include/OptionEnum.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionInputStruct.d.hpp
+++ b/feature_tests/cpp/include/OptionInputStruct.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "OptionEnum.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/OptionInputStruct.hpp
+++ b/feature_tests/cpp/include/OptionInputStruct.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "OptionEnum.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionOpaque.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "OptionEnum.hpp"
 #include "OptionInputStruct.hpp"

--- a/feature_tests/cpp/include/OptionOpaqueChar.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaqueChar.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionOpaqueChar.hpp
+++ b/feature_tests/cpp/include/OptionOpaqueChar.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionString.d.hpp
+++ b/feature_tests/cpp/include/OptionString.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionString.hpp
+++ b/feature_tests/cpp/include/OptionString.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionStruct.d.hpp
+++ b/feature_tests/cpp/include/OptionStruct.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionStruct.hpp
+++ b/feature_tests/cpp/include/OptionStruct.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "OptionOpaque.hpp"
 #include "OptionOpaqueChar.hpp"

--- a/feature_tests/cpp/include/RefList.d.hpp
+++ b/feature_tests/cpp/include/RefList.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/RefList.hpp
+++ b/feature_tests/cpp/include/RefList.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "RefListParameter.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/RefListParameter.d.hpp
+++ b/feature_tests/cpp/include/RefListParameter.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/RefListParameter.hpp
+++ b/feature_tests/cpp/include/RefListParameter.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ResultOpaque.d.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ResultOpaque.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "ErrorEnum.hpp"
 #include "ErrorStruct.hpp"

--- a/feature_tests/cpp/include/Two.d.hpp
+++ b/feature_tests/cpp/include/Two.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Two.hpp
+++ b/feature_tests/cpp/include/Two.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/UnimportedEnum.d.hpp
+++ b/feature_tests/cpp/include/UnimportedEnum.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/UnimportedEnum.hpp
+++ b/feature_tests/cpp/include/UnimportedEnum.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Unnamespaced.d.hpp
+++ b/feature_tests/cpp/include/Unnamespaced.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Unnamespaced.hpp
+++ b/feature_tests/cpp/include/Unnamespaced.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 #include "ns/AttrOpaque1Renamed.hpp"

--- a/feature_tests/cpp/include/Utf16Wrap.d.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <variant>
 #include <cstdint>
+#include <functional>
 
 #if __cplusplus >= 202002L
 #include <span>
@@ -210,6 +211,61 @@ private:
 };
 
 #endif // __cplusplus >= 202002L
+
+// Interop between std::function & our C Callback wrapper type
+
+template <typename T> struct fn_traits;
+template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
+    using fn_ptr_t = Ret(Args...);
+    using function_t = std::function<fn_ptr_t>;
+    using ret = Ret;
+
+    template <typename T, typename = void>
+    struct as_ffi {
+      using type = T;
+    };
+
+    template <typename T>
+    struct as_ffi<T, std::void_t<decltype(&T::AsFFI)>> {
+      using type = decltype(std::declval<T>().AsFFI());
+    };
+
+    template<typename T>
+    using as_ffi_t = typename as_ffi<T>::type;
+
+    template<typename T>
+    using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+
+    template<typename T>
+    using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+
+    // For a given T, creates a function that take in the C ABI version & return the C++ type.
+    template<typename T>
+    static T replace(replace_fn_t<T> val) {
+        if constexpr(std::is_same_v<T, std::string_view>)   {
+            return std::string_view{val.data, val.len};
+        } else if constexpr(!std::is_same_v<T, as_ffi_t<T>>) {
+            return T::FromFFI(val);
+        }
+        else {
+            return val;
+        }
+    }
+
+    static Ret c_run_callback(const void *cb, replace_fn_t<Args>... args) {
+        return (*reinterpret_cast<const function_t *>(cb))(replace<Args>(args)...);
+    }
+
+    static void c_delete(const void *cb) {
+        delete reinterpret_cast<const function_t *>(cb);
+    }
+
+    fn_traits(function_t) {} // Allows less clunky construction (avoids decltype)
+};
+
+// additional deduction guide required
+template<class T>
+fn_traits(T) -> fn_traits<T>;
 
 } // namespace diplomat
 

--- a/feature_tests/cpp/include/ns/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp/include/ns/AttrOpaque1Renamed.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ns/AttrOpaque1Renamed.hpp
+++ b/feature_tests/cpp/include/ns/AttrOpaque1Renamed.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../Unnamespaced.hpp"
 #include "../diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/ns/RenamedAttrEnum.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrEnum.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ns/RenamedAttrEnum.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrEnum.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ns/RenamedAttrOpaque2.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrOpaque2.d.hpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ns/RenamedAttrOpaque2.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrOpaque2.hpp
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 #include "../diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/tests/callback.cpp
+++ b/feature_tests/cpp/tests/callback.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include "../include/CallbackWrapper.hpp"
+#include "assert.hpp"
+
+int main(int argc, char *argv[])
+{
+    CallbackWrapper o;
+    int32_t tmp = 0;
+    {
+        auto out = o.test_multi_arg_callback([&tmp](int32_t a)
+                                             { tmp = a; return a+5; }, 5);
+        simple_assert_eq("multi_arg_callback arg ", tmp, 15);
+        simple_assert_eq("multi_arg_callback output", out, 20);
+    }
+    {
+        tmp = 1;
+        auto out = o.test_no_args([&tmp]()
+                                  { tmp++; });
+        simple_assert_eq("test_no_args arg ", tmp, 2);
+        simple_assert_eq("test_no_args output", out, -5);
+    }
+    {
+        tmp = 0;
+        auto out = o.test_cb_with_struct([&tmp](CallbackTestingStruct a)
+                                         { tmp = a.y; return a.x+a.y; });
+        simple_assert_eq("test_cb_with_struct arg ", tmp, 5);
+        simple_assert_eq("test_cb_with_struct output", out, 6);
+    }
+    {
+        tmp = 0;
+        int32_t tmp2 = 0;
+        auto out = o.test_multiple_cb_args([&tmp]()
+                                           { tmp = 4; return 10; }, [&tmp2](int32_t a)
+                                           {tmp2 = a; return a+1; });
+        simple_assert_eq("test_multiple_cb_args arg ", tmp, 4);
+        simple_assert_eq("test_multiple_cb_args arg2 ", tmp2, 5);
+        simple_assert_eq("test_multiple_cb_args output", out, 16);
+    }
+    {
+        auto out = o.test_str_cb_arg([](std::string_view a)
+                                     { return a.length(); });
+        simple_assert_eq("test_str_cb_arg output", out, 7);
+    }
+}

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -25,5 +25,9 @@ mod ffi {
         pub fn test_multiple_cb_args(f: impl Fn() -> i32, g: impl Fn(i32) -> i32) -> i32 {
             f() + g(5)
         }
+        #[diplomat::attr(kotlin, disable)]
+        pub fn test_str_cb_arg(f: impl Fn(&str) -> i32) -> i32 {
+            f("bananna")
+        }
     }
 }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -28,7 +28,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.iterables = false; // TODO
     a.indexing = false; // TODO
     a.option = true;
-    a.callbacks = false;
+    a.callbacks = true;
     a.traits = false;
     a.custom_errors = false;
     a.traits_are_send = false;

--- a/tool/src/cpp/ty.rs
+++ b/tool/src/cpp/ty.rs
@@ -573,7 +573,7 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx, '_> {
             Type::Opaque(..) => format!("{cpp_name}.AsFFI()").into(),
             Type::Struct(..) => format!("{cpp_name}.AsFFI()").into(),
             Type::Enum(..) => format!("{cpp_name}.AsFFI()").into(),
-            Type::Slice(Slice::Strs(..)) => format!( 
+            Type::Slice(Slice::Strs(..)) => format!(
                 // Layout of DiplomatStringView and std::string_view are guaranteed to be identical, otherwise this would be terrible
                 "{{reinterpret_cast<const diplomat::capi::DiplomatStringView*>({cpp_name}.data()), {cpp_name}.size()}}"
             ).into(),

--- a/tool/templates/cpp/base.h.jinja
+++ b/tool/templates/cpp/base.h.jinja
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <memory>
+#include <functional>
 #include <optional>
 {%- for include in includes %}
 #include "{{ include }}"

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -169,14 +169,34 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
     using function_t = std::function<fn_ptr_t>;
     using ret = Ret;
 
-    template<typename T>
-    using replace_fn_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+    template <typename T, typename = void>
+    struct as_ffi {
+      using type = T;
+    };
 
+    template <typename T>
+    struct as_ffi<T, std::void_t<decltype(&T::AsFFI)>> {
+      using type = decltype(std::declval<T>().AsFFI());
+    };
+
+    template<typename T>
+    using as_ffi_t = typename as_ffi<T>::type;
+
+    template<typename T>
+    using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+
+    template<typename T>
+    using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+
+    // For a given T, creates a function that take in the C ABI version & return the C++ type.
     template<typename T>
     static T replace(replace_fn_t<T> val) {
         if constexpr(std::is_same_v<T, std::string_view>)   {
             return std::string_view{val.data, val.len};
-        } else {
+        } else if constexpr(!std::is_same_v<T, as_ffi_t<T>>) {
+            return T::FromFFI(val);
+        }
+        else {
             return val;
         }
     }

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <variant>
 #include <cstdint>
+#include <functional>
 
 #if __cplusplus >= 202002L
 #include <span>
@@ -160,7 +161,41 @@ private:
 
 #endif // __cplusplus >= 202002L
 
+// Interop between std::function & our C Callback wrapper type
+
+template <typename T> struct fn_traits;
+template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
+    using fn_ptr_t = Ret(Args...);
+    using function_t = std::function<fn_ptr_t>;
+    using ret = Ret;
+
+    template<typename T>
+    using replace_fn_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+
+    template<typename T>
+    static T replace(replace_fn_t<T> val) {
+        if constexpr(std::is_same_v<T, std::string_view>)   {
+            return std::string_view{val.data, val.len};
+        } else {
+            return val;
+        }
+    }
+
+    static Ret c_run_callback(const void *cb, replace_fn_t<Args>... args) {
+        return (*reinterpret_cast<const function_t *>(cb))(replace<Args>(args)...);
+    }
+
+    static void c_delete(const void *cb) {
+        delete reinterpret_cast<const function_t *>(cb);
+    }
+
+    fn_traits(function_t) {} // Allows less clunky construction (avoids decltype)
+};
+
+// additional deduction guide required
+template<class T>
+fn_traits(T) -> fn_traits<T>;
+
 } // namespace diplomat
 
 #endif
-


### PR DESCRIPTION
Using the magic of template-metaprogramming, adds basic support for callbacks to the C++ backend. 