### PR TITLE
Reintroduce diplomat::WriteTrait to cpp

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1183,6 +1183,7 @@ impl TypeName {
         &self,
         mut transitivity: LifetimeTransitivity<'env>,
     ) -> Vec<&'env NamedLifetime> {
+        // We don't use the control flow here
         let _ = self.visit_lifetimes(&mut |lifetime, _| -> ControlFlow<()> {
             if let Lifetime::Named(named) = lifetime {
                 transitivity.visit(named);

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -108,6 +108,16 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
   return w;
 }
 
+template<typename T> struct WriteTrait {
+  // static inline capi::DiplomatWrite Construct(T& t);
+};
+
+template<> struct WriteTrait<std::string> {
+  static inline capi::DiplomatWrite Construct(std::string& t) {
+    return diplomat::WriteFromString(t);
+  }
+};
+
 template<class T> struct Ok {
   T inner;
   Ok(T&& i): inner(std::forward<T>(i)) {}

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -108,7 +108,13 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
   return w;
 }
 
+// This "trait" allows one to use _write() methods to efficiently
+// write to a custom string type. To do this you need to write a specialized
+// `WriteTrait<YourType>` (see WriteTrait<std::string> below)
+// that is capable of constructing a DiplomatWrite, which can wrap
+// your string type with appropriate resize/flush functionality.
 template<typename T> struct WriteTrait {
+  // Fill in this method on a specialization to implement this trait
   // static inline capi::DiplomatWrite Construct(T& t);
 };
 

--- a/example/cpp/include/icu4x/FixedDecimal.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimal.d.hpp
@@ -48,6 +48,8 @@ public:
    * See the [Rust documentation for `write_to`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.write_to) for more information.
    */
   inline diplomat::result<std::string, std::monostate> to_string() const;
+  template<typename W>
+  inline diplomat::result<std::monostate, std::monostate> to_string_write(W& writeable_output) const;
 
   inline const icu4x::capi::FixedDecimal* AsFFI() const;
   inline icu4x::capi::FixedDecimal* AsFFI();

--- a/example/cpp/include/icu4x/FixedDecimal.hpp
+++ b/example/cpp/include/icu4x/FixedDecimal.hpp
@@ -48,6 +48,13 @@ inline diplomat::result<std::string, std::monostate> icu4x::FixedDecimal::to_str
     &write);
   return result.is_ok ? diplomat::result<std::string, std::monostate>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, std::monostate>(diplomat::Err<std::monostate>());
 }
+template<typename W>
+inline diplomat::result<std::monostate, std::monostate> icu4x::FixedDecimal::to_string_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  auto result = icu4x::capi::icu4x_FixedDecimal_to_string_mv1(this->AsFFI(),
+    &write);
+  return result.is_ok ? diplomat::result<std::monostate, std::monostate>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, std::monostate>(diplomat::Err<std::monostate>());
+}
 
 inline const icu4x::capi::FixedDecimal* icu4x::FixedDecimal::AsFFI() const {
   return reinterpret_cast<const icu4x::capi::FixedDecimal*>(this);

--- a/example/cpp/include/icu4x/FixedDecimalFormatter.d.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatter.d.hpp
@@ -52,6 +52,8 @@ public:
    * See the [Rust documentation for `format`](https://docs.rs/icu/latest/icu/decimal/struct.FixedDecimalFormatter.html#method.format) for more information.
    */
   inline std::string format_write(const icu4x::FixedDecimal& value) const;
+  template<typename W>
+  inline void format_write_write(const icu4x::FixedDecimal& value, W& writeable_output) const;
 
   inline const icu4x::capi::FixedDecimalFormatter* AsFFI() const;
   inline icu4x::capi::FixedDecimalFormatter* AsFFI();

--- a/example/cpp/include/icu4x/FixedDecimalFormatter.hpp
+++ b/example/cpp/include/icu4x/FixedDecimalFormatter.hpp
@@ -48,6 +48,13 @@ inline std::string icu4x::FixedDecimalFormatter::format_write(const icu4x::Fixed
     &write);
   return output;
 }
+template<typename W>
+inline void icu4x::FixedDecimalFormatter::format_write_write(const icu4x::FixedDecimal& value, W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  icu4x::capi::icu4x_FixedDecimalFormatter_format_write_mv1(this->AsFFI(),
+    value.AsFFI(),
+    &write);
+}
 
 inline const icu4x::capi::FixedDecimalFormatter* icu4x::FixedDecimalFormatter::AsFFI() const {
   return reinterpret_cast<const icu4x::capi::FixedDecimalFormatter*>(this);

--- a/feature_tests/cpp/Makefile
+++ b/feature_tests/cpp/Makefile
@@ -28,9 +28,14 @@ $(ALL_HEADERS):
 ./tests/callback.out: ../../target/debug/libdiplomat_feature_tests.a $(ALL_HEADERS) ./tests/callback.cpp
 	$(CXX) -std=c++17 ./tests/callback.cpp ../../target/debug/libdiplomat_feature_tests.a -ldl -lpthread -lm -g -o ./tests/callback.out
 
-test: ./tests/structs.out ./tests/result.out ./tests/option.out ./tests/attrs.out ./tests/callback.out
+./tests/strings.out: ../../target/debug/libdiplomat_feature_tests.a $(ALL_HEADERS) ./tests/strings.cpp
+	$(CXX) -std=c++17 ./tests/strings.cpp ../../target/debug/libdiplomat_feature_tests.a -ldl -lpthread -lm -g -o ./tests/strings.out
+
+
+test: ./tests/structs.out ./tests/result.out ./tests/option.out ./tests/attrs.out ./tests/callback.out ./tests/strings.out
 	./tests/structs.out
 	./tests/result.out
 	./tests/option.out
 	./tests/attrs.out
 	./tests/callback.out
+	./tests/strings.out

--- a/feature_tests/cpp/include/CyclicStructA.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.d.hpp
@@ -32,10 +32,16 @@ struct CyclicStructA {
   inline static CyclicStructB get_b();
 
   inline std::string cyclic_out() const;
+  template<typename W>
+  inline void cyclic_out_write(W& writeable_output) const;
 
   inline std::string double_cyclic_out(CyclicStructA cyclic_struct_a) const;
+  template<typename W>
+  inline void double_cyclic_out_write(CyclicStructA cyclic_struct_a, W& writeable_output) const;
 
   inline std::string getter_out() const;
+  template<typename W>
+  inline void getter_out_write(W& writeable_output) const;
 
   inline diplomat::capi::CyclicStructA AsFFI() const;
   inline static CyclicStructA FromFFI(diplomat::capi::CyclicStructA c_struct);

--- a/feature_tests/cpp/include/CyclicStructA.hpp
+++ b/feature_tests/cpp/include/CyclicStructA.hpp
@@ -43,6 +43,12 @@ inline std::string CyclicStructA::cyclic_out() const {
     &write);
   return output;
 }
+template<typename W>
+inline void CyclicStructA::cyclic_out_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::CyclicStructA_cyclic_out(this->AsFFI(),
+    &write);
+}
 
 inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_a) const {
   std::string output;
@@ -52,6 +58,13 @@ inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_
     &write);
   return output;
 }
