### PR TITLE
companion methods should be static

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1183,7 +1183,7 @@ impl TypeName {
         &self,
         mut transitivity: LifetimeTransitivity<'env>,
     ) -> Vec<&'env NamedLifetime> {
-        self.visit_lifetimes(&mut |lifetime, _| -> ControlFlow<()> {
+        let _ = self.visit_lifetimes(&mut |lifetime, _| -> ControlFlow<()> {
             if let Lifetime::Named(named) = lifetime {
                 transitivity.visit(named);
             }

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DataProvider.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DataProvider.kt
@@ -30,6 +30,7 @@ class DataProvider internal constructor (
     companion object {
         internal val libClass: Class<DataProviderLib> = DataProviderLib::class.java
         internal val lib: DataProviderLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         /** See the [Rust documentation for `get_static_provider`](https://docs.rs/icu_testdata/latest/icu_testdata/fn.get_static_provider.html) for more information.
         */
@@ -42,6 +43,7 @@ class DataProvider internal constructor (
             CLEANER.register(returnOpaque, DataProvider.DataProviderCleaner(handle, DataProvider.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         /** This exists as a regression test for https://github.com/rust-diplomat/diplomat/issues/155
         */

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimal.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimal.kt
@@ -33,6 +33,7 @@ class FixedDecimal internal constructor (
     companion object {
         internal val libClass: Class<FixedDecimalLib> = FixedDecimalLib::class.java
         internal val lib: FixedDecimalLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         /** Construct an [FixedDecimal] from an integer.
         */

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatter.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatter.kt
@@ -30,6 +30,7 @@ class FixedDecimalFormatter internal constructor (
     companion object {
         internal val libClass: Class<FixedDecimalFormatterLib> = FixedDecimalFormatterLib::class.java
         internal val lib: FixedDecimalFormatterLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         /** Creates a new [FixedDecimalFormatter] from locale data.
         *

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatterOptions.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/FixedDecimalFormatterOptions.kt
@@ -31,6 +31,7 @@ class FixedDecimalFormatterOptions internal constructor (
         internal val libClass: Class<FixedDecimalFormatterOptionsLib> = FixedDecimalFormatterOptionsLib::class.java
         internal val lib: FixedDecimalFormatterOptionsLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(FixedDecimalFormatterOptionsNative::class.java).toLong()
+        @JvmStatic
         
         fun default_(): FixedDecimalFormatterOptions {
             

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Locale.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Locale.kt
@@ -29,6 +29,7 @@ class Locale internal constructor (
     companion object {
         internal val libClass: Class<LocaleLib> = LocaleLib::class.java
         internal val lib: LocaleLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         /** Construct an [Locale] from a locale identifier represented as a string.
         */

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
@@ -36,6 +36,7 @@ class AttrOpaque1 internal constructor (
     companion object {
         internal val libClass: Class<AttrOpaque1Lib> = AttrOpaque1Lib::class.java
         internal val lib: AttrOpaque1Lib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(): AttrOpaque1 {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFields.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFields.kt
@@ -36,6 +36,7 @@ class BorrowedFields internal constructor (
         internal val libClass: Class<BorrowedFieldsLib> = BorrowedFieldsLib::class.java
         internal val lib: BorrowedFieldsLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(BorrowedFieldsNative::class.java).toLong()
+        @JvmStatic
         
         fun fromBarAndStrings(bar: Bar, dstr16: String, utf8Str: String): BorrowedFields {
             val (dstr16Mem, dstr16Slice) = PrimitiveArrayTools.readUtf16(dstr16)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsWithBounds.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsWithBounds.kt
@@ -38,6 +38,7 @@ class BorrowedFieldsWithBounds internal constructor (
         internal val libClass: Class<BorrowedFieldsWithBoundsLib> = BorrowedFieldsWithBoundsLib::class.java
         internal val lib: BorrowedFieldsWithBoundsLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(BorrowedFieldsWithBoundsNative::class.java).toLong()
+        @JvmStatic
         
         fun fromFooAndStrings(foo: Foo, dstr16X: String, utf8StrZ: String): BorrowedFieldsWithBounds {
             val (dstr16XMem, dstr16XSlice) = PrimitiveArrayTools.readUtf16(dstr16X)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackHolder.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackHolder.kt
@@ -77,6 +77,7 @@ class CallbackHolder internal constructor (
     companion object {
         internal val libClass: Class<CallbackHolderLib> = CallbackHolderLib::class.java
         internal val lib: CallbackHolderLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(func: (Int)->Int): CallbackHolder {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
@@ -277,24 +277,28 @@ class CallbackWrapper internal constructor (
         internal val libClass: Class<CallbackWrapperLib> = CallbackWrapperLib::class.java
         internal val lib: CallbackWrapperLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(CallbackWrapperNative::class.java).toLong()
+        @JvmStatic
         
         fun testMultiArgCallback(f: (Int)->Int, x: Int): Int {
             
             val returnVal = lib.CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_diplomatCallback_f.fromCallback(f).nativeStruct, x);
             return (returnVal)
         }
+        @JvmStatic
         
         fun testNoArgs(h: ()->Unit): Int {
             
             val returnVal = lib.CallbackWrapper_test_no_args(DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h.fromCallback(h).nativeStruct);
             return (returnVal)
         }
+        @JvmStatic
         
         fun testCbWithStruct(f: (CallbackTestingStruct)->Int): Int {
             
             val returnVal = lib.CallbackWrapper_test_cb_with_struct(DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f.fromCallback(f).nativeStruct);
             return (returnVal)
         }
+        @JvmStatic
         
         fun testMultipleCbArgs(f: ()->Int, g: (Int)->Int): Int {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructA.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructA.kt
@@ -31,6 +31,7 @@ class CyclicStructA internal constructor (
         internal val libClass: Class<CyclicStructALib> = CyclicStructALib::class.java
         internal val lib: CyclicStructALib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(CyclicStructANative::class.java).toLong()
+        @JvmStatic
         
         fun getB(): CyclicStructB {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructB.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructB.kt
@@ -29,6 +29,7 @@ class CyclicStructB internal constructor (
         internal val libClass: Class<CyclicStructBLib> = CyclicStructBLib::class.java
         internal val lib: CyclicStructBLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(CyclicStructBNative::class.java).toLong()
+        @JvmStatic
         
         fun getA(): CyclicStructA {
             
@@ -37,6 +38,7 @@ class CyclicStructB internal constructor (
             val returnStruct = CyclicStructA(returnVal)
             return returnStruct
         }
+        @JvmStatic
         
         fun getAOption(): CyclicStructA? {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructC.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CyclicStructC.kt
@@ -29,6 +29,7 @@ class CyclicStructC internal constructor (
         internal val libClass: Class<CyclicStructCLib> = CyclicStructCLib::class.java
         internal val lib: CyclicStructCLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(CyclicStructCNative::class.java).toLong()
+        @JvmStatic
         
         fun takesNestedParameters(c: CyclicStructC): CyclicStructC {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DefaultEnum.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/DefaultEnum.kt
@@ -28,6 +28,7 @@ enum class DefaultEnum {
         fun default(): DefaultEnum {
             return A
         }
+        @JvmStatic
         
         fun new_(): DefaultEnum {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
@@ -38,6 +38,7 @@ class Float64Vec internal constructor (
     companion object {
         internal val libClass: Class<Float64VecLib> = Float64VecLib::class.java
         internal val lib: Float64VecLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun newBool(v: BooleanArray): Float64Vec {
             val (vMem, vSlice) = PrimitiveArrayTools.native(v)
@@ -50,6 +51,7 @@ class Float64Vec internal constructor (
             if (vMem != null) vMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun newI16(v: ShortArray): Float64Vec {
             val (vMem, vSlice) = PrimitiveArrayTools.native(v)
@@ -62,6 +64,7 @@ class Float64Vec internal constructor (
             if (vMem != null) vMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun newU16(v: UShortArray): Float64Vec {
             val (vMem, vSlice) = PrimitiveArrayTools.native(v)
@@ -74,6 +77,7 @@ class Float64Vec internal constructor (
             if (vMem != null) vMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun newIsize(v: LongArray): Float64Vec {
             val (vMem, vSlice) = PrimitiveArrayTools.native(v)
@@ -86,6 +90,7 @@ class Float64Vec internal constructor (
             if (vMem != null) vMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun newUsize(v: ULongArray): Float64Vec {
             val (vMem, vSlice) = PrimitiveArrayTools.native(v)
@@ -98,6 +103,7 @@ class Float64Vec internal constructor (
             if (vMem != null) vMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun newF64BeBytes(v: ByteArray): Float64Vec {
             val (vMem, vSlice) = PrimitiveArrayTools.native(v)
@@ -110,6 +116,7 @@ class Float64Vec internal constructor (
             if (vMem != null) vMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun newFromOwned(v: DoubleArray): Float64Vec {
             val (vMem, vSlice) = PrimitiveArrayTools.native(v)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Foo.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Foo.kt
@@ -32,6 +32,7 @@ class Foo internal constructor (
     companion object {
         internal val libClass: Class<FooLib> = FooLib::class.java
         internal val lib: FooLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(x: String): Foo {
             val (xMem, xSlice) = PrimitiveArrayTools.readUtf8(x)
@@ -44,6 +45,7 @@ class Foo internal constructor (
             CLEANER.register(returnOpaque, Foo.FooCleaner(handle, Foo.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun newStatic(x: String): Foo {
             val (xMem, xSlice) = PrimitiveArrayTools.readUtf8(x)
@@ -57,6 +59,7 @@ class Foo internal constructor (
             if (xMem != null) xMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun extractFromFields(fields: BorrowedFields): Foo {
             
@@ -68,6 +71,7 @@ class Foo internal constructor (
             CLEANER.register(returnOpaque, Foo.FooCleaner(handle, Foo.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         /** Test that the extraction logic correctly pins the right fields
         */

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MutableCallbackHolder.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MutableCallbackHolder.kt
@@ -77,6 +77,7 @@ class MutableCallbackHolder internal constructor (
     companion object {
         internal val libClass: Class<MutableCallbackHolderLib> = MutableCallbackHolderLib::class.java
         internal val lib: MutableCallbackHolderLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(func: (Int)->Int): MutableCallbackHolder {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyEnum.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyEnum.kt
@@ -41,6 +41,7 @@ enum class MyEnum(val inner: Int) {
         fun default(): MyEnum {
             return A
         }
+        @JvmStatic
         
         fun getA(): MyEnum {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterable.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterable.kt
@@ -27,6 +27,7 @@ class MyIterable internal constructor (
     companion object {
         internal val libClass: Class<MyIterableLib> = MyIterableLib::class.java
         internal val lib: MyIterableLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(x: UByteArray): MyIterable {
             val (xMem, xSlice) = PrimitiveArrayTools.native(x)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyOpaqueEnum.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyOpaqueEnum.kt
@@ -27,6 +27,7 @@ class MyOpaqueEnum internal constructor (
     companion object {
         internal val libClass: Class<MyOpaqueEnumLib> = MyOpaqueEnumLib::class.java
         internal val lib: MyOpaqueEnumLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(): MyOpaqueEnum {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
@@ -34,6 +34,7 @@ class MyString internal constructor (
     companion object {
         internal val libClass: Class<MyStringLib> = MyStringLib::class.java
         internal val lib: MyStringLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(v: String): MyString {
             val (vMem, vSlice) = PrimitiveArrayTools.readUtf8(v)
@@ -46,6 +47,7 @@ class MyString internal constructor (
             if (vMem != null) vMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun newUnsafe(v: String): MyString {
             val (vMem, vSlice) = PrimitiveArrayTools.readUtf8(v)
@@ -58,6 +60,7 @@ class MyString internal constructor (
             if (vMem != null) vMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun newOwned(v: String): MyString {
             val (vMem, vSlice) = PrimitiveArrayTools.readUtf8(v)
@@ -69,6 +72,7 @@ class MyString internal constructor (
             CLEANER.register(returnOpaque, MyString.MyStringCleaner(handle, MyString.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun newFromFirst(v: Array<String>): MyString {
             val (vMem, vSlice) = PrimitiveArrayTools.readUtf8s(v)
@@ -81,12 +85,14 @@ class MyString internal constructor (
             vMem.forEach {if (it != null) it.close()}
             return returnOpaque
         }
+        @JvmStatic
         
         fun getStaticStr(): String {
             
             val returnVal = lib.MyString_get_static_str();
                 return PrimitiveArrayTools.getUtf8(returnVal)
         }
+        @JvmStatic
         
         fun stringTransform(foo: String): String {
             val (fooMem, fooSlice) = PrimitiveArrayTools.readUtf8(foo)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyStruct.kt
@@ -49,6 +49,7 @@ class MyStruct internal constructor (
         internal val libClass: Class<MyStructLib> = MyStructLib::class.java
         internal val lib: MyStructLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(MyStructNative::class.java).toLong()
+        @JvmStatic
         
         fun new_(): MyStruct {
             
@@ -57,6 +58,7 @@ class MyStruct internal constructor (
             val returnStruct = MyStruct(returnVal)
             return returnStruct
         }
+        @JvmStatic
         
         fun returnsZstResult(): Result<Unit> {
             
@@ -67,6 +69,7 @@ class MyStruct internal constructor (
                 return MyZst().err()
             }
         }
+        @JvmStatic
         
         fun failsZstResult(): Result<Unit> {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/NestedBorrowedFields.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/NestedBorrowedFields.kt
@@ -38,6 +38,7 @@ class NestedBorrowedFields internal constructor (
         internal val libClass: Class<NestedBorrowedFieldsLib> = NestedBorrowedFieldsLib::class.java
         internal val lib: NestedBorrowedFieldsLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(NestedBorrowedFieldsNative::class.java).toLong()
+        @JvmStatic
         
         fun fromBarAndFooAndStrings(bar: Bar, foo: Foo, dstr16X: String, dstr16Z: String, utf8StrY: String, utf8StrZ: String): NestedBorrowedFields {
             val (dstr16XMem, dstr16XSlice) = PrimitiveArrayTools.readUtf16(dstr16X)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/One.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/One.kt
@@ -37,6 +37,7 @@ class One internal constructor (
     companion object {
         internal val libClass: Class<OneLib> = OneLib::class.java
         internal val lib: OneLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun transitivity(hold: One, nohold: One): One {
             
@@ -48,6 +49,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun cycle(hold: Two, nohold: One): One {
             
@@ -59,6 +61,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun manyDependents(a: One, b: One, c: Two, d: Two, nohold: Two): One {
             
@@ -70,6 +73,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun returnOutlivesParam(hold: Two, nohold: One): One {
             
@@ -81,6 +85,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun diamondTop(top: One, left: One, right: One, bottom: One): One {
             
@@ -92,6 +97,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun diamondLeft(top: One, left: One, right: One, bottom: One): One {
             
@@ -103,6 +109,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun diamondRight(top: One, left: One, right: One, bottom: One): One {
             
@@ -114,6 +121,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun diamondBottom(top: One, left: One, right: One, bottom: One): One {
             
@@ -125,6 +133,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun diamondAndNestedTypes(a: One, b: One, c: One, d: One, nohold: One): One {
             
@@ -136,6 +145,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun implicitBounds(explicitHold: One, implicitHold: One, nohold: One): One {
             
@@ -147,6 +157,7 @@ class One internal constructor (
             CLEANER.register(returnOpaque, One.OneCleaner(handle, One.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun implicitBoundsDeep(explicit: One, implicit1: One, implicit2: One, nohold: One): One {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
@@ -33,6 +33,7 @@ class Opaque internal constructor (
     companion object {
         internal val libClass: Class<OpaqueLib> = OpaqueLib::class.java
         internal val lib: OpaqueLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(): Opaque {
             
@@ -43,6 +44,7 @@ class Opaque internal constructor (
             CLEANER.register(returnOpaque, Opaque.OpaqueCleaner(handle, Opaque.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun tryFromUtf8(input: String): Opaque? {
             val (inputMem, inputSlice) = PrimitiveArrayTools.readUtf8(input)
@@ -55,6 +57,7 @@ class Opaque internal constructor (
             if (inputMem != null) inputMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun fromStr(input: String): Opaque {
             val (inputMem, inputSlice) = PrimitiveArrayTools.readUtf8(input)
@@ -67,12 +70,14 @@ class Opaque internal constructor (
             if (inputMem != null) inputMem.close()
             return returnOpaque
         }
+        @JvmStatic
         
         fun returnsUsize(): ULong {
             
             val returnVal = lib.Opaque_returns_usize();
             return (returnVal.toULong())
         }
+        @JvmStatic
         
         fun returnsImported(): ImportedStruct {
             
@@ -81,6 +86,7 @@ class Opaque internal constructor (
             val returnStruct = ImportedStruct(returnVal)
             return returnStruct
         }
+        @JvmStatic
         
         fun cmp(): Byte {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueMutexedString.kt
@@ -34,6 +34,7 @@ class OpaqueMutexedString internal constructor (
     companion object {
         internal val libClass: Class<OpaqueMutexedStringLib> = OpaqueMutexedStringLib::class.java
         internal val lib: OpaqueMutexedStringLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun fromUsize(number: ULong): OpaqueMutexedString {
             
@@ -44,6 +45,7 @@ class OpaqueMutexedString internal constructor (
             CLEANER.register(returnOpaque, OpaqueMutexedString.OpaqueMutexedStringCleaner(handle, OpaqueMutexedString.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun borrowOther(other: OpaqueMutexedString): OpaqueMutexedString {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueThinVec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueThinVec.kt
@@ -30,6 +30,7 @@ class OpaqueThinVec internal constructor (
     companion object {
         internal val libClass: Class<OpaqueThinVecLib> = OpaqueThinVecLib::class.java
         internal val lib: OpaqueThinVecLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun create(a: IntArray, b: FloatArray): OpaqueThinVec {
             val (aMem, aSlice) = PrimitiveArrayTools.native(a)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionOpaque.kt
@@ -38,6 +38,7 @@ class OptionOpaque internal constructor (
     companion object {
         internal val libClass: Class<OptionOpaqueLib> = OptionOpaqueLib::class.java
         internal val lib: OptionOpaqueLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(i: Int): OptionOpaque? {
             
@@ -48,6 +49,7 @@ class OptionOpaque internal constructor (
             CLEANER.register(returnOpaque, OptionOpaque.OptionOpaqueCleaner(handle, OptionOpaque.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun newNone(): OptionOpaque? {
             
@@ -58,6 +60,7 @@ class OptionOpaque internal constructor (
             CLEANER.register(returnOpaque, OptionOpaque.OptionOpaqueCleaner(handle, OptionOpaque.lib));
             return returnOpaque
         }
+        @JvmStatic
         
         fun returns(): OptionStruct? {
             
@@ -69,6 +72,7 @@ class OptionOpaque internal constructor (
             return returnStruct
                                     
         }
+        @JvmStatic
         
         fun newStruct(): OptionStruct {
             
@@ -77,6 +81,7 @@ class OptionOpaque internal constructor (
             val returnStruct = OptionStruct(returnVal)
             return returnStruct
         }
+        @JvmStatic
         
         fun newStructNones(): OptionStruct {
             
@@ -85,6 +90,7 @@ class OptionOpaque internal constructor (
             val returnStruct = OptionStruct(returnVal)
             return returnStruct
         }
+        @JvmStatic
         
         fun optionOpaqueArgument(arg: OptionOpaque?): Boolean {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
@@ -28,6 +28,7 @@ class OptionString internal constructor (
     companion object {
         internal val libClass: Class<OptionStringLib> = OptionStringLib::class.java
         internal val lib: OptionStringLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(diplomatStr: String): OptionString? {
             val (diplomatStrMem, diplomatStrSlice) = PrimitiveArrayTools.readUtf8(diplomatStr)

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/RefList.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/RefList.kt
@@ -27,6 +27,7 @@ class RefList internal constructor (
     companion object {
         internal val libClass: Class<RefListLib> = RefListLib::class.java
         internal val lib: RefListLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun node(data: RefListParameter): RefList {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
@@ -36,6 +36,7 @@ class ResultOpaque internal constructor (
     companion object {
         internal val libClass: Class<ResultOpaqueLib> = ResultOpaqueLib::class.java
         internal val lib: ResultOpaqueLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun new_(i: Int): Result<ResultOpaque> {
             
@@ -50,6 +51,7 @@ class ResultOpaque internal constructor (
                 return ErrorEnumError(ErrorEnum.fromNative(returnVal.union.err)).err()
             }
         }
+        @JvmStatic
         
         fun newFailingFoo(): Result<ResultOpaque> {
             
@@ -64,6 +66,7 @@ class ResultOpaque internal constructor (
                 return ErrorEnumError(ErrorEnum.fromNative(returnVal.union.err)).err()
             }
         }
+        @JvmStatic
         
         fun newFailingBar(): Result<ResultOpaque> {
             
@@ -78,6 +81,7 @@ class ResultOpaque internal constructor (
                 return ErrorEnumError(ErrorEnum.fromNative(returnVal.union.err)).err()
             }
         }
+        @JvmStatic
         
         fun newFailingUnit(): Result<ResultOpaque> {
             
@@ -92,6 +96,7 @@ class ResultOpaque internal constructor (
                 return UnitError().err()
             }
         }
+        @JvmStatic
         
         fun newFailingStruct(i: Int): Result<ResultOpaque> {
             
@@ -108,6 +113,7 @@ class ResultOpaque internal constructor (
                 return returnStruct.err()
             }
         }
+        @JvmStatic
         
         fun newInErr(i: Int): Result<Unit> {
             
@@ -122,6 +128,7 @@ class ResultOpaque internal constructor (
                 return returnOpaque.err()
             }
         }
+        @JvmStatic
         
         fun newInt(i: Int): Result<Int> {
             
@@ -132,6 +139,7 @@ class ResultOpaque internal constructor (
                 return UnitError().err()
             }
         }
+        @JvmStatic
         
         fun newFailingInt(i: Int): Result<Unit> {
             
@@ -142,6 +150,7 @@ class ResultOpaque internal constructor (
                 return IntError(returnVal.union.err).err()
             }
         }
+        @JvmStatic
         
         fun newInEnumErr(i: Int): Result<ErrorEnum> {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/StructWithAttrs.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/StructWithAttrs.kt
@@ -32,6 +32,7 @@ class StructWithAttrs internal constructor (
         internal val libClass: Class<StructWithAttrsLib> = StructWithAttrsLib::class.java
         internal val lib: StructWithAttrsLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(StructWithAttrsNative::class.java).toLong()
+        @JvmStatic
         
         fun newFallible(a: Boolean, b: UInt): Result<StructWithAttrs> {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/TraitWrapper.kt
@@ -29,12 +29,14 @@ class TraitWrapper internal constructor (
         internal val libClass: Class<TraitWrapperLib> = TraitWrapperLib::class.java
         internal val lib: TraitWrapperLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(TraitWrapperNative::class.java).toLong()
+        @JvmStatic
         
         fun testWithTrait(t: TesterTrait, x: Int): Int {
             
             val returnVal = lib.TraitWrapper_test_with_trait(DiplomatTrait_TesterTrait_Wrapper.fromTraitObj(t).nativeStruct, x);
             return (returnVal)
         }
+        @JvmStatic
         
         fun testTraitWithStruct(t: TesterTrait): Int {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Unnamespaced.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Unnamespaced.kt
@@ -27,6 +27,7 @@ class Unnamespaced internal constructor (
     companion object {
         internal val libClass: Class<UnnamespacedLib> = UnnamespacedLib::class.java
         internal val lib: UnnamespacedLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun make(e: AttrEnum): Unnamespaced {
             

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Utf16Wrap.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Utf16Wrap.kt
@@ -28,6 +28,7 @@ class Utf16Wrap internal constructor (
     companion object {
         internal val libClass: Class<Utf16WrapLib> = Utf16WrapLib::class.java
         internal val lib: Utf16WrapLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun fromUtf16(input: String): Utf16Wrap {
             val (inputMem, inputSlice) = PrimitiveArrayTools.readUtf16(input)

--- a/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/Float64VecTest.kt
+++ b/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/Float64VecTest.kt
@@ -7,7 +7,8 @@ class Float64VecTest {
     @Test
     fun testFloat64Vec() {
         val doubleList = listOf(1.0, 2.0, 3.0, 4.0)
-        val float64Array = Float64Vec.newFromOwned(doubleList.toDoubleArray())
+        val doubleArray = doubleList.toDoubleArray()
+        val float64Array = Float64Vec.newFromOwned(doubleArray)
         val float64ArrayStr = float64Array.toString()
         assertEquals(float64ArrayStr, doubleList.toString())
     }

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_finalizers.snap
@@ -37,12 +37,14 @@ class MyOpaqueStruct internal constructor (
     companion object {
         internal val libClass: Class<MyOpaqueStructLib> = MyOpaqueStructLib::class.java
         internal val lib: MyOpaqueStructLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun getByte(): UByte {
             
             val returnVal = lib.MyOpaqueStruct_get_byte();
             return (returnVal.toUByte())
         }
+        @JvmStatic
         
         fun getStringWrapper(in1: Int): Int {
             

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_mocking_interface.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_with_mocking_interface.snap
@@ -37,12 +37,14 @@ class MyOpaqueStruct internal constructor (
     companion object {
         internal val libClass: Class<MyOpaqueStructLib> = MyOpaqueStructLib::class.java
         internal val lib: MyOpaqueStructLib = Native.load("somelib", libClass)
+        @JvmStatic
         
         fun getByte(): UByte {
             
             val returnVal = lib.MyOpaqueStruct_get_byte();
             return (returnVal.toUByte())
         }
+        @JvmStatic
         
         fun getStringWrapper(in1: Int): Int {
             

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -131,6 +131,7 @@ class MyNativeStruct internal constructor (
         internal val libClass: Class<MyNativeStructLib> = MyNativeStructLib::class.java
         internal val lib: MyNativeStructLib = Native.load("somelib", libClass)
         val NATIVESIZE: Long = Native.getNativeSize(MyNativeStructNative::class.java).toLong()
+        @JvmStatic
         
         fun new_(): MyNativeStruct {
             
@@ -140,18 +141,21 @@ class MyNativeStruct internal constructor (
             val returnStruct = MyNativeStruct(returnVal, bEdges)
             return returnStruct
         }
+        @JvmStatic
         
         fun testMultiArgCallback(f: (Int, Int, Int)->Int, x: Int): Int {
             
             val returnVal = lib.MyNativeStruct_test_multi_arg_callback(DiplomatCallback_MyNativeStruct_test_multi_arg_callback_diplomatCallback_f.fromCallback(f).nativeStruct, x);
             return (returnVal)
         }
+        @JvmStatic
         
         fun getUByteSlice(): UByteArray {
             
             val returnVal = lib.MyNativeStruct_get_u_byte_slice();
                 return PrimitiveArrayTools.getUByteArray(returnVal)
         }
+        @JvmStatic
         
         fun booleanResult(): Result<Boolean> {
             
@@ -162,6 +166,7 @@ class MyNativeStruct internal constructor (
                 return UnitError().err()
             }
         }
+        @JvmStatic
         
         fun ubyteResult(): Result<UByte> {
             

--- a/tool/templates/kotlin/Enum.kt.jinja
+++ b/tool/templates/kotlin/Enum.kt.jinja
@@ -72,6 +72,7 @@ enum class {{type_name}}
         }
         {%- endmatch %}
 {%- for m in companion_methods %}
+        @JvmStatic
         {{m.definition|indent(8)}}
 {%- endfor %}
     }

--- a/tool/templates/kotlin/Opaque.kt.jinja
+++ b/tool/templates/kotlin/Opaque.kt.jinja
@@ -84,6 +84,7 @@ class {{type_name}} internal constructor (
         internal val lib: {{type_name}}Lib = Native.load("{{lib_name}}", libClass)
 
 {%- for m in companion_methods %}
+        @JvmStatic
         {{m.definition|indent(8)}}
 {%- endfor %}
     }

--- a/tool/templates/kotlin/Struct.kt.jinja
+++ b/tool/templates/kotlin/Struct.kt.jinja
@@ -61,7 +61,9 @@ class {{type_name}} internal constructor (
         internal val libClass: Class<{{type_name}}Lib> = {{type_name}}Lib::class.java
         internal val lib: {{type_name}}Lib = Native.load("{{lib_name}}", libClass)
         val NATIVESIZE: Long = Native.getNativeSize({{type_name}}Native::class.java).toLong()
+
 {%- for m in companion_methods %}
+        @JvmStatic
         {{m.definition|indent(8)}}
 {%- endfor %}
     }


### PR DESCRIPTION
I ran into an issue when trying to pull my kotlin code into scala, that it couldn't resolve the static methods (in the companion object) because they weren't annotated with the `@JvmStatic` annotation. This PR adds this annotation to the generation of all companion object methods.