### PR TITLE
Use std::abort() in C++, import correct header

### DIFF
--- a/example/cpp/include/icu4x/DataProvider.d.hpp
+++ b/example/cpp/include/icu4x/DataProvider.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace icu4x {

--- a/example/cpp/include/icu4x/DataProvider.hpp
+++ b/example/cpp/include/icu4x/DataProvider.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/example/cpp/include/icu4x/FixedDecimal.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimal.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace icu4x {

--- a/example/cpp/include/icu4x/FixedDecimal.hpp
+++ b/example/cpp/include/icu4x/FixedDecimal.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/example/cpp/include/icu4x/FixedDecimalFormatter.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatter.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace icu4x {

--- a/example/cpp/include/icu4x/FixedDecimalFormatter.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatter.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "DataProvider.hpp"
 #include "FixedDecimal.hpp"

--- a/example/cpp/include/icu4x/FixedDecimalFormatterOptions.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatterOptions.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "FixedDecimalGroupingStrategy.d.hpp"
 

--- a/example/cpp/include/icu4x/FixedDecimalFormatterOptions.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatterOptions.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "FixedDecimalGroupingStrategy.hpp"
 

--- a/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 
@@ -34,7 +35,7 @@ inline icu4x::FixedDecimalGroupingStrategy icu4x::FixedDecimalGroupingStrategy::
     case icu4x::capi::FixedDecimalGroupingStrategy_Min2:
       return static_cast<icu4x::FixedDecimalGroupingStrategy::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // icu4x_FixedDecimalGroupingStrategy_HPP

--- a/example/cpp/include/icu4x/Locale.d.hpp
+++ b/example/cpp/include/icu4x/Locale.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace icu4x {

--- a/example/cpp/include/icu4x/Locale.hpp
+++ b/example/cpp/include/icu4x/Locale.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/Bar.d.hpp
+++ b/feature_tests/cpp/include/Bar.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Foo; }

--- a/feature_tests/cpp/include/Bar.hpp
+++ b/feature_tests/cpp/include/Bar.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Foo.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/BorrowedFields.d.hpp
+++ b/feature_tests/cpp/include/BorrowedFields.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Bar; }

--- a/feature_tests/cpp/include/BorrowedFields.hpp
+++ b/feature_tests/cpp/include/BorrowedFields.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Bar.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/BorrowedFieldsReturning.d.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsReturning.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/BorrowedFieldsReturning.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsReturning.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/BorrowedFieldsWithBounds.d.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsWithBounds.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Foo; }

--- a/feature_tests/cpp/include/BorrowedFieldsWithBounds.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsWithBounds.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Foo.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/CallbackHolder.d.hpp
+++ b/feature_tests/cpp/include/CallbackHolder.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/CallbackHolder.hpp
+++ b/feature_tests/cpp/include/CallbackHolder.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/CallbackTestingStruct.d.hpp
+++ b/feature_tests/cpp/include/CallbackTestingStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/CallbackTestingStruct.hpp
+++ b/feature_tests/cpp/include/CallbackTestingStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/CallbackWrapper.d.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct MyString; }

--- a/feature_tests/cpp/include/CallbackWrapper.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CallbackTestingStruct.hpp"
 #include "MyString.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/ContiguousEnum.d.hpp
