### PR TITLE
Implement C++ Iterator support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Cargo.lock
 
 # VS Code configuration
 .vscode/
+
+# artifacts from running cpp-check
+*.pch

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -7,6 +7,7 @@
 #include <variant>
 #include <cstdint>
 #include <functional>
+#include <memory>
 
 #if __cplusplus >= 202002L
 #include <span>
@@ -212,22 +213,34 @@ template<class T> using span = std::span<T>;
 
 #else // __cplusplus < 202002L
 
-// C++-17-compatible std::span
-template<class T>
+// C++-17-compatible-ish std::span
+template <class T>
 class span {
-
 public:
-  constexpr span(T* data, size_t size)
+  constexpr span(T *data = nullptr, size_t size = 0)
     : data_(data), size_(size) {}
-  template<size_t N>
-  constexpr span(std::array<typename std::remove_const<T>::type, N>& arr)
-    : data_(const_cast<T*>(arr.data())), size_(N) {}
+ 
+  constexpr span(const span<T> &o)
+    : data_(o.data_), size_(o.size_) {}
+  template <size_t N>
+  constexpr span(std::array<typename std::remove_const_t<T>, N> &arr)
+    : data_(const_cast<T *>(arr.data())), size_(N) {}
+
   constexpr T* data() const noexcept {
     return this->data_;
   }
   constexpr size_t size() const noexcept {
     return this->size_;
   }
+
+  constexpr T *begin() const noexcept { return data(); }
+  constexpr T *end() const noexcept { return data() + size(); }
+
+  void operator=(span<T> o) {
+    data_ = o.data_;
+    size_ = o.size_;
+  }
+
 private:
   T* data_;
   size_t size_;
@@ -289,6 +302,54 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
 // additional deduction guide required
 template<class T>
 fn_traits(T) -> fn_traits<T>;
+
+
+// trait to detect if something is std::optional
+template<class T>
+inline constexpr bool is_optional_v = std::false_type{};
+
+template<class T>
+inline constexpr bool is_optional_v<std::optional<T>> = std::true_type{};
+
+// Trait for extracting inner types from either std::optional or std::unique_ptr.
+// These are the two potential types returned by next() functions
+template<typename T> struct inner { using type = void; };
+template<typename T> struct inner<std::unique_ptr<T>> { using type = T; };
+template<typename T> struct inner<std::optional<T>>{ using type = T; };
+
+// Adapter for iterator types
+template<typename T, typename U = void> struct has_next : std::false_type {};
+template<typename T> struct has_next < T, std::void_t<decltype(std::declval<T>().next())>> : std::true_type {};
+template<typename T> constexpr bool has_next_v = has_next<T>::value;
+
+/// Helper template enabling native iteration over unique ptrs to objects which implement next()
+template<typename T>
+struct next_to_iter_helper {
+  static_assert(has_next_v<T>, "next_to_iter_helper may only be used with types implementing next()");
+  using next_type = decltype(std::declval<T>().next());
+
+  // STL Iterator trait definitions
+  using value_type = typename inner<next_type>::type;
+  using difference_type = void;
+  using reference = std::add_lvalue_reference_t<value_type>;
+  using iterator_category = std::input_iterator_tag;
+
+  next_to_iter_helper(std::unique_ptr<T>&& ptr) : _ptr(std::move(ptr)), _curr(_ptr->next()) {}
+  
+  // https://en.cppreference.com/w/cpp/named_req/InputIterator requires that the type be copyable
+  next_to_iter_helper(const next_to_iter_helper& o) : _ptr(o._ptr), _curr(o._curr) {}
+
+  void operator++() { _curr = _ptr->next(); }
+  void operator++(int) { ++(*this); }
+  const value_type& operator*() const { return _curr.value(); }
+
+  bool operator!=(std::nullopt_t) {
+    return _curr.has_value();
+  }
+
+  std::shared_ptr<T> _ptr; // shared to satisfy the copyable requirement
+  next_type _curr;
+};
 
 } // namespace diplomat
 

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -7,6 +7,7 @@
 #include <variant>
 #include <cstdint>
 #include <functional>
