### PR TITLE
Add all C, C++ and Python keywords to the formatter exclusion list

### DIFF
--- a/tool/src/c/formatter.rs
+++ b/tool/src/c/formatter.rs
@@ -284,13 +284,38 @@ impl<'tcx> CFormatter<'tcx> {
     }
 
     pub(crate) fn fmt_identifier<'a>(&self, name: Cow<'a, str>) -> Cow<'a, str> {
-        // TODO(#60): handle other keywords
+        // Source: https://en.cppreference.com/w/c/keyword
+        #[rustfmt::skip]
         static C_KEYWORDS: LazyLock<std::collections::HashSet<&str>> =
-            LazyLock::new(|| ["const", "break", "switch"].into());
+            LazyLock::new(|| [
+                "alignas", "alignof", "auto", "bool", "break", "case", "char", "const", "constexpr", "continue",
+                "default", "do", "double", "else", "enum", "extern", "false", "float", "for", "goto", "if", "inline",
+                "int", "long", "nullptr", "register", "restrict", "return", "short", "signed", "sizeof", "static",
+                "static_assert", "struct", "switch", "thread_local", "true", "typedef", "typeof", "typeof_unqual",
+                "union", "unsigned", "void", "volatile", "while", "_Alignas", "alignas", "_Alignof", "alignof", 
+                "_Atomic", "_BitInt", "_Bool", "bool", "_Complex", "complex", "_Decimal128", "_Decimal32",
+                "_Decimal64", "_Generic", "_Imaginary", "imaginary", "_Noreturn", "noreturn", "_Static_assert",
+                "static_assert", "_Thread_local", "thread_local"].into());
 
         static CPP_KEYWORDS: LazyLock<std::collections::HashSet<&str>> = LazyLock::new(|| {
             let mut v = C_KEYWORDS.clone();
-            v.extend(["new", "default", "delete"].iter());
+            // Source: https://en.cppreference.com/w/cpp/keyword
+            #[rustfmt::skip]
+            v.extend(
+                [
+                    "alignas", "alignof", "and", "and_eq", "asm", "atomic_cancel", "atomic_commit", "atomic_noexcept",
+                    "auto", "bitand", "bitor", "bool", "break", "case", "catch", "char", "char8_t", "char16_t",
+                    "char32_t", "class", "compl", "concept", "const", "consteval", "constexpr", "constinit", "const_cast",
+                    "continue", "contract_assert", "co_await", "co_return", "co_yield", "decltype", "default", "delete",
+                    "do", "double", "dynamic_cast", "else", "enum", "explicit", "export", "extern", "false", "float", 
+                    "for", "friend", "goto", "if", "inline", "int", "long", "mutable", "namespace", "new", "noexcept",
+                    "not", "not_eq", "nullptr", "operator", "or", "or_eq", "private", "protected", "public", "reflexpr",
+                    "register", "reinterpret_cast", "requires", "return", "short", "signed", "sizeof", "static", 
+                    "static_assert", "static_cast", "struct", "switch", "synchronized", "template", "this", 
+                    "thread_local", "throw", "true", "try", "typedef", "typeid", "typename", "union", "unsigned", 
+                    "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq",                 ]
+                .iter(),
+            );
             v
         });
 


### PR DESCRIPTION
This has been a todo for some time, relatively straightforward change