### PR TITLE
Pass enum variants in termini

### DIFF
--- a/example/demo_gen/demo/index.mjs
+++ b/example/demo_gen/demo/index.mjs
@@ -28,7 +28,8 @@ let termini = Object.assign({
             {
                 name: "ICU4X Fixed Decimal Grouping Strategy",
                 type: "FixedDecimalGroupingStrategy",
-                typeUse: "enumerator"
+                typeUse: "enumerator",
+                values: ["Auto", "Never", "Always", "Min2"]
             },
             
             {

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -179,7 +179,8 @@ let termini = Object.assign({
             {
                 name: "self_g",
                 type: "MyEnum",
-                typeUse: "enumerator"
+                typeUse: "enumerator",
+                values: ["A", "B", "C", "D", "E", "F"]
             }
             
         ]
@@ -366,7 +367,8 @@ let termini = Object.assign({
             {
                 name: "arg",
                 type: "OptionEnum",
-                typeUse: "enumerator"
+                typeUse: "enumerator",
+                values: ["Foo", "Bar"]
             },
             
             {
@@ -619,7 +621,8 @@ let termini = Object.assign({
             {
                 name: "self",
                 type: "MyEnum",
-                typeUse: "enumerator"
+                typeUse: "enumerator",
+                values: ["A", "B", "C", "D", "E", "F"]
             }
             
         ]

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -15,6 +15,7 @@ pub struct OutParam {
     /// Full string name of the param.
     pub label: String,
     pub default_value: String,
+    pub values: Vec<String>,
     /// For typescript and RenderInfo output. Type that this parameter is. We get this directly from Rust.
     pub type_name: String,
     /// Also for typescript and RenderInfo output. This is used for types where we might want to know more information, like if it's an enumerator, or a custom type to be set by the default renderer.
@@ -240,6 +241,11 @@ impl RenderTerminusContext<'_, '_> {
             }
         };
 
+        let values = match type_info {
+            Type::Enum(e) => e.resolve(&self.tcx).variants.iter().map(|v| v.name.as_str().to_string()).collect(),
+            _ => vec![],
+        };
+
         let full_param_name = heck::AsLowerCamelCase(owned_full_name).to_string();
 
         let (p, n) = if self.name_collision.contains_key(&full_param_name) {
@@ -258,6 +264,7 @@ impl RenderTerminusContext<'_, '_> {
             type_name: type_name.clone(),
             type_use,
             default_value,
+            values,
         };
 
         self.terminus_info.out_params.push(out_param);

--- a/tool/templates/demo_gen/index.js.jinja
+++ b/tool/templates/demo_gen/index.js.jinja
@@ -41,6 +41,10 @@ let termini = Object.assign({
                 ,
                 defaultValue: "{{ param.default_value }}"
                 {%- endif %}
+                {%- if !param.values.is_empty() -%}
+                ,
+                values: {{ format!("{:?}", param.values) }}
+                {%- endif %}
             }{% if !loop.last %},{% endif %}
             {% endfor %}
         ]


### PR DESCRIPTION
This was we don't have to pass the library around, and we can use enum selects for custom functions.