### PR TITLE
Fix issues with returning slices of primitives or strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.8"
+          cache: 'pip'
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.6.10"
+      - name: Install nanobind
+        run: pip install numpy
       - name: Test Nanobind
         run: cargo make test-nanobind

--- a/feature_tests/nanobind/pyproject.toml
+++ b/feature_tests/nanobind/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.0.1"
 description = "A brief description of what this project does"
 requires-python = ">=3.8"
 classifiers = ["License :: Apache2.0"]
+dependencies = ["numpy"]
 
 [project.urls]
 Homepage = "https://github.com/rust-diplomat/diplomat"

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -265,7 +265,22 @@ namespace nanobind::detail
 
         // Cast C++ -> Python (when returning a span from a C++ function)
         static handle from_cpp(diplomat::span<T, E> src, rv_policy policy, cleanup_list* cleanup) {
-            return ListCaster::from_cpp(src, policy, cleanup);
+            using Array = nb::ndarray<std::remove_cv_t<T>, nb::numpy, nb::ndim<1>, nb::f_contig>;
+            if constexpr(is_ndarray_scalar_v<T>) {
+                nb::object owner;
+                if (cleanup->self()) {
+                    owner = nb::borrow(cleanup->self());
+                    policy = rv_policy::reference;
+                }
+
+                 object o = steal(type_caster<Array>::from_cpp(
+                    Array((void* )src.data(), {src.size()}, owner),
+                    policy, cleanup));
+
+                return o.release();
+            } else {
+                return ListCaster::from_cpp(src, policy, cleanup);
+            }
         }
     };
 }
@@ -483,7 +498,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<ns::RenamedMyIndexer>(ns_mod, "RenamedMyIndexer", nb::type_slots(ns_RenamedMyIndexer_slots))
-    	.def("__getitem__", &ns::RenamedMyIndexer::operator[], "i"_a, nb::keep_alive<0, 1>());
+    	.def("__getitem__", &ns::RenamedMyIndexer::operator[], "i"_a);
     
     PyType_Slot ns_RenamedMyIterable_slots[] = {
         {Py_tp_free, (void *)ns::RenamedMyIterable::operator delete },
@@ -701,7 +716,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<OptionString>(somelib_mod, "OptionString", nb::type_slots(OptionString_slots))
-    	.def("borrow", &OptionString::borrow, nb::keep_alive<0, 1>())
+    	.def("borrow", &OptionString::borrow)
     	.def_static("new", &OptionString::new_, "diplomat_str"_a)
     	.def("write", &OptionString::write);
     
@@ -764,7 +779,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<MyString>(somelib_mod, "MyString", nb::type_slots(MyString_slots))
-    	.def("borrow", &MyString::borrow, nb::keep_alive<0, 1>())
+    	.def("borrow", &MyString::borrow)
     	.def_static("get_static_str", &MyString::get_static_str)
     	.def(nb::new_(&MyString::new_), "v"_a)
     	.def_static("new_from_first", &MyString::new_from_first, "v"_a)
@@ -807,7 +822,7 @@ NB_MODULE(somelib, somelib_mod)
     	.def_static("borrow_other", &OpaqueMutexedString::borrow_other, "other"_a, nb::keep_alive<0, 1>(), nb::rv_policy::reference)
     	.def("borrow_self_or_other", &OpaqueMutexedString::borrow_self_or_other, "other"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), nb::rv_policy::reference)
     	.def("change", &OpaqueMutexedString::change, "number"_a)
-    	.def("dummy_str", &OpaqueMutexedString::dummy_str, nb::keep_alive<0, 1>())
+    	.def("dummy_str", &OpaqueMutexedString::dummy_str)
     	.def_static("from_usize", &OpaqueMutexedString::from_usize, "number"_a)
     	.def("get_len_and_add", &OpaqueMutexedString::get_len_and_add, "other"_a)
     	.def("to_unsigned_from_unsigned", &OpaqueMutexedString::to_unsigned_from_unsigned, "input"_a)
@@ -819,7 +834,7 @@ NB_MODULE(somelib, somelib_mod)
         {0, nullptr}};
     
     nb::class_<Utf16Wrap>(somelib_mod, "Utf16Wrap", nb::type_slots(Utf16Wrap_slots))
