### PR TITLE
Ensure that returned static slices in dart don't get deallocated

### DIFF
--- a/example/dart/lib/src/lib.g.dart
+++ b/example/dart/lib/src/lib.g.dart
@@ -90,6 +90,7 @@ class _FinalizedArena {
   }
 }
 
+
 final class _ResultOpaqueVoidUnion extends ffi.Union {
   external ffi.Pointer<ffi.Opaque> ok;
 
@@ -162,9 +163,9 @@ final class _SliceUtf8 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  String _toDart(core.List<Object> lifetimeEdges) {
+  String _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = Utf8Decoder().convert(_data.asTypedList(_length));
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _diplomat_free(_data.cast(), _length, 1);
     } else {
       // Lifetime edges will be cleaned up

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -58,7 +58,7 @@ final class MyString implements ffi.Finalizable {
 
   static String getStaticStr() {
     final result = _MyString_get_static_str();
-    return result._toDart([]);
+    return result._toDart([], isStatic: true);
   }
 
   static String stringTransform(String foo) {

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -130,6 +130,7 @@ class _FinalizedArena {
   }
 }
 
+
 final class _ResultCyclicStructAFfiVoidUnion extends ffi.Union {
   external _CyclicStructAFfi ok;
 
@@ -580,9 +581,9 @@ final class _SliceBool extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  core.List<bool> _toDart(core.List<Object> lifetimeEdges) {
+  core.List<bool> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = core.Iterable.generate(_length).map((i) => _data[i]).toList(growable: false);
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _rustFree.attach(r, (pointer: _data.cast(), bytes: _length, align: 1));
     } else {
       _nopFree.attach(r, lifetimeEdges); // Keep lifetime edges alive
@@ -630,9 +631,9 @@ final class _SliceDouble extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  core.List<double> _toDart(core.List<Object> lifetimeEdges) {
+  core.List<double> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = _data.asTypedList(_length);
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _rustFree.attach(r, (pointer: _data.cast(), bytes: _length * 8, align: 8));
     } else {
       _nopFree.attach(r, lifetimeEdges); // Keep lifetime edges alive
@@ -677,9 +678,9 @@ final class _SliceInt16 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  core.List<int> _toDart(core.List<Object> lifetimeEdges) {
+  core.List<int> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = _data.asTypedList(_length);
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _rustFree.attach(r, (pointer: _data.cast(), bytes: _length * 2, align: 2));
     } else {
       _nopFree.attach(r, lifetimeEdges); // Keep lifetime edges alive
@@ -724,9 +725,9 @@ final class _SliceIsize extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  core.List<int> _toDart(core.List<Object> lifetimeEdges) {
+  core.List<int> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = core.Iterable.generate(_length).map((i) => _data[i]).toList(growable: false);
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _diplomat_free(_data.cast(), _length * ffi.sizeOf<ffi.Size>(), ffi.sizeOf<ffi.Size>());
     } else {
       // Lifetime edges will be cleaned up
@@ -774,9 +775,9 @@ final class _SliceSliceUtf8 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  core.List<core.String> _toDart(core.List<Object> lifetimeEdges) {
+  core.List<core.String> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = core.Iterable.generate(_length).map((i) => _data[i]._toDart(lifetimeEdges)).toList(growable: false);
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       // unsupported
     } else {
       // Lifetime edges will be cleaned up
@@ -824,9 +825,9 @@ final class _SliceUint16 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  core.List<int> _toDart(core.List<Object> lifetimeEdges) {
+  core.List<int> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = _data.asTypedList(_length);
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _rustFree.attach(r, (pointer: _data.cast(), bytes: _length * 2, align: 2));
     } else {
       _nopFree.attach(r, lifetimeEdges); // Keep lifetime edges alive
@@ -874,9 +875,9 @@ final class _SliceUint8 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  core.List<int> _toDart(core.List<Object> lifetimeEdges) {
+  core.List<int> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = _data.asTypedList(_length);
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _rustFree.attach(r, (pointer: _data.cast(), bytes: _length, align: 1));
     } else {
       _nopFree.attach(r, lifetimeEdges); // Keep lifetime edges alive
@@ -924,9 +925,9 @@ final class _SliceUsize extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  core.List<int> _toDart(core.List<Object> lifetimeEdges) {
+  core.List<int> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = core.Iterable.generate(_length).map((i) => _data[i]).toList(growable: false);
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _diplomat_free(_data.cast(), _length * ffi.sizeOf<ffi.Size>(), ffi.sizeOf<ffi.Size>());
     } else {
       // Lifetime edges will be cleaned up
@@ -974,9 +975,9 @@ final class _SliceUtf16 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  String _toDart(core.List<Object> lifetimeEdges) {
+  String _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = core.String.fromCharCodes(_data.asTypedList(_length));
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _diplomat_free(_data.cast(), _length * 2, 2);
     } else {
       // Lifetime edges will be cleaned up
@@ -1021,9 +1022,9 @@ final class _SliceUtf8 extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  String _toDart(core.List<Object> lifetimeEdges) {
+  String _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = Utf8Decoder().convert(_data.asTypedList(_length));
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       _diplomat_free(_data.cast(), _length, 1);
     } else {
       // Lifetime edges will be cleaned up

--- a/tool/templates/dart/init.dart
+++ b/tool/templates/dart/init.dart
@@ -69,3 +69,4 @@ class _FinalizedArena {
     }
   }
 }
+

--- a/tool/templates/dart/slice.dart.jinja
+++ b/tool/templates/dart/slice.dart.jinja
@@ -24,9 +24,9 @@ final class {{slice_ty}} extends ffi.Struct {
   int get hashCode => _length.hashCode;
 
   // ignore: unused_element
-  {{dart_ty}} _toDart(core.List<Object> lifetimeEdges) {
+  {{dart_ty}} _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
     final r = {{ to_dart }};
-    if (lifetimeEdges.isEmpty) {
+    if (lifetimeEdges.isEmpty && !isStatic) {
       {{ owned_free }}
     } else {
       {{ borrowed_free }}


### PR DESCRIPTION
Followup from #796

JS does not need this fix, JS does not appear to support returning owned slices (https://github.com/rust-diplomat/diplomat/issues/786).