### PR TITLE
Add comparator support to C++ and python

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -125,7 +125,7 @@ pub enum SpecialMethod {
     Setter(Option<String>),
     /// A stringifier. Must have no parameters and return a string (DiplomatWrite)
     Stringifier,
-    /// A comparison operator. Currently unsupported
+    /// A comparison operator. Currently not universally supported
     Comparison,
     /// An iterator (a type that is mutated to produce new values)
     Iterator,

--- a/feature_tests/cpp/include/ns/RenamedComparable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedComparable.d.hpp
@@ -1,0 +1,54 @@
+#ifndef ns_RenamedComparable_D_HPP
+#define ns_RenamedComparable_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+namespace ns {
+namespace capi { struct RenamedComparable; }
+class RenamedComparable;
+}
+
+
+namespace ns {
+namespace capi {
+    struct RenamedComparable;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedComparable {
+public:
+
+  inline static std::unique_ptr<ns::RenamedComparable> new_(uint8_t int_);
+
+  inline int8_t cmp(const ns::RenamedComparable& other) const;
+  inline bool operator==(const ns::RenamedComparable& other) const;
+  inline bool operator!=(const ns::RenamedComparable& other) const;
+  inline bool operator<=(const ns::RenamedComparable& other) const;
+  inline bool operator>=(const ns::RenamedComparable& other) const;
+  inline bool operator<(const ns::RenamedComparable& other) const;
+  inline bool operator>(const ns::RenamedComparable& other) const;
+
+  inline const ns::capi::RenamedComparable* AsFFI() const;
+  inline ns::capi::RenamedComparable* AsFFI();
+  inline static const ns::RenamedComparable* FromFFI(const ns::capi::RenamedComparable* ptr);
+  inline static ns::RenamedComparable* FromFFI(ns::capi::RenamedComparable* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  RenamedComparable() = delete;
+  RenamedComparable(const ns::RenamedComparable&) = delete;
+  RenamedComparable(ns::RenamedComparable&&) noexcept = delete;
+  RenamedComparable operator=(const ns::RenamedComparable&) = delete;
+  RenamedComparable operator=(ns::RenamedComparable&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // ns_RenamedComparable_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedComparable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedComparable.hpp
@@ -1,0 +1,86 @@
+#ifndef ns_RenamedComparable_HPP
+#define ns_RenamedComparable_HPP
+
+#include "RenamedComparable.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+    
+    ns::capi::RenamedComparable* namespace_Comparable_new(uint8_t int_);
+    
+    int8_t namespace_Comparable_cmp(const ns::capi::RenamedComparable* self, const ns::capi::RenamedComparable* other);
+    
+    
+    void namespace_Comparable_destroy(RenamedComparable* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<ns::RenamedComparable> ns::RenamedComparable::new_(uint8_t int_) {
+  auto result = ns::capi::namespace_Comparable_new(int_);
+  return std::unique_ptr<ns::RenamedComparable>(ns::RenamedComparable::FromFFI(result));
+}
+
+inline int8_t ns::RenamedComparable::cmp(const ns::RenamedComparable& other) const {
+  auto result = ns::capi::namespace_Comparable_cmp(this->AsFFI(),
+    other.AsFFI());
+  return result;
+}
+inline bool ns::RenamedComparable::operator==(const ns::RenamedComparable& other) const {
+  return this->cmp(other) == 0;
+}
+
+inline bool ns::RenamedComparable::operator!=(const ns::RenamedComparable& other) const {
+  return this->cmp(other) != 0;
+}
+
+inline bool ns::RenamedComparable::operator<=(const ns::RenamedComparable& other) const {
+  return this->cmp(other) <= 0;
+}
+
+inline bool ns::RenamedComparable::operator>=(const ns::RenamedComparable& other) const {
+  return this->cmp(other) >= 0;
+}
+
+inline bool ns::RenamedComparable::operator<(const ns::RenamedComparable& other) const {
+  return this->cmp(other) < 0;
+}
+
+inline bool ns::RenamedComparable::operator>(const ns::RenamedComparable& other) const {
+  return this->cmp(other) > 0;
+}
+
+inline const ns::capi::RenamedComparable* ns::RenamedComparable::AsFFI() const {
+  return reinterpret_cast<const ns::capi::RenamedComparable*>(this);
+}
+
+inline ns::capi::RenamedComparable* ns::RenamedComparable::AsFFI() {
+  return reinterpret_cast<ns::capi::RenamedComparable*>(this);
+}
+
+inline const ns::RenamedComparable* ns::RenamedComparable::FromFFI(const ns::capi::RenamedComparable* ptr) {
+  return reinterpret_cast<const ns::RenamedComparable*>(ptr);
+}
+
+inline ns::RenamedComparable* ns::RenamedComparable::FromFFI(ns::capi::RenamedComparable* ptr) {
+  return reinterpret_cast<ns::RenamedComparable*>(ptr);
+}
+
+inline void ns::RenamedComparable::operator delete(void* ptr) {
+  ns::capi::namespace_Comparable_destroy(reinterpret_cast<ns::capi::RenamedComparable*>(ptr));
+}
+
+
+#endif // ns_RenamedComparable_HPP

--- a/feature_tests/cpp/tests/attrs.cpp
+++ b/feature_tests/cpp/tests/attrs.cpp
@@ -3,6 +3,7 @@
 #include "../include/ns/RenamedOpaqueArithmetic.hpp"
 #include "../include/ns/RenamedAttrEnum.hpp"
 #include "../include/ns/RenamedMyIterable.hpp"
+#include "../include/ns/RenamedComparable.hpp"
 #include "../include/Unnamespaced.hpp"
 #include "../include/nested/ns/Nested.hpp"
 #include "../include/nested/ns2/Nested.hpp"
@@ -59,4 +60,16 @@ int main(int argc, char* argv[]) {
     simple_assert("For loop iteration", uintVec == unitVecCopy);
 
     simple_assert("stl-algorithm iteration failed", std::equal(uintVec.begin(), uintVec.end(), myIterable->begin()));
+
+    auto cmpA = ns::RenamedComparable::new_(0);
+    auto cmpB = ns::RenamedComparable::new_(0);
+    auto cmpC = ns::RenamedComparable::new_(1);
+    simple_assert("equality", *cmpA == *cmpB);
+    simple_assert("nequality", *cmpB != *cmpC);
+    simple_assert("less or equal as equals", *cmpA <= *cmpB);
+    simple_assert("greater or equal as equals", *cmpA >= *cmpB);
+    simple_assert("less or equal", *cmpA <= *cmpC);
+    simple_assert("greater or equal", *cmpC >= *cmpA);
+    simple_assert("less", *cmpA < *cmpC);
+    simple_assert("greater", *cmpC > *cmpA);
 }

--- a/feature_tests/nanobind/src/include/ns/RenamedComparable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedComparable.d.hpp
@@ -1,0 +1,54 @@
+#ifndef ns_RenamedComparable_D_HPP
+#define ns_RenamedComparable_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+namespace ns {
+namespace capi { struct RenamedComparable; }
+class RenamedComparable;
+}
+
+
+namespace ns {
+namespace capi {
+    struct RenamedComparable;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedComparable {
+public:
+
+  inline static std::unique_ptr<ns::RenamedComparable> new_(uint8_t int_);
+
+  inline int8_t cmp(const ns::RenamedComparable& other) const;
+  inline bool operator==(const ns::RenamedComparable& other) const;
+  inline bool operator!=(const ns::RenamedComparable& other) const;
+  inline bool operator<=(const ns::RenamedComparable& other) const;
+  inline bool operator>=(const ns::RenamedComparable& other) const;
+  inline bool operator<(const ns::RenamedComparable& other) const;
+  inline bool operator>(const ns::RenamedComparable& other) const;
+
+  inline const ns::capi::RenamedComparable* AsFFI() const;
+  inline ns::capi::RenamedComparable* AsFFI();
+  inline static const ns::RenamedComparable* FromFFI(const ns::capi::RenamedComparable* ptr);
+  inline static ns::RenamedComparable* FromFFI(ns::capi::RenamedComparable* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  RenamedComparable() = delete;
+  RenamedComparable(const ns::RenamedComparable&) = delete;
+  RenamedComparable(ns::RenamedComparable&&) noexcept = delete;
+  RenamedComparable operator=(const ns::RenamedComparable&) = delete;
+  RenamedComparable operator=(ns::RenamedComparable&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // ns_RenamedComparable_D_HPP

--- a/feature_tests/nanobind/src/include/ns/RenamedComparable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedComparable.hpp
@@ -1,0 +1,86 @@
+#ifndef ns_RenamedComparable_HPP
+#define ns_RenamedComparable_HPP
+
+#include "RenamedComparable.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+    
+    ns::capi::RenamedComparable* namespace_Comparable_new(uint8_t int_);
+    
+    int8_t namespace_Comparable_cmp(const ns::capi::RenamedComparable* self, const ns::capi::RenamedComparable* other);
+    
+    
+    void namespace_Comparable_destroy(RenamedComparable* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<ns::RenamedComparable> ns::RenamedComparable::new_(uint8_t int_) {
+  auto result = ns::capi::namespace_Comparable_new(int_);
+  return std::unique_ptr<ns::RenamedComparable>(ns::RenamedComparable::FromFFI(result));
+}
+
+inline int8_t ns::RenamedComparable::cmp(const ns::RenamedComparable& other) const {
+  auto result = ns::capi::namespace_Comparable_cmp(this->AsFFI(),
+    other.AsFFI());
+  return result;
+}
+inline bool ns::RenamedComparable::operator==(const ns::RenamedComparable& other) const {
+  return this->cmp(other) == 0;
+}
+
+inline bool ns::RenamedComparable::operator!=(const ns::RenamedComparable& other) const {
+  return this->cmp(other) != 0;
+}
+
+inline bool ns::RenamedComparable::operator<=(const ns::RenamedComparable& other) const {
+  return this->cmp(other) <= 0;
+}
+
+inline bool ns::RenamedComparable::operator>=(const ns::RenamedComparable& other) const {
+  return this->cmp(other) >= 0;
+}
+
+inline bool ns::RenamedComparable::operator<(const ns::RenamedComparable& other) const {
+  return this->cmp(other) < 0;
+}
+
+inline bool ns::RenamedComparable::operator>(const ns::RenamedComparable& other) const {
+  return this->cmp(other) > 0;
+}
+
+inline const ns::capi::RenamedComparable* ns::RenamedComparable::AsFFI() const {
+  return reinterpret_cast<const ns::capi::RenamedComparable*>(this);
+}
+
+inline ns::capi::RenamedComparable* ns::RenamedComparable::AsFFI() {
+  return reinterpret_cast<ns::capi::RenamedComparable*>(this);
+}
+
+inline const ns::RenamedComparable* ns::RenamedComparable::FromFFI(const ns::capi::RenamedComparable* ptr) {
+  return reinterpret_cast<const ns::RenamedComparable*>(ptr);
+}
+
+inline ns::RenamedComparable* ns::RenamedComparable::FromFFI(ns::capi::RenamedComparable* ptr) {
+  return reinterpret_cast<ns::RenamedComparable*>(ptr);
+}
+
+inline void ns::RenamedComparable::operator delete(void* ptr) {
+  ns::capi::namespace_Comparable_destroy(reinterpret_cast<ns::capi::RenamedComparable*>(ptr));
+}
+
+
+#endif // ns_RenamedComparable_HPP

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -57,6 +57,7 @@
 #include "ns/AttrOpaque1Renamed.hpp"
 #include "ns/RenamedAttrEnum.hpp"
 #include "ns/RenamedAttrOpaque2.hpp"
+#include "ns/RenamedComparable.hpp"
 #include "ns/RenamedMyIndexer.hpp"
 #include "ns/RenamedMyIterable.hpp"
 #include "ns/RenamedMyIterator.hpp"
@@ -461,6 +462,20 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<ns::RenamedAttrOpaque2>(ns_mod, "RenamedAttrOpaque2", nb::type_slots(ns_RenamedAttrOpaque2_slots));
+    
+    PyType_Slot ns_RenamedComparable_slots[] = {
+        {Py_tp_free, (void *)ns::RenamedComparable::operator delete },
+        {Py_tp_dealloc, (void *)diplomat_tp_dealloc},
+        {0, nullptr}};
+    
+    nb::class_<ns::RenamedComparable>(ns_mod, "RenamedComparable", nb::type_slots(ns_RenamedComparable_slots))
+    	.def(nb::self == nb::self)
+    		.def(nb::self != nb::self)
+    		.def(nb::self <= nb::self)
+    		.def(nb::self >= nb::self)
+    		.def(nb::self < nb::self)
+    		.def(nb::self > nb::self)
+    	.def_static("new", &ns::RenamedComparable::new_, "int"_a);
     
     PyType_Slot ns_RenamedMyIndexer_slots[] = {
         {Py_tp_free, (void *)ns::RenamedMyIndexer::operator delete },

--- a/feature_tests/nanobind/test/test_attrs.py
+++ b/feature_tests/nanobind/test/test_attrs.py
@@ -29,3 +29,17 @@ def test_attrs():
     except Exception:
         threw = True
     assert threw, "Failing constructor should have thrown an error"
+
+
+    a = somelib.ns.RenamedComparable.new(0)
+    b = somelib.ns.RenamedComparable.new(0)
+    c = somelib.ns.RenamedComparable.new(1)
+
+    assert a == b, "equality"
+    assert b != c, "nequality"
+    assert a <= b, "less or equal as equals"
+    assert a >= b, "greater or equal as equals"
+    assert a <= c, "less or equal"
+    assert c >= a, "greater or equal"
+    assert a < c, "less"
+    assert c > a, "greater"

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -23,7 +23,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.named_constructors = false;
     a.fallible_constructors = false;
     a.accessors = false;
-    a.comparators = false; // TODO
+    a.comparators = true; // TODO
     a.stringifiers = false; // TODO
     a.iterators = true;
     a.iterables = true;

--- a/tool/src/nanobind/mod.rs
+++ b/tool/src/nanobind/mod.rs
@@ -34,9 +34,9 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.constructors = true;
     a.named_constructors = false;
     a.fallible_constructors = true;
-    a.accessors = false;
-    a.comparators = false; // TODO
-    a.stringifiers = false; // TODO
+    a.accessors = true;
+    a.comparators = true;
+    a.stringifiers = true;
     a.iterators = true;
     a.iterables = true;
     a.arithmetic = true;

--- a/tool/templates/cpp/method_decl.h.jinja
+++ b/tool/templates/cpp/method_decl.h.jinja
@@ -25,5 +25,12 @@ inline {##}
 {%- let helper_type = m.return_ty.replace("std::unique_ptr", "diplomat::next_to_iter_helper") %}
   inline {{helper_type}} begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
-{%- else -%}
+{%- when Some(hir::SpecialMethod::Comparison) %}
+  inline bool operator==(const {{type_name}}& other) const;
+  inline bool operator!=(const {{type_name}}& other) const;
+  inline bool operator<=(const {{type_name}}& other) const;
+  inline bool operator>=(const {{type_name}}& other) const;
+  inline bool operator<(const {{type_name}}& other) const;
+  inline bool operator>(const {{type_name}}& other) const;
+{%- when _ -%}
 {%- endmatch -%}

--- a/tool/templates/cpp/method_impl.h.jinja
+++ b/tool/templates/cpp/method_impl.h.jinja
@@ -50,5 +50,31 @@ inline {{ m.return_ty }}& {{type_name}}::{{m.method_name -}}=({{ param_var.type_
 inline {{helper_type}} {{- type_name }}::begin() const {
 	return iter();
 }
-{%- else -%}
+
+{%- when Some(hir::SpecialMethod::Comparison) %}
+inline bool {{type_name}}::operator==(const {{type_name}}& other) const {
+	return this->{{m.method_name}}(other) == 0;
+}
+
+inline bool {{type_name}}::operator!=(const {{type_name}}& other) const {
+	return this->{{m.method_name}}(other) != 0;
+}
+
+inline bool {{type_name}}::operator<=(const {{type_name}}& other) const {
+	return this->{{m.method_name}}(other) <= 0;
+}
+
+inline bool {{type_name}}::operator>=(const {{type_name}}& other) const {
+	return this->{{m.method_name}}(other) >= 0;
+}
+
+inline bool {{type_name}}::operator<(const {{type_name}}& other) const {
+	return this->{{m.method_name}}(other) < 0;
+}
+
+inline bool {{type_name}}::operator>(const {{type_name}}& other) const {
+	return this->{{m.method_name}}(other) > 0;
+}
+
+{%- when _ -%}
 {%- endmatch -%}

--- a/tool/templates/nanobind/method_impl.cpp.jinja
+++ b/tool/templates/nanobind/method_impl.cpp.jinja
@@ -7,6 +7,13 @@
 	{%- when crate::hir::SpecialMethod::AddAssign | crate::hir::SpecialMethod::SubAssign |
 			crate::hir::SpecialMethod::MulAssign | crate::hir::SpecialMethod::DivAssign -%}
 		(nb::self {{special_method.operator_str().unwrap()}} nb::self, nb::rv_policy::none)
+	{%- when crate::hir::SpecialMethod::Comparison -%}
+		(nb::self == nb::self)
+		.def(nb::self != nb::self)
+		.def(nb::self <= nb::self)
+		.def(nb::self >= nb::self)
+		.def(nb::self < nb::self)
+		.def(nb::self > nb::self)
 	{%- when crate::hir::SpecialMethod::Stringifier -%}
 		("__str__", &{{- type_name }}::{{ m.cpp_method_name -}})
 	{%- when crate::hir::SpecialMethod::Iterable -%}


### PR DESCRIPTION
Relies on https://github.com/rust-diplomat/diplomat/pull/840, since this enables a type which otherwise has naming conflicts with C++ keywords