-    	.def("borrow_cont", &Utf16Wrap::borrow_cont, nb::keep_alive<0, 1>())
+    	.def("borrow_cont", &Utf16Wrap::borrow_cont)
     	.def(nb::new_(&Utf16Wrap::from_utf16), "input"_a)
     	.def("get_debug_str", &Utf16Wrap::get_debug_str);
     {

--- a/feature_tests/nanobind/test/test_slices.py
+++ b/feature_tests/nanobind/test/test_slices.py
@@ -1,0 +1,13 @@
+import somelib
+import somelib.somelib
+def test_slices():
+    sl = somelib.Float64Vec.new([.1, .2, .3]).asSlice
+    b = somelib.Float64Vec.new([.1, .2, .3]).borrow()
+    assert all(sl == [.1, .2, .3])
+    assert all(b == [.1, .2, .3])
+
+    s = somelib.MyString("banannas").get_static_str()
+    b = somelib.MyString("banannas").borrow()
+    assert s == "hello"
+    assert b == "banannas"
+    assert s is not b

--- a/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__enum_gen.snap
+++ b/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__enum_gen.snap
@@ -213,7 +213,22 @@ namespace nanobind::detail
 
         // Cast C++ -> Python (when returning a span from a C++ function)
         static handle from_cpp(diplomat::span<T, E> src, rv_policy policy, cleanup_list* cleanup) {
-            return ListCaster::from_cpp(src, policy, cleanup);
+            using Array = nb::ndarray<std::remove_cv_t<T>, nb::numpy, nb::ndim<1>, nb::f_contig>;
+            if constexpr(is_ndarray_scalar_v<T>) {
+                nb::object owner;
+                if (cleanup->self()) {
+                    owner = nb::borrow(cleanup->self());
+                    policy = rv_policy::reference;
+                }
+
+                 object o = steal(type_caster<Array>::from_cpp(
+                    Array((void* )src.data(), {src.size()}, owner),
+                    policy, cleanup));
+
+                return o.release();
+            } else {
+                return ListCaster::from_cpp(src, policy, cleanup);
+            }
         }
     };
 }

--- a/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__opaque_gen.snap
+++ b/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__opaque_gen.snap
@@ -213,7 +213,22 @@ namespace nanobind::detail
 
         // Cast C++ -> Python (when returning a span from a C++ function)
         static handle from_cpp(diplomat::span<T, E> src, rv_policy policy, cleanup_list* cleanup) {
-            return ListCaster::from_cpp(src, policy, cleanup);
+            using Array = nb::ndarray<std::remove_cv_t<T>, nb::numpy, nb::ndim<1>, nb::f_contig>;
+            if constexpr(is_ndarray_scalar_v<T>) {
+                nb::object owner;
+                if (cleanup->self()) {
+                    owner = nb::borrow(cleanup->self());
+                    policy = rv_policy::reference;
+                }
+
+                 object o = steal(type_caster<Array>::from_cpp(
+                    Array((void* )src.data(), {src.size()}, owner),
+                    policy, cleanup));
+
+                return o.release();
+            } else {
+                return ListCaster::from_cpp(src, policy, cleanup);
+            }
         }
     };
 }

--- a/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__struct_gen.snap
+++ b/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__struct_gen.snap
@@ -213,7 +213,22 @@ namespace nanobind::detail
 
         // Cast C++ -> Python (when returning a span from a C++ function)
         static handle from_cpp(diplomat::span<T, E> src, rv_policy policy, cleanup_list* cleanup) {
-            return ListCaster::from_cpp(src, policy, cleanup);
+            using Array = nb::ndarray<std::remove_cv_t<T>, nb::numpy, nb::ndim<1>, nb::f_contig>;
+            if constexpr(is_ndarray_scalar_v<T>) {
+                nb::object owner;
+                if (cleanup->self()) {
+                    owner = nb::borrow(cleanup->self());
+                    policy = rv_policy::reference;
+                }
+
+                 object o = steal(type_caster<Array>::from_cpp(
+                    Array((void* )src.data(), {src.size()}, owner),
+                    policy, cleanup));
+
+                return o.release();
+            } else {
+                return ListCaster::from_cpp(src, policy, cleanup);
+            }
         }
     };
 }

--- a/tool/templates/nanobind/binding.cpp.jinja
+++ b/tool/templates/nanobind/binding.cpp.jinja
@@ -213,7 +213,22 @@ namespace nanobind::detail
 
         // Cast C++ -> Python (when returning a span from a C++ function)
         static handle from_cpp(diplomat::span<T, E> src, rv_policy policy, cleanup_list* cleanup) {
-            return ListCaster::from_cpp(src, policy, cleanup);
+            using Array = nb::ndarray<std::remove_cv_t<T>, nb::numpy, nb::ndim<1>, nb::f_contig>;
+            if constexpr(is_ndarray_scalar_v<T>) {
+                nb::object owner;
+                if (cleanup->self()) {
+                    owner = nb::borrow(cleanup->self());
+                    policy = rv_policy::reference;
+                }
+
+                 object o = steal(type_caster<Array>::from_cpp(
+                    Array((void* )src.data(), {src.size()}, owner),
+                    policy, cleanup));
+
+                return o.release();
+            } else {
+                return ListCaster::from_cpp(src, policy, cleanup);
+            }
         }
     };
 }


### PR DESCRIPTION
Improves handling when returning string slices or slices of numeric primitives.
Prior to this patch, attempting to actually use a function returning these types would result in a runtime exception.  With this, it not only works, but allows zero-copy access to numeric primitive slices