### PR TITLE
Bump core/tool to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-tool"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "askama",
  "clap",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "displaydoc",
  "either",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diplomat_core"
 description = "Shared utilities between Diplomat macros and code generation"
-version.workspace = true
+version = "0.12.1"
 rust-version.workspace = true
 authors.workspace = true
 categories.workspace = true

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diplomat-tool"
 description = "Tool for generating FFI bindings for various languages"
-version.workspace = true
+version = "0.12.1"
 rust-version.workspace = true
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
I'd like to use enum defaults and write_to in temporal_capi.