+++ b/feature_tests/cpp/include/ContiguousEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ContiguousEnum.hpp
+++ b/feature_tests/cpp/include/ContiguousEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -34,7 +35,7 @@ inline ContiguousEnum ContiguousEnum::FromFFI(diplomat::capi::ContiguousEnum c_e
     case diplomat::capi::ContiguousEnum_F:
       return static_cast<ContiguousEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // ContiguousEnum_HPP

--- a/feature_tests/cpp/include/CyclicStructA.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructB.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/CyclicStructA.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructB.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/CyclicStructB.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructB.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 struct CyclicStructA;

--- a/feature_tests/cpp/include/CyclicStructB.hpp
+++ b/feature_tests/cpp/include/CyclicStructB.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructA.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/CyclicStructC.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructC.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructA.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/CyclicStructC.hpp
+++ b/feature_tests/cpp/include/CyclicStructC.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructA.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/DefaultEnum.d.hpp
+++ b/feature_tests/cpp/include/DefaultEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/DefaultEnum.hpp
+++ b/feature_tests/cpp/include/DefaultEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -34,7 +35,7 @@ inline DefaultEnum DefaultEnum::FromFFI(diplomat::capi::DefaultEnum c_enum) {
     case diplomat::capi::DefaultEnum_B:
       return static_cast<DefaultEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 

--- a/feature_tests/cpp/include/ErrorEnum.d.hpp
+++ b/feature_tests/cpp/include/ErrorEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ErrorEnum.hpp
+++ b/feature_tests/cpp/include/ErrorEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -32,7 +33,7 @@ inline ErrorEnum ErrorEnum::FromFFI(diplomat::capi::ErrorEnum c_enum) {
     case diplomat::capi::ErrorEnum_Bar:
       return static_cast<ErrorEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // ErrorEnum_HPP

--- a/feature_tests/cpp/include/ErrorStruct.d.hpp
+++ b/feature_tests/cpp/include/ErrorStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ErrorStruct.hpp
+++ b/feature_tests/cpp/include/ErrorStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp/include/Float64Vec.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/Foo.d.hpp
+++ b/feature_tests/cpp/include/Foo.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Bar; }

--- a/feature_tests/cpp/include/Foo.hpp
+++ b/feature_tests/cpp/include/Foo.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Bar.hpp"
 #include "BorrowedFields.hpp"
 #include "BorrowedFieldsReturning.hpp"

--- a/feature_tests/cpp/include/ImportedStruct.d.hpp
+++ b/feature_tests/cpp/include/ImportedStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "UnimportedEnum.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/ImportedStruct.hpp
+++ b/feature_tests/cpp/include/ImportedStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "UnimportedEnum.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/MutableCallbackHolder.d.hpp
+++ b/feature_tests/cpp/include/MutableCallbackHolder.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/MutableCallbackHolder.hpp
+++ b/feature_tests/cpp/include/MutableCallbackHolder.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/MyEnum.d.hpp
+++ b/feature_tests/cpp/include/MyEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/MyEnum.hpp
+++ b/feature_tests/cpp/include/MyEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -40,7 +41,7 @@ inline MyEnum MyEnum::FromFFI(diplomat::capi::MyEnum c_enum) {
     case diplomat::capi::MyEnum_F:
       return static_cast<MyEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 

--- a/feature_tests/cpp/include/MyOpaqueEnum.d.hpp
+++ b/feature_tests/cpp/include/MyOpaqueEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/MyOpaqueEnum.hpp
+++ b/feature_tests/cpp/include/MyOpaqueEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/MyString.d.hpp
+++ b/feature_tests/cpp/include/MyString.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/MyStruct.d.hpp
+++ b/feature_tests/cpp/include/MyStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "MyEnum.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/MyStruct.hpp
+++ b/feature_tests/cpp/include/MyStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "MyEnum.hpp"
 #include "MyZst.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/MyStructContainingAnOption.d.hpp
+++ b/feature_tests/cpp/include/MyStructContainingAnOption.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "DefaultEnum.d.hpp"
 #include "MyStruct.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/MyStructContainingAnOption.hpp
+++ b/feature_tests/cpp/include/MyStructContainingAnOption.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "DefaultEnum.hpp"
 #include "MyStruct.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/MyZst.d.hpp
+++ b/feature_tests/cpp/include/MyZst.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/MyZst.hpp
+++ b/feature_tests/cpp/include/MyZst.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/NestedBorrowedFields.d.hpp
+++ b/feature_tests/cpp/include/NestedBorrowedFields.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "BorrowedFields.d.hpp"
 #include "BorrowedFieldsWithBounds.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/NestedBorrowedFields.hpp
+++ b/feature_tests/cpp/include/NestedBorrowedFields.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Bar.hpp"
 #include "BorrowedFields.hpp"
 #include "BorrowedFieldsWithBounds.hpp"

--- a/feature_tests/cpp/include/One.d.hpp
+++ b/feature_tests/cpp/include/One.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Two; }

--- a/feature_tests/cpp/include/One.hpp
+++ b/feature_tests/cpp/include/One.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Two.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/Opaque.d.hpp
+++ b/feature_tests/cpp/include/Opaque.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 struct ImportedStruct;

--- a/feature_tests/cpp/include/Opaque.hpp
+++ b/feature_tests/cpp/include/Opaque.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "ImportedStruct.hpp"
 #include "MyStruct.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/OpaqueMutexedString.d.hpp
+++ b/feature_tests/cpp/include/OpaqueMutexedString.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Utf16Wrap; }

--- a/feature_tests/cpp/include/OpaqueMutexedString.hpp
+++ b/feature_tests/cpp/include/OpaqueMutexedString.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Utf16Wrap.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OpaqueThin.d.hpp
+++ b/feature_tests/cpp/include/OpaqueThin.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/OpaqueThin.hpp
+++ b/feature_tests/cpp/include/OpaqueThin.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/OpaqueThinIter.d.hpp
+++ b/feature_tests/cpp/include/OpaqueThinIter.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct OpaqueThin; }

