### PR TITLE
Fix Python bindings being unaware of reference_wrapper

### DIFF
--- a/feature_tests/nanobind/test/test_result.py
+++ b/feature_tests/nanobind/test/test_result.py
@@ -35,4 +35,9 @@ class TestResult(unittest.TestCase):
         #cm.exception.assert_integer(198)
         assert(str(cm.exception).startswith("<somelib.somelib.ResultOpaque"))
 
+        a = somelib.ResultOpaque(102)
+        b = a.takes_str("Hello there")
+        a.assert_integer(102)
+        b.assert_integer(102)
+
 


### PR DESCRIPTION
Because `diplomat::result` returns a `reference_wrapper` for references (`std::optional` cannot take a plain reference), we have to make sure to unwrap that reference with Nanobind before passing things over to Python. This is a fix that does exactly that.