### PR TITLE
Enable mutable references to opaque types in callbacks

### DIFF
--- a/book/src/callbacks.md
+++ b/book/src/callbacks.md
@@ -18,4 +18,6 @@ impl MyType{
 }
 ```
 
-The callback's parameters & return types may be limited depending on the target language for now. Additional traits are not supported, however `+ 'static` may be given, which allows for moving the trait object into a `Box<dyn Fn()>`
+The callback's parameters & return types may be limited depending on the target language for now. Additional traits are not supported, however `+ 'static` may be given, which allows for moving the trait object into a `Box<dyn Fn()>`.
+
+Callback may accept references & mutable references to opaque types as parameters, however lifetime parsing for these is not yet supported. Users should assume that it is not safe to store any such parameter outside the callback.

--- a/book/src/callbacks.md
+++ b/book/src/callbacks.md
@@ -20,4 +20,4 @@ impl MyType{
 
 The callback's parameters & return types may be limited depending on the target language for now. Additional traits are not supported, however `+ 'static` may be given, which allows for moving the trait object into a `Box<dyn Fn()>`.
 
-Callback may accept references & mutable references to opaque types as parameters, however lifetime parsing for these is not yet supported. Users should assume that it is not safe to store any such parameter outside the callback.
+Some backends may support callbacks accepting \[mutable\] references to opaque types as parameters, but lifetime parsing for these is not yet supported by any backend. Only anonymous lifetimes are allowed as a result, meaning that no such parameter may be guaranteed to live longer than a single invocation of the callback.

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -941,9 +941,7 @@ impl<'ast> LoweringContext<'ast> {
                 }
                 let mut params: Vec<CallbackParam> = Vec::new();
                 for in_ty in input_types.iter() {
-                    let hir_in_ty = self
-                        .lower_out_type(in_ty, ltl, in_path, false, false)
-                        .unwrap();
+                    let hir_in_ty = self.lower_out_type(in_ty, ltl, in_path, false, false)?;
 
                     params.push(CallbackParam {
                         ty: hir_in_ty,
@@ -1060,7 +1058,7 @@ impl<'ast> LoweringContext<'ast> {
                     }
                 }
                 _ => {
-                    self.errors.push(LoweringError::Other(format!("found &T in output where T isn't a custom type and therefore not opaque. T = {ref_ty}")));
+                    self.errors.push(LoweringError::Other(format!("found &T in output where T isn't a custom type and therefore not opaque. T = {ref_ty}, path = {:?}", in_path)));
                     Err(())
                 }
             },

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -945,14 +945,6 @@ impl<'ast> LoweringContext<'ast> {
                         .lower_out_type(in_ty, ltl, in_path, false, false)
                         .unwrap();
 
-                    if !matches!(hir_in_ty, super::Type::Slice(super::Slice::Str(_, _)))
-                        && hir_in_ty.lifetimes().next().is_some()
-                    {
-                        self.errors.push(LoweringError::Other(
-                            "Callback parameters can't be borrowed, and therefore can't have lifetimes".into(),
-                        ));
-                        return Err(());
-                    }
                     params.push(CallbackParam {
                         ty: hir_in_ty,
                         name: None,

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -255,42 +255,51 @@ private:
 
 // Interop between std::function & our C Callback wrapper type
 
+template <typename T, typename = void>
+struct as_ffi {
+  using type = T;
+};
+
+template <typename T>
+struct as_ffi<T, std::void_t<decltype(std::declval<std::remove_pointer_t<T>>().AsFFI())>> {
+  using type = decltype(std::declval<std::remove_pointer_t<T>>().AsFFI());
+};
+
+template<typename T>
+using as_ffi_t = typename as_ffi<T>::type;
+
+template<typename T>
+using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+
+template<typename T>
+using replace_ref_with_ptr_t = std::conditional_t<std::is_reference_v<T>, std::add_pointer_t<std::remove_reference_t<T>>, T>;
+
+/// Replace the argument types from the std::function with the argument types for th function pointer
+template<typename T>
+using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+
 template <typename T> struct fn_traits;
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
     using fn_ptr_t = Ret(Args...);
     using function_t = std::function<fn_ptr_t>;
     using ret = Ret;
 
-    template <typename T, typename = void>
-    struct as_ffi {
-      using type = T;
-    };
-
-    template <typename T>
-    struct as_ffi<T, std::void_t<decltype(&T::AsFFI)>> {
-      using type = decltype(std::declval<T>().AsFFI());
-    };
-
-    template<typename T>
-    using as_ffi_t = typename as_ffi<T>::type;
-
-    template<typename T>
-    using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
-
-    template<typename T>
-    using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
-
     // For a given T, creates a function that take in the C ABI version & return the C++ type.
     template<typename T>
     static T replace(replace_fn_t<T> val) {
-        if constexpr(std::is_same_v<T, std::string_view>)   {
-            return std::string_view{val.data, val.len};
-        } else if constexpr(!std::is_same_v<T, as_ffi_t<T>>) {
-            return T::FromFFI(val);
+      if constexpr(std::is_same_v<T, std::string_view>)   {
+          return std::string_view{val.data, val.len};
+      } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
+        if constexpr (std::is_lvalue_reference_v<T>) {
+          return *std::remove_reference_t<T>::FromFFI(val);
         }
         else {
-            return val;
+          return T::FromFFI(val);
         }
+      }
+      else {
+          return val;
+      }
     }
 
     static Ret c_run_callback(const void *cb, replace_fn_t<Args>... args) {

--- a/feature_tests/c/include/CallbackWrapper.h
+++ b/feature_tests/c/include/CallbackWrapper.h
@@ -8,6 +8,7 @@
 #include "diplomat_runtime.h"
 
 #include "CallbackTestingStruct.d.h"
+#include "MyString.d.h"
 
 #include "CallbackWrapper.d.h"
 
@@ -45,6 +46,11 @@ typedef struct DiplomatCallback_CallbackWrapper_test_str_cb_arg_f {
     int32_t (*run_callback)(const void*, DiplomatStringView );
     void (*destructor)(const void*);
 } DiplomatCallback_CallbackWrapper_test_str_cb_arg_f;
+typedef struct DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb {
+    const void* data;
+    void (*run_callback)(const void*, MyString* );
+    void (*destructor)(const void*);
+} DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb;
 
 int32_t CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f f_cb_wrap, int32_t x);
 
@@ -55,6 +61,8 @@ int32_t CallbackWrapper_test_cb_with_struct(DiplomatCallback_CallbackWrapper_tes
 int32_t CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_f f_cb_wrap, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g g_cb_wrap);
 
 int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_str_cb_arg_f f_cb_wrap);
+
+void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb cb_cb_wrap, MyString* a);
 
 
 

--- a/feature_tests/cpp/include/CallbackWrapper.d.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.d.hpp
@@ -10,6 +10,8 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace diplomat::capi { struct MyString; }
+class MyString;
 struct CallbackTestingStruct;
 
 
@@ -36,6 +38,8 @@ struct CallbackWrapper {
   inline static int32_t test_multiple_cb_args(std::function<int32_t()> f, std::function<int32_t(int32_t)> g);
 
   inline static int32_t test_str_cb_arg(std::function<int32_t(std::string_view)> f);
+
+  inline static void test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a);
 
   inline diplomat::capi::CallbackWrapper AsFFI() const;
   inline static CallbackWrapper FromFFI(diplomat::capi::CallbackWrapper c_struct);

--- a/feature_tests/cpp/include/CallbackWrapper.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <optional>
 #include "CallbackTestingStruct.hpp"
+#include "MyString.hpp"
 #include "diplomat_runtime.hpp"
 
 
@@ -47,6 +48,11 @@ namespace capi {
         int32_t (*run_callback)(const void*, diplomat::capi::DiplomatStringView );
         void (*destructor)(const void*);
     } DiplomatCallback_CallbackWrapper_test_str_cb_arg_f;
+    typedef struct DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb {
+        const void* data;
+        void (*run_callback)(const void*, diplomat::capi::MyString* );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb;
     
     int32_t CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f f_cb_wrap, int32_t x);
     
@@ -57,6 +63,8 @@ namespace capi {
     int32_t CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_f f_cb_wrap, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g g_cb_wrap);
     
     int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_str_cb_arg_f f_cb_wrap);
+    
+    void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb cb_cb_wrap, diplomat::capi::MyString* a);
     
     
     } // extern "C"