--- a/feature_tests/cpp/include/OpaqueThinIter.hpp
+++ b/feature_tests/cpp/include/OpaqueThinIter.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OpaqueThin.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OpaqueThinVec.d.hpp
+++ b/feature_tests/cpp/include/OpaqueThinVec.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct OpaqueThin; }

--- a/feature_tests/cpp/include/OpaqueThinVec.hpp
+++ b/feature_tests/cpp/include/OpaqueThinVec.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OpaqueThin.hpp"
 #include "OpaqueThinIter.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/OptionEnum.d.hpp
+++ b/feature_tests/cpp/include/OptionEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/OptionEnum.hpp
+++ b/feature_tests/cpp/include/OptionEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -32,7 +33,7 @@ inline OptionEnum OptionEnum::FromFFI(diplomat::capi::OptionEnum c_enum) {
     case diplomat::capi::OptionEnum_Bar:
       return static_cast<OptionEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // OptionEnum_HPP

--- a/feature_tests/cpp/include/OptionInputStruct.d.hpp
+++ b/feature_tests/cpp/include/OptionInputStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OptionEnum.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionInputStruct.hpp
+++ b/feature_tests/cpp/include/OptionInputStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OptionEnum.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 struct OptionInputStruct;

--- a/feature_tests/cpp/include/OptionOpaque.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OptionEnum.hpp"
 #include "OptionInputStruct.hpp"
 #include "OptionStruct.hpp"

--- a/feature_tests/cpp/include/OptionOpaqueChar.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaqueChar.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/OptionOpaqueChar.hpp
+++ b/feature_tests/cpp/include/OptionOpaqueChar.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/OptionString.d.hpp
+++ b/feature_tests/cpp/include/OptionString.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/OptionString.hpp
+++ b/feature_tests/cpp/include/OptionString.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/OptionStruct.d.hpp
+++ b/feature_tests/cpp/include/OptionStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct OptionOpaque; }

--- a/feature_tests/cpp/include/OptionStruct.hpp
+++ b/feature_tests/cpp/include/OptionStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OptionOpaque.hpp"
 #include "OptionOpaqueChar.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/RefList.d.hpp
+++ b/feature_tests/cpp/include/RefList.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct RefListParameter; }

--- a/feature_tests/cpp/include/RefList.hpp
+++ b/feature_tests/cpp/include/RefList.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "RefListParameter.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/cpp/include/RefListParameter.d.hpp
+++ b/feature_tests/cpp/include/RefListParameter.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/RefListParameter.hpp
+++ b/feature_tests/cpp/include/RefListParameter.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ResultOpaque.d.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 struct ErrorStruct;

