### PR TITLE
Validate JS arguments

### DIFF
--- a/example/js/lib/api/FixedDecimalFormatter.mjs
+++ b/example/js/lib/api/FixedDecimalFormatter.mjs
@@ -55,7 +55,7 @@ export class FixedDecimalFormatter {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
 
 
-        const result = wasm.icu4x_FixedDecimalFormatter_try_new_mv1(diplomatReceive.buffer, locale.ffiValue, provider.ffiValue, FixedDecimalFormatterOptions._fromSuppliedValue(diplomatRuntime.internalConstructor, options)._intoFFI(diplomatRuntime.FUNCTION_PARAM_ALLOC.alloc(FixedDecimalFormatterOptions._sizeBytes), functionCleanupArena, {}, false));
+        const result = wasm.icu4x_FixedDecimalFormatter_try_new_mv1(diplomatReceive.buffer, locale instanceof Locale ? locale.ffiValue : typeError('locale', 'Locale'), provider instanceof DataProvider ? provider.ffiValue : typeError('provider', 'DataProvider'), FixedDecimalFormatterOptions._fromSuppliedValue(diplomatRuntime.internalConstructor, options)._intoFFI(diplomatRuntime.FUNCTION_PARAM_ALLOC.alloc(FixedDecimalFormatterOptions._sizeBytes), functionCleanupArena, {}, false));
 
         try {
             if (!diplomatReceive.resultFlag) {
@@ -80,7 +80,7 @@ export class FixedDecimalFormatter {
     formatWrite(value) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-    wasm.icu4x_FixedDecimalFormatter_format_write_mv1(this.ffiValue, value.ffiValue, write.buffer);
+    wasm.icu4x_FixedDecimalFormatter_format_write_mv1(this.ffiValue, value instanceof FixedDecimal ? value.ffiValue : typeError('value', 'FixedDecimal'), write.buffer);
 
         try {
             return write.readString8();

--- a/example/js/lib/api/FixedDecimalFormatterOptions.mjs
+++ b/example/js/lib/api/FixedDecimalFormatterOptions.mjs
@@ -85,7 +85,7 @@ export class FixedDecimalFormatterOptions {
         functionCleanupArena,
         appendArrayMap
     ) {
-        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, this.#groupingStrategy.ffiValue, Int32Array);
+        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, new FixedDecimalGroupingStrategy(this.#groupingStrategy).ffiValue, Int32Array);
         diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 4, this.#someOtherConfig, Uint8Array);
     }
 

--- a/example/js/lib/api/diplomat-runtime.mjs
+++ b/example/js/lib/api/diplomat-runtime.mjs
@@ -7,6 +7,10 @@ export const internalConstructor = Symbol("constructor");
  */
 export const exposeConstructor = Symbol("exposeConstructor");
 
+export function typeError(varr, ty) {
+    throw Error(`${varr} is not a ${ty}`);
+}
+
 export function readString8(wasm, ptr, len) {
     const buf = new Uint8Array(wasm.memory.buffer, ptr, len);
     return (new TextDecoder("utf-8")).decode(buf)

--- a/feature_tests/js/api/AttrOpaque1Renamed.mjs
+++ b/feature_tests/js/api/AttrOpaque1Renamed.mjs
@@ -111,7 +111,7 @@ export class AttrOpaque1Renamed {
     }
 
     useUnnamespaced(un) {
-    wasm.namespace_AttrOpaque1_use_unnamespaced(this.ffiValue, un.ffiValue);
+    wasm.namespace_AttrOpaque1_use_unnamespaced(this.ffiValue, un instanceof Unnamespaced ? un.ffiValue : typeError('un', 'Unnamespaced'));
 
         try {}
 
@@ -121,7 +121,7 @@ export class AttrOpaque1Renamed {
     }
 
     useNamespaced(n) {
-    wasm.namespace_AttrOpaque1_use_namespaced(this.ffiValue, n.ffiValue);
+    wasm.namespace_AttrOpaque1_use_namespaced(this.ffiValue, new RenamedAttrEnum(n).ffiValue);
 
         try {}
 

--- a/feature_tests/js/api/BorrowedFields.mjs
+++ b/feature_tests/js/api/BorrowedFields.mjs
@@ -141,7 +141,7 @@ export class BorrowedFields {
         let xEdges = [bar, dstr16Slice, utf8StrSlice];
 
 
-        const result = wasm.BorrowedFields_from_bar_and_strings(diplomatReceive.buffer, bar.ffiValue, dstr16Slice.ptr, utf8StrSlice.ptr);
+        const result = wasm.BorrowedFields_from_bar_and_strings(diplomatReceive.buffer, bar instanceof Bar ? bar.ffiValue : typeError('bar', 'Bar'), dstr16Slice.ptr, utf8StrSlice.ptr);
 
         try {
             return BorrowedFields._fromFFI(diplomatRuntime.internalConstructor, diplomatReceive.buffer, xEdges);

--- a/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
+++ b/feature_tests/js/api/BorrowedFieldsWithBounds.mjs
@@ -167,7 +167,7 @@ export class BorrowedFieldsWithBounds {
         let zEdges = [utf8StrZSlice];
 
 
-        const result = wasm.BorrowedFieldsWithBounds_from_foo_and_strings(diplomatReceive.buffer, foo.ffiValue, dstr16XSlice.ptr, utf8StrZSlice.ptr);
+        const result = wasm.BorrowedFieldsWithBounds_from_foo_and_strings(diplomatReceive.buffer, foo instanceof Foo ? foo.ffiValue : typeError('foo', 'Foo'), dstr16XSlice.ptr, utf8StrZSlice.ptr);
 
         try {
             return BorrowedFieldsWithBounds._fromFFI(diplomatRuntime.internalConstructor, diplomatReceive.buffer, xEdges, yEdges, zEdges);

--- a/feature_tests/js/api/ImportedStruct.mjs
+++ b/feature_tests/js/api/ImportedStruct.mjs
@@ -85,7 +85,7 @@ export class ImportedStruct {
         functionCleanupArena,
         appendArrayMap
     ) {
-        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, this.#foo.ffiValue, Int32Array);
+        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, new UnimportedEnum(this.#foo).ffiValue, Int32Array);
         diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 4, this.#count, Uint8Array);
     }
 

--- a/feature_tests/js/api/MyString.mjs
+++ b/feature_tests/js/api/MyString.mjs
@@ -214,7 +214,7 @@ export class MyString {
     static sliceOfOpaques(sl) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
-        const slSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.slice(wasm, sl.map((op) => op.ffiValue), "u32")));
+        const slSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.slice(wasm, sl.map((op) => op instanceof MyString ? op.ffiValue : typeError('op', 'MyString')), "u32")));
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
     wasm.MyString_slice_of_opaques(slSlice.ptr, write.buffer);
@@ -234,7 +234,7 @@ export class MyString {
     static optionalSliceOfOpaques(sl) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
-        const slSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.slice(wasm, sl.map((op) => op?.ffiValue ?? 0), "u32")));
+        const slSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.slice(wasm, sl.map((op) => op === null || op instanceof MyString ? op?.ffiValue ?? 0 : typeError('op', 'MyString')), "u32")));
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
     wasm.MyString_optional_slice_of_opaques(slSlice.ptr, write.buffer);
@@ -254,7 +254,7 @@ export class MyString {
     static otherOpaqueType(other) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
-        const otherSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.slice(wasm, other.map((op) => op.ffiValue), "u32")));
+        const otherSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.slice(wasm, other.map((op) => op instanceof Float64Vec ? op.ffiValue : typeError('op', 'Float64Vec')), "u32")));
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
     wasm.MyString_other_opaque_type(otherSlice.ptr, write.buffer);

--- a/feature_tests/js/api/MyStruct.mjs
+++ b/feature_tests/js/api/MyStruct.mjs
@@ -157,7 +157,7 @@ export class MyStruct {
         diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 8, this.#d, BigUint64Array);
         diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 16, this.#e, Int32Array);
         diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 20, this.#f, Uint32Array);
-        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 24, this.#g.ffiValue, Int32Array);
+        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 24, new MyEnum(this.#g).ffiValue, Int32Array);
     }
 
     // This struct contains borrowed fields, so this takes in a list of

--- a/feature_tests/js/api/MyStructContainingAnOption.mjs
+++ b/feature_tests/js/api/MyStructContainingAnOption.mjs
@@ -87,7 +87,7 @@ export class MyStructContainingAnOption {
         appendArrayMap
     ) {
         diplomatRuntime.writeOptionToArrayBuffer(arrayBuffer, offset + 0, this.#a, 32, 8, (arrayBuffer, offset, jsValue) => MyStruct._fromSuppliedValue(diplomatRuntime.internalConstructor, jsValue)._writeToArrayBuffer(arrayBuffer, offset + 0, functionCleanupArena, {}));
-        diplomatRuntime.writeOptionToArrayBuffer(arrayBuffer, offset + 40, this.#b, 4, 4, (arrayBuffer, offset, jsValue) => diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array));
+        diplomatRuntime.writeOptionToArrayBuffer(arrayBuffer, offset + 40, this.#b, 4, 4, (arrayBuffer, offset, jsValue) => diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, new DefaultEnum(jsValue).ffiValue, Int32Array));
     }
 
     // This struct contains borrowed fields, so this takes in a list of

--- a/feature_tests/js/api/NestedBorrowedFields.mjs
+++ b/feature_tests/js/api/NestedBorrowedFields.mjs
@@ -172,7 +172,7 @@ export class NestedBorrowedFields {
         let zEdges = [foo, dstr16ZSlice, utf8StrZSlice];
 
 
-        const result = wasm.NestedBorrowedFields_from_bar_and_foo_and_strings(diplomatReceive.buffer, bar.ffiValue, foo.ffiValue, dstr16XSlice.ptr, dstr16ZSlice.ptr, utf8StrYSlice.ptr, utf8StrZSlice.ptr);
+        const result = wasm.NestedBorrowedFields_from_bar_and_foo_and_strings(diplomatReceive.buffer, bar instanceof Bar ? bar.ffiValue : typeError('bar', 'Bar'), foo instanceof Foo ? foo.ffiValue : typeError('foo', 'Foo'), dstr16XSlice.ptr, dstr16ZSlice.ptr, utf8StrYSlice.ptr, utf8StrZSlice.ptr);
 
         try {
             return NestedBorrowedFields._fromFFI(diplomatRuntime.internalConstructor, diplomatReceive.buffer, xEdges, yEdges, zEdges);

--- a/feature_tests/js/api/One.mjs
+++ b/feature_tests/js/api/One.mjs
@@ -43,7 +43,7 @@ export class One {
         let aEdges = [hold];
 
 
-        const result = wasm.One_transitivity(hold.ffiValue, nohold.ffiValue);
+        const result = wasm.One_transitivity(hold instanceof One ? hold.ffiValue : typeError('hold', 'One'), nohold instanceof One ? nohold.ffiValue : typeError('nohold', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], aEdges);
@@ -59,7 +59,7 @@ export class One {
         let aEdges = [hold];
 
 
-        const result = wasm.One_cycle(hold.ffiValue, nohold.ffiValue);
+        const result = wasm.One_cycle(hold instanceof Two ? hold.ffiValue : typeError('hold', 'Two'), nohold instanceof One ? nohold.ffiValue : typeError('nohold', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], aEdges);
@@ -75,7 +75,7 @@ export class One {
         let aEdges = [a, b, c, d];
 
 
-        const result = wasm.One_many_dependents(a.ffiValue, b.ffiValue, c.ffiValue, d.ffiValue, nohold.ffiValue);
+        const result = wasm.One_many_dependents(a instanceof One ? a.ffiValue : typeError('a', 'One'), b instanceof One ? b.ffiValue : typeError('b', 'One'), c instanceof Two ? c.ffiValue : typeError('c', 'Two'), d instanceof Two ? d.ffiValue : typeError('d', 'Two'), nohold instanceof Two ? nohold.ffiValue : typeError('nohold', 'Two'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], aEdges);
@@ -91,7 +91,7 @@ export class One {
         let longEdges = [hold];
 
 
-        const result = wasm.One_return_outlives_param(hold.ffiValue, nohold.ffiValue);
+        const result = wasm.One_return_outlives_param(hold instanceof Two ? hold.ffiValue : typeError('hold', 'Two'), nohold instanceof One ? nohold.ffiValue : typeError('nohold', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], longEdges);
@@ -107,7 +107,7 @@ export class One {
         let topEdges = [top, left, right, bottom];
 
 
-        const result = wasm.One_diamond_top(top.ffiValue, left.ffiValue, right.ffiValue, bottom.ffiValue);
+        const result = wasm.One_diamond_top(top instanceof One ? top.ffiValue : typeError('top', 'One'), left instanceof One ? left.ffiValue : typeError('left', 'One'), right instanceof One ? right.ffiValue : typeError('right', 'One'), bottom instanceof One ? bottom.ffiValue : typeError('bottom', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], topEdges);
@@ -123,7 +123,7 @@ export class One {
         let leftEdges = [left, bottom];
 
 
-        const result = wasm.One_diamond_left(top.ffiValue, left.ffiValue, right.ffiValue, bottom.ffiValue);
+        const result = wasm.One_diamond_left(top instanceof One ? top.ffiValue : typeError('top', 'One'), left instanceof One ? left.ffiValue : typeError('left', 'One'), right instanceof One ? right.ffiValue : typeError('right', 'One'), bottom instanceof One ? bottom.ffiValue : typeError('bottom', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], leftEdges);
@@ -139,7 +139,7 @@ export class One {
         let rightEdges = [right, bottom];
 
 
-        const result = wasm.One_diamond_right(top.ffiValue, left.ffiValue, right.ffiValue, bottom.ffiValue);
+        const result = wasm.One_diamond_right(top instanceof One ? top.ffiValue : typeError('top', 'One'), left instanceof One ? left.ffiValue : typeError('left', 'One'), right instanceof One ? right.ffiValue : typeError('right', 'One'), bottom instanceof One ? bottom.ffiValue : typeError('bottom', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], rightEdges);
@@ -155,7 +155,7 @@ export class One {
         let bottomEdges = [bottom];
 
 
-        const result = wasm.One_diamond_bottom(top.ffiValue, left.ffiValue, right.ffiValue, bottom.ffiValue);
+        const result = wasm.One_diamond_bottom(top instanceof One ? top.ffiValue : typeError('top', 'One'), left instanceof One ? left.ffiValue : typeError('left', 'One'), right instanceof One ? right.ffiValue : typeError('right', 'One'), bottom instanceof One ? bottom.ffiValue : typeError('bottom', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], bottomEdges);
@@ -171,7 +171,7 @@ export class One {
         let aEdges = [a, b, c, d];
 
 
-        const result = wasm.One_diamond_and_nested_types(a.ffiValue, b.ffiValue, c.ffiValue, d.ffiValue, nohold.ffiValue);
+        const result = wasm.One_diamond_and_nested_types(a instanceof One ? a.ffiValue : typeError('a', 'One'), b instanceof One ? b.ffiValue : typeError('b', 'One'), c instanceof One ? c.ffiValue : typeError('c', 'One'), d instanceof One ? d.ffiValue : typeError('d', 'One'), nohold instanceof One ? nohold.ffiValue : typeError('nohold', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], aEdges);
@@ -187,7 +187,7 @@ export class One {
         let aEdges = [explicitHold, implicitHold];
 
 
-        const result = wasm.One_implicit_bounds(explicitHold.ffiValue, implicitHold.ffiValue, nohold.ffiValue);
+        const result = wasm.One_implicit_bounds(explicitHold instanceof One ? explicitHold.ffiValue : typeError('explicitHold', 'One'), implicitHold instanceof One ? implicitHold.ffiValue : typeError('implicitHold', 'One'), nohold instanceof One ? nohold.ffiValue : typeError('nohold', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], aEdges);
@@ -203,7 +203,7 @@ export class One {
         let aEdges = [explicit, implicit1, implicit2];
 
 
-        const result = wasm.One_implicit_bounds_deep(explicit.ffiValue, implicit1.ffiValue, implicit2.ffiValue, nohold.ffiValue);
+        const result = wasm.One_implicit_bounds_deep(explicit instanceof One ? explicit.ffiValue : typeError('explicit', 'One'), implicit1 instanceof One ? implicit1.ffiValue : typeError('implicit1', 'One'), implicit2 instanceof One ? implicit2.ffiValue : typeError('implicit2', 'One'), nohold instanceof One ? nohold.ffiValue : typeError('nohold', 'One'));
 
         try {
             return new One(diplomatRuntime.internalConstructor, result, [], aEdges);

--- a/feature_tests/js/api/OpaqueMutexedString.mjs
+++ b/feature_tests/js/api/OpaqueMutexedString.mjs
@@ -80,7 +80,7 @@ export class OpaqueMutexedString {
         let aEdges = [other];
 
 
-        const result = wasm.OpaqueMutexedString_borrow_other(other.ffiValue);
+        const result = wasm.OpaqueMutexedString_borrow_other(other instanceof OpaqueMutexedString ? other.ffiValue : typeError('other', 'OpaqueMutexedString'));
 
         try {
             return new OpaqueMutexedString(diplomatRuntime.internalConstructor, result, aEdges);
@@ -96,7 +96,7 @@ export class OpaqueMutexedString {
         let aEdges = [this, other];
 
 
-        const result = wasm.OpaqueMutexedString_borrow_self_or_other(this.ffiValue, other.ffiValue);
+        const result = wasm.OpaqueMutexedString_borrow_self_or_other(this.ffiValue, other instanceof OpaqueMutexedString ? other.ffiValue : typeError('other', 'OpaqueMutexedString'));
 
         try {
             return new OpaqueMutexedString(diplomatRuntime.internalConstructor, result, aEdges);

--- a/feature_tests/js/api/OptionInputStruct.mjs
+++ b/feature_tests/js/api/OptionInputStruct.mjs
@@ -100,7 +100,7 @@ export class OptionInputStruct {
     ) {
         diplomatRuntime.writeOptionToArrayBuffer(arrayBuffer, offset + 0, this.#a, 1, 1, (arrayBuffer, offset, jsValue) => diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint8Array));
         diplomatRuntime.writeOptionToArrayBuffer(arrayBuffer, offset + 4, this.#b, 4, 4, (arrayBuffer, offset, jsValue) => diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue, Uint32Array));
-        diplomatRuntime.writeOptionToArrayBuffer(arrayBuffer, offset + 12, this.#c, 4, 4, (arrayBuffer, offset, jsValue) => diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array));
+        diplomatRuntime.writeOptionToArrayBuffer(arrayBuffer, offset + 12, this.#c, 4, 4, (arrayBuffer, offset, jsValue) => diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, new OptionEnum(jsValue).ffiValue, Int32Array));
     }
 
     // This struct contains borrowed fields, so this takes in a list of

--- a/feature_tests/js/api/OptionOpaque.mjs
+++ b/feature_tests/js/api/OptionOpaque.mjs
@@ -236,7 +236,7 @@ export class OptionOpaque {
 
     static optionOpaqueArgument(arg) {
 
-        const result = wasm.OptionOpaque_option_opaque_argument(arg?.ffiValue ?? 0);
+        const result = wasm.OptionOpaque_option_opaque_argument(arg === null || arg instanceof OptionOpaque ? arg?.ffiValue ?? 0 : typeError('arg', 'OptionOpaque'));
 
         try {
             return result;
@@ -276,7 +276,7 @@ export class OptionOpaque {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
 
 
-        const result = wasm.OptionOpaque_accepts_option_enum(diplomatReceive.buffer, diplomatRuntime.optionToBufferForCalling(wasm, arg, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), sentinel);
+        const result = wasm.OptionOpaque_accepts_option_enum(diplomatReceive.buffer, diplomatRuntime.optionToBufferForCalling(wasm, arg, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, new OptionEnum(jsValue).ffiValue, Int32Array)]), sentinel);
 
         try {
             if (!diplomatReceive.resultFlag) {
@@ -313,7 +313,7 @@ export class OptionOpaque {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
 
 
-        const result = wasm.OptionOpaque_accepts_multiple_option_enum(diplomatReceive.buffer, sentinel1, diplomatRuntime.optionToBufferForCalling(wasm, arg1, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), diplomatRuntime.optionToBufferForCalling(wasm, arg2, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), diplomatRuntime.optionToBufferForCalling(wasm, arg3, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), sentinel2);
+        const result = wasm.OptionOpaque_accepts_multiple_option_enum(diplomatReceive.buffer, sentinel1, diplomatRuntime.optionToBufferForCalling(wasm, arg1, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, new OptionEnum(jsValue).ffiValue, Int32Array)]), diplomatRuntime.optionToBufferForCalling(wasm, arg2, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, new OptionEnum(jsValue).ffiValue, Int32Array)]), diplomatRuntime.optionToBufferForCalling(wasm, arg3, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, new OptionEnum(jsValue).ffiValue, Int32Array)]), sentinel2);
 
         try {
             if (!diplomatReceive.resultFlag) {

--- a/feature_tests/js/api/OptionStruct.mjs
+++ b/feature_tests/js/api/OptionStruct.mjs
@@ -98,10 +98,10 @@ export class OptionStruct {
         functionCleanupArena,
         appendArrayMap
     ) {
-        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, this.#a?.ffiValue ?? 0, Uint32Array);
-        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 4, this.#b?.ffiValue ?? 0, Uint32Array);
+        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, this.#a === null || this.#a instanceof OptionOpaque ? this.#a?.ffiValue ?? 0 : typeError('this.#a', 'OptionOpaque'), Uint32Array);
+        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 4, this.#b === null || this.#b instanceof OptionOpaqueChar ? this.#b?.ffiValue ?? 0 : typeError('this.#b', 'OptionOpaqueChar'), Uint32Array);
         diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 8, this.#c, Uint32Array);
-        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 12, this.#d.ffiValue, Uint32Array);
+        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 12, this.#d instanceof OptionOpaque ? this.#d.ffiValue : typeError('this.#d', 'OptionOpaque'), Uint32Array);
     }
 
     // This struct contains borrowed fields, so this takes in a list of

--- a/feature_tests/js/api/RefList.mjs
+++ b/feature_tests/js/api/RefList.mjs
@@ -43,7 +43,7 @@ export class RefList {
         let bEdges = [data];
 
 
-        const result = wasm.RefList_node(data.ffiValue);
+        const result = wasm.RefList_node(data instanceof RefListParameter ? data.ffiValue : typeError('data', 'RefListParameter'));
 
         try {
             return new RefList(diplomatRuntime.internalConstructor, result, [], bEdges);

--- a/feature_tests/js/api/StructOfOpaque.mjs
+++ b/feature_tests/js/api/StructOfOpaque.mjs
@@ -89,8 +89,8 @@ export class StructOfOpaque {
         functionCleanupArena,
         appendArrayMap
     ) {
-        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, this.#i.ffiValue, Uint32Array);
-        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 4, this.#j.ffiValue, Uint32Array);
+        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, this.#i instanceof Opaque ? this.#i.ffiValue : typeError('this.#i', 'Opaque'), Uint32Array);
+        diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 4, this.#j instanceof OpaqueMut ? this.#j.ffiValue : typeError('this.#j', 'OpaqueMut'), Uint32Array);
     }
 
     static _fromFFI(internalConstructor, ptr, aEdges) {

--- a/feature_tests/js/api/Unnamespaced.mjs
+++ b/feature_tests/js/api/Unnamespaced.mjs
@@ -39,7 +39,7 @@ export class Unnamespaced {
 
     static make(e) {
 
-        const result = wasm.namespace_Unnamespaced_make(e.ffiValue);
+        const result = wasm.namespace_Unnamespaced_make(new RenamedAttrEnum(e).ffiValue);
 
         try {
             return new Unnamespaced(diplomatRuntime.internalConstructor, result, []);
@@ -51,7 +51,7 @@ export class Unnamespaced {
     }
 
     useNamespaced(n) {
-    wasm.namespace_Unnamespaced_use_namespaced(this.ffiValue, n.ffiValue);
+    wasm.namespace_Unnamespaced_use_namespaced(this.ffiValue, n instanceof AttrOpaque1Renamed ? n.ffiValue : typeError('n', 'AttrOpaque1Renamed'));
 
         try {}
 

--- a/feature_tests/js/api/diplomat-runtime.mjs
+++ b/feature_tests/js/api/diplomat-runtime.mjs
@@ -7,6 +7,10 @@ export const internalConstructor = Symbol("constructor");
  */
 export const exposeConstructor = Symbol("exposeConstructor");
 
+export function typeError(varr, ty) {
+    throw Error(`${varr} is not a ${ty}`);
+}
+
 export function readString8(wasm, ptr, len) {
     const buf = new Uint8Array(wasm.memory.buffer, ptr, len);
     return (new TextDecoder("utf-8")).decode(buf)

--- a/tool/src/js/converter.rs
+++ b/tool/src/js/converter.rs
@@ -629,17 +629,17 @@ impl<'tcx> ItemGenContext<'_, 'tcx> {
         match *ty {
             Type::Primitive(p) => self.maybe_wrap_in_write(js_name, gen_context, p),
             Type::Opaque(ref op) if op.is_optional() => self.maybe_wrap_in_write(
-                format!("{js_name}?.ffiValue ?? 0").into(),
+                format!("{js_name} === null || {js_name} instanceof {ty} ? {js_name}?.ffiValue ?? 0 : typeError('{js_name}', '{ty}')", ty = self.formatter.fmt_type_name(op.tcx_id.into())).into(),
                 gen_context,
                 PrimitiveType::Int(IntType::U32),
             ),
-            Type::Opaque(..) => self.maybe_wrap_in_write(
-                format!("{js_name}.ffiValue").into(),
+            Type::Opaque(ref op) => self.maybe_wrap_in_write(
+                format!("{js_name} instanceof {ty} ? {js_name}.ffiValue : typeError('{js_name}', '{ty}')", ty = self.formatter.fmt_type_name(op.tcx_id.into())).into(),
                 gen_context,
                 PrimitiveType::Int(IntType::U32),
             ),
-            Type::Enum(..) => self.maybe_wrap_in_write(
-                format!("{js_name}.ffiValue").into(),
+            Type::Enum(ref e) => self.maybe_wrap_in_write(
+                format!("new {}({js_name}).ffiValue", self.formatter.fmt_type_name(e.tcx_id.into())).into(),
                 gen_context,
                 PrimitiveType::Int(IntType::I32),
             ),

--- a/tool/templates/js/runtime.mjs
+++ b/tool/templates/js/runtime.mjs
@@ -7,6 +7,10 @@ export const internalConstructor = Symbol("constructor");
  */
 export const exposeConstructor = Symbol("exposeConstructor");
 
+export function typeError(varr, ty) {
+    throw Error(`${varr} is not a ${ty}`);
+}
+
 export function readString8(wasm, ptr, len) {
     const buf = new Uint8Array(wasm.memory.buffer, ptr, len);
     return (new TextDecoder("utf-8")).decode(buf)


### PR DESCRIPTION
Currently when passing arguments of the wrong type, `undefined`s will quietly be created with getters like `.ffiValue`. This is not very useful for users (and probably UB passing these into Rust?), so we should validate input types.