+template<typename W>
+inline void CyclicStructA::double_cyclic_out_write(CyclicStructA cyclic_struct_a, W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::CyclicStructA_double_cyclic_out(this->AsFFI(),
+    cyclic_struct_a.AsFFI(),
+    &write);
+}
 
 inline std::string CyclicStructA::getter_out() const {
   std::string output;
@@ -59,6 +72,12 @@ inline std::string CyclicStructA::getter_out() const {
   diplomat::capi::CyclicStructA_getter_out(this->AsFFI(),
     &write);
   return output;
+}
+template<typename W>
+inline void CyclicStructA::getter_out_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::CyclicStructA_getter_out(this->AsFFI(),
+    &write);
 }
 
 

--- a/feature_tests/cpp/include/CyclicStructC.d.hpp
+++ b/feature_tests/cpp/include/CyclicStructC.d.hpp
@@ -32,6 +32,8 @@ struct CyclicStructC {
   inline static CyclicStructC takes_nested_parameters(CyclicStructC c);
 
   inline std::string cyclic_out() const;
+  template<typename W>
+  inline void cyclic_out_write(W& writeable_output) const;
 
   inline diplomat::capi::CyclicStructC AsFFI() const;
   inline static CyclicStructC FromFFI(diplomat::capi::CyclicStructC c_struct);

--- a/feature_tests/cpp/include/CyclicStructC.hpp
+++ b/feature_tests/cpp/include/CyclicStructC.hpp
@@ -39,6 +39,12 @@ inline std::string CyclicStructC::cyclic_out() const {
     &write);
   return output;
 }
+template<typename W>
+inline void CyclicStructC::cyclic_out_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::CyclicStructC_cyclic_out(this->AsFFI(),
+    &write);
+}
 
 
 inline diplomat::capi::CyclicStructC CyclicStructC::AsFFI() const {

--- a/feature_tests/cpp/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp/include/Float64Vec.d.hpp
@@ -42,6 +42,8 @@ public:
   inline void set_value(diplomat::span<const double> new_slice);
 
   inline std::string to_string() const;
+  template<typename W>
+  inline void to_string_write(W& writeable_output) const;
 
   inline diplomat::span<const double> borrow() const;
 

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -108,6 +108,12 @@ inline std::string Float64Vec::to_string() const {
     &write);
   return output;
 }
