### PR TITLE
Add Lifetimes to DiplomatSlice types

### DIFF
--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-10.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-10.snap
@@ -1,0 +1,10 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from_syn(&syn::parse_quote! { DiplomatSliceStr<'a> }, None)"
+---
+Named:
+  path:
+    elements:
+      - DiplomatSliceStr
+  lifetimes:
+    - Named: a

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-11.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-11.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from_syn(&syn::parse_quote! { DiplomatSliceMut<'a, f32> }, None)"
+---
+PrimitiveSlice:
+  - - Named: a
+    - Mutable
+  - f32
+  - Diplomat

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-12.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-12.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from_syn(&syn::parse_quote! { DiplomatSlice<i32> }, None)"
+---
+PrimitiveSlice:
+  - - Anonymous
+    - Immutable
+  - i32
+  - Diplomat

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-8.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-8.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from_syn(&syn::parse_quote! { DiplomatSlice<'a, u16> }, None)"
+---
+PrimitiveSlice:
+  - - Named: a
+    - Immutable
+  - u16
+  - Diplomat

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-9.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-9.snap
@@ -1,9 +1,8 @@
 ---
 source: core/src/ast/types.rs
-expression: "TypeName::from_syn(&syn::parse_quote! { DiplomatOwnedSlice<'a, i8> }, None)"
+expression: "TypeName::from_syn(&syn::parse_quote! { DiplomatOwnedSlice<i8> }, None)"
 ---
 PrimitiveSlice:
-  - - Named: a
-    - Mutable
+  - ~
   - i8
   - Diplomat

--- a/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-9.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__types__tests__lifetimes-9.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/types.rs
+expression: "TypeName::from_syn(&syn::parse_quote! { DiplomatOwnedSlice<'a, i8> }, None)"
+---
+PrimitiveSlice:
+  - - Named: a
+    - Mutable
+  - i8
+  - Diplomat

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -898,13 +898,16 @@ impl TypeName {
                     || is_runtime_type(p, "DiplomatSliceMut")
                     || is_runtime_type(p, "DiplomatOwnedSlice")
                 {
-                    let lt = get_lifetime_from_syn_path(p);
-                    let ltmut = if is_runtime_type(p, "DiplomatSliceMut")
-                        || is_runtime_type(p, "DiplomatOwnedSlice")
-                    {
-                        Some((lt, Mutability::Mutable))
+                    let ltmut = if is_runtime_type(p, "DiplomatOwnedSlice") {
+                        None
                     } else {
-                        Some((lt, Mutability::Immutable))
+                        let lt = get_lifetime_from_syn_path(p);
+                        let mutability = if is_runtime_type(p, "DiplomatSlice") {
+                            Mutability::Immutable
+                        } else {
+                            Mutability::Mutable
+                        };
+                        Some((lt, mutability))
                     };
 
                     let ty = get_ty_from_syn_path(p).expect("Expected type argument to DiplomatSlice/DiplomatSliceMut/DiplomatOwnedSlice");
@@ -1669,7 +1672,7 @@ mod tests {
 
         insta::assert_yaml_snapshot!(TypeName::from_syn(
             &syn::parse_quote! {
-                DiplomatOwnedSlice<'a, i8>
+                DiplomatOwnedSlice<i8>
             },
             None
         ));

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -899,7 +899,9 @@ impl TypeName {
                     || is_runtime_type(p, "DiplomatOwnedSlice")
                 {
                     let lt = get_lifetime_from_syn_path(p);
-                    let ltmut = if is_runtime_type(p, "DiplomatSliceMut") || is_runtime_type(p, "DiplomatOwnedSlice") {
+                    let ltmut = if is_runtime_type(p, "DiplomatSliceMut")
+                        || is_runtime_type(p, "DiplomatOwnedSlice")
+                    {
                         Some((lt, Mutability::Mutable))
                     } else {
                         Some((lt, Mutability::Immutable))
@@ -1678,7 +1680,7 @@ mod tests {
             },
             None
         ));
-        
+
         insta::assert_yaml_snapshot!(TypeName::from_syn(
             &syn::parse_quote! {
                 DiplomatSliceMut<'a, f32>

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -898,7 +898,7 @@ impl TypeName {
                     || is_runtime_type(p, "DiplomatSliceMut")
                     || is_runtime_type(p, "DiplomatOwnedSlice")
                 {
-                    let ltmut = if is_runtime_type(p, "DiplomatSlice") {
+                    let ltmut = if is_runtime_type(p, "DiplomatSlice") || is_runtime_type(p, "DiplomatOwnedSlice") {
                         let mutability = if is_runtime_type(p, "DiplomatOwnedSlice") {
                             Mutability::Mutable
                         } else {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -898,16 +898,11 @@ impl TypeName {
                     || is_runtime_type(p, "DiplomatSliceMut")
                     || is_runtime_type(p, "DiplomatOwnedSlice")
                 {
-                    let ltmut = if is_runtime_type(p, "DiplomatSlice") || is_runtime_type(p, "DiplomatOwnedSlice") {
-                        let mutability = if is_runtime_type(p, "DiplomatOwnedSlice") {
-                            Mutability::Mutable
-                        } else {
-                            Mutability::Immutable
-                        };
-                        let lt = get_lifetime_from_syn_path(p);
-                        Some((lt, mutability))
+                    let lt = get_lifetime_from_syn_path(p);
+                    let ltmut = if is_runtime_type(p, "DiplomatSliceMut") || is_runtime_type(p, "DiplomatOwnedSlice") {
+                        Some((lt, Mutability::Mutable))
                     } else {
-                        None
+                        Some((lt, Mutability::Immutable))
                     };
 
                     let ty = get_ty_from_syn_path(p).expect("Expected type argument to DiplomatSlice/DiplomatSliceMut/DiplomatOwnedSlice");
@@ -1669,6 +1664,7 @@ mod tests {
             },
             None
         ));
+
         insta::assert_yaml_snapshot!(TypeName::from_syn(
             &syn::parse_quote! {
                 DiplomatOwnedSlice<'a, i8>
@@ -1679,6 +1675,20 @@ mod tests {
         insta::assert_yaml_snapshot!(TypeName::from_syn(
             &syn::parse_quote! {
                 DiplomatSliceStr<'a>
+            },
+            None
+        ));
+        
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                DiplomatSliceMut<'a, f32>
+            },
+            None
+        ));
+
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                DiplomatSlice<i32>
             },
             None
         ));

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1662,5 +1662,25 @@ mod tests {
             },
             None
         ));
+
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                DiplomatSlice<'a, u16>
+            },
+            None
+        ));
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                DiplomatOwnedSlice<'a, i8>
+            },
+            None
+        ));
+
+        insta::assert_yaml_snapshot!(TypeName::from_syn(
+            &syn::parse_quote! {
+                DiplomatSliceStr<'a>
+            },
+            None
+        ));
     }
 }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -898,11 +898,11 @@ impl TypeName {
                     || is_runtime_type(p, "DiplomatSliceMut")
                     || is_runtime_type(p, "DiplomatOwnedSlice")
                 {
-                    let ltmut = if is_runtime_type(p, "DiplomatOwnedSlice") {
-                        let mutability = if is_runtime_type(p, "DiplomatSlice") {
-                            Mutability::Immutable
-                        } else {
+                    let ltmut = if is_runtime_type(p, "DiplomatSlice") {
+                        let mutability = if is_runtime_type(p, "DiplomatOwnedSlice") {
                             Mutability::Mutable
+                        } else {
+                            Mutability::Immutable
                         };
                         let lt = get_lifetime_from_syn_path(p);
                         Some((lt, mutability))

--- a/macro/src/snapshots/diplomat__tests__slices.snap
+++ b/macro/src/snapshots/diplomat__tests__slices.snap
@@ -134,12 +134,12 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Foo_boxes_runtime_types(
-        a: diplomat_runtime::DiplomatSliceMut<u8>,
-        b: diplomat_runtime::DiplomatSliceMut<u16>,
+        a: diplomat_runtime::DiplomatOwnedSlice<u8>,
+        b: diplomat_runtime::DiplomatOwnedSlice<u16>,
         c: diplomat_runtime::DiplomatOwnedUTF8StrSlice,
         d: diplomat_runtime::DiplomatOwnedStrSlice,
         e: diplomat_runtime::DiplomatOwnedStr16Slice,
-        f: diplomat_runtime::DiplomatSliceMut<DiplomatByte>,
+        f: diplomat_runtime::DiplomatOwnedSlice<DiplomatByte>,
     ) -> Foo {
         Foo::boxes_runtime_types(a, b, c, d, e, f)
     }

--- a/macro/src/snapshots/diplomat__tests__slices.snap
+++ b/macro/src/snapshots/diplomat__tests__slices.snap
@@ -106,12 +106,12 @@ mod ffi {
     }
     #[no_mangle]
     extern "C" fn Foo_make_runtime_types(
-        a: diplomat_runtime::DiplomatOwnedSlice<u8>,
-        b: diplomat_runtime::DiplomatOwnedSlice<u16>,
+        a: diplomat_runtime::DiplomatSlice<'a, u8>,
+        b: diplomat_runtime::DiplomatSlice<'a, u16>,
         c: diplomat_runtime::DiplomatUtf8StrSlice<'a>,
         d: diplomat_runtime::DiplomatStrSlice<'a>,
         e: diplomat_runtime::DiplomatStr16Slice<'a>,
-        f: diplomat_runtime::DiplomatOwnedSlice<DiplomatByte>,
+        f: diplomat_runtime::DiplomatSlice<'a, DiplomatByte>,
     ) -> Foo {
         Foo::make_runtime_types(a, b, c, d, e, f)
     }

--- a/tool/src/js/gen.rs
+++ b/tool/src/js/gen.rs
@@ -282,7 +282,8 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
                             format!("diplomatRuntime.CleanupArena.maybeCreateWith(functionCleanupArena, ...appendArrayMap['{lt_name}AppendArray'])")
                         )
                     } else {
-                        None
+                        // If there is no lifetime, this is owned, so we can clean up this field as soon as we're done passing the struct into WASM.
+                        Some("functionCleanupArena".into())
                     }
                 },
                 hir::Type::Struct(..) => Some("functionCleanupArena".into()),


### PR DESCRIPTION
We return `Some` only for `DiplomatOwnedSlice` lifetimes, when in fact:
- `DiplomatSlice` and `DiplomatSliceMut` should have lifetimes, and
- `DiplomatOwnedSlice` should not have a lifetime, as it is owned.

This fixes that