--- a/feature_tests/cpp/include/ResultOpaque.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "ErrorEnum.hpp"
 #include "ErrorStruct.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/cpp/include/StructArithmetic.d.hpp
+++ b/feature_tests/cpp/include/StructArithmetic.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/StructArithmetic.hpp
+++ b/feature_tests/cpp/include/StructArithmetic.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/StructWithSlices.d.hpp
+++ b/feature_tests/cpp/include/StructWithSlices.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/StructWithSlices.hpp
+++ b/feature_tests/cpp/include/StructWithSlices.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/Two.d.hpp
+++ b/feature_tests/cpp/include/Two.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/Two.hpp
+++ b/feature_tests/cpp/include/Two.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/UnimportedEnum.d.hpp
+++ b/feature_tests/cpp/include/UnimportedEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/UnimportedEnum.hpp
+++ b/feature_tests/cpp/include/UnimportedEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -33,7 +34,7 @@ inline UnimportedEnum UnimportedEnum::FromFFI(diplomat::capi::UnimportedEnum c_e
     case diplomat::capi::UnimportedEnum_C:
       return static_cast<UnimportedEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // UnimportedEnum_HPP

--- a/feature_tests/cpp/include/Unnamespaced.d.hpp
+++ b/feature_tests/cpp/include/Unnamespaced.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/cpp/include/Unnamespaced.hpp
+++ b/feature_tests/cpp/include/Unnamespaced.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 #include "ns/AttrOpaque1Renamed.hpp"
 #include "ns/RenamedAttrEnum.hpp"

--- a/feature_tests/cpp/include/Utf16Wrap.d.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/nested/ns/Nested.d.hpp
+++ b/feature_tests/cpp/include/nested/ns/Nested.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/nested/ns/Nested.hpp
+++ b/feature_tests/cpp/include/nested/ns/Nested.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/nested/ns2/Nested.d.hpp
+++ b/feature_tests/cpp/include/nested/ns2/Nested.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/nested/ns2/Nested.hpp
+++ b/feature_tests/cpp/include/nested/ns2/Nested.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp/include/ns/AttrOpaque1Renamed.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Unnamespaced; }

--- a/feature_tests/cpp/include/ns/AttrOpaque1Renamed.hpp
+++ b/feature_tests/cpp/include/ns/AttrOpaque1Renamed.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../Unnamespaced.hpp"
 #include "../diplomat_runtime.hpp"
 #include "RenamedAttrEnum.hpp"

--- a/feature_tests/cpp/include/ns/RenamedAttrEnum.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedAttrEnum.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 
@@ -33,7 +34,7 @@ inline ns::RenamedAttrEnum ns::RenamedAttrEnum::FromFFI(ns::capi::RenamedAttrEnu
     case ns::capi::RenamedAttrEnum_C:
       return static_cast<ns::RenamedAttrEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // ns_RenamedAttrEnum_HPP

--- a/feature_tests/cpp/include/ns/RenamedAttrOpaque2.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrOpaque2.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedAttrOpaque2.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrOpaque2.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedComparable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedComparable.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/cpp/include/ns/RenamedComparable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedComparable.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedMyIndexer.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIndexer.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedMyIndexer.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIndexer.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedMyIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterable.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/cpp/include/ns/RenamedMyIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterable.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "RenamedMyIterator.hpp"
 

--- a/feature_tests/cpp/include/ns/RenamedMyIterator.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterator.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedMyIterator.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterator.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedOpaqueArithmetic.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueArithmetic.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/cpp/include/ns/RenamedOpaqueArithmetic.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueArithmetic.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterable.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterable.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "RenamedOpaqueIterator.hpp"
 

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterator.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterator.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterator.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterator.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "AttrOpaque1Renamed.hpp"
 

--- a/feature_tests/cpp/include/ns/RenamedStructWithAttrs.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedStructWithAttrs.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/cpp/include/ns/RenamedStructWithAttrs.hpp
+++ b/feature_tests/cpp/include/ns/RenamedStructWithAttrs.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/Bar.d.hpp
+++ b/feature_tests/nanobind/src/include/Bar.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Foo; }

