### PR TITLE
Fix Option WASM ABI

### DIFF
--- a/feature_tests/c/include/OptionOpaque.h
+++ b/feature_tests/c/include/OptionOpaque.h
@@ -46,21 +46,21 @@ void OptionOpaque_assert_integer(const OptionOpaque* self, int32_t i);
 bool OptionOpaque_option_opaque_argument(const OptionOpaque* arg);
 
 typedef struct OptionOpaque_accepts_option_u8_result {union {uint8_t ok; }; bool is_ok;} OptionOpaque_accepts_option_u8_result;
-OptionOpaque_accepts_option_u8_result OptionOpaque_accepts_option_u8(OptionU8 arg);
+OptionOpaque_accepts_option_u8_result OptionOpaque_accepts_option_u8(OptionU8 arg, uint8_t sentinel);
 
 typedef struct OptionOpaque_accepts_option_enum_result {union {OptionEnum ok; }; bool is_ok;} OptionOpaque_accepts_option_enum_result;
-OptionOpaque_accepts_option_enum_result OptionOpaque_accepts_option_enum(OptionEnum_option arg);
+OptionOpaque_accepts_option_enum_result OptionOpaque_accepts_option_enum(OptionEnum_option arg, uint8_t sentinel);
 
 typedef struct OptionOpaque_accepts_option_input_struct_result {union {OptionInputStruct ok; }; bool is_ok;} OptionOpaque_accepts_option_input_struct_result;
-OptionOpaque_accepts_option_input_struct_result OptionOpaque_accepts_option_input_struct(OptionInputStruct_option arg);
+OptionOpaque_accepts_option_input_struct_result OptionOpaque_accepts_option_input_struct(OptionInputStruct_option arg, uint8_t sentinel);
 
 OptionInputStruct OptionOpaque_returns_option_input_struct(void);
 
-size_t OptionOpaque_accepts_option_str(OptionStringView arg);
+size_t OptionOpaque_accepts_option_str(OptionStringView arg, uint8_t sentinel);
 
-bool OptionOpaque_accepts_option_str_slice(OptionStringsView arg);
+bool OptionOpaque_accepts_option_str_slice(OptionStringsView arg, uint8_t sentinel);
 
-int64_t OptionOpaque_accepts_option_primitive(OptionU32View arg);
+int64_t OptionOpaque_accepts_option_primitive(OptionU32View arg, uint8_t sentinel);
 
 
 void OptionOpaque_destroy(OptionOpaque* self);

--- a/feature_tests/cpp/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.d.hpp
@@ -46,19 +46,19 @@ public:
 
   inline static bool option_opaque_argument(const OptionOpaque* arg);
 
-  inline static std::optional<uint8_t> accepts_option_u8(std::optional<uint8_t> arg);
+  inline static std::optional<uint8_t> accepts_option_u8(std::optional<uint8_t> arg, uint8_t sentinel);
 
-  inline static std::optional<OptionEnum> accepts_option_enum(std::optional<OptionEnum> arg);
+  inline static std::optional<OptionEnum> accepts_option_enum(std::optional<OptionEnum> arg, uint8_t sentinel);
 
-  inline static std::optional<OptionInputStruct> accepts_option_input_struct(std::optional<OptionInputStruct> arg);
+  inline static std::optional<OptionInputStruct> accepts_option_input_struct(std::optional<OptionInputStruct> arg, uint8_t sentinel);
 
   inline static OptionInputStruct returns_option_input_struct();
 
-  inline static size_t accepts_option_str(std::optional<std::string_view> arg);
+  inline static size_t accepts_option_str(std::optional<std::string_view> arg, uint8_t sentinel);
 
-  inline static bool accepts_option_str_slice(std::optional<diplomat::span<const std::string_view>> arg);
+  inline static bool accepts_option_str_slice(std::optional<diplomat::span<const std::string_view>> arg, uint8_t sentinel);
 
-  inline static int64_t accepts_option_primitive(std::optional<diplomat::span<const uint32_t>> arg);
+  inline static int64_t accepts_option_primitive(std::optional<diplomat::span<const uint32_t>> arg, uint8_t sentinel);
 
   inline const diplomat::capi::OptionOpaque* AsFFI() const;
   inline diplomat::capi::OptionOpaque* AsFFI();

