### PR TITLE
Fix issue with C++ & returning results containing references

### DIFF
--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -103,7 +103,7 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
 
 template<class T> struct Ok {
   T inner;
-  Ok(T&& i): inner(std::move(i)) {}
+  Ok(T&& i): inner(std::forward<T>(i)) {}
   // We don't want to expose an lvalue-capable constructor in general
   // however there is no problem doing this for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
@@ -117,7 +117,7 @@ template<class T> struct Ok {
 
 template<class T> struct Err {
   T inner;
-  Err(T&& i): inner(std::move(i)) {}
+  Err(T&& i): inner(std::forward<T>(i)) {}
   // We don't want to expose an lvalue-capable constructor in general
   // however there is no problem doing this for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>

--- a/feature_tests/c/include/ResultOpaque.h
+++ b/feature_tests/c/include/ResultOpaque.h
@@ -41,6 +41,8 @@ ResultOpaque_new_int_result ResultOpaque_new_int(int32_t i);
 typedef struct ResultOpaque_new_in_enum_err_result {union {ErrorEnum ok; ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_enum_err_result;
 ResultOpaque_new_in_enum_err_result ResultOpaque_new_in_enum_err(int32_t i);
 
+ResultOpaque* ResultOpaque_takes_str(ResultOpaque* self, DiplomatStringView _v);
+
 void ResultOpaque_assert_integer(const ResultOpaque* self, int32_t i);
 
 

--- a/feature_tests/cpp/include/ResultOpaque.d.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.d.hpp
@@ -39,6 +39,8 @@ public:
 
   inline static diplomat::result<ErrorEnum, std::unique_ptr<ResultOpaque>> new_in_enum_err(int32_t i);
 
+  inline diplomat::result<ResultOpaque&, diplomat::Utf8Error> takes_str(std::string_view _v);
+
   inline void assert_integer(int32_t i) const;
 
   inline const diplomat::capi::ResultOpaque* AsFFI() const;

--- a/feature_tests/cpp/include/ResultOpaque.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.hpp
@@ -43,6 +43,8 @@ namespace capi {
     typedef struct ResultOpaque_new_in_enum_err_result {union {diplomat::capi::ErrorEnum ok; diplomat::capi::ResultOpaque* err;}; bool is_ok;} ResultOpaque_new_in_enum_err_result;
     ResultOpaque_new_in_enum_err_result ResultOpaque_new_in_enum_err(int32_t i);
     
+    diplomat::capi::ResultOpaque* ResultOpaque_takes_str(diplomat::capi::ResultOpaque* self, diplomat::capi::DiplomatStringView _v);
+    
     void ResultOpaque_assert_integer(const diplomat::capi::ResultOpaque* self, int32_t i);
     
     
@@ -90,6 +92,15 @@ inline diplomat::result<int32_t, std::monostate> ResultOpaque::new_int(int32_t i
 inline diplomat::result<ErrorEnum, std::unique_ptr<ResultOpaque>> ResultOpaque::new_in_enum_err(int32_t i) {
   auto result = diplomat::capi::ResultOpaque_new_in_enum_err(i);
   return result.is_ok ? diplomat::result<ErrorEnum, std::unique_ptr<ResultOpaque>>(diplomat::Ok<ErrorEnum>(ErrorEnum::FromFFI(result.ok))) : diplomat::result<ErrorEnum, std::unique_ptr<ResultOpaque>>(diplomat::Err<std::unique_ptr<ResultOpaque>>(std::unique_ptr<ResultOpaque>(ResultOpaque::FromFFI(result.err))));
+}
+
+inline diplomat::result<ResultOpaque&, diplomat::Utf8Error> ResultOpaque::takes_str(std::string_view _v) {
+  if (!diplomat::capi::diplomat_is_str(_v.data(), _v.size())) {
+    return diplomat::Err<diplomat::Utf8Error>();
+  }
+  auto result = diplomat::capi::ResultOpaque_takes_str(this->AsFFI(),
+    {_v.data(), _v.size()});
+  return diplomat::Ok<ResultOpaque&>(*ResultOpaque::FromFFI(result));
 }
 
 inline void ResultOpaque::assert_integer(int32_t i) const {

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -103,7 +103,7 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
 
 template<class T> struct Ok {
   T inner;
-  Ok(T&& i): inner(std::move(i)) {}
+  Ok(T&& i): inner(std::forward<T>(i)) {}
   // We don't want to expose an lvalue-capable constructor in general
   // however there is no problem doing this for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
@@ -117,7 +117,7 @@ template<class T> struct Ok {
 
 template<class T> struct Err {
   T inner;
-  Err(T&& i): inner(std::move(i)) {}
+  Err(T&& i): inner(std::forward<T>(i)) {}
   // We don't want to expose an lvalue-capable constructor in general
   // however there is no problem doing this for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>

--- a/feature_tests/dart/lib/src/ResultOpaque.g.dart
+++ b/feature_tests/dart/lib/src/ResultOpaque.g.dart
@@ -103,6 +103,16 @@ final class ResultOpaque implements ffi.Finalizable {
     return ErrorEnum.values[result.union.ok];
   }
 
+  /// When we take &str, the return type becomes a Result
+  /// Test that this interacts gracefully with returning a reference type
+  ResultOpaque takesStr(String v) {
+    final temp = _FinalizedArena();
+    // This lifetime edge depends on lifetimes: 'a
+    core.List<Object> aEdges = [this];
+    final result = _ResultOpaque_takes_str(_ffi, v._utf8AllocIn(temp.arena));
+    return ResultOpaque._fromFfi(result, aEdges);
+  }
+
   void assertInteger(int i) {
     _ResultOpaque_assert_integer(_ffi, i);
   }
@@ -152,6 +162,11 @@ external _ResultInt32Void _ResultOpaque_new_int(int i);
 @ffi.Native<_ResultInt32Opaque Function(ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_new_in_enum_err')
 // ignore: non_constant_identifier_names
 external _ResultInt32Opaque _ResultOpaque_new_in_enum_err(int i);
+
+@meta.RecordUse()
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'ResultOpaque_takes_str')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _ResultOpaque_takes_str(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 v);
 
 @meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'ResultOpaque_assert_integer')

--- a/feature_tests/js/api/ResultOpaque.d.ts
+++ b/feature_tests/js/api/ResultOpaque.d.ts
@@ -23,6 +23,8 @@ export class ResultOpaque {
 
     static newInEnumErr(i: number): ErrorEnum;
 
+    takesStr(v: string): ResultOpaque;
+
     assertInteger(i: number): void;
 
     constructor(i: number);

--- a/feature_tests/js/api/ResultOpaque.mjs
+++ b/feature_tests/js/api/ResultOpaque.mjs
@@ -179,6 +179,25 @@ export class ResultOpaque {
         }
     }
 
+    takesStr(v) {
+        let functionCleanupArena = new diplomatRuntime.CleanupArena();
+        
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, v));
+        
+        // This lifetime edge depends on lifetimes 'a
+        let aEdges = [this];
+        
+        const result = wasm.ResultOpaque_takes_str(this.ffiValue, ...vSlice.splat());
+    
+        try {
+            return new ResultOpaque(diplomatRuntime.internalConstructor, result, aEdges);
+        }
+        
+        finally {
+            functionCleanupArena.free();
+        }
+    }
+
     assertInteger(i) {wasm.ResultOpaque_assert_integer(this.ffiValue, i);
     
         try {}

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
@@ -17,6 +17,7 @@ internal interface ResultOpaqueLib: Library {
     fun ResultOpaque_new_int(i: Int): ResultIntUnit
     fun ResultOpaque_new_failing_int(i: Int): ResultUnitInt
     fun ResultOpaque_new_in_enum_err(i: Int): ResultIntPointer
+    fun ResultOpaque_takes_str(handle: Pointer, v: Slice): Pointer
     fun ResultOpaque_assert_integer(handle: Pointer, i: Int): Unit
 }
 
@@ -156,6 +157,20 @@ class ResultOpaque internal constructor (
                 return returnOpaque.err()
             }
         }
+    }
+    
+    /** When we take &str, the return type becomes a Result
+    *Test that this interacts gracefully with returning a reference type
+    */
+    fun takesStr(v: String): ResultOpaque {
+        val (vMem, vSlice) = PrimitiveArrayTools.readUtf8(v)
+        
+        val returnVal = lib.ResultOpaque_takes_str(handle, vSlice);
+        val selfEdges: List<Any> = listOf(this)
+        val handle = returnVal 
+        val returnOpaque = ResultOpaque(handle, selfEdges)
+        if (vMem != null) vMem.close()
+        return returnOpaque
     }
     
     fun assertInteger(i: Int): Unit {

--- a/feature_tests/src/result.rs
+++ b/feature_tests/src/result.rs
@@ -62,6 +62,12 @@ pub mod ffi {
             Err(Box::new(ResultOpaque(i)))
         }
 
+        /// When we take &str, the return type becomes a Result
+        /// Test that this interacts gracefully with returning a reference type
+        pub fn takes_str<'a>(&'a mut self, _v: &str) -> &'a mut Self {
+            self
+        }
+
         pub fn assert_integer(&self, i: i32) {
             assert_eq!(i, self.0);
         }

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -52,7 +52,7 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
 
 template<class T> struct Ok {
   T inner;
-  Ok(T&& i): inner(std::move(i)) {}
+  Ok(T&& i): inner(std::forward<T>(i)) {}
   // We don't want to expose an lvalue-capable constructor in general
   // however there is no problem doing this for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
@@ -66,7 +66,7 @@ template<class T> struct Ok {
 
 template<class T> struct Err {
   T inner;
-  Err(T&& i): inner(std::move(i)) {}
+  Err(T&& i): inner(std::forward<T>(i)) {}
   // We don't want to expose an lvalue-capable constructor in general
   // however there is no problem doing this for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>


### PR DESCRIPTION
std::move unfortunately uses std::remove_reference, and so DiplomatResult will break when T is actually T&