### PR TITLE
Add lifetime checking to python

### DIFF
--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -24,12 +24,14 @@ impl Struct {
             .fields
             .iter()
             .map(|field| {
+                use quote::ToTokens;
                 // Non-opaque tuple structs will never be allowed
-                let name = field
-                    .ident
-                    .as_ref()
-                    .map(Into::into)
-                    .expect("non-opaque tuples structs are disallowed");
+                let name = field.ident.as_ref().map(Into::into).unwrap_or_else(|| {
+                    panic!(
+                        "non-opaque tuples structs are disallowed ({:?})",
+                        field.ty.to_token_stream().to_string()
+                    )
+                });
                 let type_name = TypeName::from_syn(&field.ty, Some(self_path_type.clone()));
                 let docs = Docs::from_attrs(&field.attrs);
 

--- a/feature_tests/nanobind/pyproject.toml
+++ b/feature_tests/nanobind/pyproject.toml
@@ -23,3 +23,6 @@ build-dir = "build/{wheel_tag}"
 wheel.py-api = "cp312"
 
 cmake.build-type = "Debug"
+
+[tool.scikit-build.cmake.define]
+CMAKE_BUILD_PARALLEL_LEVEL = 4

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -333,7 +333,7 @@ NB_MODULE(somelib, somelib_mod)
         .def_rw("a", &BorrowedFields::a)
         .def_rw("b", &BorrowedFields::b)
         .def_rw("c", &BorrowedFields::c)
-    	.def_static("from_bar_and_strings", &BorrowedFields::from_bar_and_strings, "bar"_a, "dstr16"_a, "utf8_str"_a);
+    	.def_static("from_bar_and_strings", &BorrowedFields::from_bar_and_strings, "bar"_a, "dstr16"_a, "utf8_str"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), nb::keep_alive<0, 3>());
     
     nb::class_<BorrowedFieldsReturning>(somelib_mod, "BorrowedFieldsReturning")
         .def(nb::init<>())
@@ -346,7 +346,7 @@ NB_MODULE(somelib, somelib_mod)
         .def_rw("field_a", &BorrowedFieldsWithBounds::field_a)
         .def_rw("field_b", &BorrowedFieldsWithBounds::field_b)
         .def_rw("field_c", &BorrowedFieldsWithBounds::field_c)
-    	.def_static("from_foo_and_strings", &BorrowedFieldsWithBounds::from_foo_and_strings, "foo"_a, "dstr16_x"_a, "utf8_str_z"_a);
+    	.def_static("from_foo_and_strings", &BorrowedFieldsWithBounds::from_foo_and_strings, "foo"_a, "dstr16_x"_a, "utf8_str_z"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), nb::keep_alive<0, 3>());
     
     nb::class_<NestedBorrowedFields>(somelib_mod, "NestedBorrowedFields")
         .def(nb::init<>())
@@ -354,7 +354,7 @@ NB_MODULE(somelib, somelib_mod)
         .def_rw("fields", &NestedBorrowedFields::fields)
         .def_rw("bounds", &NestedBorrowedFields::bounds)
         .def_rw("bounds2", &NestedBorrowedFields::bounds2)
-    	.def_static("from_bar_and_foo_and_strings", &NestedBorrowedFields::from_bar_and_foo_and_strings, "bar"_a, "foo"_a, "dstr16_x"_a, "dstr16_z"_a, "utf8_str_y"_a, "utf8_str_z"_a);
+    	.def_static("from_bar_and_foo_and_strings", &NestedBorrowedFields::from_bar_and_foo_and_strings, "bar"_a, "foo"_a, "dstr16_x"_a, "dstr16_z"_a, "utf8_str_y"_a, "utf8_str_z"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), nb::keep_alive<0, 3>(), nb::keep_alive<0, 4>(), nb::keep_alive<0, 5>(), nb::keep_alive<0, 6>());
     
     nb::class_<OptionInputStruct>(somelib_mod, "OptionInputStruct")
         .def(nb::init<>())