--- a/feature_tests/nanobind/src/include/Bar.hpp
+++ b/feature_tests/nanobind/src/include/Bar.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Foo.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/BorrowedFields.d.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFields.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Bar; }

--- a/feature_tests/nanobind/src/include/BorrowedFields.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFields.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Bar.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/BorrowedFieldsReturning.d.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFieldsReturning.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/BorrowedFieldsReturning.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFieldsReturning.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/BorrowedFieldsWithBounds.d.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFieldsWithBounds.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Foo; }

--- a/feature_tests/nanobind/src/include/BorrowedFieldsWithBounds.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFieldsWithBounds.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Foo.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/CallbackHolder.d.hpp
+++ b/feature_tests/nanobind/src/include/CallbackHolder.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/CallbackHolder.hpp
+++ b/feature_tests/nanobind/src/include/CallbackHolder.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/CallbackTestingStruct.d.hpp
+++ b/feature_tests/nanobind/src/include/CallbackTestingStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/CallbackTestingStruct.hpp
+++ b/feature_tests/nanobind/src/include/CallbackTestingStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/CallbackWrapper.d.hpp
+++ b/feature_tests/nanobind/src/include/CallbackWrapper.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct MyString; }

--- a/feature_tests/nanobind/src/include/CallbackWrapper.hpp
+++ b/feature_tests/nanobind/src/include/CallbackWrapper.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CallbackTestingStruct.hpp"
 #include "MyString.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/ContiguousEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/ContiguousEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ContiguousEnum.hpp
