### PR TITLE
Add support for default enum variants to C++

### DIFF
--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__elision_in_struct.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__elision_in_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: core/src/hir/elision.rs
-assertion_line: 536
 expression: method
 ---
 Method {
@@ -46,6 +45,7 @@ Method {
                 },
                 special_method: None,
                 custom_errors: false,
+                default: false,
                 demo_attrs: DemoInfo {
                     generate: false,
                     default_constructor: false,
@@ -100,6 +100,7 @@ Method {
                 },
                 special_method: None,
                 custom_errors: false,
+                default: false,
                 demo_attrs: DemoInfo {
                     generate: false,
                     default_constructor: false,
@@ -127,6 +128,7 @@ Method {
         },
         special_method: None,
         custom_errors: false,
+        default: false,
         demo_attrs: DemoInfo {
             generate: false,
             default_constructor: false,

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -1,6 +1,5 @@
 ---
 source: core/src/hir/elision.rs
-assertion_line: 473
 expression: tcx
 ---
 TypeContext {
@@ -49,6 +48,7 @@ TypeContext {
                         },
                         special_method: None,
                         custom_errors: false,
+                        default: false,
                         demo_attrs: DemoInfo {
                             generate: false,
                             default_constructor: false,
@@ -107,6 +107,7 @@ TypeContext {
                                 },
                                 special_method: None,
                                 custom_errors: false,
+                                default: false,
                                 demo_attrs: DemoInfo {
                                     generate: false,
                                     default_constructor: false,
@@ -153,6 +154,7 @@ TypeContext {
                         },
                         special_method: None,
                         custom_errors: false,
+                        default: false,
                         demo_attrs: DemoInfo {
                             generate: false,
                             default_constructor: false,
@@ -177,6 +179,7 @@ TypeContext {
                 },
                 special_method: None,
                 custom_errors: false,
+                default: false,
                 demo_attrs: DemoInfo {
                     generate: false,
                     default_constructor: false,
@@ -242,6 +245,7 @@ TypeContext {
                         },
                         special_method: None,
                         custom_errors: false,
+                        default: false,
                         demo_attrs: DemoInfo {
                             generate: false,
                             default_constructor: false,
@@ -302,6 +306,7 @@ TypeContext {
                                 },
                                 special_method: None,
                                 custom_errors: false,
+                                default: false,
                                 demo_attrs: DemoInfo {
                                     generate: false,
                                     default_constructor: false,
@@ -341,6 +346,7 @@ TypeContext {
                                 },
                                 special_method: None,
                                 custom_errors: false,
+                                default: false,
                                 demo_attrs: DemoInfo {
                                     generate: false,
                                     default_constructor: false,
@@ -381,6 +387,7 @@ TypeContext {
                         },
                         special_method: None,
                         custom_errors: false,
+                        default: false,
                         demo_attrs: DemoInfo {
                             generate: false,
                             default_constructor: false,
@@ -405,6 +412,7 @@ TypeContext {
                 },
                 special_method: None,
                 custom_errors: false,
+                default: false,
                 demo_attrs: DemoInfo {
                     generate: false,
                     default_constructor: false,
@@ -452,6 +460,7 @@ TypeContext {
                 },
                 special_method: None,
                 custom_errors: false,
+                default: false,
                 demo_attrs: DemoInfo {
                     generate: false,
                     default_constructor: false,

--- a/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalGroupingStrategy.d.hpp
@@ -35,7 +35,8 @@ public:
     Min2 = 3,
   };
 
-  FixedDecimalGroupingStrategy() = default;
+  FixedDecimalGroupingStrategy(): value(Value::Auto) {}
+
   // Implicit conversions between enum and ::Value
   constexpr FixedDecimalGroupingStrategy(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/cpp/include/ContiguousEnum.d.hpp
+++ b/feature_tests/cpp/include/ContiguousEnum.d.hpp
@@ -34,7 +34,8 @@ public:
     F = 3,
   };
 
-  ContiguousEnum() = default;
+  ContiguousEnum(): value(Value::E) {}
+
   // Implicit conversions between enum and ::Value
   constexpr ContiguousEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/cpp/include/DefaultEnum.d.hpp
+++ b/feature_tests/cpp/include/DefaultEnum.d.hpp
@@ -30,7 +30,8 @@ public:
     B = 1,
   };
 
-  DefaultEnum() = default;
+  DefaultEnum(): value(Value::A) {}
+
   // Implicit conversions between enum and ::Value
   constexpr DefaultEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/cpp/include/ErrorEnum.d.hpp
+++ b/feature_tests/cpp/include/ErrorEnum.d.hpp
@@ -30,7 +30,8 @@ public:
     Bar = 1,
   };
 
-  ErrorEnum() = default;
+  ErrorEnum(): value(Value::Foo) {}
+
   // Implicit conversions between enum and ::Value
   constexpr ErrorEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/cpp/include/MyEnum.d.hpp
+++ b/feature_tests/cpp/include/MyEnum.d.hpp
@@ -38,7 +38,8 @@ public:
     F = 3,
   };
 
-  MyEnum() = default;
+  MyEnum(): value(Value::D) {}
+
   // Implicit conversions between enum and ::Value
   constexpr MyEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/cpp/include/OptionEnum.d.hpp
+++ b/feature_tests/cpp/include/OptionEnum.d.hpp
@@ -30,7 +30,8 @@ public:
     Bar = 1,
   };
 
-  OptionEnum() = default;
+  OptionEnum(): value(Value::Foo) {}
+
   // Implicit conversions between enum and ::Value
   constexpr OptionEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/cpp/include/UnimportedEnum.d.hpp
+++ b/feature_tests/cpp/include/UnimportedEnum.d.hpp
@@ -32,7 +32,8 @@ public:
     C = 2,
   };
 
-  UnimportedEnum() = default;
+  UnimportedEnum(): value(Value::A) {}
+
   // Implicit conversions between enum and ::Value
   constexpr UnimportedEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/cpp/include/ns/RenamedAttrEnum.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedAttrEnum.d.hpp
@@ -33,7 +33,8 @@ public:
     Renamed = 2,
   };
 
-  RenamedAttrEnum() = default;
+  RenamedAttrEnum(): value(Value::A) {}
+
   // Implicit conversions between enum and ::Value
   constexpr RenamedAttrEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/cpp/tests/structs.cpp
+++ b/feature_tests/cpp/tests/structs.cpp
@@ -26,6 +26,10 @@ int main(int argc, char* argv[]) {
     simple_assert_eq("enum fn", s.g.into_value(), -1);
     simple_assert_eq("struct fn", s.into_a(), 17);
 
+
+    MyStruct default_s;
+    simple_assert_eq("default struct values", default_s.g.into_value(), MyEnum(MyEnum::D).into_value());
+
     auto a = StructArithmetic{ 1, 2 };
     auto b = StructArithmetic{ 2, 3 };
     {

--- a/feature_tests/nanobind/src/include/ContiguousEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/ContiguousEnum.d.hpp
@@ -34,7 +34,8 @@ public:
     F = 3,
   };
 
-  ContiguousEnum() = default;
+  ContiguousEnum(): value(Value::E) {}
+
   // Implicit conversions between enum and ::Value
   constexpr ContiguousEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/nanobind/src/include/DefaultEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/DefaultEnum.d.hpp
@@ -30,7 +30,8 @@ public:
     B = 1,
   };
 
-  DefaultEnum() = default;
+  DefaultEnum(): value(Value::A) {}
+
   // Implicit conversions between enum and ::Value
   constexpr DefaultEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/nanobind/src/include/ErrorEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/ErrorEnum.d.hpp
@@ -30,7 +30,8 @@ public:
     Bar = 1,
   };
 
-  ErrorEnum() = default;
+  ErrorEnum(): value(Value::Foo) {}
+
   // Implicit conversions between enum and ::Value
   constexpr ErrorEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/nanobind/src/include/MyEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/MyEnum.d.hpp
@@ -38,7 +38,8 @@ public:
     F = 3,
   };
 
-  MyEnum() = default;
+  MyEnum(): value(Value::D) {}
+
   // Implicit conversions between enum and ::Value
   constexpr MyEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/nanobind/src/include/OptionEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionEnum.d.hpp
@@ -30,7 +30,8 @@ public:
     Bar = 1,
   };
 
-  OptionEnum() = default;
+  OptionEnum(): value(Value::Foo) {}
+
   // Implicit conversions between enum and ::Value
   constexpr OptionEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/nanobind/src/include/UnimportedEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/UnimportedEnum.d.hpp
@@ -32,7 +32,8 @@ public:
     C = 2,
   };
 
-  UnimportedEnum() = default;
+  UnimportedEnum(): value(Value::A) {}
+
   // Implicit conversions between enum and ::Value
   constexpr UnimportedEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/nanobind/src/include/ns/RenamedAttrEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedAttrEnum.d.hpp
@@ -33,7 +33,8 @@ public:
     Renamed = 2,
   };
 
-  RenamedAttrEnum() = default;
+  RenamedAttrEnum(): value(Value::A) {}
+
   // Implicit conversions between enum and ::Value
   constexpr RenamedAttrEnum(Value v) : value(v) {}
   constexpr operator Value() const { return value; }

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -22,6 +22,7 @@ pub mod ffi {
         A = -2,
         B = -1,
         C = 0,
+        #[diplomat::attr(auto, default)]
         D = 1,
         E = 2,
         F = 3,
@@ -31,6 +32,7 @@ pub mod ffi {
     pub enum ContiguousEnum {
         C = 0,
         D = 1,
+        #[diplomat::attr(auto, default)]
         E = 2,
         F = 3,
     }

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -18,6 +18,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.utf8_strings = true;
     a.utf16_strings = true;
     a.static_slices = true;
+    a.defaults = true;
 
     a.constructors = false; // TODO
     a.named_constructors = false;

--- a/tool/src/nanobind/mod.rs
+++ b/tool/src/nanobind/mod.rs
@@ -32,6 +32,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.utf8_strings = true;
     a.utf16_strings = true;
     a.static_slices = true;
+    a.defaults = true;
 
     a.constructors = true;
     a.named_constructors = false;

--- a/tool/templates/cpp/enum_decl.h.jinja
+++ b/tool/templates/cpp/enum_decl.h.jinja
@@ -16,7 +16,8 @@ public:
 		{%- endfor %}
 	};
 
-	{{type_name_unnamespaced}}() = default;
+	{{type_name_unnamespaced}}(): value(Value::{{default_variant}}) {}
+
 	// Implicit conversions between enum and ::Value
 	constexpr {{type_name_unnamespaced}}(Value v) : value(v) {}
 	constexpr operator Value() const { return value; }


### PR DESCRIPTION
Fixes https://github.com/rust-diplomat/diplomat/issues/247

Progress on https://github.com/rust-diplomat/diplomat/issues/882, potentially fixing it to the extent I think we need to.


Fixes https://github.com/rust-diplomat/diplomat/issues/271 by ensuring that all Diplomat types are safe to default-initialize if they have a default ctor.