@@ -88,6 +96,11 @@ inline int32_t CallbackWrapper::test_multiple_cb_args(std::function<int32_t()> f
 inline int32_t CallbackWrapper::test_str_cb_arg(std::function<int32_t(std::string_view)> f) {
   auto result = diplomat::capi::CallbackWrapper_test_str_cb_arg({new decltype(f)(std::move(f)), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
   return result;
+}
+
+inline void CallbackWrapper::test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a) {
+  diplomat::capi::CallbackWrapper_test_opaque_cb_arg({new decltype(cb)(std::move(cb)), diplomat::fn_traits(cb).c_run_callback, diplomat::fn_traits(cb).c_delete},
+    a.AsFFI());
 }
 
 

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -255,42 +255,51 @@ private:
 
 // Interop between std::function & our C Callback wrapper type
 
+template <typename T, typename = void>
+struct as_ffi {
+  using type = T;
+};
+
+template <typename T>
+struct as_ffi<T, std::void_t<decltype(std::declval<std::remove_pointer_t<T>>().AsFFI())>> {
+  using type = decltype(std::declval<std::remove_pointer_t<T>>().AsFFI());
+};
+
+template<typename T>
+using as_ffi_t = typename as_ffi<T>::type;
+
+template<typename T>
+using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+
+template<typename T>
+using replace_ref_with_ptr_t = std::conditional_t<std::is_reference_v<T>, std::add_pointer_t<std::remove_reference_t<T>>, T>;
+
+/// Replace the argument types from the std::function with the argument types for th function pointer
+template<typename T>
+using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+
 template <typename T> struct fn_traits;
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
     using fn_ptr_t = Ret(Args...);
     using function_t = std::function<fn_ptr_t>;
     using ret = Ret;
 
-    template <typename T, typename = void>
-    struct as_ffi {
-      using type = T;
-    };
-
-    template <typename T>
-    struct as_ffi<T, std::void_t<decltype(&T::AsFFI)>> {
-      using type = decltype(std::declval<T>().AsFFI());
-    };
-
-    template<typename T>
-    using as_ffi_t = typename as_ffi<T>::type;
-
-    template<typename T>
-    using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
-
-    template<typename T>
-    using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
-
     // For a given T, creates a function that take in the C ABI version & return the C++ type.
     template<typename T>
     static T replace(replace_fn_t<T> val) {
-        if constexpr(std::is_same_v<T, std::string_view>)   {
-            return std::string_view{val.data, val.len};
-        } else if constexpr(!std::is_same_v<T, as_ffi_t<T>>) {
-            return T::FromFFI(val);
+      if constexpr(std::is_same_v<T, std::string_view>)   {
+          return std::string_view{val.data, val.len};
+      } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
+        if constexpr (std::is_lvalue_reference_v<T>) {
+          return *std::remove_reference_t<T>::FromFFI(val);
         }
         else {
-            return val;
+          return T::FromFFI(val);
         }
+      }
+      else {
+          return val;
+      }
     }
 
     static Ret c_run_callback(const void *cb, replace_fn_t<Args>... args) {

--- a/feature_tests/cpp/tests/callback.cpp
+++ b/feature_tests/cpp/tests/callback.cpp
@@ -2,10 +2,12 @@
 #include "../include/CallbackWrapper.hpp"
 #include "../include/CallbackHolder.hpp"
 #include "../include/MutableCallbackHolder.hpp"
+#include "../include/MyString.hpp"
 #include "assert.hpp"
 
 int main(int argc, char *argv[])
 {
+
     CallbackWrapper o;
     int32_t tmp = 0;
     {
@@ -57,5 +59,14 @@ int main(int argc, char *argv[])
         auto cb = MutableCallbackHolder::new_([copied](int32_t a) mutable { copied += a; return copied;});
         simple_assert_eq("mutable cb object", cb->call(5), 5);
         simple_assert_eq("mutable cb object", cb->call(5), 10);
+    }
+    {
+        
+        auto opaque = MyString::new_("Bananna");
+        simple_assert_eq("opaque cb arg", opaque->borrow(), "Bananna");
+        o.test_opaque_cb_arg([](MyString& op) {
+            op.set_str("split");
+        }, *opaque);
+        simple_assert_eq("opaque cb arg", opaque->borrow(), "split");
     }
 }

--- a/feature_tests/cpp/tests/structs.cpp
+++ b/feature_tests/cpp/tests/structs.cpp
@@ -3,10 +3,13 @@
 #include "../include/MyEnum.hpp"
 #include "../include/Opaque.hpp"
 #include "../include/StructArithmetic.hpp"
+#include "../include/ns/RenamedOpaqueArithmetic.hpp"
 #include "assert.hpp"
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char* argv[]) {
+
+    static_assert(std::is_same_v<diplomat::as_ffi_t<ns::RenamedOpaqueArithmetic>, ns::capi::RenamedOpaqueArithmetic*>);
+
     std::unique_ptr<Opaque> o = Opaque::new_();
     MyStruct s = MyStruct::new_();
 
@@ -23,8 +26,8 @@ int main(int argc, char *argv[])
     simple_assert_eq("enum fn", s.g.into_value(), -1);
     simple_assert_eq("struct fn", s.into_a(), 17);
 
-    auto a = StructArithmetic{1, 2};
-    auto b = StructArithmetic{2, 3};
+    auto a = StructArithmetic{ 1, 2 };
+    auto b = StructArithmetic{ 2, 3 };
     {
         auto r = a + b;
 
@@ -34,4 +37,5 @@ int main(int argc, char *argv[])
         simple_assert_eq("self-adding x", r.x, 4);
         simple_assert_eq("self-adding y", r.y, 7);
     }
+
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
@@ -11,6 +11,7 @@ internal interface CallbackWrapperLib: Library {
     fun CallbackWrapper_test_no_args(h: DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h_Native): Int
     fun CallbackWrapper_test_cb_with_struct(f: DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f_Native): Int
     fun CallbackWrapper_test_multiple_cb_args(f: DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f_Native, g: DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g_Native): Int
+    fun CallbackWrapper_test_opaque_cb_arg(cb: DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native, a: Pointer): Unit
 }
 
 internal class CallbackWrapperNative: Structure(), Structure.ByValue {
@@ -269,6 +270,55 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
         }
     }
 }
+internal interface Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb: Callback {
+    fun invoke(lang_specific_context: Pointer?, arg0: Pointer ): Unit
+}
+
+internal class DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var data_: Pointer = Pointer(0L);
+    @JvmField
+    internal var run_callback: Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb
+        = object :  Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Pointer ): Unit {
+                    throw Exception("Default callback runner -- should be replaced.")
+                }
+            }
+    @JvmField
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("data_", "run_callback", "destructor")
+    }
+}
+
+internal class DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb internal constructor (
+    internal val nativeStruct: DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native) {
+    val data_: Pointer = nativeStruct.data_
+    val run_callback: Callback = nativeStruct.run_callback
+    val destructor: Callback = nativeStruct.destructor
+
+    companion object {
+        val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native::class.java).toLong()
+        
+        fun fromCallback(cb: (MyString)->Unit): DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb {
+            val callback: Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb = object :  Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Pointer ): Unit {
+                    return cb(MyString(arg0, listOf()));
+                }
+            }
+            val cb_wrap = DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native()
+            cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
+            return DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb(cb_wrap)
+        }
+    }
+}
 class CallbackWrapper internal constructor (
     internal val nativeStruct: CallbackWrapperNative) {
     val cantBeEmpty: Boolean = nativeStruct.cantBeEmpty > 0
@@ -300,6 +350,12 @@ class CallbackWrapper internal constructor (
             
             val returnVal = lib.CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f.fromCallback(f).nativeStruct, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g.fromCallback(g).nativeStruct);
             return (returnVal)
+        }
+        
+        fun testOpaqueCbArg(cb: (MyString)->Unit, a: MyString): Unit {
+            
+            val returnVal = lib.CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb.fromCallback(cb).nativeStruct, a.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
+            
         }
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
@@ -11,7 +11,6 @@ internal interface CallbackWrapperLib: Library {
     fun CallbackWrapper_test_no_args(h: DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h_Native): Int
     fun CallbackWrapper_test_cb_with_struct(f: DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f_Native): Int
     fun CallbackWrapper_test_multiple_cb_args(f: DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f_Native, g: DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g_Native): Int
-    fun CallbackWrapper_test_opaque_cb_arg(cb: DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native, a: Pointer): Unit
 }
 
 internal class CallbackWrapperNative: Structure(), Structure.ByValue {
@@ -270,55 +269,6 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
         }
     }
 }
