### PR TITLE
Add renaming to c++ method params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "heck",
  "indenter",
  "insta",
+ "once_cell",
  "proc-macro2",
  "pulldown-cmark",
  "quote",
@@ -1054,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1143,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -317,7 +317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -406,6 +406,7 @@ dependencies = [
  "heck",
  "indenter",
  "insta",
+ "itertools 0.14.0",
  "once_cell",
  "proc-macro2",
  "pulldown-cmark",
@@ -1012,6 +1013,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 
 [dependencies]
 diplomat_core = { workspace = true, features = ["displaydoc", "hir"] }
-syn = { version = "2", features = [ "full", "extra-traits" ] }
+syn = { version = "2", features = ["full", "extra-traits"] }
 syn-inline-mod = "0.6.0"
 quote = "1.0"
 indenter = "0.3.3"
@@ -21,11 +21,12 @@ clap = { features = ["color", "derive", "std", "suggestions"], version = "4.2" }
 colored = "2.0"
 serde = { features = ["derive"], version = "1.0.130" }
 toml = "0.5.8"
-heck = "0.4" # conversion between naming convention
+heck = "0.4"                                                                     # conversion between naming convention
 displaydoc = "0.2"
 askama = "0.12"
+once_cell = "1.20.2"
 
 [dev-dependencies]
-insta = { version = "1.7.1", features = [ "yaml" ] }
+insta = { version = "1.7.1", features = ["yaml"] }
 quote = "1.0"
 proc-macro2 = "1.0.79"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -21,7 +21,7 @@ clap = { features = ["color", "derive", "std", "suggestions"], version = "4.2" }
 colored = "2.0"
 serde = { features = ["derive"], version = "1.0.130" }
 toml = "0.5.8"
-heck = "0.4"                                                                     # conversion between naming convention
+heck = "0.4" # conversion between naming convention
 displaydoc = "0.2"
 askama = "0.12"
 once_cell = "1.20.2"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -25,6 +25,7 @@ heck = "0.4"                                                                    
 displaydoc = "0.2"
 askama = "0.12"
 once_cell = "1.20.2"
+itertools = "0.14.0"
 
 [dev-dependencies]
 insta = { version = "1.7.1", features = ["yaml"] }

--- a/tool/src/c/formatter.rs
+++ b/tool/src/c/formatter.rs
@@ -241,6 +241,30 @@ impl<'tcx> CFormatter<'tcx> {
         )
     }
 