+++ b/feature_tests/nanobind/src/include/ContiguousEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -34,7 +35,7 @@ inline ContiguousEnum ContiguousEnum::FromFFI(diplomat::capi::ContiguousEnum c_e
     case diplomat::capi::ContiguousEnum_F:
       return static_cast<ContiguousEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // ContiguousEnum_HPP

--- a/feature_tests/nanobind/src/include/CyclicStructA.d.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructA.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructB.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/CyclicStructA.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructA.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructB.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/CyclicStructB.d.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructB.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 struct CyclicStructA;

--- a/feature_tests/nanobind/src/include/CyclicStructB.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructB.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructA.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/CyclicStructC.d.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructC.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructA.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/CyclicStructC.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructC.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "CyclicStructA.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/DefaultEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/DefaultEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/DefaultEnum.hpp
+++ b/feature_tests/nanobind/src/include/DefaultEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -34,7 +35,7 @@ inline DefaultEnum DefaultEnum::FromFFI(diplomat::capi::DefaultEnum c_enum) {
     case diplomat::capi::DefaultEnum_B:
       return static_cast<DefaultEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 

--- a/feature_tests/nanobind/src/include/ErrorEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/ErrorEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ErrorEnum.hpp
+++ b/feature_tests/nanobind/src/include/ErrorEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -32,7 +33,7 @@ inline ErrorEnum ErrorEnum::FromFFI(diplomat::capi::ErrorEnum c_enum) {
     case diplomat::capi::ErrorEnum_Bar:
       return static_cast<ErrorEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // ErrorEnum_HPP

--- a/feature_tests/nanobind/src/include/ErrorStruct.d.hpp
+++ b/feature_tests/nanobind/src/include/ErrorStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ErrorStruct.hpp
+++ b/feature_tests/nanobind/src/include/ErrorStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/Float64Vec.d.hpp
+++ b/feature_tests/nanobind/src/include/Float64Vec.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/Float64Vec.hpp
+++ b/feature_tests/nanobind/src/include/Float64Vec.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/Foo.d.hpp
+++ b/feature_tests/nanobind/src/include/Foo.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Bar; }

--- a/feature_tests/nanobind/src/include/Foo.hpp
+++ b/feature_tests/nanobind/src/include/Foo.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Bar.hpp"
 #include "BorrowedFields.hpp"
 #include "BorrowedFieldsReturning.hpp"

--- a/feature_tests/nanobind/src/include/ImportedStruct.d.hpp
+++ b/feature_tests/nanobind/src/include/ImportedStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "UnimportedEnum.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/ImportedStruct.hpp
+++ b/feature_tests/nanobind/src/include/ImportedStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "UnimportedEnum.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/MutableCallbackHolder.d.hpp
+++ b/feature_tests/nanobind/src/include/MutableCallbackHolder.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/MutableCallbackHolder.hpp
+++ b/feature_tests/nanobind/src/include/MutableCallbackHolder.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/MyEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/MyEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/MyEnum.hpp
+++ b/feature_tests/nanobind/src/include/MyEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -40,7 +41,7 @@ inline MyEnum MyEnum::FromFFI(diplomat::capi::MyEnum c_enum) {
     case diplomat::capi::MyEnum_F:
       return static_cast<MyEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 

--- a/feature_tests/nanobind/src/include/MyOpaqueEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/MyOpaqueEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/MyOpaqueEnum.hpp
+++ b/feature_tests/nanobind/src/include/MyOpaqueEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/MyString.d.hpp
+++ b/feature_tests/nanobind/src/include/MyString.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/MyString.hpp
+++ b/feature_tests/nanobind/src/include/MyString.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/MyStruct.d.hpp
+++ b/feature_tests/nanobind/src/include/MyStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "MyEnum.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/MyStruct.hpp
+++ b/feature_tests/nanobind/src/include/MyStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "MyEnum.hpp"
 #include "MyZst.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/MyStructContainingAnOption.d.hpp
+++ b/feature_tests/nanobind/src/include/MyStructContainingAnOption.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "DefaultEnum.d.hpp"
 #include "MyStruct.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/MyStructContainingAnOption.hpp
+++ b/feature_tests/nanobind/src/include/MyStructContainingAnOption.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "DefaultEnum.hpp"
 #include "MyStruct.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/MyZst.d.hpp
+++ b/feature_tests/nanobind/src/include/MyZst.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/MyZst.hpp
+++ b/feature_tests/nanobind/src/include/MyZst.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/NestedBorrowedFields.d.hpp
+++ b/feature_tests/nanobind/src/include/NestedBorrowedFields.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "BorrowedFields.d.hpp"
 #include "BorrowedFieldsWithBounds.d.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/NestedBorrowedFields.hpp
+++ b/feature_tests/nanobind/src/include/NestedBorrowedFields.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Bar.hpp"
 #include "BorrowedFields.hpp"
 #include "BorrowedFieldsWithBounds.hpp"

--- a/feature_tests/nanobind/src/include/One.d.hpp
+++ b/feature_tests/nanobind/src/include/One.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Two; }

--- a/feature_tests/nanobind/src/include/One.hpp
+++ b/feature_tests/nanobind/src/include/One.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Two.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/Opaque.d.hpp
+++ b/feature_tests/nanobind/src/include/Opaque.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 struct ImportedStruct;

--- a/feature_tests/nanobind/src/include/Opaque.hpp
+++ b/feature_tests/nanobind/src/include/Opaque.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "ImportedStruct.hpp"
 #include "MyStruct.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/OpaqueMutexedString.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueMutexedString.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Utf16Wrap; }

--- a/feature_tests/nanobind/src/include/OpaqueMutexedString.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueMutexedString.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "Utf16Wrap.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/OpaqueThin.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThin.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/OpaqueThin.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThin.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/OpaqueThinIter.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinIter.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct OpaqueThin; }

--- a/feature_tests/nanobind/src/include/OpaqueThinIter.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinIter.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OpaqueThin.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/OpaqueThinVec.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinVec.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct OpaqueThin; }

--- a/feature_tests/nanobind/src/include/OpaqueThinVec.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinVec.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OpaqueThin.hpp"
 #include "OpaqueThinIter.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/OptionEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/OptionEnum.hpp
+++ b/feature_tests/nanobind/src/include/OptionEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -32,7 +33,7 @@ inline OptionEnum OptionEnum::FromFFI(diplomat::capi::OptionEnum c_enum) {
     case diplomat::capi::OptionEnum_Bar:
       return static_cast<OptionEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // OptionEnum_HPP

--- a/feature_tests/nanobind/src/include/OptionInputStruct.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionInputStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OptionEnum.d.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/OptionInputStruct.hpp
+++ b/feature_tests/nanobind/src/include/OptionInputStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OptionEnum.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 struct OptionInputStruct;

--- a/feature_tests/nanobind/src/include/OptionOpaque.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OptionEnum.hpp"
 #include "OptionInputStruct.hpp"
 #include "OptionStruct.hpp"

--- a/feature_tests/nanobind/src/include/OptionOpaqueChar.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaqueChar.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/OptionOpaqueChar.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaqueChar.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/OptionString.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionString.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/OptionString.hpp
+++ b/feature_tests/nanobind/src/include/OptionString.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/OptionStruct.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionStruct.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct OptionOpaque; }

--- a/feature_tests/nanobind/src/include/OptionStruct.hpp
+++ b/feature_tests/nanobind/src/include/OptionStruct.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "OptionOpaque.hpp"
 #include "OptionOpaqueChar.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/RefList.d.hpp
+++ b/feature_tests/nanobind/src/include/RefList.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct RefListParameter; }

