### PR TITLE
Replace unwrap in diplomat AST with an expect

### DIFF
--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -248,7 +248,8 @@ impl Module {
 
                         let self_ident = self_path.path.elements.last().unwrap();
 
-                        match custom_types_by_name.get_mut(self_ident).unwrap() {
+                        match custom_types_by_name.get_mut(self_ident)
+                                                  .expect("Diplomat currently requires impls to be in the same module as their self type") {
                             CustomType::Struct(strct) => {
                                 strct.methods.append(&mut new_methods);
                             }


### PR DESCRIPTION
Unfortunately making this unnecessary requires flattening the AST a bit: currently methods must live as fields on custom types.

This is not a fundamental restriction: the AST does not actually need to know anything about the type being impld on, however this means we need to hoist `methods` out into its own toplevel thing.

Now that we have the HIR there are a bunch of fixes that can be made to the AST to make it *less* structured to provide more freedom to bridge code.