+    pub(crate) fn fmt_identifier<'a>(&self, name: Cow<'a, str>) -> Cow<'a, str> {
+        // TODO(#60): handle other keywords
+        // TODO: Replace with LazyLock when MSRV is bumped to >= 1.80.0
+        static C_KEYWORDS: once_cell::sync::Lazy<std::collections::HashSet<&str>> =
+            once_cell::sync::Lazy::new(|| [].into());
+
+        static CPP_KEYWORDS: once_cell::sync::Lazy<std::collections::HashSet<&str>> =
+            once_cell::sync::Lazy::new(|| ["new", "default", "delete"].into());
+
+        let lang_keywords = {
+            if self.is_for_cpp {
+                &CPP_KEYWORDS
+            } else {
+                &C_KEYWORDS
+            }
+        };
+
+        if lang_keywords.contains(name.as_ref()) {
+            format!("{name}_").into()
+        } else {
+            name
+        }
+    }
+
     fn diplomat_namespace(&self, ty: Cow<'tcx, str>) -> Cow<'tcx, str> {
         if self.is_for_cpp {
             format!("diplomat::{CAPI_NAMESPACE}::{ty}").into()

--- a/tool/src/c/ty.rs
+++ b/tool/src/c/ty.rs
@@ -74,13 +74,13 @@ pub struct TyGenContext<'cx, 'tcx> {
     pub errors: &'cx ErrorStore<'tcx, String>,
     pub is_for_cpp: bool,
     pub id: SymbolId,
-    pub decl_header_path: &'cx String,
-    pub impl_header_path: &'cx String,
+    pub decl_header_path: &'cx str,
+    pub impl_header_path: &'cx str,
 }
 
 impl<'tcx> TyGenContext<'_, 'tcx> {
     pub fn gen_enum_def(&self, def: &'tcx hir::EnumDef) -> Header {
-        let mut decl_header = Header::new(self.decl_header_path.clone(), self.is_for_cpp);
+        let mut decl_header = Header::new(self.decl_header_path.to_owned(), self.is_for_cpp);
         let ty_name = self.formatter.fmt_type_name(self.id.try_into().unwrap());
         EnumTemplate {
             ty: def,
@@ -95,7 +95,7 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
     }
 
     pub fn gen_opaque_def(&self, _def: &'tcx hir::OpaqueDef) -> Header {
-        let mut decl_header = Header::new(self.decl_header_path.clone(), self.is_for_cpp);
+        let mut decl_header = Header::new(self.decl_header_path.to_owned(), self.is_for_cpp);
         let ty_name = self.formatter.fmt_type_name(self.id.try_into().unwrap());
         OpaqueTemplate {
             ty_name,
@@ -108,7 +108,7 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
     }
 
     pub fn gen_struct_def<P: TyPosition>(&self, def: &'tcx hir::StructDef<P>) -> Header {
-        let mut decl_header = Header::new(self.decl_header_path.clone(), self.is_for_cpp);
+        let mut decl_header = Header::new(self.decl_header_path.to_owned(), self.is_for_cpp);
         let ty_name = self.formatter.fmt_type_name(self.id.try_into().unwrap());
         let mut fields = vec![];
         let mut cb_structs_and_defs = vec![];
@@ -134,7 +134,7 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
     }
 
     pub fn gen_trait_def(&self, def: &'tcx hir::TraitDef) -> Header {
-        let mut decl_header = Header::new(self.decl_header_path.clone(), self.is_for_cpp);
+        let mut decl_header = Header::new(self.decl_header_path.to_owned(), self.is_for_cpp);
         let trt_name = self.formatter.fmt_trait_name(self.id.try_into().unwrap());
         let mut method_sigs = vec![];
         for m in &def.methods {
@@ -169,7 +169,7 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
     }
 
     pub fn gen_impl(&self, ty: hir::TypeDef<'tcx>) -> Header {
-        let mut impl_header = Header::new(self.impl_header_path.clone(), self.is_for_cpp);
+        let mut impl_header = Header::new(self.impl_header_path.to_owned(), self.is_for_cpp);
         let mut methods = vec![];
         let mut cb_structs_and_defs = vec![];
         for method in ty.methods() {
@@ -203,7 +203,7 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
         .render_into(&mut impl_header)
         .unwrap();
 
-        impl_header.decl_include = Some(self.decl_header_path.clone());
+        impl_header.decl_include = Some(self.decl_header_path.to_owned());
 
         // In some cases like generating decls for `self` parameters,
         // a header will get its own includes. Instead of

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -2,7 +2,7 @@
 
 use crate::c::{CFormatter, CAPI_NAMESPACE};
 use diplomat_core::hir::{self, StringEncoding, TypeContext, TypeId};
-use std::{borrow::Cow, collections::HashSet};
+use std::borrow::Cow;
 
 /// This type mediates all formatting
 ///
@@ -184,16 +184,7 @@ impl<'tcx> Cpp2Formatter<'tcx> {
 
     /// Replace any keywords used
     pub fn fmt_identifier<'a>(&self, name: Cow<'a, str>) -> Cow<'a, str> {
-        // TODO(#60): handle other keywords
-        // TODO: Replace with LazyLock when MSRV is bumped to >= 1.80.0
-        static KEYWORDS: once_cell::sync::Lazy<HashSet<&str>> =
-            once_cell::sync::Lazy::new(|| ["new", "default", "delete"].into());
-
-        if KEYWORDS.contains(name.as_ref()) {
-            format!("{name}_").into()
-        } else {
-            name
-        }
+        self.c.fmt_identifier(name)
     }
 }
 

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -198,11 +198,10 @@ impl<'tcx> Cpp2Formatter<'tcx> {
 #[cfg(test)]
 pub mod test {
     use super::*;
-
     use proc_macro2::TokenStream;
 
     pub fn new_tcx(tk_stream: TokenStream) -> TypeContext {
-        let file = syn::parse2::<syn::File>(tk_stream).expect("failed to parse item ");
+        let file = syn::parse2::<syn::File>(tk_stream).unwrap();
 
         let mut attr_validator = hir::BasicAttributeValidator::new("cpp_test");
         attr_validator.support = super::super::attr_support();

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -2,7 +2,7 @@
 
 use crate::c::{CFormatter, CAPI_NAMESPACE};
 use diplomat_core::hir::{self, StringEncoding, TypeContext, TypeId};
-use std::{borrow::Cow, collections::HashSet, sync::LazyLock};
+use std::{borrow::Cow, collections::HashSet};
 
 /// This type mediates all formatting
 ///
@@ -185,8 +185,9 @@ impl<'tcx> Cpp2Formatter<'tcx> {
     /// Replace any keywords used
     pub fn fmt_identifier<'a>(&self, name: Cow<'a, str>) -> Cow<'a, str> {
         // TODO(#60): handle other keywords
-        static KEYWORDS: LazyLock<HashSet<&str>> =
-            LazyLock::new(|| ["new", "default", "delete"].into());
+        // TODO: Replace with LazyLock when MSRV is bumped to >= 1.80.0
+        static KEYWORDS: once_cell::sync::Lazy<HashSet<&str>> =
+            once_cell::sync::Lazy::new(|| ["new", "default", "delete"].into());
 
         if KEYWORDS.contains(name.as_ref()) {
             format!("{name}_").into()

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -2,7 +2,7 @@
 
 use crate::c::{CFormatter, CAPI_NAMESPACE};
 use diplomat_core::hir::{self, StringEncoding, TypeContext, TypeId};
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashSet, sync::LazyLock};
 
 /// This type mediates all formatting
 ///
@@ -185,10 +185,11 @@ impl<'tcx> Cpp2Formatter<'tcx> {
     /// Replace any keywords used
     pub fn fmt_identifier<'a>(&self, name: Cow<'a, str>) -> Cow<'a, str> {
         // TODO(#60): handle other keywords
-        if name == "new" {
-            "new_".into()
-        } else if name == "default" {
-            "default_".into()
+        static KEYWORDS: LazyLock<HashSet<&str>> =
+            LazyLock::new(|| ["new", "default", "delete"].into());
+
+        if KEYWORDS.contains(name.as_ref()) {
+            format!("{name}_").into()
         } else {
             name
         }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -124,7 +124,7 @@ mod test {
                 struct MyStruct(u64);
 
                 impl MyStruct {
-                    pub fn keywordparam(&self, default: u8) {
+                    pub fn new(&self, default: u8) {
                         self.0 = default;
                     }
                 }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -107,8 +107,6 @@ pub(crate) fn run(tcx: &hir::TypeContext) -> (FileMap, ErrorStore<String>) {
 #[cfg(test)]
 mod test {
 
-    use std::collections::HashMap;
-
     use diplomat_core::hir::TypeDef;
     use quote::quote;
 

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -107,8 +107,7 @@ pub(crate) fn run(tcx: &hir::TypeContext) -> (FileMap, ErrorStore<String>) {
 #[cfg(test)]
 mod test {
 
-    use std::cell::RefCell;
-    use std::collections::{BTreeSet, HashMap};
+    use std::collections::HashMap;
 
     use diplomat_core::hir::TypeDef;
     use quote::quote;
@@ -119,7 +118,7 @@ mod test {
     use super::{formatter::test::new_tcx, formatter::Cpp2Formatter, TyGenContext};
 
     #[test]
-    fn test_enum() {
+    fn test_rename_param() {
         let tk_stream = quote! {
             #[diplomat::bridge]
             mod ffi {
@@ -127,7 +126,7 @@ mod test {
                 struct MyStruct(u64);
 
                 impl MyStruct {
-                    pub fn(&self, default: u8) {
+                    pub fn keywordparam(&self, default: u8) {
                         self.0 = default;
                     }
                 }
@@ -141,11 +140,7 @@ mod test {
             .expect("Failed to generate first opaque def")
         {
             let error_store = ErrorStore::default();
-            let docs_urls = HashMap::new();
-            let docs_generator =
-                diplomat_core::hir::DocsUrlGenerator::with_base_urls(None, docs_urls);
             let formatter = Cpp2Formatter::new(&tcx);
-            let mut callback_params = Vec::new();
             let mut decl_header = header::Header::new("decl_thing".into());
             let mut impl_header = header::Header::new("impl_thing".into());
 
@@ -166,9 +161,9 @@ mod test {
                 generating_struct_fields: false,
             };
 
-            let type_name = opaque_def.name.to_string();
-
-            insta::assert_snapshot!(opaque_def)
+            ty_gen_cx.gen_opaque_def(opaque_def, id);
+            insta::assert_snapshot!(decl_header.body);
+            insta::assert_snapshot!(impl_header.body);
         }
     }
 }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -103,3 +103,72 @@ pub(crate) fn run(tcx: &hir::TypeContext) -> (FileMap, ErrorStore<String>) {
 
     (files, errors)
 }
+
+#[cfg(test)]
+mod test {
+
+    use std::cell::RefCell;
+    use std::collections::{BTreeSet, HashMap};
+
+    use diplomat_core::hir::TypeDef;
+    use quote::quote;
+
+    use crate::cpp::header;
+    use crate::ErrorStore;
+
+    use super::{formatter::test::new_tcx, formatter::Cpp2Formatter, TyGenContext};
+
+    #[test]
+    fn test_enum() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                struct MyStruct(u64);
+
+                impl MyStruct {
+                    pub fn(&self, default: u8) {
+                        self.0 = default;
+                    }
+                }
+            }
+        };
+
+        let tcx = new_tcx(tk_stream);
+        let mut all_types = tcx.all_types();
+        if let (id, TypeDef::Opaque(opaque_def)) = all_types
+            .next()
+            .expect("Failed to generate first opaque def")
+        {
+            let error_store = ErrorStore::default();
+            let docs_urls = HashMap::new();
+            let docs_generator =
+                diplomat_core::hir::DocsUrlGenerator::with_base_urls(None, docs_urls);
+            let formatter = Cpp2Formatter::new(&tcx);
+            let mut callback_params = Vec::new();
+            let mut decl_header = header::Header::new("decl_thing".into());
+            let mut impl_header = header::Header::new("impl_thing".into());
+
+            let mut ty_gen_cx = TyGenContext {
+                errors: &error_store,
+                formatter: &formatter,
+                c: crate::c::TyGenContext {
+                    tcx: &tcx,
+                    formatter: &formatter.c,
+                    errors: &error_store,
+                    is_for_cpp: true,
+                    id: id.into(),
+                    decl_header_path: "test/",
+                    impl_header_path: "test/",
+                },
+                decl_header: &mut decl_header,
+                impl_header: &mut impl_header,
+                generating_struct_fields: false,
+            };
+
+            let type_name = opaque_def.name.to_string();
+
+            insta::assert_snapshot!(opaque_def)
+        }
+    }
+}

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__test__rename_param-2.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__test__rename_param-2.snap
@@ -6,7 +6,7 @@ namespace diplomat {
 namespace capi {
     extern "C" {
     
-    void MyStruct_keywordparam(const diplomat::capi::MyStruct* self, uint8_t default);
+    void MyStruct_new(const diplomat::capi::MyStruct* self, uint8_t default_);
     
     
     void MyStruct_destroy(MyStruct* self);
@@ -15,8 +15,8 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline void MyStruct::keywordparam(uint8_t default_) const {
-	diplomat::capi::MyStruct_keywordparam(this->AsFFI(),
+inline void MyStruct::new_(uint8_t default_) const {
+	diplomat::capi::MyStruct_new(this->AsFFI(),
 		default_);
 }
 

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__test__rename_param-2.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__test__rename_param-2.snap
@@ -1,0 +1,41 @@
+---
+source: tool/src/cpp/mod.rs
+expression: impl_header.body
+---
+namespace diplomat {
+namespace capi {
+    extern "C" {
+    
+    void MyStruct_keywordparam(const diplomat::capi::MyStruct* self, uint8_t default);
+    
+    
+    void MyStruct_destroy(MyStruct* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline void MyStruct::keywordparam(uint8_t default_) const {
+	diplomat::capi::MyStruct_keywordparam(this->AsFFI(),
+		default_);
+}
+
+inline const diplomat::capi::MyStruct* MyStruct::AsFFI() const {
+	return reinterpret_cast<const diplomat::capi::MyStruct*>(this);
+}
+
+inline diplomat::capi::MyStruct* MyStruct::AsFFI() {
+	return reinterpret_cast<diplomat::capi::MyStruct*>(this);
+}
+
+inline const MyStruct* MyStruct::FromFFI(const diplomat::capi::MyStruct* ptr) {
+	return reinterpret_cast<const MyStruct*>(ptr);
+}
+
+inline MyStruct* MyStruct::FromFFI(diplomat::capi::MyStruct* ptr) {
+	return reinterpret_cast<MyStruct*>(ptr);
+}
+
+inline void MyStruct::operator delete(void* ptr) {
+	diplomat::capi::MyStruct_destroy(reinterpret_cast<diplomat::capi::MyStruct*>(ptr));
+}

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__test__rename_param.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__test__rename_param.snap
@@ -11,7 +11,7 @@ namespace capi {
 class MyStruct {
 public:
 
-	inline void keywordparam(uint8_t default_) const;
+	inline void new_(uint8_t default_) const;
 
 	inline const diplomat::capi::MyStruct* AsFFI() const;
 	inline diplomat::capi::MyStruct* AsFFI();

--- a/tool/src/cpp/snapshots/diplomat_tool__cpp__test__rename_param.snap
+++ b/tool/src/cpp/snapshots/diplomat_tool__cpp__test__rename_param.snap
@@ -1,0 +1,28 @@
+---
+source: tool/src/cpp/mod.rs
+expression: decl_header.body
+---
+namespace diplomat {
+namespace capi {
+    struct MyStruct;
+} // namespace capi
+} // namespace
+
+class MyStruct {
+public:
+
+	inline void keywordparam(uint8_t default_) const;
+
+	inline const diplomat::capi::MyStruct* AsFFI() const;
+	inline diplomat::capi::MyStruct* AsFFI();
+	inline static const MyStruct* FromFFI(const diplomat::capi::MyStruct* ptr);
+	inline static MyStruct* FromFFI(diplomat::capi::MyStruct* ptr);
+	inline static void operator delete(void* ptr);
+private:
+	MyStruct() = delete;
+	MyStruct(const MyStruct&) = delete;
+	MyStruct(MyStruct&&) noexcept = delete;
+	MyStruct operator=(const MyStruct&) = delete;
+	MyStruct operator=(MyStruct&&) noexcept = delete;
+	static void operator delete[](void*, size_t) = delete;
+};


### PR DESCRIPTION
I hit an issue with clang compilation when a method had a parameter that was a c++ keyword, so I've updated the formatter to rename params which conflict with the list of c++ keywords