-internal interface Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb: Callback {
-    fun invoke(lang_specific_context: Pointer?, arg0: Pointer ): Unit
-}
-
-internal class DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native: Structure(), Structure.ByValue {
-    @JvmField
-    internal var data_: Pointer = Pointer(0L);
-    @JvmField
-    internal var run_callback: Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb
-        = object :  Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb {
-                override fun invoke(lang_specific_context: Pointer?, arg0: Pointer ): Unit {
-                    throw Exception("Default callback runner -- should be replaced.")
-                }
-            }
-    @JvmField
-    internal var destructor: Callback = object : Callback {
-        fun invoke(obj_pointer: Pointer) {
-            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
-        }
-    };
-
-    // Define the fields of the struct
-    override fun getFieldOrder(): List<String> {
-        return listOf("data_", "run_callback", "destructor")
-    }
-}
-
-internal class DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb internal constructor (
-    internal val nativeStruct: DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native) {
-    val data_: Pointer = nativeStruct.data_
-    val run_callback: Callback = nativeStruct.run_callback
-    val destructor: Callback = nativeStruct.destructor
-
-    companion object {
-        val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native::class.java).toLong()
-        
-        fun fromCallback(cb: (MyString)->Unit): DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb {
-            val callback: Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb = object :  Runner_DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb {
-                override fun invoke(lang_specific_context: Pointer?, arg0: Pointer ): Unit {
-                    return cb(MyString(arg0, listOf()));
-                }
-            }
-            val cb_wrap = DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb_Native()
-            cb_wrap.run_callback = callback;
-            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
-            return DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb(cb_wrap)
-        }
-    }
-}
 class CallbackWrapper internal constructor (
     internal val nativeStruct: CallbackWrapperNative) {
     val cantBeEmpty: Boolean = nativeStruct.cantBeEmpty > 0
@@ -350,12 +300,6 @@ class CallbackWrapper internal constructor (
             
             val returnVal = lib.CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f.fromCallback(f).nativeStruct, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g.fromCallback(g).nativeStruct);
             return (returnVal)
-        }
-        
-        fun testOpaqueCbArg(cb: (MyString)->Unit, a: MyString): Unit {
-            
-            val returnVal = lib.CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_diplomatCallback_cb.fromCallback(cb).nativeStruct, a.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
-            
         }
     }
 

