### PR TITLE
Update clang, fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       uses: taiki-e/install-action@cargo-make
 
     - name: clang
-      run: CXX=clang++-14 cargo make test-cpp
+      run: CXX=clang++-16 cargo make test-cpp
 
     - name: gcc
       run: CXX=g++ cargo make test-cpp

--- a/example/cpp/Makefile
+++ b/example/cpp/Makefile
@@ -4,7 +4,7 @@
 ALL_HEADERS := $(wildcard *.h) $(wildcard *.hpp) $(wildcard tests/*.hpp)
 ALL_RUST := $(wildcard ../src/*.rs)
 
-CXX?=clang++-14
+CXX?=clang++-16
 
 $(ALL_RUST):
 

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <type_traits>
 #include <variant>
+#include <cstdint>
 
 #if __cplusplus >= 202002L
 #include <span>

--- a/feature_tests/cpp/Makefile
+++ b/feature_tests/cpp/Makefile
@@ -4,7 +4,7 @@
 ALL_HEADERS := $(wildcard include/*.h) $(wildcard include/*.hpp) $(wildcard tests/*.hpp)
 ALL_RUST := $(wildcard ../src/*.rs)
 
-CXX?=clang++-14
+CXX?=clang++-16
 
 $(ALL_RUST):
 

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <type_traits>
 #include <variant>
+#include <cstdint>
 
 #if __cplusplus >= 202002L
 #include <span>

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -5,6 +5,7 @@
 #include <string>
 #include <type_traits>
 #include <variant>
+#include <cstdint>
 
 #if __cplusplus >= 202002L
 #include <span>


### PR DESCRIPTION
Github's Ubuntu runners now have a newer gcc and no longer have Clang 14