--- a/feature_tests/cpp/include/OptionOpaque.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.hpp
@@ -48,21 +48,21 @@ namespace capi {
     bool OptionOpaque_option_opaque_argument(const diplomat::capi::OptionOpaque* arg);
     
     typedef struct OptionOpaque_accepts_option_u8_result {union {uint8_t ok; }; bool is_ok;} OptionOpaque_accepts_option_u8_result;
-    OptionOpaque_accepts_option_u8_result OptionOpaque_accepts_option_u8(diplomat::capi::OptionU8 arg);
+    OptionOpaque_accepts_option_u8_result OptionOpaque_accepts_option_u8(diplomat::capi::OptionU8 arg, uint8_t sentinel);
     
     typedef struct OptionOpaque_accepts_option_enum_result {union {diplomat::capi::OptionEnum ok; }; bool is_ok;} OptionOpaque_accepts_option_enum_result;
-    OptionOpaque_accepts_option_enum_result OptionOpaque_accepts_option_enum(diplomat::capi::OptionEnum_option arg);
+    OptionOpaque_accepts_option_enum_result OptionOpaque_accepts_option_enum(diplomat::capi::OptionEnum_option arg, uint8_t sentinel);
     
     typedef struct OptionOpaque_accepts_option_input_struct_result {union {diplomat::capi::OptionInputStruct ok; }; bool is_ok;} OptionOpaque_accepts_option_input_struct_result;
-    OptionOpaque_accepts_option_input_struct_result OptionOpaque_accepts_option_input_struct(diplomat::capi::OptionInputStruct_option arg);
+    OptionOpaque_accepts_option_input_struct_result OptionOpaque_accepts_option_input_struct(diplomat::capi::OptionInputStruct_option arg, uint8_t sentinel);
     
     diplomat::capi::OptionInputStruct OptionOpaque_returns_option_input_struct(void);
     
-    size_t OptionOpaque_accepts_option_str(diplomat::capi::OptionStringView arg);
+    size_t OptionOpaque_accepts_option_str(diplomat::capi::OptionStringView arg, uint8_t sentinel);
     
-    bool OptionOpaque_accepts_option_str_slice(diplomat::capi::OptionStringsView arg);
+    bool OptionOpaque_accepts_option_str_slice(diplomat::capi::OptionStringsView arg, uint8_t sentinel);
     
-    int64_t OptionOpaque_accepts_option_primitive(diplomat::capi::OptionU32View arg);
+    int64_t OptionOpaque_accepts_option_primitive(diplomat::capi::OptionU32View arg, uint8_t sentinel);
     
     
     void OptionOpaque_destroy(OptionOpaque* self);
@@ -126,18 +126,21 @@ inline bool OptionOpaque::option_opaque_argument(const OptionOpaque* arg) {
   return result;
 }
 
-inline std::optional<uint8_t> OptionOpaque::accepts_option_u8(std::optional<uint8_t> arg) {
-  auto result = diplomat::capi::OptionOpaque_accepts_option_u8(arg.has_value() ? (diplomat::capi::OptionU8{ { arg.value() }, true }) : (diplomat::capi::OptionU8{ {}, false }));
+inline std::optional<uint8_t> OptionOpaque::accepts_option_u8(std::optional<uint8_t> arg, uint8_t sentinel) {
+  auto result = diplomat::capi::OptionOpaque_accepts_option_u8(arg.has_value() ? (diplomat::capi::OptionU8{ { arg.value() }, true }) : (diplomat::capi::OptionU8{ {}, false }),
+    sentinel);
   return result.is_ok ? std::optional<uint8_t>(result.ok) : std::nullopt;
 }
 
-inline std::optional<OptionEnum> OptionOpaque::accepts_option_enum(std::optional<OptionEnum> arg) {
-  auto result = diplomat::capi::OptionOpaque_accepts_option_enum(arg.has_value() ? (diplomat::capi::OptionEnum_option{ { arg.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }));
+inline std::optional<OptionEnum> OptionOpaque::accepts_option_enum(std::optional<OptionEnum> arg, uint8_t sentinel) {
+  auto result = diplomat::capi::OptionOpaque_accepts_option_enum(arg.has_value() ? (diplomat::capi::OptionEnum_option{ { arg.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
+    sentinel);
   return result.is_ok ? std::optional<OptionEnum>(OptionEnum::FromFFI(result.ok)) : std::nullopt;
 }
 
-inline std::optional<OptionInputStruct> OptionOpaque::accepts_option_input_struct(std::optional<OptionInputStruct> arg) {
-  auto result = diplomat::capi::OptionOpaque_accepts_option_input_struct(arg.has_value() ? (diplomat::capi::OptionInputStruct_option{ { arg.value().AsFFI() }, true }) : (diplomat::capi::OptionInputStruct_option{ {}, false }));
+inline std::optional<OptionInputStruct> OptionOpaque::accepts_option_input_struct(std::optional<OptionInputStruct> arg, uint8_t sentinel) {
+  auto result = diplomat::capi::OptionOpaque_accepts_option_input_struct(arg.has_value() ? (diplomat::capi::OptionInputStruct_option{ { arg.value().AsFFI() }, true }) : (diplomat::capi::OptionInputStruct_option{ {}, false }),
+    sentinel);
   return result.is_ok ? std::optional<OptionInputStruct>(OptionInputStruct::FromFFI(result.ok)) : std::nullopt;
 }
 
@@ -146,18 +149,21 @@ inline OptionInputStruct OptionOpaque::returns_option_input_struct() {
   return OptionInputStruct::FromFFI(result);
 }
 
-inline size_t OptionOpaque::accepts_option_str(std::optional<std::string_view> arg) {
-  auto result = diplomat::capi::OptionOpaque_accepts_option_str(arg.has_value() ? (diplomat::capi::OptionStringView{ { {arg.value().data(), arg.value().size()} }, true }) : (diplomat::capi::OptionStringView{ {}, false }));
+inline size_t OptionOpaque::accepts_option_str(std::optional<std::string_view> arg, uint8_t sentinel) {
+  auto result = diplomat::capi::OptionOpaque_accepts_option_str(arg.has_value() ? (diplomat::capi::OptionStringView{ { {arg.value().data(), arg.value().size()} }, true }) : (diplomat::capi::OptionStringView{ {}, false }),
+    sentinel);
   return result;
 }
 
-inline bool OptionOpaque::accepts_option_str_slice(std::optional<diplomat::span<const std::string_view>> arg) {
-  auto result = diplomat::capi::OptionOpaque_accepts_option_str_slice(arg.has_value() ? (diplomat::capi::OptionStringsView{ { {reinterpret_cast<const diplomat::capi::DiplomatStringView*>(arg.value().data()), arg.value().size()} }, true }) : (diplomat::capi::OptionStringsView{ {}, false }));
+inline bool OptionOpaque::accepts_option_str_slice(std::optional<diplomat::span<const std::string_view>> arg, uint8_t sentinel) {
+  auto result = diplomat::capi::OptionOpaque_accepts_option_str_slice(arg.has_value() ? (diplomat::capi::OptionStringsView{ { {reinterpret_cast<const diplomat::capi::DiplomatStringView*>(arg.value().data()), arg.value().size()} }, true }) : (diplomat::capi::OptionStringsView{ {}, false }),
+    sentinel);
   return result;
 }
 
-inline int64_t OptionOpaque::accepts_option_primitive(std::optional<diplomat::span<const uint32_t>> arg) {
-  auto result = diplomat::capi::OptionOpaque_accepts_option_primitive(arg.has_value() ? (diplomat::capi::OptionU32View{ { {arg.value().data(), arg.value().size()} }, true }) : (diplomat::capi::OptionU32View{ {}, false }));
+inline int64_t OptionOpaque::accepts_option_primitive(std::optional<diplomat::span<const uint32_t>> arg, uint8_t sentinel) {
+  auto result = diplomat::capi::OptionOpaque_accepts_option_primitive(arg.has_value() ? (diplomat::capi::OptionU32View{ { {arg.value().data(), arg.value().size()} }, true }) : (diplomat::capi::OptionU32View{ {}, false }),
+    sentinel);
   return result;
 }
 

--- a/feature_tests/cpp/tests/option.cpp
+++ b/feature_tests/cpp/tests/option.cpp
@@ -25,17 +25,17 @@ int main(int argc, char *argv[])
     simple_assert("new_struct_nones() returns None", !s.b);
     simple_assert_eq("correct struct returned", s.c, 908);
 
-    auto opt_u8 = OptionOpaque::accepts_option_u8(std::nullopt);
+    auto opt_u8 = OptionOpaque::accepts_option_u8(std::nullopt, 123);
     simple_assert("accepts_option_u8 is idempotent", !opt_u8.has_value());
-    opt_u8 = OptionOpaque::accepts_option_u8(5);
+    opt_u8 = OptionOpaque::accepts_option_u8(5, 123);
     simple_assert("accepts_option_u8 is idempotent", opt_u8.value() == 5);
-    auto opt_enum = OptionOpaque::accepts_option_enum(std::nullopt);
+    auto opt_enum = OptionOpaque::accepts_option_enum(std::nullopt, 123);
     simple_assert("accepts_option_enum is idempotent", !opt_enum.has_value());
-    opt_enum = OptionOpaque::accepts_option_enum(OptionEnum::Foo);
+    opt_enum = OptionOpaque::accepts_option_enum(OptionEnum::Foo, 123);
     simple_assert("accepts_option_enum is idempotent", opt_enum.value() == OptionEnum::Foo);
-    auto opt_struct = OptionOpaque::accepts_option_input_struct(std::nullopt);
+    auto opt_struct = OptionOpaque::accepts_option_input_struct(std::nullopt, 123);
     simple_assert("accepts_option_input_struct is idempotent", !opt_struct.has_value());
-    opt_struct = OptionOpaque::accepts_option_input_struct(std::optional<OptionInputStruct>({std::optional(1), std::nullopt, std::optional(OptionEnum::Foo)}));
+    opt_struct = OptionOpaque::accepts_option_input_struct(std::optional<OptionInputStruct>({std::optional(1), std::nullopt, std::optional(OptionEnum::Foo)}), 123);
     simple_assert("accepts_option_input_struct is idempotent", opt_struct.value().a == 1);
     simple_assert("accepts_option_input_struct is idempotent", !opt_struct.value().b.has_value());
     simple_assert("accepts_option_input_struct is idempotent", opt_struct.value().c == OptionEnum::Foo);
@@ -49,13 +49,13 @@ int main(int argc, char *argv[])
 
     std::array<std::string_view, 2> string_array{"string1"sv, "string2"sv};
     diplomat::span<const std::string_view> arg{string_array};
-    auto str_slice_result = OptionOpaque::accepts_option_str_slice(std::make_optional(std::move(arg)));
+    auto str_slice_result = OptionOpaque::accepts_option_str_slice(std::make_optional(std::move(arg)), 123);
     simple_assert("option_str_slice functions", str_slice_result);
 
-    simple_assert_eq("Optional string param (Some)", OptionOpaque::accepts_option_str(std::make_optional("accepts optional string!")), 24);
-    simple_assert_eq("Optional string param (None)", OptionOpaque::accepts_option_str(std::nullopt), 0);
+    simple_assert_eq("Optional string param (Some)", OptionOpaque::accepts_option_str(std::make_optional("accepts optional string!"), 123), 24);
+    simple_assert_eq("Optional string param (None)", OptionOpaque::accepts_option_str(std::nullopt, 123), 0);
 
     constexpr uint32_t array[]{1, 2, 3, 4};
-    simple_assert_eq("Optional primitive param (Some)", OptionOpaque::accepts_option_primitive(std::make_optional(diplomat::span{array, 4})), 10);
-    simple_assert_eq("Optional primitive param (None)", OptionOpaque::accepts_option_primitive(std::nullopt), -1);
+    simple_assert_eq("Optional primitive param (Some)", OptionOpaque::accepts_option_primitive(std::make_optional(diplomat::span{array, 4}), 123), 10);
+    simple_assert_eq("Optional primitive param (None)", OptionOpaque::accepts_option_primitive(std::nullopt, 123), -1);
 }

--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -91,25 +91,25 @@ final class OptionOpaque implements ffi.Finalizable {
     return result;
   }
 
-  static int? acceptsOptionU8([int? arg]) {
-    final result = _OptionOpaque_accepts_option_u8(arg != null ? _ResultUint8Void.ok(arg) : _ResultUint8Void.err());
+  static int? acceptsOptionU8(int sentinel, [int? arg]) {
+    final result = _OptionOpaque_accepts_option_u8(arg != null ? _ResultUint8Void.ok(arg) : _ResultUint8Void.err(), sentinel);
     if (!result.isOk) {
       return null;
     }
     return result.union.ok;
   }
 
-  static OptionEnum? acceptsOptionEnum([OptionEnum? arg]) {
-    final result = _OptionOpaque_accepts_option_enum(arg != null ? _ResultInt32Void.ok(arg.index) : _ResultInt32Void.err());
+  static OptionEnum? acceptsOptionEnum(int sentinel, [OptionEnum? arg]) {
+    final result = _OptionOpaque_accepts_option_enum(arg != null ? _ResultInt32Void.ok(arg.index) : _ResultInt32Void.err(), sentinel);
     if (!result.isOk) {
       return null;
     }
     return OptionEnum.values[result.union.ok];
   }
 
-  static OptionInputStruct? acceptsOptionInputStruct([OptionInputStruct? arg]) {
+  static OptionInputStruct? acceptsOptionInputStruct(int sentinel, [OptionInputStruct? arg]) {
     final temp = _FinalizedArena();
-    final result = _OptionOpaque_accepts_option_input_struct(arg != null ? _ResultOptionInputStructFfiVoid.ok(arg._toFfi(temp.arena)) : _ResultOptionInputStructFfiVoid.err());
+    final result = _OptionOpaque_accepts_option_input_struct(arg != null ? _ResultOptionInputStructFfiVoid.ok(arg._toFfi(temp.arena)) : _ResultOptionInputStructFfiVoid.err(), sentinel);
     if (!result.isOk) {
       return null;
     }
@@ -183,19 +183,19 @@ external void _OptionOpaque_assert_integer(ffi.Pointer<ffi.Opaque> self, int i);
 external bool _OptionOpaque_option_opaque_argument(ffi.Pointer<ffi.Opaque> arg);
 
 @_DiplomatFfiUse('OptionOpaque_accepts_option_u8')
-@ffi.Native<_ResultUint8Void Function(_ResultUint8Void)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_u8')
+@ffi.Native<_ResultUint8Void Function(_ResultUint8Void, ffi.Uint8)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_u8')
 // ignore: non_constant_identifier_names
-external _ResultUint8Void _OptionOpaque_accepts_option_u8(_ResultUint8Void arg);
+external _ResultUint8Void _OptionOpaque_accepts_option_u8(_ResultUint8Void arg, int sentinel);
 
 @_DiplomatFfiUse('OptionOpaque_accepts_option_enum')
-@ffi.Native<_ResultInt32Void Function(_ResultInt32Void)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_enum')
+@ffi.Native<_ResultInt32Void Function(_ResultInt32Void, ffi.Uint8)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_enum')
 // ignore: non_constant_identifier_names
-external _ResultInt32Void _OptionOpaque_accepts_option_enum(_ResultInt32Void arg);
+external _ResultInt32Void _OptionOpaque_accepts_option_enum(_ResultInt32Void arg, int sentinel);
 
 @_DiplomatFfiUse('OptionOpaque_accepts_option_input_struct')
-@ffi.Native<_ResultOptionInputStructFfiVoid Function(_ResultOptionInputStructFfiVoid)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_input_struct')
+@ffi.Native<_ResultOptionInputStructFfiVoid Function(_ResultOptionInputStructFfiVoid, ffi.Uint8)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_input_struct')
 // ignore: non_constant_identifier_names
-external _ResultOptionInputStructFfiVoid _OptionOpaque_accepts_option_input_struct(_ResultOptionInputStructFfiVoid arg);
+external _ResultOptionInputStructFfiVoid _OptionOpaque_accepts_option_input_struct(_ResultOptionInputStructFfiVoid arg, int sentinel);
 
 @_DiplomatFfiUse('OptionOpaque_returns_option_input_struct')
 @ffi.Native<_OptionInputStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_returns_option_input_struct')

--- a/feature_tests/dart/test/option_test.dart
+++ b/feature_tests/dart/test/option_test.dart
@@ -18,19 +18,20 @@ void main() {
     expect(sn.b, null);
     expect(sn.c, 908);
 
-    var maybeU8 = OptionOpaque.acceptsOptionU8(null);
+    var maybeU8 = OptionOpaque.acceptsOptionU8(123);
     expect(maybeU8, null);
-    maybeU8 = OptionOpaque.acceptsOptionU8(5);
+    maybeU8 = OptionOpaque.acceptsOptionU8(123, 5);
     expect(maybeU8, 5);
 
-    var maybeEnum = OptionOpaque.acceptsOptionEnum(null);
+    var maybeEnum = OptionOpaque.acceptsOptionEnum(123);
     expect(maybeEnum, null);
-    maybeEnum = OptionOpaque.acceptsOptionEnum(OptionEnum.foo);
+    maybeEnum = OptionOpaque.acceptsOptionEnum(123, OptionEnum.foo);
     expect(maybeEnum, OptionEnum.foo);
 
-    var maybeStruct = OptionOpaque.acceptsOptionInputStruct(null);
+    var maybeStruct = OptionOpaque.acceptsOptionInputStruct(123);
     expect(maybeStruct, null);
     maybeStruct = OptionOpaque.acceptsOptionInputStruct(
+      123,
       new OptionInputStruct(a: 7, b: null, c: OptionEnum.bar),
     );
     expect(maybeStruct?.a, 7);

--- a/feature_tests/js/api/OptionInputStruct.mjs
+++ b/feature_tests/js/api/OptionInputStruct.mjs
@@ -74,7 +74,7 @@ export class OptionInputStruct {
         functionCleanupArena,
         appendArrayMap
     ) {
-        return [...diplomatRuntime.optionToArgsForCalling(this.#a, 1, 1, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint8Array)]), /* [2 x i8] padding */ 0, 0 /* end padding */, ...diplomatRuntime.optionToArgsForCalling(this.#b, 4, 4, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint32Array)]), ...diplomatRuntime.optionToArgsForCalling(this.#c, 4, 4, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)])]
+        return [...diplomatRuntime.optionToArgsForCalling(this.#a, 1, 1, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint8Array)]), /* [2 x i8] padding */ 0, 0 /* end padding */, ...diplomatRuntime.optionToArgsForCalling(this.#b, 4, 4, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint32Array)]), ...diplomatRuntime.optionToArgsForCalling(this.#c, 4, 4, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)])]
     }
 
     static _fromSuppliedValue(internalConstructor, obj) {

--- a/feature_tests/js/api/OptionOpaque.d.ts
+++ b/feature_tests/js/api/OptionOpaque.d.ts
@@ -32,11 +32,11 @@ export class OptionOpaque {
 
     static optionOpaqueArgument(arg: OptionOpaque | null): boolean;
 
-    static acceptsOptionU8(arg: number | null): number | null;
+    static acceptsOptionU8(arg: number | null, sentinel: number): number | null;
 
-    static acceptsOptionEnum(arg: OptionEnum | null): OptionEnum | null;
+    static acceptsOptionEnum(arg: OptionEnum | null, sentinel: number): OptionEnum | null;
 
-    static acceptsOptionInputStruct(arg: OptionInputStruct | null): OptionInputStruct | null;
+    static acceptsOptionInputStruct(arg: OptionInputStruct | null, sentinel: number): OptionInputStruct | null;
 
     static returnsOptionInputStruct(): OptionInputStruct;
 }

--- a/feature_tests/js/api/OptionOpaque.mjs
+++ b/feature_tests/js/api/OptionOpaque.mjs
@@ -191,7 +191,7 @@ export class OptionOpaque {
     static acceptsOptionU8(arg, sentinel) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 2, 1, true);
         
-        const result = wasm.OptionOpaque_accepts_option_u8(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 1, 1, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint8Array)]), sentinel);
+        const result = wasm.OptionOpaque_accepts_option_u8(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 1, 1, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint8Array)]), sentinel);
     
         try {
             if (!diplomatReceive.resultFlag) {
@@ -208,7 +208,7 @@ export class OptionOpaque {
     static acceptsOptionEnum(arg, sentinel) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
         
-        const result = wasm.OptionOpaque_accepts_option_enum(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 4, 4, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), sentinel);
+        const result = wasm.OptionOpaque_accepts_option_enum(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 4, 4, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), sentinel);
     
         try {
             if (!diplomatReceive.resultFlag) {
@@ -227,7 +227,7 @@ export class OptionOpaque {
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 21, 4, true);
         
-        const result = wasm.OptionOpaque_accepts_option_input_struct(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 20, 4, false, (arrayBuffer, offset, jsValue) => [OptionInputStruct._fromSuppliedValue(diplomatRuntime.internalConstructor, jsValue)._writeToArrayBuffer(arrayBuffer, offset + 0, functionCleanupArena, {})]), sentinel);
+        const result = wasm.OptionOpaque_accepts_option_input_struct(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 20, 4, (arrayBuffer, offset, jsValue) => [OptionInputStruct._fromSuppliedValue(diplomatRuntime.internalConstructor, jsValue)._writeToArrayBuffer(arrayBuffer, offset + 0, functionCleanupArena, {})]), sentinel);
     
         try {
             if (!diplomatReceive.resultFlag) {

--- a/feature_tests/js/api/OptionOpaque.mjs
+++ b/feature_tests/js/api/OptionOpaque.mjs
@@ -188,10 +188,10 @@ export class OptionOpaque {
         finally {}
     }
 
-    static acceptsOptionU8(arg) {
+    static acceptsOptionU8(arg, sentinel) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 2, 1, true);
         
-        const result = wasm.OptionOpaque_accepts_option_u8(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 1, 1, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint8Array)]));
+        const result = wasm.OptionOpaque_accepts_option_u8(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 1, 1, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint8Array)]), sentinel);
     
         try {
             if (!diplomatReceive.resultFlag) {
@@ -205,10 +205,10 @@ export class OptionOpaque {
         }
     }
 
-    static acceptsOptionEnum(arg) {
+    static acceptsOptionEnum(arg, sentinel) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
         
-        const result = wasm.OptionOpaque_accepts_option_enum(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 4, 4, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]));
+        const result = wasm.OptionOpaque_accepts_option_enum(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 4, 4, false, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), sentinel);
     
         try {
             if (!diplomatReceive.resultFlag) {
@@ -222,12 +222,12 @@ export class OptionOpaque {
         }
     }
 
-    static acceptsOptionInputStruct(arg) {
+    static acceptsOptionInputStruct(arg, sentinel) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 21, 4, true);
         
-        const result = wasm.OptionOpaque_accepts_option_input_struct(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 20, 4, false, (arrayBuffer, offset, jsValue) => [OptionInputStruct._fromSuppliedValue(diplomatRuntime.internalConstructor, jsValue)._writeToArrayBuffer(arrayBuffer, offset + 0, functionCleanupArena, {})]));
+        const result = wasm.OptionOpaque_accepts_option_input_struct(diplomatReceive.buffer, ...diplomatRuntime.optionToArgsForCalling(arg, 20, 4, false, (arrayBuffer, offset, jsValue) => [OptionInputStruct._fromSuppliedValue(diplomatRuntime.internalConstructor, jsValue)._writeToArrayBuffer(arrayBuffer, offset + 0, functionCleanupArena, {})]), sentinel);
     
         try {
             if (!diplomatReceive.resultFlag) {

--- a/feature_tests/js/test/option.mts
+++ b/feature_tests/js/test/option.mts
@@ -22,15 +22,24 @@ test("Verify option methods", t => {
     t.is(sn.c, 908);
 });
 
-test("DiplomatOption tests", t => {
-    let maybeU8 = OptionOpaque.acceptsOptionU8(null);
+test("DiplomatOption test u8", t => {
+    let maybeU8 = OptionOpaque.acceptsOptionU8(null, 123);
     t.assert(maybeU8 === null);
-    maybeU8 = OptionOpaque.acceptsOptionU8(47);
+    maybeU8 = OptionOpaque.acceptsOptionU8(47, 123);
     t.is(maybeU8, 47);
+});
 
-    let maybeStruct = OptionOpaque.acceptsOptionInputStruct(null);
+test("DiplomatOption test enum", t => {
+    let enm = OptionOpaque.acceptsOptionEnum(null, 123);
+    t.assert(enm === null);
+    enm = OptionOpaque.acceptsOptionEnum(OptionEnum.Bar, 123);
+    t.is(enm, OptionEnum.Bar);
+});
+
+test("DiplomatOption test struct", t => {
+    let maybeStruct = OptionOpaque.acceptsOptionInputStruct(null, 123);
     t.assert(maybeStruct === null);
-    maybeStruct = OptionOpaque.acceptsOptionInputStruct(new OptionInputStruct({a: 7, c: OptionEnum.Bar}));
+    maybeStruct = OptionOpaque.acceptsOptionInputStruct(new OptionInputStruct({a: 7, c: OptionEnum.Bar}), 123);
     t.is(maybeStruct.a, 7);
     t.assert(maybeStruct.b === null);
     t.is(maybeStruct.c.value, OptionEnum.Bar.value);

--- a/feature_tests/src/option.rs
+++ b/feature_tests/src/option.rs
@@ -123,18 +123,22 @@ pub mod ffi {
         }
 
         #[diplomat::attr(not(supports = option), disable)]
-        pub fn accepts_option_u8(arg: Option<u8>) -> Option<u8> {
+        pub fn accepts_option_u8(arg: Option<u8>, sentinel: u8) -> Option<u8> {
+            assert_eq!(sentinel, 123, "{arg:?}");
             arg
         }
 
         #[diplomat::attr(not(supports = option), disable)]
-        pub fn accepts_option_enum(arg: Option<OptionEnum>) -> Option<OptionEnum> {
+        pub fn accepts_option_enum(arg: Option<OptionEnum>, sentinel: u8) -> Option<OptionEnum> {
+            assert_eq!(sentinel, 123, "{arg:?}");
             arg
         }
         #[diplomat::attr(not(supports = option), disable)]
         pub fn accepts_option_input_struct(
             arg: Option<OptionInputStruct>,
+            sentinel: u8,
         ) -> Option<OptionInputStruct> {
+            assert_eq!(sentinel, 123, "{arg:?}");
             arg
         }
         #[diplomat::attr(not(supports = option), disable)]
@@ -147,17 +151,20 @@ pub mod ffi {
         }
 
         #[diplomat::attr(any(not(supports = option), not(any(c, cpp))), disable)]
-        pub fn accepts_option_str(arg: Option<&str>) -> usize {
+        pub fn accepts_option_str(arg: Option<&str>, sentinel: u8) -> usize {
+            assert_eq!(sentinel, 123, "{arg:?}");
             arg.unwrap_or_default().len()
         }
 
         #[diplomat::attr(any(not(supports = option), not(any(c, cpp))), disable)]
-        pub fn accepts_option_str_slice(arg: Option<&[DiplomatStrSlice]>) -> bool {
+        pub fn accepts_option_str_slice(arg: Option<&[DiplomatStrSlice]>, sentinel: u8) -> bool {
+            assert_eq!(sentinel, 123);
             arg.is_some()
         }
 
         #[diplomat::attr(any(not(supports = option), not(any(c, cpp))), disable)]
-        pub fn accepts_option_primitive(arg: Option<&[u32]>) -> i64 {
+        pub fn accepts_option_primitive(arg: Option<&[u32]>, sentinel: u8) -> i64 {
+            assert_eq!(sentinel, 123);
             arg.map(|v| v.iter().sum::<u32>().into()).unwrap_or(-1)
         }
     }

--- a/tool/src/js/converter.rs
+++ b/tool/src/js/converter.rs
@@ -649,13 +649,8 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
                     JsToCConversionContext::SlicePrealloc => {
                         unreachable!("Used SlicePrealloc context for an Option type!");
                     }
-                    JsToCConversionContext::List(force_padding) => {
-                        let needs_padding = match force_padding {
-                            ForcePaddingStatus::NoForce => "false",
-                            ForcePaddingStatus::Force => "true",
-                            ForcePaddingStatus::PassThrough => "forcePadding",
-                        };
-                        format!("...diplomatRuntime.optionToArgsForCalling({js_name}, {size}, {align}, {needs_padding}, (arrayBuffer, offset, jsValue) => [{inner_conversion}])").into()
+                    JsToCConversionContext::List(..) => {
+                        format!("...diplomatRuntime.optionToArgsForCalling({js_name}, {size}, {align}, (arrayBuffer, offset, jsValue) => [{inner_conversion}])").into()
 
                     }
                     JsToCConversionContext::WriteToBuffer(offset_var, offset) => {

--- a/tool/src/js/layout.rs
+++ b/tool/src/js/layout.rs
@@ -160,7 +160,7 @@ pub fn type_size_alignment_and_scalar_count<P: hir::TyPosition>(
             debug_assert!(size % align == 0, "Found inner type {typ:?} with size {size} that is not a multiple of its alignment {align}");
             // A DiplomatOption will always add a new, aligned-to-T boolean field and requisite padding, which just increases the size by `align`
             let layout = Layout::from_size_align(size + align, align).unwrap();
-            (layout, inner_scalar + 1)
+            (layout, inner_scalar + 2)
         }
         _ => unreachable!("Unknown AST/HIR variant {:?}", typ),
     }


### PR DESCRIPTION
JS seems to generate the wrong arguments for optional enums and structs. These are the function signatures:

```wat
  (func $OptionOpaque_accepts_option_u8 (type 9) (param i32 i32 i32 i32)
  (func $OptionOpaque_accepts_option_enum (type 23) (param i32 i32 i32 i32 i32 i32 i32)
  (func $OptionOpaque_accepts_option_input_struct (type 15) (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
```

The first i32 is the out-buffer, the last is the sentinel I added, so this means:
* `Option<u8>` is two `i32`s. This makes sense, value and discriminant
* `Option<OptionEnum>` is 5 `i32`s. This makes less sense.
* `Option<OptionInputStruct>` is 9 `i32`s. This makes no sense, as the struct is 20 bytes/5 words.

#788 