### PR TITLE
Add tests for returning optional references to opaques

### DIFF
--- a/feature_tests/c/include/OptionOpaque.h
+++ b/feature_tests/c/include/OptionOpaque.h
@@ -41,6 +41,10 @@ OptionStruct OptionOpaque_new_struct(void);
 
 OptionStruct OptionOpaque_new_struct_nones(void);
 
+const OptionOpaque* OptionOpaque_returns_none_self(const OptionOpaque* self);
+
+const OptionOpaque* OptionOpaque_returns_some_self(const OptionOpaque* self);
+
 void OptionOpaque_assert_integer(const OptionOpaque* self, int32_t i);
 
 bool OptionOpaque_option_opaque_argument(const OptionOpaque* arg);

--- a/feature_tests/cpp/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.d.hpp
@@ -42,6 +42,10 @@ public:
 
   inline static OptionStruct new_struct_nones();
 
+  inline const OptionOpaque* returns_none_self() const;
+
+  inline const OptionOpaque* returns_some_self() const;
+
   inline void assert_integer(int32_t i) const;
 
   inline static bool option_opaque_argument(const OptionOpaque* arg);

--- a/feature_tests/cpp/include/OptionOpaque.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.hpp
@@ -43,6 +43,10 @@ namespace capi {
     
     diplomat::capi::OptionStruct OptionOpaque_new_struct_nones(void);
     
+    const diplomat::capi::OptionOpaque* OptionOpaque_returns_none_self(const diplomat::capi::OptionOpaque* self);
+    
+    const diplomat::capi::OptionOpaque* OptionOpaque_returns_some_self(const diplomat::capi::OptionOpaque* self);
+    
     void OptionOpaque_assert_integer(const diplomat::capi::OptionOpaque* self, int32_t i);
     
     bool OptionOpaque_option_opaque_argument(const diplomat::capi::OptionOpaque* arg);
@@ -114,6 +118,16 @@ inline OptionStruct OptionOpaque::new_struct() {
 inline OptionStruct OptionOpaque::new_struct_nones() {
   auto result = diplomat::capi::OptionOpaque_new_struct_nones();
   return OptionStruct::FromFFI(result);
+}
+
+inline const OptionOpaque* OptionOpaque::returns_none_self() const {
+  auto result = diplomat::capi::OptionOpaque_returns_none_self(this->AsFFI());
+  return result ? { *OptionOpaque::FromFFI(result) } : std::nullopt;
+}
+
+inline const OptionOpaque* OptionOpaque::returns_some_self() const {
+  auto result = diplomat::capi::OptionOpaque_returns_some_self(this->AsFFI());
+  return result ? { *OptionOpaque::FromFFI(result) } : std::nullopt;
 }
 
 inline void OptionOpaque::assert_integer(int32_t i) const {

--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -82,6 +82,20 @@ final class OptionOpaque implements ffi.Finalizable {
     return OptionStruct._fromFfi(result);
   }
 
+  OptionOpaque? returnsNoneSelf() {
+    // This lifetime edge depends on lifetimes: 'a
+    core.List<Object> aEdges = [this];
+    final result = _OptionOpaque_returns_none_self(_ffi);
+    return result.address == 0 ? null : OptionOpaque._fromFfi(result, aEdges);
+  }
+
+  OptionOpaque? returnsSomeSelf() {
+    // This lifetime edge depends on lifetimes: 'a
+    core.List<Object> aEdges = [this];
+    final result = _OptionOpaque_returns_some_self(_ffi);
+    return result.address == 0 ? null : OptionOpaque._fromFfi(result, aEdges);
+  }
+
   void assertInteger(int i) {
     _OptionOpaque_assert_integer(_ffi, i);
   }
@@ -171,6 +185,16 @@ external _OptionStructFfi _OptionOpaque_new_struct();
 @ffi.Native<_OptionStructFfi Function()>(isLeaf: true, symbol: 'OptionOpaque_new_struct_nones')
 // ignore: non_constant_identifier_names
 external _OptionStructFfi _OptionOpaque_new_struct_nones();
+
+@_DiplomatFfiUse('OptionOpaque_returns_none_self')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_returns_none_self')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _OptionOpaque_returns_none_self(ffi.Pointer<ffi.Opaque> self);
+
+@_DiplomatFfiUse('OptionOpaque_returns_some_self')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OptionOpaque_returns_some_self')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _OptionOpaque_returns_some_self(ffi.Pointer<ffi.Opaque> self);
 
 @_DiplomatFfiUse('OptionOpaque_assert_integer')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'OptionOpaque_assert_integer')

--- a/feature_tests/js/api/OptionOpaque.d.ts
+++ b/feature_tests/js/api/OptionOpaque.d.ts
@@ -18,6 +18,8 @@ optionI32(): number | null;
 optionU32(): number | null;
 static newStruct(): OptionStruct;
 static newStructNones(): OptionStruct;
+returnsNoneSelf(): OptionOpaque | null;
+returnsSomeSelf(): OptionOpaque | null;
 assertInteger(i: number): void;
 static optionOpaqueArgument(arg: OptionOpaque | null): boolean;
 static acceptsOptionU8(arg: number | null, sentinel: number): number | null;

--- a/feature_tests/js/api/OptionOpaque.mjs
+++ b/feature_tests/js/api/OptionOpaque.mjs
@@ -161,6 +161,30 @@ static newStructNones() {
             diplomatReceive.free();
         }
     }
+returnsNoneSelf() {
+        // This lifetime edge depends on lifetimes 'a
+        let aEdges = [this];
+        
+        const result = wasm.OptionOpaque_returns_none_self(this.ffiValue);
+    
+        try {
+            return result === 0 ? null : new OptionOpaque(diplomatRuntime.internalConstructor, result, aEdges);
+        }
+        
+        finally {}
+    }
+returnsSomeSelf() {
+        // This lifetime edge depends on lifetimes 'a
+        let aEdges = [this];
+        
+        const result = wasm.OptionOpaque_returns_some_self(this.ffiValue);
+    
+        try {
+            return result === 0 ? null : new OptionOpaque(diplomatRuntime.internalConstructor, result, aEdges);
+        }
+        
+        finally {}
+    }
 assertInteger(i) {wasm.OptionOpaque_assert_integer(this.ffiValue, i);
     
         try {}

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
@@ -17,6 +17,8 @@ internal interface OptionOpaqueLib: Library {
     fun OptionOpaque_option_u32(handle: Pointer): OptionFFIUint32
     fun OptionOpaque_new_struct(): OptionStructNative
     fun OptionOpaque_new_struct_nones(): OptionStructNative
+    fun OptionOpaque_returns_none_self(handle: Pointer): Pointer?
+    fun OptionOpaque_returns_some_self(handle: Pointer): Pointer?
     fun OptionOpaque_assert_integer(handle: Pointer, i: Int): Unit
     fun OptionOpaque_option_opaque_argument(arg: Pointer?): Byte
 }
@@ -114,6 +116,24 @@ class OptionOpaque internal constructor (
         
         val returnVal = lib.OptionOpaque_option_u32(handle);
         return returnVal.option()?.toUInt()
+    }
+    
+    fun returnsNoneSelf(): OptionOpaque? {
+        
+        val returnVal = lib.OptionOpaque_returns_none_self(handle);
+        val selfEdges: List<Any> = listOf(this)
+        val handle = returnVal ?: return null
+        val returnOpaque = OptionOpaque(handle, selfEdges)
+        return returnOpaque
+    }
+    
+    fun returnsSomeSelf(): OptionOpaque? {
+        
+        val returnVal = lib.OptionOpaque_returns_some_self(handle);
+        val selfEdges: List<Any> = listOf(this)
+        val handle = returnVal ?: return null
+        val returnOpaque = OptionOpaque(handle, selfEdges)
+        return returnOpaque
     }
     
     fun assertInteger(i: Int): Unit {

--- a/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
@@ -42,6 +42,10 @@ public:
 
   inline static OptionStruct new_struct_nones();
 
+  inline const OptionOpaque* returns_none_self() const;
+
+  inline const OptionOpaque* returns_some_self() const;
+
   inline void assert_integer(int32_t i) const;
 
   inline static bool option_opaque_argument(const OptionOpaque* arg);

--- a/feature_tests/nanobind/src/include/OptionOpaque.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.hpp
@@ -43,6 +43,10 @@ namespace capi {
     
     diplomat::capi::OptionStruct OptionOpaque_new_struct_nones(void);
     
+    const diplomat::capi::OptionOpaque* OptionOpaque_returns_none_self(const diplomat::capi::OptionOpaque* self);
+    
+    const diplomat::capi::OptionOpaque* OptionOpaque_returns_some_self(const diplomat::capi::OptionOpaque* self);
+    
     void OptionOpaque_assert_integer(const diplomat::capi::OptionOpaque* self, int32_t i);
     
     bool OptionOpaque_option_opaque_argument(const diplomat::capi::OptionOpaque* arg);
@@ -114,6 +118,16 @@ inline OptionStruct OptionOpaque::new_struct() {
 inline OptionStruct OptionOpaque::new_struct_nones() {
   auto result = diplomat::capi::OptionOpaque_new_struct_nones();
   return OptionStruct::FromFFI(result);
+}
+
+inline const OptionOpaque* OptionOpaque::returns_none_self() const {
+  auto result = diplomat::capi::OptionOpaque_returns_none_self(this->AsFFI());
+  return result ? { *OptionOpaque::FromFFI(result) } : std::nullopt;
+}
+
+inline const OptionOpaque* OptionOpaque::returns_some_self() const {
+  auto result = diplomat::capi::OptionOpaque_returns_some_self(this->AsFFI());
+  return result ? { *OptionOpaque::FromFFI(result) } : std::nullopt;
 }
 
 inline void OptionOpaque::assert_integer(int32_t i) const {

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -588,7 +588,9 @@ NB_MODULE(somelib, somelib_mod)
     	.def("option_u32", &OptionOpaque::option_u32)
     	.def("option_usize", &OptionOpaque::option_usize)
     	.def_static("returns", &OptionOpaque::returns)
-    	.def_static("returns_option_input_struct", &OptionOpaque::returns_option_input_struct);
+    	.def("returns_none_self", &OptionOpaque::returns_none_self)
+    	.def_static("returns_option_input_struct", &OptionOpaque::returns_option_input_struct)
+    	.def("returns_some_self", &OptionOpaque::returns_some_self);
     
     PyType_Slot OptionOpaqueChar_slots[] = {
         {Py_tp_free, (void *)OptionOpaqueChar::operator delete },

--- a/feature_tests/src/option.rs
+++ b/feature_tests/src/option.rs
@@ -114,6 +114,14 @@ pub mod ffi {
             }
         }
 
+        pub fn returns_none_self<'a>(&'a self) -> Option<&'a OptionOpaque> {
+            None
+        }
+
+        pub fn returns_some_self<'a>(&'a self) -> Option<&'a OptionOpaque> {
+            Some(self)
+        }
+
         pub fn assert_integer(&self, i: i32) {
             assert_eq!(i, self.0);
         }


### PR DESCRIPTION
Surprised we don't test this yet, it's subtle behavior for C++