--- a/feature_tests/nanobind/src/include/RefList.hpp
+++ b/feature_tests/nanobind/src/include/RefList.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "RefListParameter.hpp"
 #include "diplomat_runtime.hpp"
 

--- a/feature_tests/nanobind/src/include/RefListParameter.d.hpp
+++ b/feature_tests/nanobind/src/include/RefListParameter.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/RefListParameter.hpp
+++ b/feature_tests/nanobind/src/include/RefListParameter.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ResultOpaque.d.hpp
+++ b/feature_tests/nanobind/src/include/ResultOpaque.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 struct ErrorStruct;

--- a/feature_tests/nanobind/src/include/ResultOpaque.hpp
+++ b/feature_tests/nanobind/src/include/ResultOpaque.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "ErrorEnum.hpp"
 #include "ErrorStruct.hpp"
 #include "diplomat_runtime.hpp"

--- a/feature_tests/nanobind/src/include/StructArithmetic.d.hpp
+++ b/feature_tests/nanobind/src/include/StructArithmetic.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/StructArithmetic.hpp
+++ b/feature_tests/nanobind/src/include/StructArithmetic.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/StructWithSlices.d.hpp
+++ b/feature_tests/nanobind/src/include/StructWithSlices.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/StructWithSlices.hpp
+++ b/feature_tests/nanobind/src/include/StructWithSlices.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/Two.d.hpp
+++ b/feature_tests/nanobind/src/include/Two.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/Two.hpp
+++ b/feature_tests/nanobind/src/include/Two.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/UnimportedEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/UnimportedEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/UnimportedEnum.hpp
+++ b/feature_tests/nanobind/src/include/UnimportedEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 
@@ -33,7 +34,7 @@ inline UnimportedEnum UnimportedEnum::FromFFI(diplomat::capi::UnimportedEnum c_e
     case diplomat::capi::UnimportedEnum_C:
       return static_cast<UnimportedEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // UnimportedEnum_HPP

--- a/feature_tests/nanobind/src/include/Unnamespaced.d.hpp
+++ b/feature_tests/nanobind/src/include/Unnamespaced.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/nanobind/src/include/Unnamespaced.hpp
+++ b/feature_tests/nanobind/src/include/Unnamespaced.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 #include "ns/AttrOpaque1Renamed.hpp"
 #include "ns/RenamedAttrEnum.hpp"

--- a/feature_tests/nanobind/src/include/Utf16Wrap.d.hpp
+++ b/feature_tests/nanobind/src/include/Utf16Wrap.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/Utf16Wrap.hpp
+++ b/feature_tests/nanobind/src/include/Utf16Wrap.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/nested/ns/Nested.d.hpp
+++ b/feature_tests/nanobind/src/include/nested/ns/Nested.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/nested/ns/Nested.hpp
+++ b/feature_tests/nanobind/src/include/nested/ns/Nested.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/nested/ns2/Nested.d.hpp
+++ b/feature_tests/nanobind/src/include/nested/ns2/Nested.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/nested/ns2/Nested.hpp
+++ b/feature_tests/nanobind/src/include/nested/ns2/Nested.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/AttrOpaque1Renamed.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace diplomat::capi { struct Unnamespaced; }

--- a/feature_tests/nanobind/src/include/ns/AttrOpaque1Renamed.hpp
+++ b/feature_tests/nanobind/src/include/ns/AttrOpaque1Renamed.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../Unnamespaced.hpp"
 #include "../diplomat_runtime.hpp"
 #include "RenamedAttrEnum.hpp"

--- a/feature_tests/nanobind/src/include/ns/RenamedAttrEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedAttrEnum.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedAttrEnum.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedAttrEnum.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 
@@ -33,7 +34,7 @@ inline ns::RenamedAttrEnum ns::RenamedAttrEnum::FromFFI(ns::capi::RenamedAttrEnu
     case ns::capi::RenamedAttrEnum_C:
       return static_cast<ns::RenamedAttrEnum::Value>(c_enum);
     default:
-      abort();
+      std::abort();
   }
 }
 #endif // ns_RenamedAttrEnum_HPP

