### PR TITLE
Add support for return static slices in JS and Dart

### DIFF
--- a/feature_tests/c/include/MyString.h
+++ b/feature_tests/c/include/MyString.h
@@ -27,6 +27,8 @@ void MyString_set_str(MyString* self, DiplomatStringView new_str);
 
 void MyString_get_str(const MyString* self, DiplomatWrite* write);
 
+DiplomatStringView MyString_get_static_str(void);
+
 void MyString_string_transform(DiplomatStringView foo, DiplomatWrite* write);
 
 DiplomatStringView MyString_borrow(const MyString* self);

--- a/feature_tests/cpp/include/MyString.d.hpp
+++ b/feature_tests/cpp/include/MyString.d.hpp
@@ -32,6 +32,8 @@ public:
 
   inline std::string get_str() const;
 
+  inline static std::string_view get_static_str();
+
   inline static diplomat::result<std::string, diplomat::Utf8Error> string_transform(std::string_view foo);
 
   inline std::string_view borrow() const;

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -29,6 +29,8 @@ namespace capi {
     
     void MyString_get_str(const diplomat::capi::MyString* self, diplomat::capi::DiplomatWrite* write);
     
+    diplomat::capi::DiplomatStringView MyString_get_static_str(void);
+    
     void MyString_string_transform(diplomat::capi::DiplomatStringView foo, diplomat::capi::DiplomatWrite* write);
     
     diplomat::capi::DiplomatStringView MyString_borrow(const diplomat::capi::MyString* self);
@@ -74,6 +76,11 @@ inline std::string MyString::get_str() const {
   diplomat::capi::MyString_get_str(this->AsFFI(),
     &write);
   return output;
+}
+
+inline std::string_view MyString::get_static_str() {
+  auto result = diplomat::capi::MyString_get_static_str();
+  return std::string_view(result.data, result.len);
 }
 
 inline diplomat::result<std::string, diplomat::Utf8Error> MyString::string_transform(std::string_view foo) {

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -55,6 +55,11 @@ final class MyString implements ffi.Finalizable {
     return write.finalize();
   }
 
+  static String getStaticStr() {
+    final result = _MyString_get_static_str();
+    return result._toDart([]);
+  }
+
   static String stringTransform(String foo) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -104,6 +109,11 @@ external void _MyString_set_str(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 newStr)
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_get_str')
 // ignore: non_constant_identifier_names
 external void _MyString_get_str(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
+
+@_DiplomatFfiUse('MyString_get_static_str')
+@ffi.Native<_SliceUtf8 Function()>(isLeaf: true, symbol: 'MyString_get_static_str')
+// ignore: non_constant_identifier_names
+external _SliceUtf8 _MyString_get_static_str();
 
 @_DiplomatFfiUse('MyString_string_transform')
 @ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'MyString_string_transform')

--- a/feature_tests/js/api/MyString.d.ts
+++ b/feature_tests/js/api/MyString.d.ts
@@ -17,6 +17,8 @@ export class MyString {
 
     get str(): string;
 
+    static getStaticStr(): string;
+
     static stringTransform(foo: string): string;
 
     borrow(): string;

--- a/feature_tests/js/api/MyString.mjs
+++ b/feature_tests/js/api/MyString.mjs
@@ -125,6 +125,20 @@ export class MyString {
         }
     }
 
+    static getStaticStr() {
+        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 8, 4, false);
+        
+        const result = wasm.MyString_get_static_str(diplomatReceive.buffer);
+    
+        try {
+            return new diplomatRuntime.DiplomatSliceStr(wasm, diplomatReceive.buffer,  "string8", []).getValue();
+        }
+        
+        finally {
+            diplomatReceive.free();
+        }
+    }
+
     static stringTransform(foo) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
@@ -14,6 +14,7 @@ internal interface MyStringLib: Library {
     fun MyString_new_from_first(v: Slice): Pointer
     fun MyString_set_str(handle: Pointer, newStr: Slice): Unit
     fun MyString_get_str(handle: Pointer, write: Pointer): Unit
+    fun MyString_get_static_str(): Slice
     fun MyString_string_transform(foo: Slice, write: Pointer): Unit
     fun MyString_borrow(handle: Pointer): Slice
 }
@@ -80,6 +81,12 @@ class MyString internal constructor (
             CLEANER.register(returnOpaque, MyString.MyStringCleaner(handle, MyString.lib));
             vMem.forEach {if (it != null) it.close()}
             return returnOpaque
+        }
+        
+        fun getStaticStr(): String {
+            
+            val returnVal = lib.MyString_get_static_str();
+                return PrimitiveArrayTools.getUtf8(returnVal)
         }
         
         fun stringTransform(foo: String): String {

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -35,6 +35,10 @@ mod ffi {
             let _infallible = write!(write, "{}", self.0);
         }
 
+        pub fn get_static_str() -> &'static str {
+            "hello"
+        }
+
         pub fn string_transform(foo: &str, write: &mut DiplomatWrite) {
             let _ = foo;
             let _ = write;

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -274,10 +274,7 @@ impl<'cx> TyGenContext<'_, 'cx> {
                 /// Get the name/initializer of the allocator needed for a particular type
                 fn alloc_name<P: TyPosition>(ty: &hir::StructDef<P>, field_ty: &Type<P>) -> Option<String> {
                     if let &hir::Type::Slice(slice) = field_ty {
-                        if let Some(lt) = slice.lifetime() {
-                            let MaybeStatic::NonStatic(lt) = lt else {
-                                panic!("'static not supported in Dart");
-                            };
+                        if let Some(MaybeStatic::NonStatic(lt)) = slice.lifetime() {
                             Some(format!(
                                 "{lt_name}AppendArray.isNotEmpty ? _FinalizedArena.withLifetime({lt_name}AppendArray).arena : temp",
                                 lt_name = ty.lifetimes.fmt_lifetime(lt),
@@ -1015,10 +1012,7 @@ impl<'cx> TyGenContext<'_, 'cx> {
                 format!("{type_name}.values.firstWhere((v) => v._ffi == {var_name})").into()
             }
             Type::Slice(slice) => {
-                if let Some(lt) = slice.lifetime() {
-                    let MaybeStatic::NonStatic(lifetime) = lt else {
-                        panic!("'static not supported in Dart");
-                    };
+                if let Some(MaybeStatic::NonStatic(lifetime)) = slice.lifetime() {
                     format!(
                         "{var_name}._toDart({}Edges)",
                         lifetime_env.fmt_lifetime(lifetime)

--- a/tool/src/js/converter.rs
+++ b/tool/src/js/converter.rs
@@ -227,11 +227,8 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
             }
             Type::Slice(slice) => {
                 let edges = match slice.lifetime() {
-                    Some(lt) => {
-                        let hir::MaybeStatic::NonStatic(lifetime) = lt else {
-                            panic!("'static not supported for JS backend");
-                        };
-                        format!("{}Edges", lifetime_environment.fmt_lifetime(lifetime))
+                    Some(hir::MaybeStatic::NonStatic(lt)) => {
+                        format!("{}Edges", lifetime_environment.fmt_lifetime(lt))
                     }
                     _ => "[]".into(),
                 };


### PR DESCRIPTION
These are basically identical to owned slices for these backends (which convert the type) anyway.