+#include <memory>
 
 #if __cplusplus >= 202002L
 #include <span>
@@ -212,22 +213,34 @@ template<class T> using span = std::span<T>;
 
 #else // __cplusplus < 202002L
 
-// C++-17-compatible std::span
-template<class T>
+// C++-17-compatible-ish std::span
+template <class T>
 class span {
-
 public:
-  constexpr span(T* data, size_t size)
+  constexpr span(T *data = nullptr, size_t size = 0)
     : data_(data), size_(size) {}
-  template<size_t N>
-  constexpr span(std::array<typename std::remove_const<T>::type, N>& arr)
-    : data_(const_cast<T*>(arr.data())), size_(N) {}
+ 
+  constexpr span(const span<T> &o)
+    : data_(o.data_), size_(o.size_) {}
+  template <size_t N>
+  constexpr span(std::array<typename std::remove_const_t<T>, N> &arr)
+    : data_(const_cast<T *>(arr.data())), size_(N) {}
+
   constexpr T* data() const noexcept {
     return this->data_;
   }
   constexpr size_t size() const noexcept {
     return this->size_;
   }
+
+  constexpr T *begin() const noexcept { return data(); }
+  constexpr T *end() const noexcept { return data() + size(); }
+
+  void operator=(span<T> o) {
+    data_ = o.data_;
+    size_ = o.size_;
+  }
+
 private:
   T* data_;
   size_t size_;
@@ -289,6 +302,54 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
 // additional deduction guide required
 template<class T>
 fn_traits(T) -> fn_traits<T>;
+
+
+// trait to detect if something is std::optional
+template<class T>
+inline constexpr bool is_optional_v = std::false_type{};
+
+template<class T>
+inline constexpr bool is_optional_v<std::optional<T>> = std::true_type{};
+
+// Trait for extracting inner types from either std::optional or std::unique_ptr.
+// These are the two potential types returned by next() functions
+template<typename T> struct inner { using type = void; };
+template<typename T> struct inner<std::unique_ptr<T>> { using type = T; };
+template<typename T> struct inner<std::optional<T>>{ using type = T; };
+
+// Adapter for iterator types
+template<typename T, typename U = void> struct has_next : std::false_type {};
+template<typename T> struct has_next < T, std::void_t<decltype(std::declval<T>().next())>> : std::true_type {};
+template<typename T> constexpr bool has_next_v = has_next<T>::value;
+
+/// Helper template enabling native iteration over unique ptrs to objects which implement next()
+template<typename T>
+struct next_to_iter_helper {
+  static_assert(has_next_v<T>, "next_to_iter_helper may only be used with types implementing next()");
+  using next_type = decltype(std::declval<T>().next());
+
+  // STL Iterator trait definitions
+  using value_type = typename inner<next_type>::type;
+  using difference_type = void;
+  using reference = std::add_lvalue_reference_t<value_type>;
+  using iterator_category = std::input_iterator_tag;
+
+  next_to_iter_helper(std::unique_ptr<T>&& ptr) : _ptr(std::move(ptr)), _curr(_ptr->next()) {}
+  
+  // https://en.cppreference.com/w/cpp/named_req/InputIterator requires that the type be copyable
+  next_to_iter_helper(const next_to_iter_helper& o) : _ptr(o._ptr), _curr(o._curr) {}
+
+  void operator++() { _curr = _ptr->next(); }
+  void operator++(int) { ++(*this); }
+  const value_type& operator*() const { return _curr.value(); }
+
+  bool operator!=(std::nullopt_t) {
+    return _curr.has_value();
+  }
+
+  std::shared_ptr<T> _ptr; // shared to satisfy the copyable requirement
+  next_type _curr;
+};
 
 } // namespace diplomat
 