--- a/feature_tests/nanobind/src/include/ns/RenamedAttrOpaque2.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedAttrOpaque2.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedAttrOpaque2.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedAttrOpaque2.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedComparable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedComparable.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/nanobind/src/include/ns/RenamedComparable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedComparable.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIndexer.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIndexer.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIndexer.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIndexer.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIterable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIterable.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIterable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIterable.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "RenamedMyIterator.hpp"
 

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIterator.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIterator.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIterator.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIterator.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueArithmetic.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueArithmetic.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueArithmetic.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueArithmetic.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterable.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterable.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "RenamedOpaqueIterator.hpp"
 

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterator.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterator.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterator.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterator.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 #include "AttrOpaque1Renamed.hpp"
 

--- a/feature_tests/nanobind/src/include/ns/RenamedStructWithAttrs.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedStructWithAttrs.d.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 namespace ns {

--- a/feature_tests/nanobind/src/include/ns/RenamedStructWithAttrs.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedStructWithAttrs.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 #include "../diplomat_runtime.hpp"
 
 

--- a/tool/templates/cpp/base.h.jinja
+++ b/tool/templates/cpp/base.h.jinja
@@ -14,6 +14,7 @@
 #include <memory>
 #include <functional>
 #include <optional>
+#include <cstdlib>
 {%- for include in includes %}
 #include "{{ include }}"
 {%- endfor %}

--- a/tool/templates/cpp/enum_impl.h.jinja
+++ b/tool/templates/cpp/enum_impl.h.jinja
@@ -11,7 +11,7 @@ inline {{type_name}} {{type_name}}::FromFFI({{ctype}} c_enum) {
 {%- endfor %}
 			return static_cast<{{type_name}}::Value>(c_enum);
 		default:
-			abort();
+			std::abort();
 	}
 }
 


### PR DESCRIPTION
We were referencing `abort()` without including it. Instead of directly including the C header `stdlib.h` for it, I switched to `std::abort` and used `<cstdlib>`.

My recollection is that using the `cfoo` headers is more portable.