@@ -465,7 +465,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<ns::RenamedMyIndexer>(ns_mod, "RenamedMyIndexer", nb::type_slots(ns_RenamedMyIndexer_slots))
-    	.def("__getitem__", &ns::RenamedMyIndexer::operator[], "i"_a);
+    	.def("__getitem__", &ns::RenamedMyIndexer::operator[], "i"_a, nb::keep_alive<0, 1>());
     
     PyType_Slot ns_RenamedMyIterable_slots[] = {
         {Py_tp_free, (void *)ns::RenamedMyIterable::operator delete },
@@ -572,11 +572,11 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<Foo>(somelib_mod, "Foo", nb::type_slots(Foo_slots))
-    	.def("as_returning", &Foo::as_returning)
+    	.def("as_returning", &Foo::as_returning, nb::keep_alive<0, 1>())
     	.def_prop_ro("bar", &Foo::get_bar)
-    	.def_static("extract_from_bounds", &Foo::extract_from_bounds, "bounds"_a, "another_string"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("extract_from_fields", &Foo::extract_from_fields, "fields"_a ) // unsupported special method NamedConstructor(None)
-    	.def(nb::new_(&Foo::new_), "x"_a)
+    	.def_static("extract_from_bounds", &Foo::extract_from_bounds, "bounds"_a, "another_string"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("extract_from_fields", &Foo::extract_from_fields, "fields"_a, nb::keep_alive<0, 1>() ) // unsupported special method NamedConstructor(None)
+    	.def(nb::new_(&Foo::new_), "x"_a, nb::keep_alive<1, 2>())
     	.def_static("new_static", &Foo::new_static, "x"_a ) // unsupported special method NamedConstructor(Some("static"))
     ;
     
@@ -586,17 +586,17 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<One>(somelib_mod, "One", nb::type_slots(One_slots))
-    	.def_static("cycle", &One::cycle, "hold"_a, "nohold"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("diamond_and_nested_types", &One::diamond_and_nested_types, "a"_a, "b"_a, "c"_a, "d"_a, "nohold"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("diamond_bottom", &One::diamond_bottom, "top"_a, "left"_a, "right"_a, "bottom"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("diamond_left", &One::diamond_left, "top"_a, "left"_a, "right"_a, "bottom"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("diamond_right", &One::diamond_right, "top"_a, "left"_a, "right"_a, "bottom"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("diamond_top", &One::diamond_top, "top"_a, "left"_a, "right"_a, "bottom"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("implicit_bounds", &One::implicit_bounds, "explicit_hold"_a, "implicit_hold"_a, "nohold"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("implicit_bounds_deep", &One::implicit_bounds_deep, "explicit_"_a, "implicit_1"_a, "implicit_2"_a, "nohold"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("many_dependents", &One::many_dependents, "a"_a, "b"_a, "c"_a, "d"_a, "nohold"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("return_outlives_param", &One::return_outlives_param, "hold"_a, "nohold"_a ) // unsupported special method NamedConstructor(None)
-    	.def_static("transitivity", &One::transitivity, "hold"_a, "nohold"_a ) // unsupported special method NamedConstructor(None)
+    	.def_static("cycle", &One::cycle, "hold"_a, "nohold"_a, nb::keep_alive<0, 1>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("diamond_and_nested_types", &One::diamond_and_nested_types, "a"_a, "b"_a, "c"_a, "d"_a, "nohold"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), nb::keep_alive<0, 3>(), nb::keep_alive<0, 4>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("diamond_bottom", &One::diamond_bottom, "top"_a, "left"_a, "right"_a, "bottom"_a, nb::keep_alive<0, 4>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("diamond_left", &One::diamond_left, "top"_a, "left"_a, "right"_a, "bottom"_a, nb::keep_alive<0, 2>(), nb::keep_alive<0, 4>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("diamond_right", &One::diamond_right, "top"_a, "left"_a, "right"_a, "bottom"_a, nb::keep_alive<0, 3>(), nb::keep_alive<0, 4>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("diamond_top", &One::diamond_top, "top"_a, "left"_a, "right"_a, "bottom"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), nb::keep_alive<0, 3>(), nb::keep_alive<0, 4>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("implicit_bounds", &One::implicit_bounds, "explicit_hold"_a, "implicit_hold"_a, "nohold"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("implicit_bounds_deep", &One::implicit_bounds_deep, "explicit_"_a, "implicit_1"_a, "implicit_2"_a, "nohold"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), nb::keep_alive<0, 3>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("many_dependents", &One::many_dependents, "a"_a, "b"_a, "c"_a, "d"_a, "nohold"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), nb::keep_alive<0, 3>(), nb::keep_alive<0, 4>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("return_outlives_param", &One::return_outlives_param, "hold"_a, "nohold"_a, nb::keep_alive<0, 1>() ) // unsupported special method NamedConstructor(None)
+    	.def_static("transitivity", &One::transitivity, "hold"_a, "nohold"_a, nb::keep_alive<0, 1>() ) // unsupported special method NamedConstructor(None)
     ;
     
     PyType_Slot Two_slots[] = {
@@ -629,9 +629,9 @@ NB_MODULE(somelib, somelib_mod)
     	.def("option_u32", &OptionOpaque::option_u32)
     	.def("option_usize", &OptionOpaque::option_usize)
     	.def_static("returns", &OptionOpaque::returns)
-    	.def("returns_none_self", &OptionOpaque::returns_none_self)
+    	.def("returns_none_self", &OptionOpaque::returns_none_self, nb::keep_alive<0, 1>())
     	.def_static("returns_option_input_struct", &OptionOpaque::returns_option_input_struct)
-    	.def("returns_some_self", &OptionOpaque::returns_some_self);
+    	.def("returns_some_self", &OptionOpaque::returns_some_self, nb::keep_alive<0, 1>());
     
     PyType_Slot OptionOpaqueChar_slots[] = {
         {Py_tp_free, (void *)OptionOpaqueChar::operator delete },
@@ -647,7 +647,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<OptionString>(somelib_mod, "OptionString", nb::type_slots(OptionString_slots))
-    	.def("borrow", &OptionString::borrow)
+    	.def("borrow", &OptionString::borrow, nb::keep_alive<0, 1>())
     	.def_static("new", &OptionString::new_, "diplomat_str"_a)
     	.def("write", &OptionString::write);
     
@@ -666,7 +666,7 @@ NB_MODULE(somelib, somelib_mod)
     	.def_static("new_in_enum_err", &ResultOpaque::new_in_enum_err, "i"_a)
     	.def_static("new_in_err", &ResultOpaque::new_in_err, "i"_a)
     	.def_static("new_int", &ResultOpaque::new_int, "i"_a)
-    	.def("takes_str", &ResultOpaque::takes_str, "_v"_a);
+    	.def("takes_str", &ResultOpaque::takes_str, "_v"_a, nb::keep_alive<0, 1>());
     
     PyType_Slot RefList_slots[] = {
         {Py_tp_free, (void *)RefList::operator delete },
@@ -674,7 +674,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<RefList>(somelib_mod, "RefList", nb::type_slots(RefList_slots))
-    	.def_static("node", &RefList::node, "data"_a ) // unsupported special method NamedConstructor(None)
+    	.def_static("node", &RefList::node, "data"_a, nb::keep_alive<0, 1>() ) // unsupported special method NamedConstructor(None)
     ;
     
     PyType_Slot RefListParameter_slots[] = {
@@ -691,7 +691,7 @@ NB_MODULE(somelib, somelib_mod)
     
     nb::class_<Float64Vec>(somelib_mod, "Float64Vec", nb::type_slots(Float64Vec_slots))
     	.def_prop_ro("asSlice", &Float64Vec::as_slice)
-    	.def("borrow", &Float64Vec::borrow)
+    	.def("borrow", &Float64Vec::borrow, nb::keep_alive<0, 1>())
     	.def("fill_slice", &Float64Vec::fill_slice, "v"_a)
     	.def("__getitem__", &Float64Vec::operator[], "i"_a)
     	.def_static("new", &Float64Vec::new_, "v"_a)
@@ -710,7 +710,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<MyString>(somelib_mod, "MyString", nb::type_slots(MyString_slots))
-    	.def("borrow", &MyString::borrow)
+    	.def("borrow", &MyString::borrow, nb::keep_alive<0, 1>())
     	.def_static("get_static_str", &MyString::get_static_str)
     	.def(nb::new_(&MyString::new_), "v"_a)
     	.def_static("new_from_first", &MyString::new_from_first, "v"_a)
@@ -749,11 +749,11 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<OpaqueMutexedString>(somelib_mod, "OpaqueMutexedString", nb::type_slots(OpaqueMutexedString_slots))
-    	.def("borrow", &OpaqueMutexedString::borrow)
-    	.def_static("borrow_other", &OpaqueMutexedString::borrow_other, "other"_a)
-    	.def("borrow_self_or_other", &OpaqueMutexedString::borrow_self_or_other, "other"_a)
+    	.def("borrow", &OpaqueMutexedString::borrow, nb::keep_alive<0, 1>())
+    	.def_static("borrow_other", &OpaqueMutexedString::borrow_other, "other"_a, nb::keep_alive<0, 1>())
+    	.def("borrow_self_or_other", &OpaqueMutexedString::borrow_self_or_other, "other"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>())
     	.def("change", &OpaqueMutexedString::change, "number"_a)
-    	.def("dummy_str", &OpaqueMutexedString::dummy_str)
+    	.def("dummy_str", &OpaqueMutexedString::dummy_str, nb::keep_alive<0, 1>())
     	.def_static("from_usize", &OpaqueMutexedString::from_usize, "number"_a)
     	.def("get_len_and_add", &OpaqueMutexedString::get_len_and_add, "other"_a)
     	.def("to_unsigned_from_unsigned", &OpaqueMutexedString::to_unsigned_from_unsigned, "input"_a)
@@ -765,7 +765,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<Utf16Wrap>(somelib_mod, "Utf16Wrap", nb::type_slots(Utf16Wrap_slots))
-    	.def("borrow_cont", &Utf16Wrap::borrow_cont)
+    	.def("borrow_cont", &Utf16Wrap::borrow_cont, nb::keep_alive<0, 1>())
     	.def(nb::new_(&Utf16Wrap::from_utf16), "input"_a)
     	.def("get_debug_str", &Utf16Wrap::get_debug_str);
     {

--- a/feature_tests/nanobind/test/test_lifetimes.py
+++ b/feature_tests/nanobind/test/test_lifetimes.py
@@ -1,0 +1,12 @@
+import somelib
+import gc
+
+def test_lifetimes():
+    retained_string = "bananna"
+    retained_string = retained_string.replace('b', 'f') # modification prevents static storage
+    a = somelib.Foo(retained_string)
+    retained_string = "bobanna"
+    
+    gc.collect()
+
+    assert a.as_returning().bytes == "fananna"

--- a/tool/src/nanobind/ty.rs
+++ b/tool/src/nanobind/ty.rs
@@ -28,6 +28,9 @@ struct MethodInfo<'a> {
     setter_name: Option<Cow<'a, str>>,
     // In the *rare* event that they're required, the C++ names & types of the function params
     param_decls: Option<Vec<NamedType<'a>>>,
+    // The lifetime annotation required for the method, if any. May be keep_alive<...> or reference_internal
+    // Everything else is handled by the automatic behavior depending on return type.
+    lifetime_args: Option<Cow<'a, str>>,
 }
 
 /// Context for generating a particular type's impl
@@ -310,6 +313,47 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
             }
         };
 
+        let mut visitor = method.borrowing_param_visitor(self.c2.tcx);
+
+        // Collect all the relevant borrowed params, with self in position 1 if present
+        let mut param_borrows = method
+            .param_self
+            .iter()
+            .map(|s| visitor.visit_param(&s.ty.clone().into(), "self"))
+            .collect::<Vec<_>>();
+        // Must be a separate call *after* collect to avoid double-borrowing visitor
+        param_borrows.extend(
+            method
+                .params
+                .iter()
+                .map(|p| visitor.visit_param(&p.ty, p.name.as_str())),
+        );
+
+        let self_number = if matches!(
+            method.attrs.special_method,
+            Some(hir::SpecialMethod::Constructor)
+        ) {
+            1 // per the docs, constructors don't have "returns", they act on "self"
+        } else {
+            0
+        };
+
+        let lifetime_args = param_borrows
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, p)| match p {
+                hir::borrowing_param::ParamBorrowInfo::BorrowedSlice
+                | hir::borrowing_param::ParamBorrowInfo::Struct(_)
+                | hir::borrowing_param::ParamBorrowInfo::BorrowedOpaque => {
+                    Some(format!(
+                        "nb::keep_alive<{self_number}, {}>()",
+                        i + 1 + self_number
+                    )) // Keep 0 (the return) alive until the element at P is returned
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
         Some(MethodInfo {
             method,
             method_name,
@@ -318,6 +362,11 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
             setter_name,
             prop_name,
             param_decls,
+            lifetime_args: if lifetime_args.is_empty() {
+                None
+            } else {
+                Some(lifetime_args.join(", ").into())
+            },
         })
     }
 

--- a/tool/templates/nanobind/method_params.cpp.jinja
+++ b/tool/templates/nanobind/method_params.cpp.jinja
@@ -10,3 +10,6 @@
 	{%- else -%}
 	{%- endmatch -%}
 {%- endfor -%}
+{%- if let Some(lifetime_args) = m.lifetime_args -%} 
+	, {{lifetime_args}}
+{%- endif -%}


### PR DESCRIPTION
Uses the 'keep_alive' notation to keep any objects used in the construction of an output alive until the output object is destroyed.

Previously I'd been relying on nanobind intelligently managing things based on return type, however this handles more complex cases like storing borrowed strings & struct fields.