### PR TITLE
workflow enforces gradle version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,8 @@ jobs:
         distribution: 'temurin'
         architecture: x64
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        gradle-version: "8.10"
     - name: Test Kotlin
       run: cargo make test-kotlin


### PR DESCRIPTION
This introduces a version fix in the kotlin workflow. We could probably introduce a gradle wrapper step into the Makefile. This should mean the locally installed gradle version shouldn't matter.   