### PR TITLE
Fix storing Fn trait objects, Add support for FnMut

### DIFF
--- a/book/src/callbacks.md
+++ b/book/src/callbacks.md
@@ -1,0 +1,21 @@
+# Callbacks
+
+Diplomat has limited, experimental support for exposing and working with callbacks. See [tracking issue](https://github.com/rust-diplomat/diplomat/issues/146)
+Currently these are only supported in the C++, kotlin, and nanobind backends.
+
+Functions taking callbacks as parameters take the form
+
+```rust
+#[diplomat::bridge]
+impl MyType{
+    pub fn acceptsCallback(&self, impl Fn())
+}
+```
+or
+```rust
+impl MyType{
+    pub fn acceptsCallback(&self, impl FnMut())
+}
+```
+
+The callback's parameters & return types may be limited depending on the target language for now. Additional traits are not supported, however `+ 'static` may be given, which allows for moving the trait object into a `Box<dyn Fn()>`

--- a/book/src/types.md
+++ b/book/src/types.md
@@ -20,7 +20,7 @@ Diplomat only supports a small set of types that can be passed over FFI.
          - `&DiplomatStr16`: An unvalidated string expected to be UTF-16.
      - [`DiplomatWriteable`](./writeable.md) for returning strings. This needs to be the last parameter of the method.
      - [`Option<&T>` ,`Option<Box<T>>`](./option.md) of opaque types, `Option<T>` of structs, enums, primitives, or the above slice types
-     - Callbacks in parameters (Undocumented in the book, but implemented in some backends. See [tracking issue](https://github.com/rust-diplomat/diplomat/issues/146))
+     - [Callbacks](./callbacks.md) in parameters. Support is limited.
      - `Result<T, E>` in return values
      - `()` as a `Result` `Ok`/`Error` type, or as a return value
  - Custom types

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -927,7 +927,7 @@ impl<'ast> LoweringContext<'ast> {
                     PrimitiveType::from_ast(*prim),
                 )))
             }
-            ast::TypeName::Function(input_types, out_type) => {
+            ast::TypeName::Function(input_types, out_type, _mutability) => {
                 if !self.attr_validator.attrs_supported().callbacks {
                     self.errors.push(LoweringError::Other(
                         "Callback arguments are not supported by this backend".into(),
@@ -1255,7 +1255,7 @@ impl<'ast> LoweringContext<'ast> {
                 self.errors.push(LoweringError::Other("Unit types can only appear as the return value of a method, or as the Ok/Err variants of a returned result".into()));
                 Err(())
             }
-            ast::TypeName::Function(_, _) => {
+            ast::TypeName::Function(..) => {
                 self.errors.push(LoweringError::Other(
                     "Function types can only be an input type".into(),
                 ));

--- a/feature_tests/c/include/CallbackHolder.d.h
+++ b/feature_tests/c/include/CallbackHolder.d.h
@@ -1,0 +1,19 @@
+#ifndef CallbackHolder_D_H
+#define CallbackHolder_D_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+
+
+
+
+typedef struct CallbackHolder CallbackHolder;
+
+
+
+
+#endif // CallbackHolder_D_H

--- a/feature_tests/c/include/CallbackHolder.h
+++ b/feature_tests/c/include/CallbackHolder.h
@@ -1,0 +1,34 @@
+#ifndef CallbackHolder_H
+#define CallbackHolder_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+
+#include "CallbackHolder.d.h"
+
+
+
+
+
+typedef struct DiplomatCallback_CallbackHolder_new_func {
+    const void* data;
+    int32_t (*run_callback)(const void*, int32_t );
+    void (*destructor)(const void*);
+} DiplomatCallback_CallbackHolder_new_func;
+
+CallbackHolder* CallbackHolder_new(DiplomatCallback_CallbackHolder_new_func func_cb_wrap);
+
+int32_t CallbackHolder_call(const CallbackHolder* self, int32_t a);
+
+
+void CallbackHolder_destroy(CallbackHolder* self);
+
+
+
+
+
+#endif // CallbackHolder_H

--- a/feature_tests/c/include/MutableCallbackHolder.d.h
+++ b/feature_tests/c/include/MutableCallbackHolder.d.h
@@ -1,0 +1,19 @@
+#ifndef MutableCallbackHolder_D_H
+#define MutableCallbackHolder_D_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+
+
+
+
+typedef struct MutableCallbackHolder MutableCallbackHolder;
+
+
+
+
+#endif // MutableCallbackHolder_D_H

--- a/feature_tests/c/include/MutableCallbackHolder.h
+++ b/feature_tests/c/include/MutableCallbackHolder.h
@@ -1,0 +1,34 @@
+#ifndef MutableCallbackHolder_H
+#define MutableCallbackHolder_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "diplomat_runtime.h"
+
+
+#include "MutableCallbackHolder.d.h"
+
+
+
+
+
+typedef struct DiplomatCallback_MutableCallbackHolder_new_func {
+    const void* data;
+    int32_t (*run_callback)(const void*, int32_t );
+    void (*destructor)(const void*);
+} DiplomatCallback_MutableCallbackHolder_new_func;
+
+MutableCallbackHolder* MutableCallbackHolder_new(DiplomatCallback_MutableCallbackHolder_new_func func_cb_wrap);
+
+int32_t MutableCallbackHolder_call(MutableCallbackHolder* self, int32_t a);
+
+
+void MutableCallbackHolder_destroy(MutableCallbackHolder* self);
+
+
+
+
+
+#endif // MutableCallbackHolder_H

--- a/feature_tests/cpp/include/CallbackHolder.d.hpp
+++ b/feature_tests/cpp/include/CallbackHolder.d.hpp
@@ -1,0 +1,42 @@
+#ifndef CallbackHolder_D_HPP
+#define CallbackHolder_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    struct CallbackHolder;
+} // namespace capi
+} // namespace
+
+class CallbackHolder {
+public:
+
+  inline static std::unique_ptr<CallbackHolder> new_(std::function<int32_t(int32_t)> func);
+
+  inline int32_t call(int32_t a) const;
+
+  inline const diplomat::capi::CallbackHolder* AsFFI() const;
+  inline diplomat::capi::CallbackHolder* AsFFI();
+  inline static const CallbackHolder* FromFFI(const diplomat::capi::CallbackHolder* ptr);
+  inline static CallbackHolder* FromFFI(diplomat::capi::CallbackHolder* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  CallbackHolder() = delete;
+  CallbackHolder(const CallbackHolder&) = delete;
+  CallbackHolder(CallbackHolder&&) noexcept = delete;
+  CallbackHolder operator=(const CallbackHolder&) = delete;
+  CallbackHolder operator=(CallbackHolder&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+
+#endif // CallbackHolder_D_HPP

--- a/feature_tests/cpp/include/CallbackHolder.hpp
+++ b/feature_tests/cpp/include/CallbackHolder.hpp
@@ -1,0 +1,68 @@
+#ifndef CallbackHolder_HPP
+#define CallbackHolder_HPP
+
+#include "CallbackHolder.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    extern "C" {
+    typedef struct DiplomatCallback_CallbackHolder_new_func {
+        const void* data;
+        int32_t (*run_callback)(const void*, int32_t );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackHolder_new_func;
+    
+    diplomat::capi::CallbackHolder* CallbackHolder_new(DiplomatCallback_CallbackHolder_new_func func_cb_wrap);
+    
+    int32_t CallbackHolder_call(const diplomat::capi::CallbackHolder* self, int32_t a);
+    
+    
+    void CallbackHolder_destroy(CallbackHolder* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<CallbackHolder> CallbackHolder::new_(std::function<int32_t(int32_t)> func) {
+  auto result = diplomat::capi::CallbackHolder_new({new decltype(func)(std::move(func)), diplomat::fn_traits(func).c_run_callback, diplomat::fn_traits(func).c_delete});
+  return std::unique_ptr<CallbackHolder>(CallbackHolder::FromFFI(result));
+}
+
+inline int32_t CallbackHolder::call(int32_t a) const {
+  auto result = diplomat::capi::CallbackHolder_call(this->AsFFI(),
+    a);
+  return result;
+}
+
+inline const diplomat::capi::CallbackHolder* CallbackHolder::AsFFI() const {
+  return reinterpret_cast<const diplomat::capi::CallbackHolder*>(this);
+}
+
+inline diplomat::capi::CallbackHolder* CallbackHolder::AsFFI() {
+  return reinterpret_cast<diplomat::capi::CallbackHolder*>(this);
+}
+
+inline const CallbackHolder* CallbackHolder::FromFFI(const diplomat::capi::CallbackHolder* ptr) {
+  return reinterpret_cast<const CallbackHolder*>(ptr);
+}
+
+inline CallbackHolder* CallbackHolder::FromFFI(diplomat::capi::CallbackHolder* ptr) {
+  return reinterpret_cast<CallbackHolder*>(ptr);
+}
+
+inline void CallbackHolder::operator delete(void* ptr) {
+  diplomat::capi::CallbackHolder_destroy(reinterpret_cast<diplomat::capi::CallbackHolder*>(ptr));
+}
+
+
+#endif // CallbackHolder_HPP

--- a/feature_tests/cpp/include/MutableCallbackHolder.d.hpp
+++ b/feature_tests/cpp/include/MutableCallbackHolder.d.hpp
@@ -1,0 +1,42 @@
+#ifndef MutableCallbackHolder_D_HPP
+#define MutableCallbackHolder_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    struct MutableCallbackHolder;
+} // namespace capi
+} // namespace
+
+class MutableCallbackHolder {
+public:
+
+  inline static std::unique_ptr<MutableCallbackHolder> new_(std::function<int32_t(int32_t)> func);
+
+  inline int32_t call(int32_t a);
+
+  inline const diplomat::capi::MutableCallbackHolder* AsFFI() const;
+  inline diplomat::capi::MutableCallbackHolder* AsFFI();
+  inline static const MutableCallbackHolder* FromFFI(const diplomat::capi::MutableCallbackHolder* ptr);
+  inline static MutableCallbackHolder* FromFFI(diplomat::capi::MutableCallbackHolder* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  MutableCallbackHolder() = delete;
+  MutableCallbackHolder(const MutableCallbackHolder&) = delete;
+  MutableCallbackHolder(MutableCallbackHolder&&) noexcept = delete;
+  MutableCallbackHolder operator=(const MutableCallbackHolder&) = delete;
+  MutableCallbackHolder operator=(MutableCallbackHolder&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+
+#endif // MutableCallbackHolder_D_HPP

--- a/feature_tests/cpp/include/MutableCallbackHolder.hpp
+++ b/feature_tests/cpp/include/MutableCallbackHolder.hpp
@@ -1,0 +1,68 @@
+#ifndef MutableCallbackHolder_HPP
+#define MutableCallbackHolder_HPP
+
+#include "MutableCallbackHolder.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    extern "C" {
+    typedef struct DiplomatCallback_MutableCallbackHolder_new_func {
+        const void* data;
+        int32_t (*run_callback)(const void*, int32_t );
+        void (*destructor)(const void*);
+    } DiplomatCallback_MutableCallbackHolder_new_func;
+    
+    diplomat::capi::MutableCallbackHolder* MutableCallbackHolder_new(DiplomatCallback_MutableCallbackHolder_new_func func_cb_wrap);
+    
+    int32_t MutableCallbackHolder_call(diplomat::capi::MutableCallbackHolder* self, int32_t a);
+    
+    
+    void MutableCallbackHolder_destroy(MutableCallbackHolder* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<MutableCallbackHolder> MutableCallbackHolder::new_(std::function<int32_t(int32_t)> func) {
+  auto result = diplomat::capi::MutableCallbackHolder_new({new decltype(func)(std::move(func)), diplomat::fn_traits(func).c_run_callback, diplomat::fn_traits(func).c_delete});
+  return std::unique_ptr<MutableCallbackHolder>(MutableCallbackHolder::FromFFI(result));
+}
+
+inline int32_t MutableCallbackHolder::call(int32_t a) {
+  auto result = diplomat::capi::MutableCallbackHolder_call(this->AsFFI(),
+    a);
+  return result;
+}
+
+inline const diplomat::capi::MutableCallbackHolder* MutableCallbackHolder::AsFFI() const {
+  return reinterpret_cast<const diplomat::capi::MutableCallbackHolder*>(this);
+}
+
+inline diplomat::capi::MutableCallbackHolder* MutableCallbackHolder::AsFFI() {
+  return reinterpret_cast<diplomat::capi::MutableCallbackHolder*>(this);
+}
+
+inline const MutableCallbackHolder* MutableCallbackHolder::FromFFI(const diplomat::capi::MutableCallbackHolder* ptr) {
+  return reinterpret_cast<const MutableCallbackHolder*>(ptr);
+}
+
+inline MutableCallbackHolder* MutableCallbackHolder::FromFFI(diplomat::capi::MutableCallbackHolder* ptr) {
+  return reinterpret_cast<MutableCallbackHolder*>(ptr);
+}
+
+inline void MutableCallbackHolder::operator delete(void* ptr) {
+  diplomat::capi::MutableCallbackHolder_destroy(reinterpret_cast<diplomat::capi::MutableCallbackHolder*>(ptr));
+}
+
+
+#endif // MutableCallbackHolder_HPP

--- a/feature_tests/cpp/tests/callback.cpp
+++ b/feature_tests/cpp/tests/callback.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include "../include/CallbackWrapper.hpp"
+#include "../include/CallbackHolder.hpp"
+#include "../include/MutableCallbackHolder.hpp"
 #include "assert.hpp"
 
 int main(int argc, char *argv[])
@@ -40,5 +42,20 @@ int main(int argc, char *argv[])
         auto out = o.test_str_cb_arg([](std::string_view a)
                                      { return a.length(); });
         simple_assert_eq("test_str_cb_arg output", out, 7);
+    }
+    {
+        int copied = 0;
+        // TODO: Make C++ reject this by using move_only_function in c++23.
+        // We cannot reject this in earlier standards due to a defect in std::function.
+        // See: https://lesleylai.info/en/const-correcness-std-function/
+        auto cb = CallbackHolder::new_([copied](int32_t a) mutable { copied += a; return copied;});
+        simple_assert_eq("mutable cb object", cb->call(5), 5);
+        simple_assert_eq("mutable cb object", cb->call(5), 10);
+    }
+    {
+        int copied = 0;
+        auto cb = MutableCallbackHolder::new_([copied](int32_t a) mutable { copied += a; return copied;});
+        simple_assert_eq("mutable cb object", cb->call(5), 5);
+        simple_assert_eq("mutable cb object", cb->call(5), 10);
     }
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackHolder.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackHolder.kt
@@ -1,0 +1,99 @@
+package dev.diplomattest.somelib;
+import com.sun.jna.Callback
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+
+
+internal interface CallbackHolderLib: Library {
+    fun CallbackHolder_destroy(handle: Pointer)
+    fun CallbackHolder_new(func: DiplomatCallback_CallbackHolder_new_diplomatCallback_func_Native): Pointer
+    fun CallbackHolder_call(handle: Pointer, a: Int): Int
+}
+internal interface Runner_DiplomatCallback_CallbackHolder_new_diplomatCallback_func: Callback {
+    fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int
+}
+
+internal class DiplomatCallback_CallbackHolder_new_diplomatCallback_func_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var data_: Pointer = Pointer(0L);
+    @JvmField
+    internal var run_callback: Runner_DiplomatCallback_CallbackHolder_new_diplomatCallback_func
+        = object :  Runner_DiplomatCallback_CallbackHolder_new_diplomatCallback_func {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int {
+                    throw Exception("Default callback runner -- should be replaced.")
+                }
+            }
+    @JvmField
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("data_", "run_callback", "destructor")
+    }
+}
+
+internal class DiplomatCallback_CallbackHolder_new_diplomatCallback_func internal constructor (
+    internal val nativeStruct: DiplomatCallback_CallbackHolder_new_diplomatCallback_func_Native) {
+    val data_: Pointer = nativeStruct.data_
+    val run_callback: Callback = nativeStruct.run_callback
+    val destructor: Callback = nativeStruct.destructor
+
+    companion object {
+        val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackHolder_new_diplomatCallback_func_Native::class.java).toLong()
+        
+        fun fromCallback(cb: (Int)->Int): DiplomatCallback_CallbackHolder_new_diplomatCallback_func {
+            val callback: Runner_DiplomatCallback_CallbackHolder_new_diplomatCallback_func = object :  Runner_DiplomatCallback_CallbackHolder_new_diplomatCallback_func {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int {
+                    return cb(arg0);
+                }
+            }
+            val cb_wrap = DiplomatCallback_CallbackHolder_new_diplomatCallback_func_Native()
+            cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
+            return DiplomatCallback_CallbackHolder_new_diplomatCallback_func(cb_wrap)
+        }
+    }
+}
+
+
+class CallbackHolder internal constructor (
+    internal val handle: Pointer,
+    // These ensure that anything that is borrowed is kept alive and not cleaned
+    // up by the garbage collector.
+    internal val selfEdges: List<Any>,
+)  {
+
+    internal class CallbackHolderCleaner(val handle: Pointer, val lib: CallbackHolderLib) : Runnable {
+        override fun run() {
+            lib.CallbackHolder_destroy(handle)
+        }
+    }
+
+    companion object {
+        internal val libClass: Class<CallbackHolderLib> = CallbackHolderLib::class.java
+        internal val lib: CallbackHolderLib = Native.load("somelib", libClass)
+        
+        fun new_(func: (Int)->Int): CallbackHolder {
+            
+            val returnVal = lib.CallbackHolder_new(DiplomatCallback_CallbackHolder_new_diplomatCallback_func.fromCallback(func).nativeStruct);
+            val selfEdges: List<Any> = listOf()
+            val handle = returnVal 
+            val returnOpaque = CallbackHolder(handle, selfEdges)
+            CLEANER.register(returnOpaque, CallbackHolder.CallbackHolderCleaner(handle, CallbackHolder.lib));
+            return returnOpaque
+        }
+    }
+    
+    fun call(a: Int): Int {
+        
+        val returnVal = lib.CallbackHolder_call(handle, a);
+        return (returnVal)
+    }
+
+}

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MutableCallbackHolder.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MutableCallbackHolder.kt
@@ -1,0 +1,99 @@
+package dev.diplomattest.somelib;
+import com.sun.jna.Callback
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+
+
+internal interface MutableCallbackHolderLib: Library {
+    fun MutableCallbackHolder_destroy(handle: Pointer)
+    fun MutableCallbackHolder_new(func: DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func_Native): Pointer
+    fun MutableCallbackHolder_call(handle: Pointer, a: Int): Int
+}
+internal interface Runner_DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func: Callback {
+    fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int
+}
+
+internal class DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var data_: Pointer = Pointer(0L);
+    @JvmField
+    internal var run_callback: Runner_DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func
+        = object :  Runner_DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int {
+                    throw Exception("Default callback runner -- should be replaced.")
+                }
+            }
+    @JvmField
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("data_", "run_callback", "destructor")
+    }
+}
+
+internal class DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func internal constructor (
+    internal val nativeStruct: DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func_Native) {
+    val data_: Pointer = nativeStruct.data_
+    val run_callback: Callback = nativeStruct.run_callback
+    val destructor: Callback = nativeStruct.destructor
+
+    companion object {
+        val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func_Native::class.java).toLong()
+        
+        fun fromCallback(cb: (Int)->Int): DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func {
+            val callback: Runner_DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func = object :  Runner_DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Int ): Int {
+                    return cb(arg0);
+                }
+            }
+            val cb_wrap = DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func_Native()
+            cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
+            return DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func(cb_wrap)
+        }
+    }
+}
+
+
+class MutableCallbackHolder internal constructor (
+    internal val handle: Pointer,
+    // These ensure that anything that is borrowed is kept alive and not cleaned
+    // up by the garbage collector.
+    internal val selfEdges: List<Any>,
+)  {
+
+    internal class MutableCallbackHolderCleaner(val handle: Pointer, val lib: MutableCallbackHolderLib) : Runnable {
+        override fun run() {
+            lib.MutableCallbackHolder_destroy(handle)
+        }
+    }
+
+    companion object {
+        internal val libClass: Class<MutableCallbackHolderLib> = MutableCallbackHolderLib::class.java
+        internal val lib: MutableCallbackHolderLib = Native.load("somelib", libClass)
+        
+        fun new_(func: (Int)->Int): MutableCallbackHolder {
+            
+            val returnVal = lib.MutableCallbackHolder_new(DiplomatCallback_MutableCallbackHolder_new_diplomatCallback_func.fromCallback(func).nativeStruct);
+            val selfEdges: List<Any> = listOf()
+            val handle = returnVal 
+            val returnOpaque = MutableCallbackHolder(handle, selfEdges)
+            CLEANER.register(returnOpaque, MutableCallbackHolder.MutableCallbackHolderCleaner(handle, MutableCallbackHolder.lib));
+            return returnOpaque
+        }
+    }
+    
+    fun call(a: Int): Int {
+        
+        val returnVal = lib.MutableCallbackHolder_call(handle, a);
+        return (returnVal)
+    }
+
+}

--- a/feature_tests/nanobind/src/include/CallbackHolder.d.hpp
+++ b/feature_tests/nanobind/src/include/CallbackHolder.d.hpp
@@ -1,0 +1,42 @@
+#ifndef CallbackHolder_D_HPP
+#define CallbackHolder_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    struct CallbackHolder;
+} // namespace capi
+} // namespace
+
+class CallbackHolder {
+public:
+
+  inline static std::unique_ptr<CallbackHolder> new_(std::function<int32_t(int32_t)> func);
+
+  inline int32_t call(int32_t a) const;
+
+  inline const diplomat::capi::CallbackHolder* AsFFI() const;
+  inline diplomat::capi::CallbackHolder* AsFFI();
+  inline static const CallbackHolder* FromFFI(const diplomat::capi::CallbackHolder* ptr);
+  inline static CallbackHolder* FromFFI(diplomat::capi::CallbackHolder* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  CallbackHolder() = delete;
+  CallbackHolder(const CallbackHolder&) = delete;
+  CallbackHolder(CallbackHolder&&) noexcept = delete;
+  CallbackHolder operator=(const CallbackHolder&) = delete;
+  CallbackHolder operator=(CallbackHolder&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+
+#endif // CallbackHolder_D_HPP

--- a/feature_tests/nanobind/src/include/CallbackHolder.hpp
+++ b/feature_tests/nanobind/src/include/CallbackHolder.hpp
@@ -1,0 +1,68 @@
+#ifndef CallbackHolder_HPP
+#define CallbackHolder_HPP
+
+#include "CallbackHolder.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    extern "C" {
+    typedef struct DiplomatCallback_CallbackHolder_new_func {
+        const void* data;
+        int32_t (*run_callback)(const void*, int32_t );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackHolder_new_func;
+    
+    diplomat::capi::CallbackHolder* CallbackHolder_new(DiplomatCallback_CallbackHolder_new_func func_cb_wrap);
+    
+    int32_t CallbackHolder_call(const diplomat::capi::CallbackHolder* self, int32_t a);
+    
+    
+    void CallbackHolder_destroy(CallbackHolder* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<CallbackHolder> CallbackHolder::new_(std::function<int32_t(int32_t)> func) {
+  auto result = diplomat::capi::CallbackHolder_new({new decltype(func)(std::move(func)), diplomat::fn_traits(func).c_run_callback, diplomat::fn_traits(func).c_delete});
+  return std::unique_ptr<CallbackHolder>(CallbackHolder::FromFFI(result));
+}
+
+inline int32_t CallbackHolder::call(int32_t a) const {
+  auto result = diplomat::capi::CallbackHolder_call(this->AsFFI(),
+    a);
+  return result;
+}
+
+inline const diplomat::capi::CallbackHolder* CallbackHolder::AsFFI() const {
+  return reinterpret_cast<const diplomat::capi::CallbackHolder*>(this);
+}
+
+inline diplomat::capi::CallbackHolder* CallbackHolder::AsFFI() {
+  return reinterpret_cast<diplomat::capi::CallbackHolder*>(this);
+}
+
+inline const CallbackHolder* CallbackHolder::FromFFI(const diplomat::capi::CallbackHolder* ptr) {
+  return reinterpret_cast<const CallbackHolder*>(ptr);
+}
+
+inline CallbackHolder* CallbackHolder::FromFFI(diplomat::capi::CallbackHolder* ptr) {
+  return reinterpret_cast<CallbackHolder*>(ptr);
+}
+
+inline void CallbackHolder::operator delete(void* ptr) {
+  diplomat::capi::CallbackHolder_destroy(reinterpret_cast<diplomat::capi::CallbackHolder*>(ptr));
+}
+
+
+#endif // CallbackHolder_HPP

--- a/feature_tests/nanobind/src/include/MutableCallbackHolder.d.hpp
+++ b/feature_tests/nanobind/src/include/MutableCallbackHolder.d.hpp
@@ -1,0 +1,42 @@
+#ifndef MutableCallbackHolder_D_HPP
+#define MutableCallbackHolder_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    struct MutableCallbackHolder;
+} // namespace capi
+} // namespace
+
+class MutableCallbackHolder {
+public:
+
+  inline static std::unique_ptr<MutableCallbackHolder> new_(std::function<int32_t(int32_t)> func);
+
+  inline int32_t call(int32_t a);
+
+  inline const diplomat::capi::MutableCallbackHolder* AsFFI() const;
+  inline diplomat::capi::MutableCallbackHolder* AsFFI();
+  inline static const MutableCallbackHolder* FromFFI(const diplomat::capi::MutableCallbackHolder* ptr);
+  inline static MutableCallbackHolder* FromFFI(diplomat::capi::MutableCallbackHolder* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  MutableCallbackHolder() = delete;
+  MutableCallbackHolder(const MutableCallbackHolder&) = delete;
+  MutableCallbackHolder(MutableCallbackHolder&&) noexcept = delete;
+  MutableCallbackHolder operator=(const MutableCallbackHolder&) = delete;
+  MutableCallbackHolder operator=(MutableCallbackHolder&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+
+#endif // MutableCallbackHolder_D_HPP

--- a/feature_tests/nanobind/src/include/MutableCallbackHolder.hpp
+++ b/feature_tests/nanobind/src/include/MutableCallbackHolder.hpp
@@ -1,0 +1,68 @@
+#ifndef MutableCallbackHolder_HPP
+#define MutableCallbackHolder_HPP
+
+#include "MutableCallbackHolder.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    extern "C" {
+    typedef struct DiplomatCallback_MutableCallbackHolder_new_func {
+        const void* data;
+        int32_t (*run_callback)(const void*, int32_t );
+        void (*destructor)(const void*);
+    } DiplomatCallback_MutableCallbackHolder_new_func;
+    
+    diplomat::capi::MutableCallbackHolder* MutableCallbackHolder_new(DiplomatCallback_MutableCallbackHolder_new_func func_cb_wrap);
+    
+    int32_t MutableCallbackHolder_call(diplomat::capi::MutableCallbackHolder* self, int32_t a);
+    
+    
+    void MutableCallbackHolder_destroy(MutableCallbackHolder* self);
+    
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<MutableCallbackHolder> MutableCallbackHolder::new_(std::function<int32_t(int32_t)> func) {
+  auto result = diplomat::capi::MutableCallbackHolder_new({new decltype(func)(std::move(func)), diplomat::fn_traits(func).c_run_callback, diplomat::fn_traits(func).c_delete});
+  return std::unique_ptr<MutableCallbackHolder>(MutableCallbackHolder::FromFFI(result));
+}
+
+inline int32_t MutableCallbackHolder::call(int32_t a) {
+  auto result = diplomat::capi::MutableCallbackHolder_call(this->AsFFI(),
+    a);
+  return result;
+}
+
+inline const diplomat::capi::MutableCallbackHolder* MutableCallbackHolder::AsFFI() const {
+  return reinterpret_cast<const diplomat::capi::MutableCallbackHolder*>(this);
+}
+
+inline diplomat::capi::MutableCallbackHolder* MutableCallbackHolder::AsFFI() {
+  return reinterpret_cast<diplomat::capi::MutableCallbackHolder*>(this);
+}
+
+inline const MutableCallbackHolder* MutableCallbackHolder::FromFFI(const diplomat::capi::MutableCallbackHolder* ptr) {
+  return reinterpret_cast<const MutableCallbackHolder*>(ptr);
+}
+
+inline MutableCallbackHolder* MutableCallbackHolder::FromFFI(diplomat::capi::MutableCallbackHolder* ptr) {
+  return reinterpret_cast<MutableCallbackHolder*>(ptr);
+}
+
+inline void MutableCallbackHolder::operator delete(void* ptr) {
+  diplomat::capi::MutableCallbackHolder_destroy(reinterpret_cast<diplomat::capi::MutableCallbackHolder*>(ptr));
+}
+
+
+#endif // MutableCallbackHolder_HPP

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -13,6 +13,7 @@
 #include "BorrowedFields.hpp"
 #include "BorrowedFieldsReturning.hpp"
 #include "BorrowedFieldsWithBounds.hpp"
+#include "CallbackHolder.hpp"
 #include "CallbackTestingStruct.hpp"
 #include "CallbackWrapper.hpp"
 #include "ContiguousEnum.hpp"
@@ -25,6 +26,7 @@
 #include "Float64Vec.hpp"
 #include "Foo.hpp"
 #include "ImportedStruct.hpp"
+#include "MutableCallbackHolder.hpp"
 #include "MyEnum.hpp"
 #include "MyOpaqueEnum.hpp"
 #include "MyString.hpp"
@@ -601,6 +603,24 @@ NB_MODULE(somelib, somelib_mod)
     nb::class_<Unnamespaced>(somelib_mod, "Unnamespaced", nb::type_slots(Unnamespaced_slots))
     	.def_static("make", &Unnamespaced::make, "_e"_a ) // unsupported special method NamedConstructor(None)
     	.def("use_namespaced", &Unnamespaced::use_namespaced, "_n"_a);
+    
+    PyType_Slot CallbackHolder_slots[] = {
+        {Py_tp_free, (void *)CallbackHolder::operator delete },
+        {Py_tp_dealloc, (void *)diplomat_tp_dealloc},
+        {0, nullptr}};
+    
+    nb::class_<CallbackHolder>(somelib_mod, "CallbackHolder", nb::type_slots(CallbackHolder_slots))
+    	.def("call", &CallbackHolder::call, "a"_a)
+    	.def(nb::new_(&CallbackHolder::new_), "func"_a);
+    
+    PyType_Slot MutableCallbackHolder_slots[] = {
+        {Py_tp_free, (void *)MutableCallbackHolder::operator delete },
+        {Py_tp_dealloc, (void *)diplomat_tp_dealloc},
+        {0, nullptr}};
+    
+    nb::class_<MutableCallbackHolder>(somelib_mod, "MutableCallbackHolder", nb::type_slots(MutableCallbackHolder_slots))
+    	.def("call", &MutableCallbackHolder::call, "a"_a)
+    	.def(nb::new_(&MutableCallbackHolder::new_), "func"_a);
     
     PyType_Slot Bar_slots[] = {
         {Py_tp_free, (void *)Bar::operator delete },

--- a/feature_tests/nanobind/test/test_callback.py
+++ b/feature_tests/nanobind/test/test_callback.py
@@ -59,3 +59,31 @@ def test_callback():
     out = o.test_str_cb_arg(lambda a: len(a))
     assert out == 7, "test_str_cb_arg output"
     print("END")
+
+            
+    cb = lambda a: 100 - a
+    holder = somelib.CallbackHolder(cb)
+    del cb
+
+    assert holder.call(5) == 95
+    assert holder.call(5) == 95
+
+    class HasMutatingStatic:
+        i = 100
+        @classmethod
+        def decrement(__cls__, a):
+            __cls__.i -= a
+            return __cls__.i
+        
+    assert HasMutatingStatic.decrement(5) == 95
+    assert HasMutatingStatic.decrement(5) == 90
+
+    # 'Fn' vs 'FnMut' is at best a suggestion with python, as there is no real way to distinguish between
+    # mutable and immutable callables
+    holder = somelib.CallbackHolder(lambda a: HasMutatingStatic.decrement(a))
+    assert holder.call(5) == 85
+    assert holder.call(5) == 80
+
+    holder = somelib.MutableCallbackHolder(lambda a: HasMutatingStatic.decrement(a))
+    assert holder.call(5) == 75
+    assert holder.call(5) == 70

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -30,4 +30,42 @@ mod ffi {
             f("bananna")
         }
     }
+
+    #[diplomat::attr(not(supports = "callbacks"), disable)]
+    #[diplomat::opaque]
+    pub struct CallbackHolder {
+        held: Box<dyn Fn(i32) -> i32>,
+    }
+
+    impl CallbackHolder {
+        #[diplomat::attr(auto, constructor)]
+        pub fn new(func: impl Fn(i32) -> i32 + 'static) -> Box<Self> {
+            Box::new(Self {
+                held: Box::new(func),
+            })
+        }
+
+        pub fn call(&self, a: i32) -> i32 {
+            (self.held)(a)
+        }
+    }
+
+    #[diplomat::attr(not(supports = "callbacks"), disable)]
+    #[diplomat::opaque]
+    pub struct MutableCallbackHolder {
+        held: Box<dyn FnMut(i32) -> i32>,
+    }
+
+    impl MutableCallbackHolder {
+        #[diplomat::attr(auto, constructor)]
+        pub fn new(func: impl FnMut(i32) -> i32 + 'static) -> Box<Self> {
+            Box::new(Self {
+                held: Box::new(func),
+            })
+        }
+
+        pub fn call(&mut self, a: i32) -> i32 {
+            (self.held)(a)
+        }
+    }
 }

--- a/macro/src/snapshots/diplomat__tests__callback_arguments.snap
+++ b/macro/src/snapshots/diplomat__tests__callback_arguments.snap
@@ -46,8 +46,9 @@ mod ffi {
         x: i32,
     ) -> i32 {
         let f = move |arg0: i32| unsafe {
+            let _ = &f;
             std::mem::transmute::<
-                unsafe extern "C" fn(*const c_void, ...) -> i32,
+                unsafe extern "C" fn(*mut c_void, ...) -> i32,
                 unsafe extern "C" fn(*const c_void, i32) -> i32,
             >(f.run_callback)(f.data, arg0)
         };
@@ -57,8 +58,9 @@ mod ffi {
     extern "C" fn Wrapper_test_multiarg_void_callback(f: DiplomatCallback<()>) {
         let f = move |arg0: i32, arg1: &str| unsafe {
             let arg1: diplomat_runtime::DiplomatUtf8StrSlice = arg1.into();
+            let _ = &f;
             std::mem::transmute::<
-                unsafe extern "C" fn(*const c_void, ...) -> (),
+                unsafe extern "C" fn(*mut c_void, ...) -> (),
                 unsafe extern "C" fn(
                     *const c_void,
                     i32,
@@ -72,8 +74,9 @@ mod ffi {
     extern "C" fn Wrapper_test_mod_array(g: DiplomatCallback<()>) {
         let g = move |arg0: &[u8]| unsafe {
             let arg0: diplomat_runtime::DiplomatSlice<u8> = arg0.into();
+            let _ = &g;
             std::mem::transmute::<
-                unsafe extern "C" fn(*const c_void, ...) -> (),
+                unsafe extern "C" fn(*mut c_void, ...) -> (),
                 unsafe extern "C" fn(
                     *const c_void,
                     diplomat_runtime::DiplomatSlice<u8>,
@@ -85,8 +88,9 @@ mod ffi {
     #[no_mangle]
     extern "C" fn Wrapper_test_no_args(h: DiplomatCallback<()>) -> i32 {
         let h = move || unsafe {
+            let _ = &h;
             std::mem::transmute::<
-                unsafe extern "C" fn(*const c_void, ...) -> (),
+                unsafe extern "C" fn(*mut c_void, ...) -> (),
                 unsafe extern "C" fn(*const c_void) -> (),
             >(h.run_callback)(h.data)
         };
@@ -95,8 +99,9 @@ mod ffi {
     #[no_mangle]
     extern "C" fn Wrapper_test_cb_with_struct(f: DiplomatCallback<i32>) -> i32 {
         let f = move |arg0: TestingStruct| unsafe {
+            let _ = &f;
             std::mem::transmute::<
-                unsafe extern "C" fn(*const c_void, ...) -> i32,
+                unsafe extern "C" fn(*mut c_void, ...) -> i32,
                 unsafe extern "C" fn(*const c_void, TestingStruct) -> i32,
             >(f.run_callback)(f.data, arg0)
         };
@@ -108,14 +113,16 @@ mod ffi {
         g: DiplomatCallback<i32>,
     ) -> i32 {
         let f = move || unsafe {
+            let _ = &f;
             std::mem::transmute::<
-                unsafe extern "C" fn(*const c_void, ...) -> i32,
+                unsafe extern "C" fn(*mut c_void, ...) -> i32,
                 unsafe extern "C" fn(*const c_void) -> i32,
             >(f.run_callback)(f.data)
         };
         let g = move |arg0: i32| unsafe {
+            let _ = &g;
             std::mem::transmute::<
-                unsafe extern "C" fn(*const c_void, ...) -> i32,
+                unsafe extern "C" fn(*mut c_void, ...) -> i32,
                 unsafe extern "C" fn(*const c_void, i32) -> i32,
             >(g.run_callback)(g.data, arg0)
         };

--- a/runtime/src/callback.rs
+++ b/runtime/src/callback.rs
@@ -15,10 +15,12 @@ pub struct DiplomatCallback<ReturnType> {
     // any data required to run the callback; e.g. a pointer to the
     // callback wrapper object in the foreign runtime + the runtime itself
     pub data: *mut c_void,
-    // function to actually run the callback
-    pub run_callback: unsafe extern "C" fn(*const c_void, ...) -> ReturnType,
+    // function to actually run the callback. Note the first param is mutable, but depending
+    // on if this is passed to a Fn or FnMut may not actually need to be. FFI-Callers
+    // of said functions should cast to mutable.
+    pub run_callback: unsafe extern "C" fn(*mut c_void, ...) -> ReturnType,
     // function to destroy this callback struct
-    pub destructor: Option<unsafe extern "C" fn(*const c_void)>,
+    pub destructor: Option<unsafe extern "C" fn(*mut c_void)>,
 }
 
 impl<ReturnType> Drop for DiplomatCallback<ReturnType> {

--- a/runtime/src/write.rs
+++ b/runtime/src/write.rs
@@ -27,7 +27,7 @@ use core::{fmt, ptr};
 ///
 /// # Safety invariants:
 ///  - `flush()` and `grow()` will be passed `self` including `context` and it should always be safe to do so.
-///     `context` may be  null, however `flush()` and `grow()` must then be ready to receive it as such.
+///    `context` may be  null, however `flush()` and `grow()` must then be ready to receive it as such.
 ///  - `buf` must be `cap` bytes long
 ///  - `grow()` must either return false or update `buf` and `cap` for a valid buffer
 ///    of at least the requested buffer size

--- a/tool/src/cpp/header.rs
+++ b/tool/src/cpp/header.rs
@@ -139,7 +139,7 @@ impl fmt::Display for Header {
                 .decl_include
                 .as_ref()
                 // The decl is always in the same namespace/directory
-                .map(|s| Cow::Borrowed(s.as_str().split('/').last().unwrap())),
+                .map(|s| Cow::Borrowed(s.as_str().split('/').next_back().unwrap())),
             includes: self
                 .includes
                 .iter()

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1392,7 +1392,7 @@ returnVal.option() ?: return null
                     &mut unused_special_methods,
                     method,
                     None,
-                    None,
+                    Some(type_name),
                     use_finalizers_not_cleaners,
                 )
             })
@@ -1941,7 +1941,13 @@ returnVal.option() ?: return null
             Type::Slice(hir::Slice::Primitive(_, ty)) => {
                 self.formatter.fmt_primitive_slice(ty).into()
             }
-            Type::Callback(_) => format!("DiplomatCallback_{}", additional_name.unwrap()).into(),
+            Type::Callback(_) => {
+                println!(
+                    "Generating type name for {}",
+                    additional_name.as_ref().unwrap()
+                );
+                format!("DiplomatCallback_{}", additional_name.unwrap()).into()
+            }
             Type::Slice(hir::Slice::Strs(_)) => self.formatter.fmt_str_slices().into(),
             _ => unreachable!("unknown AST/HIR variant"),
         }


### PR DESCRIPTION
- Fixes a bug where Fn trait objects would be destructed as soon as the function returned, preventing capture or storage in Box<dyn Fn> members
- Adds support for FnMut callback signatures
- Adds support for 'static annotations on traits (required to allow storage in `Box<dyn Fn>`)