+template<typename W>
+inline void Float64Vec::to_string_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::Float64Vec_to_string(this->AsFFI(),
+    &write);
+}
 
 inline diplomat::span<const double> Float64Vec::borrow() const {
   auto result = diplomat::capi::Float64Vec_borrow(this->AsFFI());

--- a/feature_tests/cpp/include/MyOpaqueEnum.d.hpp
+++ b/feature_tests/cpp/include/MyOpaqueEnum.d.hpp
@@ -24,6 +24,8 @@ public:
   inline static std::unique_ptr<MyOpaqueEnum> new_();
 
   inline std::string to_string() const;
+  template<typename W>
+  inline void to_string_write(W& writeable_output) const;
 
   inline const diplomat::capi::MyOpaqueEnum* AsFFI() const;
   inline diplomat::capi::MyOpaqueEnum* AsFFI();

--- a/feature_tests/cpp/include/MyOpaqueEnum.hpp
+++ b/feature_tests/cpp/include/MyOpaqueEnum.hpp
@@ -40,6 +40,12 @@ inline std::string MyOpaqueEnum::to_string() const {
     &write);
   return output;
 }
+template<typename W>
+inline void MyOpaqueEnum::to_string_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::MyOpaqueEnum_to_string(this->AsFFI(),
+    &write);
+}
 
 inline const diplomat::capi::MyOpaqueEnum* MyOpaqueEnum::AsFFI() const {
   return reinterpret_cast<const diplomat::capi::MyOpaqueEnum*>(this);

--- a/feature_tests/cpp/include/MyString.d.hpp
+++ b/feature_tests/cpp/include/MyString.d.hpp
@@ -32,10 +32,14 @@ public:
   inline void set_str(std::string_view new_str);
 
   inline std::string get_str() const;
+  template<typename W>
+  inline void get_str_write(W& writeable_output) const;
 
   inline static std::string_view get_static_str();
 
   inline static diplomat::result<std::string, diplomat::Utf8Error> string_transform(std::string_view foo);
+  template<typename W>
+  inline static diplomat::result<std::monostate, diplomat::Utf8Error> string_transform_write(std::string_view foo, W& writeable_output);
 
   inline std::string_view borrow() const;
 

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -77,6 +77,12 @@ inline std::string MyString::get_str() const {
     &write);
   return output;
 }