--- a/feature_tests/nanobind/src/include/CallbackWrapper.d.hpp
+++ b/feature_tests/nanobind/src/include/CallbackWrapper.d.hpp
@@ -10,6 +10,8 @@
 #include <optional>
 #include "diplomat_runtime.hpp"
 
+namespace diplomat::capi { struct MyString; }
+class MyString;
 struct CallbackTestingStruct;
 
 
@@ -36,6 +38,8 @@ struct CallbackWrapper {
   inline static int32_t test_multiple_cb_args(std::function<int32_t()> f, std::function<int32_t(int32_t)> g);
 
   inline static int32_t test_str_cb_arg(std::function<int32_t(std::string_view)> f);
+
+  inline static void test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a);
 
   inline diplomat::capi::CallbackWrapper AsFFI() const;
   inline static CallbackWrapper FromFFI(diplomat::capi::CallbackWrapper c_struct);

--- a/feature_tests/nanobind/src/include/CallbackWrapper.hpp
+++ b/feature_tests/nanobind/src/include/CallbackWrapper.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <optional>
 #include "CallbackTestingStruct.hpp"
+#include "MyString.hpp"
 #include "diplomat_runtime.hpp"
 
 
@@ -47,6 +48,11 @@ namespace capi {
         int32_t (*run_callback)(const void*, diplomat::capi::DiplomatStringView );
         void (*destructor)(const void*);
     } DiplomatCallback_CallbackWrapper_test_str_cb_arg_f;
