### PR TITLE
Fix returning references in results in C++

### DIFF
--- a/feature_tests/cpp/tests/result.cpp
+++ b/feature_tests/cpp/tests/result.cpp
@@ -4,7 +4,8 @@
 #include "../include/ErrorStruct.hpp"
 #include "assert.hpp"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
     std::unique_ptr<ResultOpaque> r;
     std::unique_ptr<ResultOpaque> r2 = ResultOpaque::new_(5).ok().value();
     r2->assert_integer(5);
@@ -17,7 +18,7 @@ int main(int argc, char *argv[]) {
     auto unit_err = ResultOpaque::new_failing_unit();
     simple_assert("unit error", unit_err.is_err())
 
-    auto struc = ResultOpaque::new_failing_struct(109).err().value();
+        auto struc = ResultOpaque::new_failing_struct(109).err().value();
     simple_assert_eq("struct error", struc.i, 109);
 
     auto integer = ResultOpaque::new_int(109).ok().value();
@@ -28,4 +29,7 @@ int main(int argc, char *argv[]) {
 
     auto in_enum_err = ResultOpaque::new_in_enum_err(989).err().value();
     in_enum_err->assert_integer(989);
+
+    auto str_result = r2->takes_str("fish").ok();
+    simple_assert_eq("Did not return a chaining value correctly", &str_result.value().get(), r2.get());
 }

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -98,17 +98,37 @@ public:
     return std::holds_alternative<Err<E>>(this->val);
   }
 
+  template<typename U = T, typename std::enable_if_t<!std::is_reference_v<U>, std::nullptr_t> = nullptr>
   std::optional<T> ok() && {
     if (!this->is_ok()) {
       return std::nullopt;
     }
     return std::make_optional(std::move(std::get<Ok<T>>(std::move(this->val)).inner));
   }
+
+  template<typename U = E, typename std::enable_if_t<!std::is_reference_v<U>, std::nullptr_t> = nullptr>
   std::optional<E> err() && {
     if (!this->is_err()) {
       return std::nullopt;
     }
     return std::make_optional(std::move(std::get<Err<E>>(std::move(this->val)).inner));
+  }
+
+  // std::optional does not work with reference types directly, so wrap them if present
+  template<typename U = T, typename std::enable_if_t<std::is_reference_v<U>, std::nullptr_t> = nullptr>
+  std::optional<std::reference_wrapper<std::remove_reference_t<T>>> ok() && {
+    if (!this->is_ok()) {
+      return std::nullopt;
+    }
+    return std::make_optional(std::reference_wrapper(std::forward<T>(std::get<Ok<T>>(std::move(this->val)).inner)));
+  }
+
+  template<typename U = E, typename std::enable_if_t<std::is_reference_v<U>, std::nullptr_t> = nullptr>
+  std::optional<std::reference_wrapper<std::remove_reference_t<E>>> err() && {
+    if (!this->is_err()) {
+      return std::nullopt;
+    }
+    return std::make_optional(std::reference_wrapper(std::forward<E>(std::get<Err<E>>(std::move(this->val)).inner)));
   }
 
   void set_ok(T&& t) {


### PR DESCRIPTION
Fixes a problem caused by std::optional being incompatible with reference types by design