+template<typename W>
+inline void MyString::get_str_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::MyString_get_str(this->AsFFI(),
+    &write);
+}
 
 inline std::string_view MyString::get_static_str() {
   auto result = diplomat::capi::MyString_get_static_str();
@@ -92,6 +98,16 @@ inline diplomat::result<std::string, diplomat::Utf8Error> MyString::string_trans
   diplomat::capi::MyString_string_transform({foo.data(), foo.size()},
     &write);
   return diplomat::Ok<std::string>(std::move(output));
+}
+template<typename W>
+inline diplomat::result<std::monostate, diplomat::Utf8Error> MyString::string_transform_write(std::string_view foo, W& writeable) {
+  if (!diplomat::capi::diplomat_is_str(foo.data(), foo.size())) {
+    return diplomat::Err<diplomat::Utf8Error>();
+  }
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::MyString_string_transform({foo.data(), foo.size()},
+    &write);
+  return diplomat::Ok<std::monostate>();
 }
 
 inline std::string_view MyString::borrow() const {

--- a/feature_tests/cpp/include/Opaque.d.hpp
+++ b/feature_tests/cpp/include/Opaque.d.hpp
@@ -31,6 +31,8 @@ public:
   inline static diplomat::result<std::unique_ptr<Opaque>, diplomat::Utf8Error> from_str(std::string_view input);
 
   inline std::string get_debug_str() const;
+  template<typename W>
+  inline void get_debug_str_write(W& writeable_output) const;
 
   /**
    * See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.

--- a/feature_tests/cpp/include/Opaque.hpp
+++ b/feature_tests/cpp/include/Opaque.hpp
@@ -67,6 +67,12 @@ inline std::string Opaque::get_debug_str() const {
     &write);
   return output;
 }
+template<typename W>
+inline void Opaque::get_debug_str_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::Opaque_get_debug_str(this->AsFFI(),
+    &write);
+}
 
 inline void Opaque::assert_struct(MyStruct s) const {
   diplomat::capi::Opaque_assert_struct(this->AsFFI(),

--- a/feature_tests/cpp/include/OptionString.d.hpp
+++ b/feature_tests/cpp/include/OptionString.d.hpp
@@ -24,6 +24,8 @@ public:
   inline static std::unique_ptr<OptionString> new_(std::string_view diplomat_str);
 
   inline diplomat::result<std::string, std::monostate> write() const;
+  template<typename W>
+  inline diplomat::result<std::monostate, std::monostate> write_write(W& writeable_output) const;
 
   inline std::optional<std::string_view> borrow() const;
 

--- a/feature_tests/cpp/include/OptionString.hpp
+++ b/feature_tests/cpp/include/OptionString.hpp
@@ -44,6 +44,13 @@ inline diplomat::result<std::string, std::monostate> OptionString::write() const
     &write);
   return result.is_ok ? diplomat::result<std::string, std::monostate>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, std::monostate>(diplomat::Err<std::monostate>());
 }
+template<typename W>
+inline diplomat::result<std::monostate, std::monostate> OptionString::write_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  auto result = diplomat::capi::OptionString_write(this->AsFFI(),
+    &write);
+  return result.is_ok ? diplomat::result<std::monostate, std::monostate>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, std::monostate>(diplomat::Err<std::monostate>());
+}
 
 inline std::optional<std::string_view> OptionString::borrow() const {
   auto result = diplomat::capi::OptionString_borrow(this->AsFFI());

--- a/feature_tests/cpp/include/StructWithSlices.d.hpp
+++ b/feature_tests/cpp/include/StructWithSlices.d.hpp
@@ -29,6 +29,8 @@ struct StructWithSlices {
   diplomat::span<const uint16_t> second;
 
   inline std::string return_last() const;
+  template<typename W>
+  inline void return_last_write(W& writeable_output) const;
 
   inline diplomat::capi::StructWithSlices AsFFI() const;
   inline static StructWithSlices FromFFI(diplomat::capi::StructWithSlices c_struct);

--- a/feature_tests/cpp/include/StructWithSlices.hpp
+++ b/feature_tests/cpp/include/StructWithSlices.hpp
@@ -31,6 +31,12 @@ inline std::string StructWithSlices::return_last() const {
     &write);
   return output;
 }
+template<typename W>
+inline void StructWithSlices::return_last_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::StructWithSlices_return_last(this->AsFFI(),
+    &write);
+}
 
 
 inline diplomat::capi::StructWithSlices StructWithSlices::AsFFI() const {

--- a/feature_tests/cpp/include/Utf16Wrap.d.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.d.hpp
@@ -24,6 +24,8 @@ public:
   inline static std::unique_ptr<Utf16Wrap> from_utf16(std::u16string_view input);
 
   inline std::string get_debug_str() const;
+  template<typename W>
+  inline void get_debug_str_write(W& writeable_output) const;
 
   inline std::u16string_view borrow_cont() const;
 

--- a/feature_tests/cpp/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.hpp
@@ -42,6 +42,12 @@ inline std::string Utf16Wrap::get_debug_str() const {
     &write);
   return output;
 }
+template<typename W>
+inline void Utf16Wrap::get_debug_str_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::Utf16Wrap_get_debug_str(this->AsFFI(),
+    &write);
+}
 
 inline std::u16string_view Utf16Wrap::borrow_cont() const {
   auto result = diplomat::capi::Utf16Wrap_borrow_cont(this->AsFFI());

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -108,6 +108,16 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
   return w;
 }
 
+template<typename T> struct WriteTrait {
+  // static inline capi::DiplomatWrite Construct(T& t);
+};
+
+template<> struct WriteTrait<std::string> {
+  static inline capi::DiplomatWrite Construct(std::string& t) {
+    return diplomat::WriteFromString(t);
+  }
+};
+
 template<class T> struct Ok {
   T inner;
   Ok(T&& i): inner(std::forward<T>(i)) {}

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -108,7 +108,13 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
   return w;
 }
 
+// This "trait" allows one to use _write() methods to efficiently
+// write to a custom string type. To do this you need to write a specialized
+// `WriteTrait<YourType>` (see WriteTrait<std::string> below)
+// that is capable of constructing a DiplomatWrite, which can wrap
+// your string type with appropriate resize/flush functionality.
 template<typename T> struct WriteTrait {
+  // Fill in this method on a specialization to implement this trait
   // static inline capi::DiplomatWrite Construct(T& t);
 };
 

--- a/feature_tests/cpp/tests/result.cpp
+++ b/feature_tests/cpp/tests/result.cpp
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
     auto unit_err = ResultOpaque::new_failing_unit();
     simple_assert("unit error", unit_err.is_err())
 
-        auto struc = ResultOpaque::new_failing_struct(109).err().value();
+    auto struc = ResultOpaque::new_failing_struct(109).err().value();
     simple_assert_eq("struct error", struc.i, 109);
 
     auto integer = ResultOpaque::new_int(109).ok().value();

--- a/feature_tests/cpp/tests/strings.cpp
+++ b/feature_tests/cpp/tests/strings.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include "../include/Opaque.hpp"
+#include "../include/OptionString.hpp"
+#include "assert.hpp"
+
+int main(int argc, char* argv[]) {
+    std::unique_ptr<Opaque> o = Opaque::from_str("hello world").ok().value();
+    std::string output = o->get_debug_str();
+    simple_assert_eq("simple string get",  output, "\"hello world\"");
+    output = "prefix ";
+    o->get_debug_str_write(output);
+    simple_assert_eq("string write", output, "prefix \"hello world\"");
+
+
+    std::unique_ptr<OptionString> os = OptionString::new_("hello world");
+    output = os->write().ok().value();
+    simple_assert_eq("simple string get with result", output, "hello world");
+    output = "prefix ";
+    os->write_write(output).ok().value();
+    simple_assert_eq("string write with result", output, "prefix hello world");
+}

--- a/feature_tests/nanobind/src/include/CyclicStructA.d.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructA.d.hpp
@@ -32,10 +32,16 @@ struct CyclicStructA {
   inline static CyclicStructB get_b();
 
   inline std::string cyclic_out() const;
+  template<typename W>
+  inline void cyclic_out_write(W& writeable_output) const;
 
   inline std::string double_cyclic_out(CyclicStructA cyclic_struct_a) const;
+  template<typename W>
+  inline void double_cyclic_out_write(CyclicStructA cyclic_struct_a, W& writeable_output) const;
 
   inline std::string getter_out() const;
+  template<typename W>
+  inline void getter_out_write(W& writeable_output) const;
 
   inline diplomat::capi::CyclicStructA AsFFI() const;
   inline static CyclicStructA FromFFI(diplomat::capi::CyclicStructA c_struct);

--- a/feature_tests/nanobind/src/include/CyclicStructA.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructA.hpp
@@ -43,6 +43,12 @@ inline std::string CyclicStructA::cyclic_out() const {
     &write);
   return output;
 }
+template<typename W>
+inline void CyclicStructA::cyclic_out_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::CyclicStructA_cyclic_out(this->AsFFI(),
+    &write);
+}
 
 inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_a) const {
   std::string output;
@@ -52,6 +58,13 @@ inline std::string CyclicStructA::double_cyclic_out(CyclicStructA cyclic_struct_
     &write);
   return output;
 }
+template<typename W>
+inline void CyclicStructA::double_cyclic_out_write(CyclicStructA cyclic_struct_a, W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::CyclicStructA_double_cyclic_out(this->AsFFI(),
+    cyclic_struct_a.AsFFI(),
+    &write);
+}
 
 inline std::string CyclicStructA::getter_out() const {
   std::string output;
@@ -59,6 +72,12 @@ inline std::string CyclicStructA::getter_out() const {
   diplomat::capi::CyclicStructA_getter_out(this->AsFFI(),
     &write);
   return output;
+}
+template<typename W>
+inline void CyclicStructA::getter_out_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::CyclicStructA_getter_out(this->AsFFI(),
+    &write);
 }
 
 

--- a/feature_tests/nanobind/src/include/CyclicStructC.d.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructC.d.hpp
@@ -32,6 +32,8 @@ struct CyclicStructC {
   inline static CyclicStructC takes_nested_parameters(CyclicStructC c);
 
   inline std::string cyclic_out() const;
+  template<typename W>
+  inline void cyclic_out_write(W& writeable_output) const;
 
   inline diplomat::capi::CyclicStructC AsFFI() const;
   inline static CyclicStructC FromFFI(diplomat::capi::CyclicStructC c_struct);

--- a/feature_tests/nanobind/src/include/CyclicStructC.hpp
+++ b/feature_tests/nanobind/src/include/CyclicStructC.hpp
@@ -39,6 +39,12 @@ inline std::string CyclicStructC::cyclic_out() const {
     &write);
   return output;
 }
+template<typename W>
+inline void CyclicStructC::cyclic_out_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::CyclicStructC_cyclic_out(this->AsFFI(),
+    &write);
+}
 
 
 inline diplomat::capi::CyclicStructC CyclicStructC::AsFFI() const {

--- a/feature_tests/nanobind/src/include/Float64Vec.d.hpp
+++ b/feature_tests/nanobind/src/include/Float64Vec.d.hpp
@@ -42,6 +42,8 @@ public:
   inline void set_value(diplomat::span<const double> new_slice);
 
   inline std::string to_string() const;
+  template<typename W>
+  inline void to_string_write(W& writeable_output) const;
 
   inline diplomat::span<const double> borrow() const;
 

--- a/feature_tests/nanobind/src/include/Float64Vec.hpp
+++ b/feature_tests/nanobind/src/include/Float64Vec.hpp
@@ -108,6 +108,12 @@ inline std::string Float64Vec::to_string() const {
     &write);
   return output;
 }
+template<typename W>
+inline void Float64Vec::to_string_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::Float64Vec_to_string(this->AsFFI(),
+    &write);
+}
 
 inline diplomat::span<const double> Float64Vec::borrow() const {
   auto result = diplomat::capi::Float64Vec_borrow(this->AsFFI());

--- a/feature_tests/nanobind/src/include/MyOpaqueEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/MyOpaqueEnum.d.hpp
@@ -24,6 +24,8 @@ public:
   inline static std::unique_ptr<MyOpaqueEnum> new_();
 
   inline std::string to_string() const;
+  template<typename W>
+  inline void to_string_write(W& writeable_output) const;
 
   inline const diplomat::capi::MyOpaqueEnum* AsFFI() const;
   inline diplomat::capi::MyOpaqueEnum* AsFFI();

--- a/feature_tests/nanobind/src/include/MyOpaqueEnum.hpp
+++ b/feature_tests/nanobind/src/include/MyOpaqueEnum.hpp
@@ -40,6 +40,12 @@ inline std::string MyOpaqueEnum::to_string() const {
     &write);
   return output;
 }
+template<typename W>
+inline void MyOpaqueEnum::to_string_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::MyOpaqueEnum_to_string(this->AsFFI(),
+    &write);
+}
 
 inline const diplomat::capi::MyOpaqueEnum* MyOpaqueEnum::AsFFI() const {
   return reinterpret_cast<const diplomat::capi::MyOpaqueEnum*>(this);

--- a/feature_tests/nanobind/src/include/MyString.d.hpp
+++ b/feature_tests/nanobind/src/include/MyString.d.hpp
@@ -32,10 +32,14 @@ public:
   inline void set_str(std::string_view new_str);
 
   inline std::string get_str() const;
+  template<typename W>
+  inline void get_str_write(W& writeable_output) const;
 
   inline static std::string_view get_static_str();
 
   inline static diplomat::result<std::string, diplomat::Utf8Error> string_transform(std::string_view foo);
+  template<typename W>
+  inline static diplomat::result<std::monostate, diplomat::Utf8Error> string_transform_write(std::string_view foo, W& writeable_output);
 
   inline std::string_view borrow() const;
 

--- a/feature_tests/nanobind/src/include/MyString.hpp
+++ b/feature_tests/nanobind/src/include/MyString.hpp
@@ -77,6 +77,12 @@ inline std::string MyString::get_str() const {
     &write);
   return output;
 }
+template<typename W>
+inline void MyString::get_str_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::MyString_get_str(this->AsFFI(),
+    &write);
+}
 
 inline std::string_view MyString::get_static_str() {
   auto result = diplomat::capi::MyString_get_static_str();
@@ -92,6 +98,16 @@ inline diplomat::result<std::string, diplomat::Utf8Error> MyString::string_trans
   diplomat::capi::MyString_string_transform({foo.data(), foo.size()},
     &write);
   return diplomat::Ok<std::string>(std::move(output));
+}
+template<typename W>
+inline diplomat::result<std::monostate, diplomat::Utf8Error> MyString::string_transform_write(std::string_view foo, W& writeable) {
+  if (!diplomat::capi::diplomat_is_str(foo.data(), foo.size())) {
+    return diplomat::Err<diplomat::Utf8Error>();
+  }
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::MyString_string_transform({foo.data(), foo.size()},
+    &write);
+  return diplomat::Ok<std::monostate>();
 }
 
 inline std::string_view MyString::borrow() const {

--- a/feature_tests/nanobind/src/include/Opaque.d.hpp
+++ b/feature_tests/nanobind/src/include/Opaque.d.hpp
@@ -31,6 +31,8 @@ public:
   inline static diplomat::result<std::unique_ptr<Opaque>, diplomat::Utf8Error> from_str(std::string_view input);
 
   inline std::string get_debug_str() const;
+  template<typename W>
+  inline void get_debug_str_write(W& writeable_output) const;
 
   /**
    * See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.

--- a/feature_tests/nanobind/src/include/Opaque.hpp
+++ b/feature_tests/nanobind/src/include/Opaque.hpp
@@ -67,6 +67,12 @@ inline std::string Opaque::get_debug_str() const {
     &write);
   return output;
 }
+template<typename W>
+inline void Opaque::get_debug_str_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::Opaque_get_debug_str(this->AsFFI(),
+    &write);
+}
 
 inline void Opaque::assert_struct(MyStruct s) const {
   diplomat::capi::Opaque_assert_struct(this->AsFFI(),

--- a/feature_tests/nanobind/src/include/OptionString.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionString.d.hpp
@@ -24,6 +24,8 @@ public:
   inline static std::unique_ptr<OptionString> new_(std::string_view diplomat_str);
 
   inline diplomat::result<std::string, std::monostate> write() const;
+  template<typename W>
+  inline diplomat::result<std::monostate, std::monostate> write_write(W& writeable_output) const;
 
   inline std::optional<std::string_view> borrow() const;
 

--- a/feature_tests/nanobind/src/include/OptionString.hpp
+++ b/feature_tests/nanobind/src/include/OptionString.hpp
@@ -44,6 +44,13 @@ inline diplomat::result<std::string, std::monostate> OptionString::write() const
     &write);
   return result.is_ok ? diplomat::result<std::string, std::monostate>(diplomat::Ok<std::string>(std::move(output))) : diplomat::result<std::string, std::monostate>(diplomat::Err<std::monostate>());
 }
+template<typename W>
+inline diplomat::result<std::monostate, std::monostate> OptionString::write_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  auto result = diplomat::capi::OptionString_write(this->AsFFI(),
+    &write);
+  return result.is_ok ? diplomat::result<std::monostate, std::monostate>(diplomat::Ok<std::monostate>()) : diplomat::result<std::monostate, std::monostate>(diplomat::Err<std::monostate>());
+}
 
 inline std::optional<std::string_view> OptionString::borrow() const {
   auto result = diplomat::capi::OptionString_borrow(this->AsFFI());

--- a/feature_tests/nanobind/src/include/StructWithSlices.d.hpp
+++ b/feature_tests/nanobind/src/include/StructWithSlices.d.hpp
@@ -29,6 +29,8 @@ struct StructWithSlices {
   diplomat::span<const uint16_t> second;
 
   inline std::string return_last() const;
+  template<typename W>
+  inline void return_last_write(W& writeable_output) const;
 
   inline diplomat::capi::StructWithSlices AsFFI() const;
   inline static StructWithSlices FromFFI(diplomat::capi::StructWithSlices c_struct);

--- a/feature_tests/nanobind/src/include/StructWithSlices.hpp
+++ b/feature_tests/nanobind/src/include/StructWithSlices.hpp
@@ -31,6 +31,12 @@ inline std::string StructWithSlices::return_last() const {
     &write);
   return output;
 }
+template<typename W>
+inline void StructWithSlices::return_last_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::StructWithSlices_return_last(this->AsFFI(),
+    &write);
+}
 
 
 inline diplomat::capi::StructWithSlices StructWithSlices::AsFFI() const {

--- a/feature_tests/nanobind/src/include/Utf16Wrap.d.hpp
+++ b/feature_tests/nanobind/src/include/Utf16Wrap.d.hpp
@@ -24,6 +24,8 @@ public:
   inline static std::unique_ptr<Utf16Wrap> from_utf16(std::u16string_view input);
 
   inline std::string get_debug_str() const;
+  template<typename W>
+  inline void get_debug_str_write(W& writeable_output) const;
 
   inline std::u16string_view borrow_cont() const;
 

--- a/feature_tests/nanobind/src/include/Utf16Wrap.hpp
+++ b/feature_tests/nanobind/src/include/Utf16Wrap.hpp
@@ -42,6 +42,12 @@ inline std::string Utf16Wrap::get_debug_str() const {
     &write);
   return output;
 }
+template<typename W>
+inline void Utf16Wrap::get_debug_str_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::Utf16Wrap_get_debug_str(this->AsFFI(),
+    &write);
+}
 
 inline std::u16string_view Utf16Wrap::borrow_cont() const {
   auto result = diplomat::capi::Utf16Wrap_borrow_cont(this->AsFFI());

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -108,6 +108,16 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
   return w;
 }
 
+template<typename T> struct WriteTrait {
+  // static inline capi::DiplomatWrite Construct(T& t);
+};
+
+template<> struct WriteTrait<std::string> {
+  static inline capi::DiplomatWrite Construct(std::string& t) {
+    return diplomat::WriteFromString(t);
+  }
+};
+
 template<class T> struct Ok {
   T inner;
   Ok(T&& i): inner(std::forward<T>(i)) {}

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -108,7 +108,13 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
   return w;
 }
 
+// This "trait" allows one to use _write() methods to efficiently
+// write to a custom string type. To do this you need to write a specialized
+// `WriteTrait<YourType>` (see WriteTrait<std::string> below)
+// that is capable of constructing a DiplomatWrite, which can wrap
+// your string type with appropriate resize/flush functionality.
 template<typename T> struct WriteTrait {
+  // Fill in this method on a specialization to implement this trait
   // static inline capi::DiplomatWrite Construct(T& t);
 };
 

--- a/tool/templates/cpp/method_decl.h.jinja
+++ b/tool/templates/cpp/method_decl.h.jinja
@@ -3,12 +3,7 @@ inline {##}
 {%- for qualifier in m.pre_qualifiers %}{{qualifier}} {% endfor -%}
 {{ m.return_ty }} {##}
 {{- m.method_name -}}
-(
-	{%- for param in m.param_decls %}
-		{%- if !loop.first %}, {% endif -%}
-		{{ param.type_name }} {{ param.var_name }}
-	{%- endfor -%}
-)
+({% include "param_decls_list.h.jinja" %})
 {%- for qualifier in m.post_qualifiers %} {{qualifier}}{% endfor %};
 
 {#- Extra method definitions for special types -#}

--- a/tool/templates/cpp/method_decl.h.jinja
+++ b/tool/templates/cpp/method_decl.h.jinja
@@ -6,6 +6,19 @@ inline {##}
 ({% include "param_decls_list.h.jinja" %})
 {%- for qualifier in m.post_qualifiers %} {{qualifier}}{% endfor %};
 
+{#- Extra method definitions for writeables -#}
+{%- if let Some(m_writeable) = m.writeable_info %}
+  template<typename W>
+  inline {##}
+{%- for qualifier in m.pre_qualifiers %}{{qualifier}} {% endfor -%}
+{{ m_writeable.return_ty }} {##}
+{{- m_writeable.method_name -}} (
+{%- include "param_decls_list.h.jinja" %}{% if !m.param_decls.is_empty() %}, {%endif%}W& writeable_output)
+{%- for qualifier in m.post_qualifiers %} {{qualifier}}{% endfor %};
+
+{%- endif %}
+
+
 {#- Extra method definitions for special types -#}
 {%- match m.method.attrs.special_method -%}
 

--- a/tool/templates/cpp/method_impl.h.jinja
+++ b/tool/templates/cpp/method_impl.h.jinja
@@ -1,16 +1,23 @@
-{%- let is_self_opaque = matches!(m.method.param_self, Some(hir::ParamSelf{ ty : SelfType::Opaque(_), ..})) -%}
+{%- macro method_body(method_name, is_generic_writeable, return_ty, c_to_cpp_return_expression) -%}
 inline {##}
-{{- m.return_ty }} {##}
-{{- type_name }}::{{ m.method_name -}}
-({% include "param_decls_list.h.jinja" %}) {##}
+{{- return_ty }} {##}
+{{- type_name }}::{{ method_name -}}
+(
+	{%- include "param_decls_list.h.jinja" %}
+	{%- if is_generic_writeable %}{% if !m.param_decls.is_empty() %}, {%endif%}W& writeable{% endif -%}
+) {##}
 {%- for qualifier in m.post_qualifiers %}{{qualifier}} {% endfor -%}
 {
 	{%- for validation in m.param_validations %}
 	{{ validation.replace('\n', "\n  ") }}
 	{%- endfor -%}
 	{%- if m.method.output.is_write() %}
+	{%- if is_generic_writeable %}
+	diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+	{%- else %}
 	std::string output;
 	diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
+	{%- endif %}
 	{%- endif %}
 	{% if !m.method.output.is_ffi_unit() -%}
 	auto result = {##}
@@ -22,12 +29,20 @@ inline {##}
 		{{ param }}
 		{%- endfor -%}
 	);
-	{%- match m.c_to_cpp_return_expression %}
-	{%- when Some with (statement) %}
+	{%- if let Some(statement) = c_to_cpp_return_expression %}
 	return {{ statement }};
-	{%- when None %}
-	{%- endmatch %}
+	{%- endif %}
 }
+{%- endmacro %}
+
+{%- let is_self_opaque = matches!(m.method.param_self, Some(hir::ParamSelf{ ty : SelfType::Opaque(_), ..})) -%}
+{% call method_body(m.method_name, false, m.return_ty, m.c_to_cpp_return_expression) %}
+
+{#- Extra method definitions for writeables -#}
+{%- if let Some(m_writeable) = m.writeable_info %}
+template<typename W>
+{% call method_body(m_writeable.method_name, true, m_writeable.return_ty, m_writeable.c_to_cpp_return_expression) %}
+{%- endif %}
 
 {%- match m.method.attrs.special_method -%}
 {%- when Some(hir::SpecialMethod::Add) | Some(hir::SpecialMethod::Sub) | Some(hir::SpecialMethod::Mul) | Some(hir::SpecialMethod::Div) -%}

--- a/tool/templates/cpp/method_impl.h.jinja
+++ b/tool/templates/cpp/method_impl.h.jinja
@@ -2,12 +2,7 @@
 inline {##}
 {{- m.return_ty }} {##}
 {{- type_name }}::{{ m.method_name -}}
-(
-	{%- for param in m.param_decls %}
-		{%- if !loop.first %}, {% endif -%}
-		{{ param.type_name }} {{ param.var_name }}
-	{%- endfor -%}
-) {##}
+({% include "param_decls_list.h.jinja" %}) {##}
 {%- for qualifier in m.post_qualifiers %}{{qualifier}} {% endfor -%}
 {
 	{%- for validation in m.param_validations %}

--- a/tool/templates/cpp/param_decls_list.h.jinja
+++ b/tool/templates/cpp/param_decls_list.h.jinja
@@ -1,0 +1,4 @@
+    {%- for param in m.param_decls %}
+        {%- if !loop.first %}, {% endif -%}
+        {{ param.type_name }} {{ param.var_name }}
+    {%- endfor -%}

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -54,7 +54,13 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
   return w;
 }
 
+// This "trait" allows one to use _write() methods to efficiently
+// write to a custom string type. To do this you need to write a specialized
+// `WriteTrait<YourType>` (see WriteTrait<std::string> below)
+// that is capable of constructing a DiplomatWrite, which can wrap
+// your string type with appropriate resize/flush functionality.
 template<typename T> struct WriteTrait {
+  // Fill in this method on a specialization to implement this trait
   // static inline capi::DiplomatWrite Construct(T& t);
 };
 

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -54,6 +54,16 @@ inline capi::DiplomatWrite WriteFromString(std::string& string) {
   return w;
 }
 
+template<typename T> struct WriteTrait {
+  // static inline capi::DiplomatWrite Construct(T& t);
+};
+
+template<> struct WriteTrait<std::string> {
+  static inline capi::DiplomatWrite Construct(std::string& t) {
+    return diplomat::WriteFromString(t);
+  }
+};
+
 template<class T> struct Ok {
   T inner;
   Ok(T&& i): inner(std::forward<T>(i)) {}


### PR DESCRIPTION
Fixes https://github.com/rust-diplomat/diplomat/issues/866

Bit hard to make the template code reusable. It's easier to have the template generate two sets of conversions instead of having the string code call the template code, but it could be attempted.