### PR TITLE
Fix arithmetic operator overloads for structs

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -690,7 +690,10 @@ impl Attrs {
                         check_param_count(name, 1, errors);
                         check_self_param(name, true, errors);
                         if let Some(self_param) = &method.param_self {
-                            if self_param.ty.is_immutably_borrowed() {
+                            if matches!(self_param.ty, SelfType::Struct(_) | SelfType::Enum(_)) {
+                                errors.push(LoweringError::Other("*Assign arithmetic operations not allowed on non-opaque types. \
+                                     Use the non-mutating arithmetic operators instead".to_string()));
+                            } else if self_param.ty.is_immutably_borrowed() {
                                 errors.push(LoweringError::Other(format!(
                                     "{name} must take self by mutable reference"
                                 )));

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -459,7 +459,10 @@ impl Attrs {
                         match method.output {
                             ReturnType::Infallible(_) => (),
                             ReturnType::Fallible(..) => {
-                                if !validator.attrs_supported().fallible_constructors {
+                                // Only report an error if constructors *are* supported but failable constructors *arent*
+                                if validator.attrs_supported().constructors
+                                    && !validator.attrs_supported().fallible_constructors
+                                {
                                     errors.push(LoweringError::Other(
                                         "This backend doesn't support fallible constructors"
                                             .to_string(),
@@ -673,17 +676,31 @@ impl Attrs {
                                 .push(LoweringError::Other(format!("{name} must return a value")));
                         }
                     }
-                    SpecialMethod::AddAssign => {
-                        check_param_count("AddAssign", 1, errors);
-                    }
-                    SpecialMethod::SubAssign => {
-                        check_param_count("SubAssign", 1, errors);
-                    }
-                    SpecialMethod::MulAssign => {
-                        check_param_count("MulAssign", 1, errors);
-                    }
-                    SpecialMethod::DivAssign => {
-                        check_param_count("DivAssign", 1, errors);
+                    e @ (SpecialMethod::AddAssign
+                    | SpecialMethod::SubAssign
+                    | SpecialMethod::MulAssign
+                    | SpecialMethod::DivAssign) => {
+                        let name = match e {
+                            SpecialMethod::AddAssign => "AddAssign",
+                            SpecialMethod::SubAssign => "SubAssign",
+                            SpecialMethod::MulAssign => "MulAssign",
+                            SpecialMethod::DivAssign => "DivAssign",
+                            _ => unreachable!(),
+                        };
+                        check_param_count(name, 1, errors);
+                        check_self_param(name, true, errors);
+                        if let Some(self_param) = &method.param_self {
+                            if self_param.ty.is_immutably_borrowed() {
+                                errors.push(LoweringError::Other(format!(
+                                    "{name} must take self by mutable reference"
+                                )));
+                            }
+                        }
+                        if !method.output.success_type().is_unit() {
+                            errors.push(LoweringError::Other(format!(
+                                "{name} must not return a value"
+                            )));
+                        }
                     }
                 }
             } else {

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -171,6 +171,15 @@ impl SelfType {
             _ => false,
         }
     }
+    /// Returns whether the self parameter is consuming.
+    ///
+    /// Currently this can only (and must) only happen for non-opaque types.
+    pub fn is_consuming(&self) -> bool {
+        match self {
+            SelfType::Enum(_) | SelfType::Struct(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl Slice {

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -166,19 +166,13 @@ impl SelfType {
     ///
     /// Curently this can only happen with opaque types.
     pub fn is_immutably_borrowed(&self) -> bool {
-        match self {
-            SelfType::Opaque(opaque_path) => opaque_path.owner.mutability == Mutability::Immutable,
-            _ => false,
-        }
+        matches!(self, SelfType::Opaque(opaque_path) if opaque_path.owner.mutability == Mutability::Immutable)
     }
     /// Returns whether the self parameter is consuming.
     ///
     /// Currently this can only (and must) only happen for non-opaque types.
     pub fn is_consuming(&self) -> bool {
-        match self {
-            SelfType::Enum(_) | SelfType::Struct(_) => true,
-            _ => false,
-        }
+        matches!(self, SelfType::Enum(_) | SelfType::Struct(_))
     }
 }
 

--- a/feature_tests/cpp/include/CyclicStructA.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.d.hpp
@@ -30,11 +30,11 @@ struct CyclicStructA {
 
   inline static CyclicStructB get_b();
 
-  inline std::string cyclic_out();
+  inline std::string cyclic_out() const;
 
-  inline std::string double_cyclic_out(CyclicStructA cyclic_struct_a);
+  inline std::string double_cyclic_out(CyclicStructA cyclic_struct_a) const;
 
-  inline std::string getter_out();
+  inline std::string getter_out() const;
 
   inline diplomat::capi::CyclicStructA AsFFI() const;
   inline static CyclicStructA FromFFI(diplomat::capi::CyclicStructA c_struct);

--- a/feature_tests/cpp/include/CyclicStructA.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.hpp
@@ -36,7 +36,7 @@ inline CyclicStructB CyclicStructA::get_b() {
   return CyclicStructB::FromFFI(result);
 }
 
-inline std::string CyclicStructA::cyclic_out() {
+inline std::string CyclicStructA::cyclic_out() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   diplomat::capi::CyclicStructA_cyclic_out(this->AsFFI(),
@@ -44,7 +44,7 @@ inline std::string CyclicStructA::cyclic_out() {
   return output;
 }
 
-inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_a) {
+inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_a) const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   diplomat::capi::CyclicStructA_double_cyclic_out(this->AsFFI(),
@@ -53,7 +53,7 @@ inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_
   return output;
 }
 
-inline std::string CyclicStructA::getter_out() {
+inline std::string CyclicStructA::getter_out() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   diplomat::capi::CyclicStructA_getter_out(this->AsFFI(),

--- a/feature_tests/cpp/include/CyclicStructC.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructC.d.hpp
@@ -30,7 +30,7 @@ struct CyclicStructC {
 
   inline static CyclicStructC takes_nested_parameters(CyclicStructC c);
 
-  inline std::string cyclic_out();
+  inline std::string cyclic_out() const;
 
   inline diplomat::capi::CyclicStructC AsFFI() const;
   inline static CyclicStructC FromFFI(diplomat::capi::CyclicStructC c_struct);

--- a/feature_tests/cpp/include/CyclicStructC.hpp
+++ b/feature_tests/cpp/include/CyclicStructC.hpp
@@ -32,7 +32,7 @@ inline CyclicStructC CyclicStructC::takes_nested_parameters(CyclicStructC c) {
   return CyclicStructC::FromFFI(result);
 }
 
-inline std::string CyclicStructC::cyclic_out() {
+inline std::string CyclicStructC::cyclic_out() const {
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
   diplomat::capi::CyclicStructC_cyclic_out(this->AsFFI(),

--- a/feature_tests/cpp/include/MyEnum.d.hpp
+++ b/feature_tests/cpp/include/MyEnum.d.hpp
@@ -44,7 +44,7 @@ public:
   // Prevent usage as boolean value
   explicit operator bool() const = delete;
 
-  inline int8_t into_value();
+  inline int8_t into_value() const;
 
   inline static MyEnum get_a();
 

--- a/feature_tests/cpp/include/MyEnum.hpp
+++ b/feature_tests/cpp/include/MyEnum.hpp
@@ -44,7 +44,7 @@ inline MyEnum MyEnum::FromFFI(diplomat::capi::MyEnum c_enum) {
   }
 }
 
-inline int8_t MyEnum::into_value() {
+inline int8_t MyEnum::into_value() const {
   auto result = diplomat::capi::MyEnum_into_value(this->AsFFI());
   return result;
 }

--- a/feature_tests/cpp/include/MyStruct.d.hpp
+++ b/feature_tests/cpp/include/MyStruct.d.hpp
@@ -43,7 +43,7 @@ struct MyStruct {
 
   inline static MyStruct new_();
 
-  inline uint8_t into_a();
+  inline uint8_t into_a() const;
 
   inline static diplomat::result<std::monostate, MyZst> returns_zst_result();
 

--- a/feature_tests/cpp/include/MyStruct.hpp
+++ b/feature_tests/cpp/include/MyStruct.hpp
@@ -39,7 +39,7 @@ inline MyStruct MyStruct::new_() {
   return MyStruct::FromFFI(result);
 }
 
-inline uint8_t MyStruct::into_a() {
+inline uint8_t MyStruct::into_a() const {
   auto result = diplomat::capi::MyStruct_into_a(this->AsFFI());
   return result;
 }

--- a/feature_tests/cpp/include/StructArithmetic.d.hpp
+++ b/feature_tests/cpp/include/StructArithmetic.d.hpp
@@ -1,0 +1,49 @@
+#ifndef StructArithmetic_D_HPP
+#define StructArithmetic_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    struct StructArithmetic {
+      int32_t x;
+      int32_t y;
+    };
+    
+    typedef struct StructArithmetic_option {union { StructArithmetic ok; }; bool is_ok; } StructArithmetic_option;
+} // namespace capi
+} // namespace
+
+
+struct StructArithmetic {
+  int32_t x;
+  int32_t y;
+
+  inline static StructArithmetic new_(int32_t x, int32_t y);
+
+  inline StructArithmetic operator+(StructArithmetic o) const;
+  inline StructArithmetic& operator+=(StructArithmetic o);
+
+  inline StructArithmetic operator-(StructArithmetic o) const;
+  inline StructArithmetic& operator-=(StructArithmetic o);
+
+  inline StructArithmetic operator*(StructArithmetic o) const;
+  inline StructArithmetic& operator*=(StructArithmetic o);
+
+  inline StructArithmetic operator/(StructArithmetic o) const;
+  inline StructArithmetic& operator/=(StructArithmetic o);
+
+  inline diplomat::capi::StructArithmetic AsFFI() const;
+  inline static StructArithmetic FromFFI(diplomat::capi::StructArithmetic c_struct);
+};
+
+
+#endif // StructArithmetic_D_HPP

--- a/feature_tests/cpp/include/StructArithmetic.hpp
+++ b/feature_tests/cpp/include/StructArithmetic.hpp
@@ -1,0 +1,97 @@
+#ifndef StructArithmetic_HPP
+#define StructArithmetic_HPP
+
+#include "StructArithmetic.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    extern "C" {
+    
+    diplomat::capi::StructArithmetic StructArithmetic_new(int32_t x, int32_t y);
+    
+    diplomat::capi::StructArithmetic StructArithmetic_add(diplomat::capi::StructArithmetic self, diplomat::capi::StructArithmetic o);
+    
+    diplomat::capi::StructArithmetic StructArithmetic_sub(diplomat::capi::StructArithmetic self, diplomat::capi::StructArithmetic o);
+    
+    diplomat::capi::StructArithmetic StructArithmetic_mul(diplomat::capi::StructArithmetic self, diplomat::capi::StructArithmetic o);
+    
+    diplomat::capi::StructArithmetic StructArithmetic_div(diplomat::capi::StructArithmetic self, diplomat::capi::StructArithmetic o);
+    
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline StructArithmetic StructArithmetic::new_(int32_t x, int32_t y) {
+  auto result = diplomat::capi::StructArithmetic_new(x,
+    y);
+  return StructArithmetic::FromFFI(result);
+}
+
+inline StructArithmetic StructArithmetic::operator+(StructArithmetic o) const {
+  auto result = diplomat::capi::StructArithmetic_add(this->AsFFI(),
+    o.AsFFI());
+  return StructArithmetic::FromFFI(result);
+}
+inline StructArithmetic& StructArithmetic::operator+=(StructArithmetic o) {
+  *this = *this + o;
+  return *this;
+}
+
+inline StructArithmetic StructArithmetic::operator-(StructArithmetic o) const {
+  auto result = diplomat::capi::StructArithmetic_sub(this->AsFFI(),
+    o.AsFFI());
+  return StructArithmetic::FromFFI(result);
+}
+inline StructArithmetic& StructArithmetic::operator-=(StructArithmetic o) {
+  *this = *this - o;
+  return *this;
+}
+
+inline StructArithmetic StructArithmetic::operator*(StructArithmetic o) const {
+  auto result = diplomat::capi::StructArithmetic_mul(this->AsFFI(),
+    o.AsFFI());
+  return StructArithmetic::FromFFI(result);
+}
+inline StructArithmetic& StructArithmetic::operator*=(StructArithmetic o) {
+  *this = *this * o;
+  return *this;
+}
+
+inline StructArithmetic StructArithmetic::operator/(StructArithmetic o) const {
+  auto result = diplomat::capi::StructArithmetic_div(this->AsFFI(),
+    o.AsFFI());
+  return StructArithmetic::FromFFI(result);
+}
+inline StructArithmetic& StructArithmetic::operator/=(StructArithmetic o) {
+  *this = *this / o;
+  return *this;
+}
+
+
+inline diplomat::capi::StructArithmetic StructArithmetic::AsFFI() const {
+  return diplomat::capi::StructArithmetic {
+    /* .x = */ x,
+    /* .y = */ y,
+  };
+}
+
+inline StructArithmetic StructArithmetic::FromFFI(diplomat::capi::StructArithmetic c_struct) {
+  return StructArithmetic {
+    /* .x = */ c_struct.x,
+    /* .y = */ c_struct.y,
+  };
+}
+
+
+#endif // StructArithmetic_HPP

--- a/feature_tests/cpp/tests/structs.cpp
+++ b/feature_tests/cpp/tests/structs.cpp
@@ -2,9 +2,11 @@
 #include "../include/MyStruct.hpp"
 #include "../include/MyEnum.hpp"
 #include "../include/Opaque.hpp"
+#include "../include/StructArithmetic.hpp"
 #include "assert.hpp"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
     std::unique_ptr<Opaque> o = Opaque::new_();
     MyStruct s = MyStruct::new_();
 
@@ -20,4 +22,16 @@ int main(int argc, char *argv[]) {
 
     simple_assert_eq("enum fn", s.g.into_value(), -1);
     simple_assert_eq("struct fn", s.into_a(), 17);
+
+    auto a = StructArithmetic{1, 2};
+    auto b = StructArithmetic{2, 3};
+    {
+        auto r = a + b;
+
+        simple_assert_eq("adding x", r.x, 3);
+        simple_assert_eq("adding y", r.y, 5);
+        r += a;
+        simple_assert_eq("self-adding x", r.x, 4);
+        simple_assert_eq("self-adding y", r.y, 7);
+    }
 }

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -174,24 +174,24 @@ pub mod ffi {
         #[diplomat::attr(auto, sub)]
         pub fn sub(&self, o: &Self) -> Box<Self> {
             Box::new(Self {
-                x: self.x + o.x,
-                y: self.y + o.y,
+                x: self.x - o.x,
+                y: self.y - o.y,
             })
         }
 
         #[diplomat::attr(auto, mul)]
         pub fn mul(&self, o: &Self) -> Box<Self> {
             Box::new(Self {
-                x: self.x + o.x,
-                y: self.y + o.y,
+                x: self.x * o.x,
+                y: self.y * o.y,
             })
         }
 
         #[diplomat::attr(auto, div)]
         pub fn div(&self, o: &Self) -> Box<Self> {
             Box::new(Self {
-                x: self.x + o.x,
-                y: self.y + o.y,
+                x: self.x / o.x,
+                y: self.y / o.y,
             })
         }
 

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -340,6 +340,51 @@ pub mod ffi {
             assert_eq!(extra_val, 853);
         }
     }
+
+    #[diplomat::attr(not(supports = arithmetic), disable)]
+    struct StructArithmetic {
+        x: i32,
+        y: i32,
+    }
+
+    impl StructArithmetic {
+        #[diplomat::attr(auto, constructor)]
+        pub fn new(x: i32, y: i32) -> Self {
+            Self { x, y }
+        }
+
+        #[diplomat::attr(auto, add)]
+        pub fn add(self, o: Self) -> Self {
+            Self {
+                x: self.x + o.x,
+                y: self.y + o.y,
+            }
+        }
+
+        #[diplomat::attr(auto, sub)]
+        pub fn sub(self, o: Self) -> Self {
+            Self {
+                x: self.x - o.x,
+                y: self.y - o.y,
+            }
+        }
+
+        #[diplomat::attr(auto, mul)]
+        pub fn mul(self, o: Self) -> Self {
+            Self {
+                x: self.x * o.x,
+                y: self.y * o.y,
+            }
+        }
+
+        #[diplomat::attr(auto, div)]
+        pub fn div(self, o: Self) -> Self {
+            Self {
+                x: self.x / o.x,
+                y: self.y / o.y,
+            }
+        }
+    }
 }
 
 #[allow(unused)]

--- a/tool/src/cpp/ty.rs
+++ b/tool/src/cpp/ty.rs
@@ -375,7 +375,11 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx, '_> {
         };
 
         let post_qualifiers = match &method.param_self {
-            Some(param_self) if param_self.ty.is_immutably_borrowed() => vec!["const".into()],
+            Some(param_self)
+                if param_self.ty.is_immutably_borrowed() || param_self.ty.is_consuming() =>
+            {
+                vec!["const".into()]
+            }
             Some(_) => vec![],
             None => vec![],
         };

--- a/tool/templates/cpp/enum_decl.h.jinja
+++ b/tool/templates/cpp/enum_decl.h.jinja
@@ -1,5 +1,5 @@
 {% include "c_include.h.jinja" %}
-
+{% let auto_define_self_arithmatic = true %}
 {% if let Some(ns) = namespace -%}
 namespace {{ns}} {
 {% endif -%}

--- a/tool/templates/cpp/enum_decl.h.jinja
+++ b/tool/templates/cpp/enum_decl.h.jinja
@@ -1,5 +1,5 @@
 {% include "c_include.h.jinja" %}
-{% let auto_define_self_arithmatic = true %}
+{% let auto_define_self_arithmetic = true %}
 {% if let Some(ns) = namespace -%}
 namespace {{ns}} {
 {% endif -%}

--- a/tool/templates/cpp/enum_impl.h.jinja
+++ b/tool/templates/cpp/enum_impl.h.jinja
@@ -1,4 +1,5 @@
-{% include "c_include.h.jinja" %}
+{% include "c_include.h.jinja" -%}
+{% let auto_define_self_arithmatic = true %}
 
 inline {{ctype}} {{type_name}}::AsFFI() const {
 	return static_cast<{{ctype}}>(value);

--- a/tool/templates/cpp/enum_impl.h.jinja
+++ b/tool/templates/cpp/enum_impl.h.jinja
@@ -1,5 +1,5 @@
 {% include "c_include.h.jinja" -%}
-{% let auto_define_self_arithmatic = true %}
+{% let auto_define_self_arithmetic = true %}
 
 inline {{ctype}} {{type_name}}::AsFFI() const {
 	return static_cast<{{ctype}}>(value);

--- a/tool/templates/cpp/method_decl.h.jinja
+++ b/tool/templates/cpp/method_decl.h.jinja
@@ -9,3 +9,11 @@ inline {##}
 	{%- endfor -%}
 )
 {%- for qualifier in m.post_qualifiers %} {{qualifier}}{% endfor %};
+{%- if auto_define_self_arithmatic -%}
+{%- if let Some(op_str) = m.method_name.strip_prefix("operator") -%}
+{%- if ["+", "-", "*", "/"].contains(op_str) -%}
+{%- let param_var = m.param_decls[0] ~%}
+{##}  inline {{ m.return_ty }}& {{m.method_name -}}=({{ param_var.type_name }} {{ param_var.var_name }});
+{%- endif -%}
+{%- endif -%}
+{%- endif -%}

--- a/tool/templates/cpp/method_decl.h.jinja
+++ b/tool/templates/cpp/method_decl.h.jinja
@@ -9,7 +9,7 @@ inline {##}
 	{%- endfor -%}
 )
 {%- for qualifier in m.post_qualifiers %} {{qualifier}}{% endfor %};
-{%- if auto_define_self_arithmatic -%}
+{%- if auto_define_self_arithmetic -%}
 {%- if let Some(op_str) = m.method_name.strip_prefix("operator") -%}
 {%- if ["+", "-", "*", "/"].contains(op_str) -%}
 {%- let param_var = m.param_decls[0] ~%}

--- a/tool/templates/cpp/method_impl.h.jinja
+++ b/tool/templates/cpp/method_impl.h.jinja
@@ -32,7 +32,7 @@ inline {##}
 	{%- when None %}
 	{%- endmatch %}
 }
-{%- if auto_define_self_arithmatic -%}
+{%- if auto_define_self_arithmetic -%}
 {%- if let Some(op_str) = m.method_name.strip_prefix("operator") -%}
 {%- if ["+", "-", "*", "/"].contains(op_str) -%}
 {%- let param_var = m.param_decls[0] ~%}

--- a/tool/templates/cpp/method_impl.h.jinja
+++ b/tool/templates/cpp/method_impl.h.jinja
@@ -32,3 +32,14 @@ inline {##}
 	{%- when None %}
 	{%- endmatch %}
 }
+{%- if auto_define_self_arithmatic -%}
+{%- if let Some(op_str) = m.method_name.strip_prefix("operator") -%}
+{%- if ["+", "-", "*", "/"].contains(op_str) -%}
+{%- let param_var = m.param_decls[0] ~%}
+inline {{ m.return_ty }}& {{type_name}}::{{m.method_name -}}=({{ param_var.type_name }} {{ param_var.var_name }}) {
+  *this = *this {{op_str}} {{param_var.var_name}};
+  return *this;
+}
+{%- endif -%}
+{%- endif -%}
+{%- endif -%}

--- a/tool/templates/cpp/opaque_decl.h.jinja
+++ b/tool/templates/cpp/opaque_decl.h.jinja
@@ -4,7 +4,7 @@
 {% let mut_cptr = fmt.fmt_c_ptr(ctype, Mutability::Mutable) -%}
 {% let const_ref = fmt.fmt_borrowed(type_name, Mutability::Immutable) -%}
 {% let move_ref = fmt.fmt_move_ref(type_name) -%}
-{% let auto_define_self_arithmatic = false -%}
+{% let auto_define_self_arithmetic = false -%}
 
 {% include "c_include.h.jinja" %}
 

--- a/tool/templates/cpp/opaque_decl.h.jinja
+++ b/tool/templates/cpp/opaque_decl.h.jinja
@@ -4,6 +4,7 @@
 {% let mut_cptr = fmt.fmt_c_ptr(ctype, Mutability::Mutable) -%}
 {% let const_ref = fmt.fmt_borrowed(type_name, Mutability::Immutable) -%}
 {% let move_ref = fmt.fmt_move_ref(type_name) -%}
+{% let auto_define_self_arithmatic = false -%}
 
 {% include "c_include.h.jinja" %}
 

--- a/tool/templates/cpp/opaque_impl.h.jinja
+++ b/tool/templates/cpp/opaque_impl.h.jinja
@@ -6,7 +6,7 @@
 {% let mut_cptr = fmt.fmt_c_ptr(ctype, Mutability::Mutable) -%}
 {% let const_ref = fmt.fmt_borrowed(type_name, Mutability::Immutable) -%}
 {% let move_ref = fmt.fmt_move_ref(type_name) -%}
-{% let auto_define_self_arithmatic = false -%}
+{% let auto_define_self_arithmetic = false -%}
 
 {% for m in methods -%}
 {% include "method_impl.h.jinja" %}

--- a/tool/templates/cpp/opaque_impl.h.jinja
+++ b/tool/templates/cpp/opaque_impl.h.jinja
@@ -6,6 +6,7 @@
 {% let mut_cptr = fmt.fmt_c_ptr(ctype, Mutability::Mutable) -%}
 {% let const_ref = fmt.fmt_borrowed(type_name, Mutability::Immutable) -%}
 {% let move_ref = fmt.fmt_move_ref(type_name) -%}
+{% let auto_define_self_arithmatic = false -%}
 
 {% for m in methods -%}
 {% include "method_impl.h.jinja" %}

--- a/tool/templates/cpp/struct_decl.h.jinja
+++ b/tool/templates/cpp/struct_decl.h.jinja
@@ -1,5 +1,5 @@
 {% include "c_include.h.jinja" %}
-{% let auto_define_self_arithmatic = true %}
+{% let auto_define_self_arithmetic = true %}
 
 {% if let Some(ns) = namespace -%}
 namespace {{ns}} {

--- a/tool/templates/cpp/struct_decl.h.jinja
+++ b/tool/templates/cpp/struct_decl.h.jinja
@@ -1,5 +1,5 @@
 {% include "c_include.h.jinja" %}
-
+{% let auto_define_self_arithmatic = true %}
 
 {% if let Some(ns) = namespace -%}
 namespace {{ns}} {

--- a/tool/templates/cpp/struct_impl.h.jinja
+++ b/tool/templates/cpp/struct_impl.h.jinja
@@ -1,4 +1,5 @@
-{% include "c_include.h.jinja" %}
+{% include "c_include.h.jinja" -%}
+{% let auto_define_self_arithmatic = true %}
 
 {% for m in methods -%}
 {% include "method_impl.h.jinja" %}

--- a/tool/templates/cpp/struct_impl.h.jinja
+++ b/tool/templates/cpp/struct_impl.h.jinja
@@ -1,5 +1,5 @@
 {% include "c_include.h.jinja" -%}
-{% let auto_define_self_arithmatic = true %}
+{% let auto_define_self_arithmetic = true %}
 
 {% for m in methods -%}
 {% include "method_impl.h.jinja" %}


### PR DESCRIPTION
For structs & enums where it's impossible to define a function taking `&mut self`, define `[*]=` operators in terms of their immutable variants in the target language to allow good ergonomics.