+    typedef struct DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb {
+        const void* data;
+        void (*run_callback)(const void*, diplomat::capi::MyString* );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb;
     
     int32_t CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f f_cb_wrap, int32_t x);
     
@@ -57,6 +63,8 @@ namespace capi {
     int32_t CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_f f_cb_wrap, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_g g_cb_wrap);
     
     int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_str_cb_arg_f f_cb_wrap);
+    
+    void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb cb_cb_wrap, diplomat::capi::MyString* a);
     
     
     } // extern "C"
@@ -88,6 +96,11 @@ inline int32_t CallbackWrapper::test_multiple_cb_args(std::function<int32_t()> f
 inline int32_t CallbackWrapper::test_str_cb_arg(std::function<int32_t(std::string_view)> f) {
   auto result = diplomat::capi::CallbackWrapper_test_str_cb_arg({new decltype(f)(std::move(f)), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
   return result;
+}
+
+inline void CallbackWrapper::test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a) {
+  diplomat::capi::CallbackWrapper_test_opaque_cb_arg({new decltype(cb)(std::move(cb)), diplomat::fn_traits(cb).c_run_callback, diplomat::fn_traits(cb).c_delete},
+    a.AsFFI());
 }
 
 

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -255,42 +255,51 @@ private:
 
 // Interop between std::function & our C Callback wrapper type
 
+template <typename T, typename = void>
+struct as_ffi {
+  using type = T;
+};
+
+template <typename T>
+struct as_ffi<T, std::void_t<decltype(std::declval<std::remove_pointer_t<T>>().AsFFI())>> {
+  using type = decltype(std::declval<std::remove_pointer_t<T>>().AsFFI());
+};
+
+template<typename T>
+using as_ffi_t = typename as_ffi<T>::type;
+
+template<typename T>
+using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+
+template<typename T>
+using replace_ref_with_ptr_t = std::conditional_t<std::is_reference_v<T>, std::add_pointer_t<std::remove_reference_t<T>>, T>;
+
+/// Replace the argument types from the std::function with the argument types for th function pointer
+template<typename T>
+using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+
 template <typename T> struct fn_traits;
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
     using fn_ptr_t = Ret(Args...);
     using function_t = std::function<fn_ptr_t>;
     using ret = Ret;
 
-    template <typename T, typename = void>
-    struct as_ffi {
-      using type = T;
-    };
-
-    template <typename T>
-    struct as_ffi<T, std::void_t<decltype(&T::AsFFI)>> {
-      using type = decltype(std::declval<T>().AsFFI());
-    };
-
-    template<typename T>
-    using as_ffi_t = typename as_ffi<T>::type;
-
-    template<typename T>
-    using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
-
-    template<typename T>
-    using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
-
     // For a given T, creates a function that take in the C ABI version & return the C++ type.
     template<typename T>
     static T replace(replace_fn_t<T> val) {
-        if constexpr(std::is_same_v<T, std::string_view>)   {
-            return std::string_view{val.data, val.len};
-        } else if constexpr(!std::is_same_v<T, as_ffi_t<T>>) {
-            return T::FromFFI(val);
+      if constexpr(std::is_same_v<T, std::string_view>)   {
+          return std::string_view{val.data, val.len};
+      } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
+        if constexpr (std::is_lvalue_reference_v<T>) {
+          return *std::remove_reference_t<T>::FromFFI(val);
         }
         else {
-            return val;
+          return T::FromFFI(val);
         }
+      }
+      else {
+          return val;
+      }
     }
 
     static Ret c_run_callback(const void *cb, replace_fn_t<Args>... args) {

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -341,6 +341,7 @@ NB_MODULE(somelib, somelib_mod)
     	.def_static("test_multi_arg_callback", &CallbackWrapper::test_multi_arg_callback, "f"_a, "x"_a)
     	.def_static("test_multiple_cb_args", &CallbackWrapper::test_multiple_cb_args, "f"_a, "g"_a)
     	.def_static("test_no_args", &CallbackWrapper::test_no_args, "h"_a)
+    	.def_static("test_opaque_cb_arg", &CallbackWrapper::test_opaque_cb_arg, "cb"_a, "a"_a)
     	.def_static("test_str_cb_arg", &CallbackWrapper::test_str_cb_arg, "f"_a);
     
     nb::class_<ImportedStruct>(somelib_mod, "ImportedStruct")

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -148,7 +148,7 @@ pub mod ffi {
 
     #[diplomat::opaque]
     #[diplomat::attr(not(supports = arithmetic), disable)]
-    struct OpaqueArithmetic {
+    pub(crate) struct OpaqueArithmetic {
         x: i32,
         y: i32,
     }

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -32,7 +32,7 @@ mod ffi {
             f("bananna")
         }
 
-        pub fn test_opaque_cb_arg(cb: impl Fn(&mut MyString), a: &mut MyString) {
+        pub fn test_opaque_cb_arg<'a>(cb: impl Fn(&mut MyString), a: &'a mut MyString) {
             cb(a);
         }
     }

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -32,6 +32,7 @@ mod ffi {
             f("bananna")
         }
 
+        #[diplomat::attr(kotlin, disable)]
         pub fn test_opaque_cb_arg<'a>(cb: impl Fn(&mut MyString), a: &'a mut MyString) {
             cb(a);
         }

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -1,5 +1,7 @@
 #[diplomat::bridge]
 mod ffi {
+    use crate::slices::ffi::MyString;
+
     #[diplomat::attr(not(supports = "callbacks"), disable)]
     pub struct CallbackWrapper {
         cant_be_empty: bool,
@@ -28,6 +30,10 @@ mod ffi {
         #[diplomat::attr(kotlin, disable)]
         pub fn test_str_cb_arg(f: impl Fn(&str) -> i32) -> i32 {
             f("bananna")
+        }
+
+        pub fn test_opaque_cb_arg(cb: impl Fn(&mut MyString), a: &mut MyString) {
+            cb(a);
         }
     }
 

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -1,10 +1,10 @@
 #[diplomat::bridge]
-mod ffi {
+pub mod ffi {
     use diplomat_runtime::{DiplomatStr, DiplomatStrSlice, DiplomatWrite};
     use std::fmt::Write as _;
 
     #[diplomat::opaque]
-    struct MyString(String);
+    pub struct MyString(String);
 
     impl MyString {
         #[diplomat::attr(auto, constructor)]

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -54,7 +54,6 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
 pub struct KotlinConfig {
     domain: Option<String>,
     use_finalizers_not_cleaners: Option<bool>,
-    allow_callback_ref_args: Option<bool>,
 }
 
 impl KotlinConfig {
@@ -81,7 +80,6 @@ pub(crate) fn run<'tcx>(
     let KotlinConfig {
         domain,
         use_finalizers_not_cleaners,
-        allow_callback_ref_args,
     } = conf.kotlin_config;
 
     let domain = domain.expect("Failed to parse Kotlin config. Missing required field `domain`.");
@@ -105,7 +103,6 @@ pub(crate) fn run<'tcx>(
         option_types: RefCell::new(BTreeSet::new()),
         formatter: &formatter,
         callback_params: &mut callback_params,
-        allow_callback_ref_args,
     };
 
     for (_id, ty) in tcx.all_types() {
@@ -283,7 +280,6 @@ struct TyGenContext<'a, 'cx> {
     option_types: RefCell<BTreeSet<TypeForResult<'cx>>>,
     errors: &'a ErrorStore<'cx, String>,
     callback_params: &'a mut Vec<CallbackParamInfo>,
-    allow_callback_ref_args: Option<bool>,
 }
 
 impl<'cx> TyGenContext<'_, 'cx> {
@@ -1097,8 +1093,6 @@ returnVal.option() ?: return null
                     output,
                     ..
                 }) => {
-                    assert!(!params.iter().any(|p| p.ty.lifetimes().next().is_some()), "Callback reference inputs are not allowed unless allow_callback_ref_args is set");
-
                     let param_name = "diplomatCallback_".to_owned() + &param_name;
                     additional_name = Some(
                         struct_name.unwrap().to_owned()

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -201,42 +201,51 @@ private:
 
 // Interop between std::function & our C Callback wrapper type
 
+template <typename T, typename = void>
+struct as_ffi {
+  using type = T;
+};
+
+template <typename T>
+struct as_ffi<T, std::void_t<decltype(std::declval<std::remove_pointer_t<T>>().AsFFI())>> {
+  using type = decltype(std::declval<std::remove_pointer_t<T>>().AsFFI());
+};
+
+template<typename T>
+using as_ffi_t = typename as_ffi<T>::type;
+
+template<typename T>
+using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
+
+template<typename T>
+using replace_ref_with_ptr_t = std::conditional_t<std::is_reference_v<T>, std::add_pointer_t<std::remove_reference_t<T>>, T>;
+
+/// Replace the argument types from the std::function with the argument types for th function pointer
+template<typename T>
+using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+
 template <typename T> struct fn_traits;
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
     using fn_ptr_t = Ret(Args...);
     using function_t = std::function<fn_ptr_t>;
     using ret = Ret;
 
-    template <typename T, typename = void>
-    struct as_ffi {
-      using type = T;
-    };
-
-    template <typename T>
-    struct as_ffi<T, std::void_t<decltype(&T::AsFFI)>> {
-      using type = decltype(std::declval<T>().AsFFI());
-    };
-
-    template<typename T>
-    using as_ffi_t = typename as_ffi<T>::type;
-
-    template<typename T>
-    using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
-
-    template<typename T>
-    using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
-
     // For a given T, creates a function that take in the C ABI version & return the C++ type.
     template<typename T>
     static T replace(replace_fn_t<T> val) {
-        if constexpr(std::is_same_v<T, std::string_view>)   {
-            return std::string_view{val.data, val.len};
-        } else if constexpr(!std::is_same_v<T, as_ffi_t<T>>) {
-            return T::FromFFI(val);
+      if constexpr(std::is_same_v<T, std::string_view>)   {
+          return std::string_view{val.data, val.len};
+      } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
+        if constexpr (std::is_lvalue_reference_v<T>) {
+          return *std::remove_reference_t<T>::FromFFI(val);
         }
         else {
-            return val;
+          return T::FromFFI(val);
         }
+      }
+      else {
+          return val;
+      }
     }
 
     static Ret c_run_callback(const void *cb, replace_fn_t<Args>... args) {


### PR DESCRIPTION
We need some way to have references to opaque types in callbacks. Per discussion with @Manishearth , this enforces that references in callbacks may *not* have named lifetimes. This ensures they will do the default thing, which is equivalent to `for<'_> impl Fn(&'_ XYZ)`, an HRTB with a lifetime separate from any others given. This basically means 'the lifetime of this reference is not guaranteed to be any longer than any given entry into the callback', which is roughly what we want
Related issue: #852