--- a/feature_tests/cpp/include/ns/RenamedMyIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterable.d.hpp
@@ -1,0 +1,52 @@
+#ifndef ns_RenamedMyIterable_D_HPP
+#define ns_RenamedMyIterable_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+namespace ns {
+namespace capi { struct RenamedMyIterable; }
+class RenamedMyIterable;
+namespace capi { struct RenamedMyIterator; }
+class RenamedMyIterator;
+}
+
+
+namespace ns {
+namespace capi {
+    struct RenamedMyIterable;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedMyIterable {
+public:
+
+  inline static std::unique_ptr<ns::RenamedMyIterable> new_(diplomat::span<const uint8_t> x);
+
+  inline std::unique_ptr<ns::RenamedMyIterator> iter() const;
+  inline diplomat::next_to_iter_helper<ns::RenamedMyIterator> begin() const;
+  inline std::nullopt_t end() const { return std::nullopt; }
+
+  inline const ns::capi::RenamedMyIterable* AsFFI() const;
+  inline ns::capi::RenamedMyIterable* AsFFI();
+  inline static const ns::RenamedMyIterable* FromFFI(const ns::capi::RenamedMyIterable* ptr);
+  inline static ns::RenamedMyIterable* FromFFI(ns::capi::RenamedMyIterable* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  RenamedMyIterable() = delete;
+  RenamedMyIterable(const ns::RenamedMyIterable&) = delete;
+  RenamedMyIterable(ns::RenamedMyIterable&&) noexcept = delete;
+  RenamedMyIterable operator=(const ns::RenamedMyIterable&) = delete;
+  RenamedMyIterable operator=(ns::RenamedMyIterable&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // ns_RenamedMyIterable_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedMyIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterable.hpp
@@ -1,0 +1,67 @@
+#ifndef ns_RenamedMyIterable_HPP
+#define ns_RenamedMyIterable_HPP
+
+#include "RenamedMyIterable.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+#include "RenamedMyIterator.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+    
+    ns::capi::RenamedMyIterable* namespace_MyIterable_new(diplomat::capi::DiplomatU8View x);
+    
+    ns::capi::RenamedMyIterator* namespace_MyIterable_iter(const ns::capi::RenamedMyIterable* self);
+    
+    
+    void namespace_MyIterable_destroy(RenamedMyIterable* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<ns::RenamedMyIterable> ns::RenamedMyIterable::new_(diplomat::span<const uint8_t> x) {
+  auto result = ns::capi::namespace_MyIterable_new({x.data(), x.size()});
+  return std::unique_ptr<ns::RenamedMyIterable>(ns::RenamedMyIterable::FromFFI(result));
+}
+
+inline std::unique_ptr<ns::RenamedMyIterator> ns::RenamedMyIterable::iter() const {
+  auto result = ns::capi::namespace_MyIterable_iter(this->AsFFI());
+  return std::unique_ptr<ns::RenamedMyIterator>(ns::RenamedMyIterator::FromFFI(result));
+}
+
+inline diplomat::next_to_iter_helper<ns::RenamedMyIterator>ns::RenamedMyIterable::begin() const {
+  return iter();
+}
+
+inline const ns::capi::RenamedMyIterable* ns::RenamedMyIterable::AsFFI() const {
+  return reinterpret_cast<const ns::capi::RenamedMyIterable*>(this);
+}
+
+inline ns::capi::RenamedMyIterable* ns::RenamedMyIterable::AsFFI() {
+  return reinterpret_cast<ns::capi::RenamedMyIterable*>(this);
+}
+
+inline const ns::RenamedMyIterable* ns::RenamedMyIterable::FromFFI(const ns::capi::RenamedMyIterable* ptr) {
+  return reinterpret_cast<const ns::RenamedMyIterable*>(ptr);
+}
+
+inline ns::RenamedMyIterable* ns::RenamedMyIterable::FromFFI(ns::capi::RenamedMyIterable* ptr) {
+  return reinterpret_cast<ns::RenamedMyIterable*>(ptr);
+}
+
+inline void ns::RenamedMyIterable::operator delete(void* ptr) {
+  ns::capi::namespace_MyIterable_destroy(reinterpret_cast<ns::capi::RenamedMyIterable*>(ptr));
+}
+
+
+#endif // ns_RenamedMyIterable_HPP

--- a/feature_tests/cpp/include/ns/RenamedMyIterator.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterator.d.hpp
@@ -1,0 +1,41 @@
+#ifndef ns_RenamedMyIterator_D_HPP
+#define ns_RenamedMyIterator_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    struct RenamedMyIterator;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedMyIterator {
+public:
+
+  inline std::optional<uint8_t> next();
+
+  inline const ns::capi::RenamedMyIterator* AsFFI() const;
+  inline ns::capi::RenamedMyIterator* AsFFI();
+  inline static const ns::RenamedMyIterator* FromFFI(const ns::capi::RenamedMyIterator* ptr);
+  inline static ns::RenamedMyIterator* FromFFI(ns::capi::RenamedMyIterator* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  RenamedMyIterator() = delete;
+  RenamedMyIterator(const ns::RenamedMyIterator&) = delete;
+  RenamedMyIterator(ns::RenamedMyIterator&&) noexcept = delete;
+  RenamedMyIterator operator=(const ns::RenamedMyIterator&) = delete;
+  RenamedMyIterator operator=(ns::RenamedMyIterator&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // ns_RenamedMyIterator_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedMyIterator.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterator.hpp
@@ -1,0 +1,56 @@
+#ifndef ns_RenamedMyIterator_HPP
+#define ns_RenamedMyIterator_HPP
+
+#include "RenamedMyIterator.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+    
+    typedef struct namespace_MyIterator_next_result {union {uint8_t ok; }; bool is_ok;} namespace_MyIterator_next_result;
+    namespace_MyIterator_next_result namespace_MyIterator_next(ns::capi::RenamedMyIterator* self);
+    
+    
+    void namespace_MyIterator_destroy(RenamedMyIterator* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::optional<uint8_t> ns::RenamedMyIterator::next() {
+  auto result = ns::capi::namespace_MyIterator_next(this->AsFFI());
+  return result.is_ok ? std::optional<uint8_t>(result.ok) : std::nullopt;
+}
+
+inline const ns::capi::RenamedMyIterator* ns::RenamedMyIterator::AsFFI() const {
+  return reinterpret_cast<const ns::capi::RenamedMyIterator*>(this);
+}
+
+inline ns::capi::RenamedMyIterator* ns::RenamedMyIterator::AsFFI() {
+  return reinterpret_cast<ns::capi::RenamedMyIterator*>(this);
+}
+
+inline const ns::RenamedMyIterator* ns::RenamedMyIterator::FromFFI(const ns::capi::RenamedMyIterator* ptr) {
+  return reinterpret_cast<const ns::RenamedMyIterator*>(ptr);
+}
+
+inline ns::RenamedMyIterator* ns::RenamedMyIterator::FromFFI(ns::capi::RenamedMyIterator* ptr) {
+  return reinterpret_cast<ns::RenamedMyIterator*>(ptr);
+}
+
+inline void ns::RenamedMyIterator::operator delete(void* ptr) {
+  ns::capi::namespace_MyIterator_destroy(reinterpret_cast<ns::capi::RenamedMyIterator*>(ptr));
+}
+
+
+#endif // ns_RenamedMyIterator_HPP

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterable.d.hpp
@@ -1,0 +1,48 @@
+#ifndef ns_RenamedOpaqueIterable_D_HPP
+#define ns_RenamedOpaqueIterable_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+namespace ns {
+namespace capi { struct RenamedOpaqueIterator; }
+class RenamedOpaqueIterator;
+}
+
+
+namespace ns {
+namespace capi {
+    struct RenamedOpaqueIterable;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedOpaqueIterable {
+public:
+
+  inline std::unique_ptr<ns::RenamedOpaqueIterator> iter() const;
+  inline diplomat::next_to_iter_helper<ns::RenamedOpaqueIterator> begin() const;
+  inline std::nullopt_t end() const { return std::nullopt; }
+
+  inline const ns::capi::RenamedOpaqueIterable* AsFFI() const;
+  inline ns::capi::RenamedOpaqueIterable* AsFFI();
+  inline static const ns::RenamedOpaqueIterable* FromFFI(const ns::capi::RenamedOpaqueIterable* ptr);
+  inline static ns::RenamedOpaqueIterable* FromFFI(ns::capi::RenamedOpaqueIterable* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  RenamedOpaqueIterable() = delete;
+  RenamedOpaqueIterable(const ns::RenamedOpaqueIterable&) = delete;
+  RenamedOpaqueIterable(ns::RenamedOpaqueIterable&&) noexcept = delete;
+  RenamedOpaqueIterable operator=(const ns::RenamedOpaqueIterable&) = delete;
+  RenamedOpaqueIterable operator=(ns::RenamedOpaqueIterable&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // ns_RenamedOpaqueIterable_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterable.hpp
@@ -1,0 +1,60 @@
+#ifndef ns_RenamedOpaqueIterable_HPP
+#define ns_RenamedOpaqueIterable_HPP
+
+#include "RenamedOpaqueIterable.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+#include "RenamedOpaqueIterator.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+    
+    ns::capi::RenamedOpaqueIterator* namespace_OpaqueIterable_iter(const ns::capi::RenamedOpaqueIterable* self);
+    
+    
+    void namespace_OpaqueIterable_destroy(RenamedOpaqueIterable* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<ns::RenamedOpaqueIterator> ns::RenamedOpaqueIterable::iter() const {
+  auto result = ns::capi::namespace_OpaqueIterable_iter(this->AsFFI());
+  return std::unique_ptr<ns::RenamedOpaqueIterator>(ns::RenamedOpaqueIterator::FromFFI(result));
+}
+
+inline diplomat::next_to_iter_helper<ns::RenamedOpaqueIterator>ns::RenamedOpaqueIterable::begin() const {
+  return iter();
+}
+
+inline const ns::capi::RenamedOpaqueIterable* ns::RenamedOpaqueIterable::AsFFI() const {
+  return reinterpret_cast<const ns::capi::RenamedOpaqueIterable*>(this);
+}
+
+inline ns::capi::RenamedOpaqueIterable* ns::RenamedOpaqueIterable::AsFFI() {
+  return reinterpret_cast<ns::capi::RenamedOpaqueIterable*>(this);
+}
+
+inline const ns::RenamedOpaqueIterable* ns::RenamedOpaqueIterable::FromFFI(const ns::capi::RenamedOpaqueIterable* ptr) {
+  return reinterpret_cast<const ns::RenamedOpaqueIterable*>(ptr);
+}
+
+inline ns::RenamedOpaqueIterable* ns::RenamedOpaqueIterable::FromFFI(ns::capi::RenamedOpaqueIterable* ptr) {
+  return reinterpret_cast<ns::RenamedOpaqueIterable*>(ptr);
+}
+
+inline void ns::RenamedOpaqueIterable::operator delete(void* ptr) {
+  ns::capi::namespace_OpaqueIterable_destroy(reinterpret_cast<ns::capi::RenamedOpaqueIterable*>(ptr));
+}
+
+
+#endif // ns_RenamedOpaqueIterable_HPP

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterator.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterator.d.hpp
@@ -1,0 +1,46 @@
+#ifndef ns_RenamedOpaqueIterator_D_HPP
+#define ns_RenamedOpaqueIterator_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+namespace ns {
+namespace capi { struct AttrOpaque1Renamed; }
+class AttrOpaque1Renamed;
+}
+
+
+namespace ns {
+namespace capi {
+    struct RenamedOpaqueIterator;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedOpaqueIterator {
+public:
+
+  inline std::unique_ptr<ns::AttrOpaque1Renamed> next();
+
+  inline const ns::capi::RenamedOpaqueIterator* AsFFI() const;
+  inline ns::capi::RenamedOpaqueIterator* AsFFI();
+  inline static const ns::RenamedOpaqueIterator* FromFFI(const ns::capi::RenamedOpaqueIterator* ptr);
+  inline static ns::RenamedOpaqueIterator* FromFFI(ns::capi::RenamedOpaqueIterator* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  RenamedOpaqueIterator() = delete;
+  RenamedOpaqueIterator(const ns::RenamedOpaqueIterator&) = delete;
+  RenamedOpaqueIterator(ns::RenamedOpaqueIterator&&) noexcept = delete;
+  RenamedOpaqueIterator operator=(const ns::RenamedOpaqueIterator&) = delete;
+  RenamedOpaqueIterator operator=(ns::RenamedOpaqueIterator&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // ns_RenamedOpaqueIterator_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterator.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterator.hpp
@@ -1,0 +1,56 @@
+#ifndef ns_RenamedOpaqueIterator_HPP
+#define ns_RenamedOpaqueIterator_HPP
+
+#include "RenamedOpaqueIterator.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+#include "AttrOpaque1Renamed.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+    
+    ns::capi::AttrOpaque1Renamed* namespace_OpaqueIterator_next(ns::capi::RenamedOpaqueIterator* self);
+    
+    
+    void namespace_OpaqueIterator_destroy(RenamedOpaqueIterator* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<ns::AttrOpaque1Renamed> ns::RenamedOpaqueIterator::next() {
+  auto result = ns::capi::namespace_OpaqueIterator_next(this->AsFFI());
+  return std::unique_ptr<ns::AttrOpaque1Renamed>(ns::AttrOpaque1Renamed::FromFFI(result));
+}
+
+inline const ns::capi::RenamedOpaqueIterator* ns::RenamedOpaqueIterator::AsFFI() const {
+  return reinterpret_cast<const ns::capi::RenamedOpaqueIterator*>(this);
+}
+
+inline ns::capi::RenamedOpaqueIterator* ns::RenamedOpaqueIterator::AsFFI() {
+  return reinterpret_cast<ns::capi::RenamedOpaqueIterator*>(this);
+}
+
+inline const ns::RenamedOpaqueIterator* ns::RenamedOpaqueIterator::FromFFI(const ns::capi::RenamedOpaqueIterator* ptr) {
+  return reinterpret_cast<const ns::RenamedOpaqueIterator*>(ptr);
+}
+
+inline ns::RenamedOpaqueIterator* ns::RenamedOpaqueIterator::FromFFI(ns::capi::RenamedOpaqueIterator* ptr) {
+  return reinterpret_cast<ns::RenamedOpaqueIterator*>(ptr);
+}
+
+inline void ns::RenamedOpaqueIterator::operator delete(void* ptr) {
+  ns::capi::namespace_OpaqueIterator_destroy(reinterpret_cast<ns::capi::RenamedOpaqueIterator*>(ptr));
+}
+
+
+#endif // ns_RenamedOpaqueIterator_HPP

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -85,16 +85,12 @@ pub mod ffi {
     }
 
     #[diplomat::opaque]
-    #[diplomat::attr(not(supports = iterators), disable)]
-    pub struct MyIterable(Vec<u8>);
-
-    #[diplomat::opaque]
-    #[diplomat::attr(not(supports = iterators), disable)]
-    pub struct MyIterator<'a>(std::slice::Iter<'a, u8>);
-
-    #[diplomat::opaque]
     #[diplomat::attr(not(supports = indexing), disable)]
     pub struct MyIndexer(Vec<String>);
+
+    #[diplomat::opaque]
+    #[diplomat::attr(not(supports = iterators), disable)]
+    pub struct MyIterable(Vec<u8>);
 
     impl MyIterable {
         #[diplomat::attr(auto, constructor)]
@@ -107,6 +103,9 @@ pub mod ffi {
         }
     }
 
+    #[diplomat::opaque]
+    #[diplomat::attr(not(supports = iterators), disable)]
+    pub struct MyIterator<'a>(std::slice::Iter<'a, u8>);
     impl<'a> MyIterator<'a> {
         #[diplomat::attr(auto, iterator)]
         pub fn next(&mut self) -> Option<u8> {
@@ -125,10 +124,6 @@ pub mod ffi {
     #[diplomat::attr(not(supports = iterators), disable)]
     struct OpaqueIterable(Vec<AttrOpaque1>);
 
-    #[diplomat::opaque]
-    #[diplomat::attr(not(supports = iterators), disable)]
-    struct OpaqueIterator<'a>(Box<dyn Iterator<Item = AttrOpaque1> + 'a>);
-
     impl OpaqueIterable {
         #[diplomat::attr(auto, iterable)]
         pub fn iter<'a>(&'a self) -> Box<OpaqueIterator<'a>> {
@@ -136,6 +131,9 @@ pub mod ffi {
         }
     }
 
+    #[diplomat::opaque]
+    #[diplomat::attr(not(supports = iterators), disable)]
+    struct OpaqueIterator<'a>(Box<dyn Iterator<Item = AttrOpaque1> + 'a>);
     impl<'a> OpaqueIterator<'a> {
         #[diplomat::attr(auto, iterator)]
         pub fn next(&'a mut self) -> Option<Box<AttrOpaque1>> {

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -24,8 +24,8 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.accessors = false;
     a.comparators = false; // TODO
     a.stringifiers = false; // TODO
-    a.iterators = false; // TODO
-    a.iterables = false; // TODO
+    a.iterators = true; // TODO
+    a.iterables = true; // TODO
     a.indexing = true;
     a.arithmetic = true;
     a.option = true;

--- a/tool/templates/cpp/method_decl.h.jinja
+++ b/tool/templates/cpp/method_decl.h.jinja
@@ -9,6 +9,8 @@ inline {##}
 	{%- endfor -%}
 )
 {%- for qualifier in m.post_qualifiers %} {{qualifier}}{% endfor %};
+
+{#- Merge this with the match block below when we get '|' support in when blocks -#}
 {%- if auto_define_self_arithmetic -%}
 {%- if let Some(op_str) = m.method_name.strip_prefix("operator") -%}
 {%- if ["+", "-", "*", "/"].contains(op_str) -%}
@@ -17,3 +19,12 @@ inline {##}
 {%- endif -%}
 {%- endif -%}
 {%- endif -%}
+
+{#- Extra method definitions for special types -#}
+{%- match m.method.attrs.special_method -%}
+{%- when Some(hir::SpecialMethod::Iterable) -%}
+{%- let helper_type = m.return_ty.replace("std::unique_ptr", "diplomat::next_to_iter_helper") %}
+  inline {{helper_type}} begin() const;
+  inline std::nullopt_t end() const { return std::nullopt; }
+{%- else -%}
+{%- endmatch -%}

--- a/tool/templates/cpp/method_impl.h.jinja
+++ b/tool/templates/cpp/method_impl.h.jinja
@@ -32,6 +32,8 @@ inline {##}
 	{%- when None %}
 	{%- endmatch %}
 }
+
+{#- Merge this with the match block below when we get '|' support in when blocks -#}
 {%- if auto_define_self_arithmetic -%}
 {%- if let Some(op_str) = m.method_name.strip_prefix("operator") -%}
 {%- if ["+", "-", "*", "/"].contains(op_str) -%}
@@ -43,3 +45,12 @@ inline {{ m.return_ty }}& {{type_name}}::{{m.method_name -}}=({{ param_var.type_
 {%- endif -%}
 {%- endif -%}
 {%- endif -%}
+
+{%- match m.method.attrs.special_method -%}
+{%- when Some(hir::SpecialMethod::Iterable) %}
+{% let helper_type = m.return_ty.replace("std::unique_ptr", "diplomat::next_to_iter_helper") %}
+inline {{helper_type}} {{- type_name }}::begin() const {
+	return iter();
+}
+{%- else -%}
+{%- endmatch -%}

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -7,6 +7,7 @@
 #include <variant>
 #include <cstdint>
 #include <functional>
+#include <memory>
 
 #if __cplusplus >= 202002L
 #include <span>
@@ -158,22 +159,34 @@ template<class T> using span = std::span<T>;
 
 #else // __cplusplus < 202002L
 
-// C++-17-compatible std::span
-template<class T>
+// C++-17-compatible-ish std::span
+template <class T>
 class span {
-
 public:
-  constexpr span(T* data, size_t size)
+  constexpr span(T *data = nullptr, size_t size = 0)
     : data_(data), size_(size) {}
-  template<size_t N>
-  constexpr span(std::array<typename std::remove_const<T>::type, N>& arr)
-    : data_(const_cast<T*>(arr.data())), size_(N) {}
+ 
+  constexpr span(const span<T> &o)
+    : data_(o.data_), size_(o.size_) {}
+  template <size_t N>
+  constexpr span(std::array<typename std::remove_const_t<T>, N> &arr)
+    : data_(const_cast<T *>(arr.data())), size_(N) {}
+
   constexpr T* data() const noexcept {
     return this->data_;
   }
   constexpr size_t size() const noexcept {
     return this->size_;
   }
+
+  constexpr T *begin() const noexcept { return data(); }
+  constexpr T *end() const noexcept { return data() + size(); }
+
+  void operator=(span<T> o) {
+    data_ = o.data_;
+    size_ = o.size_;
+  }
+
 private:
   T* data_;
   size_t size_;
@@ -235,6 +248,54 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
 // additional deduction guide required
 template<class T>
 fn_traits(T) -> fn_traits<T>;
+
+
+// trait to detect if something is std::optional
+template<class T>
+inline constexpr bool is_optional_v = std::false_type{};
+
+template<class T>
+inline constexpr bool is_optional_v<std::optional<T>> = std::true_type{};
+
+// Trait for extracting inner types from either std::optional or std::unique_ptr.
+// These are the two potential types returned by next() functions
+template<typename T> struct inner { using type = void; };
+template<typename T> struct inner<std::unique_ptr<T>> { using type = T; };
+template<typename T> struct inner<std::optional<T>>{ using type = T; };
+
+// Adapter for iterator types
+template<typename T, typename U = void> struct has_next : std::false_type {};
+template<typename T> struct has_next < T, std::void_t<decltype(std::declval<T>().next())>> : std::true_type {};
+template<typename T> constexpr bool has_next_v = has_next<T>::value;
+
+/// Helper template enabling native iteration over unique ptrs to objects which implement next()
+template<typename T>
+struct next_to_iter_helper {
+  static_assert(has_next_v<T>, "next_to_iter_helper may only be used with types implementing next()");
+  using next_type = decltype(std::declval<T>().next());
+
+  // STL Iterator trait definitions
+  using value_type = typename inner<next_type>::type;
+  using difference_type = void;
+  using reference = std::add_lvalue_reference_t<value_type>;
+  using iterator_category = std::input_iterator_tag;
+
+  next_to_iter_helper(std::unique_ptr<T>&& ptr) : _ptr(std::move(ptr)), _curr(_ptr->next()) {}
+  
+  // https://en.cppreference.com/w/cpp/named_req/InputIterator requires that the type be copyable
+  next_to_iter_helper(const next_to_iter_helper& o) : _ptr(o._ptr), _curr(o._curr) {}
+
+  void operator++() { _curr = _ptr->next(); }
+  void operator++(int) { ++(*this); }
+  const value_type& operator*() const { return _curr.value(); }
+
+  bool operator!=(std::nullopt_t) {
+    return _curr.has_value();
+  }
+
+  std::shared_ptr<T> _ptr; // shared to satisfy the copyable requirement
+  next_type _curr;
+};
 
 } // namespace diplomat
 


### PR DESCRIPTION
Adds support for C++ iterators.
This is a bit tricky since STL iterators must have independent dereference & increment operations, must be copy constructable, and must be passed around by-value. 

I achieved this by creating and adapter template which stores the last value retrieved from next() for deref & equality checks, as well as providing the appropriate definitions for the iterator_traits macro to function.

I chose to mark the iterators as input-iterators (IE, you can't go over the iterator more than once) since that's maximally restrictive, and we can relax it later if required.

Also includes 2 minor fixes, one to the span fallback implementation, and another to allow movable but non-copyable functors