### PR TITLE
Fix `RecordUse` in Dart

### DIFF
--- a/example/dart/lib/src/DataProvider.g.dart
+++ b/example/dart/lib/src/DataProvider.g.dart
@@ -22,7 +22,8 @@ final class DataProvider implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('icu4x_DataProvider_destroy_mv1')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DataProvider_destroy_mv1));
 
   /// See the [Rust documentation for `get_static_provider`](https://docs.rs/icu_testdata/latest/icu_testdata/fn.get_static_provider.html) for more information.

--- a/example/dart/lib/src/DataProvider.g.dart
+++ b/example/dart/lib/src/DataProvider.g.dart
@@ -22,7 +22,7 @@ final class DataProvider implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('icu4x_DataProvider_destroy_mv1')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DataProvider_destroy_mv1));
 

--- a/example/dart/lib/src/FixedDecimal.g.dart
+++ b/example/dart/lib/src/FixedDecimal.g.dart
@@ -20,7 +20,7 @@ final class FixedDecimal implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('icu4x_FixedDecimal_destroy_mv1')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_FixedDecimal_destroy_mv1));
 

--- a/example/dart/lib/src/FixedDecimal.g.dart
+++ b/example/dart/lib/src/FixedDecimal.g.dart
@@ -20,7 +20,8 @@ final class FixedDecimal implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('icu4x_FixedDecimal_destroy_mv1')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_FixedDecimal_destroy_mv1));
 
   /// Construct an [FixedDecimal] from an integer.

--- a/example/dart/lib/src/FixedDecimalFormatter.g.dart
+++ b/example/dart/lib/src/FixedDecimalFormatter.g.dart
@@ -22,7 +22,7 @@ final class FixedDecimalFormatter implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('icu4x_FixedDecimalFormatter_destroy_mv1')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_FixedDecimalFormatter_destroy_mv1));
 

--- a/example/dart/lib/src/FixedDecimalFormatter.g.dart
+++ b/example/dart/lib/src/FixedDecimalFormatter.g.dart
@@ -22,7 +22,8 @@ final class FixedDecimalFormatter implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('icu4x_FixedDecimalFormatter_destroy_mv1')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_FixedDecimalFormatter_destroy_mv1));
 
   /// Creates a new [FixedDecimalFormatter] from locale data.

--- a/example/dart/lib/src/Locale.g.dart
+++ b/example/dart/lib/src/Locale.g.dart
@@ -22,7 +22,8 @@ final class Locale implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('icu4x_Locale_destroy_mv1')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Locale_destroy_mv1));
 
   /// Construct an [Locale] from a locale identifier represented as a string.

--- a/example/dart/lib/src/Locale.g.dart
+++ b/example/dart/lib/src/Locale.g.dart
@@ -22,7 +22,7 @@ final class Locale implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('icu4x_Locale_destroy_mv1')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Locale_destroy_mv1));
 

--- a/example/dart/lib/src/lib.g.dart
+++ b/example/dart/lib/src/lib.g.dart
@@ -18,7 +18,8 @@ part 'FixedDecimalFormatterOptions.g.dart';
 part 'FixedDecimalGroupingStrategy.g.dart';
 part 'Locale.g.dart';
 
-class _DiplomatFfiUse extends meta.RecordUse {
+@meta.RecordUse()
+class _DiplomatFfiUse {
   final String symbol;
 
   const _DiplomatFfiUse(@meta.mustBeConst this.symbol);
@@ -45,13 +46,19 @@ final _callocFree = core.Finalizer(ffi2.calloc.free);
 final _nopFree = core.Finalizer((nothing) => {});
 
 // ignore: unused_element
-final _rustFree = core.Finalizer((({ffi.Pointer<ffi.Void> pointer, int bytes, int align}) record) => _diplomat_free(record.pointer, record.bytes, record.align));
+final _rustFree = core.Finalizer(
+  (({ffi.Pointer<ffi.Void> pointer, int bytes, int align}) record) =>
+      _diplomat_free(record.pointer, record.bytes, record.align),
+);
 
 // ignore: unused_element
 final class _RustAlloc implements ffi.Allocator {
   @override
-  ffi.Pointer<T> allocate<T extends ffi.NativeType>(int byteCount, {int? alignment}) {
-      return _diplomat_alloc(byteCount, alignment ?? 1).cast();
+  ffi.Pointer<T> allocate<T extends ffi.NativeType>(
+    int byteCount, {
+    int? alignment,
+  }) {
+    return _diplomat_alloc(byteCount, alignment ?? 1).cast();
   }
 
   @override
@@ -61,20 +68,27 @@ final class _RustAlloc implements ffi.Allocator {
 }
 
 @_DiplomatFfiUse('diplomat_alloc')
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(
+  symbol: 'diplomat_alloc',
+  isLeaf: true,
+)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
 @_DiplomatFfiUse('diplomat_free')
-@ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
+@ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(
+  symbol: 'diplomat_free',
+  isLeaf: true,
+)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);
-
 
 // ignore: unused_element
 class _FinalizedArena {
   final ffi2.Arena arena;
-  static final core.Finalizer<ffi2.Arena> _finalizer = core.Finalizer((arena) => arena.releaseAll());
+  static final core.Finalizer<ffi2.Arena> _finalizer = core.Finalizer(
+    (arena) => arena.releaseAll(),
+  );
 
   // ignore: unused_element
   _FinalizedArena() : arena = ffi2.Arena() {
@@ -82,14 +96,14 @@ class _FinalizedArena {
   }
 
   // ignore: unused_element
-  _FinalizedArena.withLifetime(core.List<core.List<Object>> lifetimeAppendArray) : arena = ffi2.Arena() {
+  _FinalizedArena.withLifetime(core.List<core.List<Object>> lifetimeAppendArray)
+    : arena = ffi2.Arena() {
     _finalizer.attach(this, arena);
     for (final edge in lifetimeAppendArray) {
       edge.add(this);
     }
   }
 }
-
 
 final class _ResultOpaqueVoidUnion extends ffi.Union {
   external ffi.Pointer<ffi.Opaque> ok;

--- a/example/dart/test/example_test.dart
+++ b/example/dart/test/example_test.dart
@@ -18,12 +18,11 @@ void main() {
 
     final dataProvider = DataProvider.static_();
 
-    final fdf =
-        FixedDecimalFormatter.tryNew(
-          locale,
-          dataProvider,
-          FixedDecimalFormatterOptions(),
-        )!;
+    final fdf = FixedDecimalFormatter.tryNew(
+      locale,
+      dataProvider,
+      FixedDecimalFormatterOptions(),
+    )!;
 
     expect(fdf.formatWrite(myDecimal), "১২.৩");
   });

--- a/example/dart/test/example_test.dart
+++ b/example/dart/test/example_test.dart
@@ -18,11 +18,12 @@ void main() {
 
     final dataProvider = DataProvider.static_();
 
-    final fdf = FixedDecimalFormatter.tryNew(
-      locale,
-      dataProvider,
-      FixedDecimalFormatterOptions(),
-    )!;
+    final fdf =
+        FixedDecimalFormatter.tryNew(
+          locale,
+          dataProvider,
+          FixedDecimalFormatterOptions(),
+        )!;
 
     expect(fdf.formatWrite(myDecimal), "১২.৩");
   });

--- a/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
@@ -19,7 +19,7 @@ final class AttrOpaque1Renamed implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_AttrOpaque1_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_AttrOpaque1_destroy));
 

--- a/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
@@ -19,7 +19,8 @@ final class AttrOpaque1Renamed implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_AttrOpaque1_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_AttrOpaque1_destroy));
 
   factory AttrOpaque1Renamed() {

--- a/feature_tests/dart/lib/src/Bar.g.dart
+++ b/feature_tests/dart/lib/src/Bar.g.dart
@@ -23,7 +23,7 @@ final class Bar implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('Bar_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Bar_destroy));
 

--- a/feature_tests/dart/lib/src/Bar.g.dart
+++ b/feature_tests/dart/lib/src/Bar.g.dart
@@ -23,7 +23,8 @@ final class Bar implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('Bar_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Bar_destroy));
 
   Foo get foo {

--- a/feature_tests/dart/lib/src/Float64Vec.g.dart
+++ b/feature_tests/dart/lib/src/Float64Vec.g.dart
@@ -19,7 +19,7 @@ final class Float64Vec implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('Float64Vec_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Float64Vec_destroy));
 

--- a/feature_tests/dart/lib/src/Float64Vec.g.dart
+++ b/feature_tests/dart/lib/src/Float64Vec.g.dart
@@ -19,7 +19,8 @@ final class Float64Vec implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('Float64Vec_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Float64Vec_destroy));
 
   factory Float64Vec.bool(core.List<bool> v) {

--- a/feature_tests/dart/lib/src/Foo.g.dart
+++ b/feature_tests/dart/lib/src/Foo.g.dart
@@ -21,7 +21,7 @@ final class Foo implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('Foo_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Foo_destroy));
 

--- a/feature_tests/dart/lib/src/Foo.g.dart
+++ b/feature_tests/dart/lib/src/Foo.g.dart
@@ -21,7 +21,8 @@ final class Foo implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('Foo_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Foo_destroy));
 
   factory Foo(String x) {

--- a/feature_tests/dart/lib/src/MyOpaqueEnum.g.dart
+++ b/feature_tests/dart/lib/src/MyOpaqueEnum.g.dart
@@ -19,7 +19,7 @@ final class MyOpaqueEnum implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('MyOpaqueEnum_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_MyOpaqueEnum_destroy));
 

--- a/feature_tests/dart/lib/src/MyOpaqueEnum.g.dart
+++ b/feature_tests/dart/lib/src/MyOpaqueEnum.g.dart
@@ -19,7 +19,8 @@ final class MyOpaqueEnum implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('MyOpaqueEnum_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_MyOpaqueEnum_destroy));
 
   static MyOpaqueEnum new_() {

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -19,7 +19,7 @@ final class MyString implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('MyString_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_MyString_destroy));
 

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -19,7 +19,8 @@ final class MyString implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('MyString_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_MyString_destroy));
 
   factory MyString(String v) {

--- a/feature_tests/dart/lib/src/One.g.dart
+++ b/feature_tests/dart/lib/src/One.g.dart
@@ -21,7 +21,8 @@ final class One implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('One_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_One_destroy));
 
   factory One.transitivity(One hold, One nohold) {

--- a/feature_tests/dart/lib/src/One.g.dart
+++ b/feature_tests/dart/lib/src/One.g.dart
@@ -21,7 +21,7 @@ final class One implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('One_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_One_destroy));
 

--- a/feature_tests/dart/lib/src/Opaque.g.dart
+++ b/feature_tests/dart/lib/src/Opaque.g.dart
@@ -19,7 +19,8 @@ final class Opaque implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('Opaque_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Opaque_destroy));
 
   factory Opaque() {

--- a/feature_tests/dart/lib/src/Opaque.g.dart
+++ b/feature_tests/dart/lib/src/Opaque.g.dart
@@ -19,7 +19,7 @@ final class Opaque implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('Opaque_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Opaque_destroy));
 

--- a/feature_tests/dart/lib/src/OpaqueMutexedString.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueMutexedString.g.dart
@@ -19,7 +19,7 @@ final class OpaqueMutexedString implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('OpaqueMutexedString_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueMutexedString_destroy));
 

--- a/feature_tests/dart/lib/src/OpaqueMutexedString.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueMutexedString.g.dart
@@ -19,7 +19,8 @@ final class OpaqueMutexedString implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('OpaqueMutexedString_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueMutexedString_destroy));
 
   static OpaqueMutexedString fromUsize(int number) {

--- a/feature_tests/dart/lib/src/OpaqueThin.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueThin.g.dart
@@ -19,7 +19,8 @@ final class OpaqueThin implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('OpaqueThin_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueThin_destroy));
 
   int get a {

--- a/feature_tests/dart/lib/src/OpaqueThin.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueThin.g.dart
@@ -19,7 +19,7 @@ final class OpaqueThin implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('OpaqueThin_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueThin_destroy));
 

--- a/feature_tests/dart/lib/src/OpaqueThinIter.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueThinIter.g.dart
@@ -21,7 +21,8 @@ final class OpaqueThinIter implements ffi.Finalizable, core.Iterator<OpaqueThin>
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('OpaqueThinIter_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueThinIter_destroy));
 
   OpaqueThin? _current;

--- a/feature_tests/dart/lib/src/OpaqueThinIter.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueThinIter.g.dart
@@ -21,7 +21,7 @@ final class OpaqueThinIter implements ffi.Finalizable, core.Iterator<OpaqueThin>
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('OpaqueThinIter_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueThinIter_destroy));
 

--- a/feature_tests/dart/lib/src/OpaqueThinVec.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueThinVec.g.dart
@@ -19,7 +19,7 @@ final class OpaqueThinVec with core.Iterable<OpaqueThin> implements ffi.Finaliza
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('OpaqueThinVec_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueThinVec_destroy));
 

--- a/feature_tests/dart/lib/src/OpaqueThinVec.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueThinVec.g.dart
@@ -19,7 +19,8 @@ final class OpaqueThinVec with core.Iterable<OpaqueThin> implements ffi.Finaliza
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('OpaqueThinVec_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueThinVec_destroy));
 
   factory OpaqueThinVec(core.List<int> a, core.List<double> b) {

--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -19,7 +19,7 @@ final class OptionOpaque implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('OptionOpaque_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OptionOpaque_destroy));
 

--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -19,7 +19,8 @@ final class OptionOpaque implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('OptionOpaque_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OptionOpaque_destroy));
 
   static OptionOpaque? new_(int i) {

--- a/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
@@ -19,7 +19,7 @@ final class OptionOpaqueChar implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('OptionOpaqueChar_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OptionOpaqueChar_destroy));
 

--- a/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaqueChar.g.dart
@@ -19,7 +19,8 @@ final class OptionOpaqueChar implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('OptionOpaqueChar_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OptionOpaqueChar_destroy));
 
   void assertChar(Rune ch) {

--- a/feature_tests/dart/lib/src/RefList.g.dart
+++ b/feature_tests/dart/lib/src/RefList.g.dart
@@ -21,7 +21,7 @@ final class RefList implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('RefList_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_RefList_destroy));
 

--- a/feature_tests/dart/lib/src/RefList.g.dart
+++ b/feature_tests/dart/lib/src/RefList.g.dart
@@ -21,7 +21,8 @@ final class RefList implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('RefList_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_RefList_destroy));
 
   factory RefList.node(RefListParameter data) {

--- a/feature_tests/dart/lib/src/RefListParameter.g.dart
+++ b/feature_tests/dart/lib/src/RefListParameter.g.dart
@@ -19,7 +19,8 @@ final class RefListParameter implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('RefListParameter_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_RefListParameter_destroy));
 
 }

--- a/feature_tests/dart/lib/src/RefListParameter.g.dart
+++ b/feature_tests/dart/lib/src/RefListParameter.g.dart
@@ -19,7 +19,7 @@ final class RefListParameter implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('RefListParameter_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_RefListParameter_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedAttrOpaque2.g.dart
+++ b/feature_tests/dart/lib/src/RenamedAttrOpaque2.g.dart
@@ -19,7 +19,7 @@ final class RenamedAttrOpaque2 implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_AttrOpaque2_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_AttrOpaque2_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedAttrOpaque2.g.dart
+++ b/feature_tests/dart/lib/src/RenamedAttrOpaque2.g.dart
@@ -19,7 +19,8 @@ final class RenamedAttrOpaque2 implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_AttrOpaque2_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_AttrOpaque2_destroy));
 
 }

--- a/feature_tests/dart/lib/src/RenamedComparable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedComparable.g.dart
@@ -19,7 +19,8 @@ final class RenamedComparable implements ffi.Finalizable, core.Comparable<Rename
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_Comparable_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_Comparable_destroy));
 
   static RenamedComparable new_(int int) {

--- a/feature_tests/dart/lib/src/RenamedComparable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedComparable.g.dart
@@ -19,7 +19,7 @@ final class RenamedComparable implements ffi.Finalizable, core.Comparable<Rename
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_Comparable_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_Comparable_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedMyIndexer.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIndexer.g.dart
@@ -19,7 +19,7 @@ final class RenamedMyIndexer implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_MyIndexer_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_MyIndexer_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedMyIndexer.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIndexer.g.dart
@@ -19,7 +19,8 @@ final class RenamedMyIndexer implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_MyIndexer_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_MyIndexer_destroy));
 
   String? operator [](int i) {

--- a/feature_tests/dart/lib/src/RenamedMyIterable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIterable.g.dart
@@ -19,7 +19,7 @@ final class RenamedMyIterable with core.Iterable<int> implements ffi.Finalizable
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_MyIterable_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_MyIterable_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedMyIterable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIterable.g.dart
@@ -19,7 +19,8 @@ final class RenamedMyIterable with core.Iterable<int> implements ffi.Finalizable
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_MyIterable_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_MyIterable_destroy));
 
   factory RenamedMyIterable(core.List<int> x) {

--- a/feature_tests/dart/lib/src/RenamedMyIterator.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIterator.g.dart
@@ -21,7 +21,8 @@ final class RenamedMyIterator implements ffi.Finalizable, core.Iterator<int> {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_MyIterator_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_MyIterator_destroy));
 
   int? _current;

--- a/feature_tests/dart/lib/src/RenamedMyIterator.g.dart
+++ b/feature_tests/dart/lib/src/RenamedMyIterator.g.dart
@@ -21,7 +21,7 @@ final class RenamedMyIterator implements ffi.Finalizable, core.Iterator<int> {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_MyIterator_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_MyIterator_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedNested.g.dart
+++ b/feature_tests/dart/lib/src/RenamedNested.g.dart
@@ -19,7 +19,8 @@ final class RenamedNested implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_Nested_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_Nested_destroy));
 
 }

--- a/feature_tests/dart/lib/src/RenamedNested.g.dart
+++ b/feature_tests/dart/lib/src/RenamedNested.g.dart
@@ -19,7 +19,7 @@ final class RenamedNested implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_Nested_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_Nested_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedNested2.g.dart
+++ b/feature_tests/dart/lib/src/RenamedNested2.g.dart
@@ -19,7 +19,8 @@ final class RenamedNested2 implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_Nested2_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_Nested2_destroy));
 
 }

--- a/feature_tests/dart/lib/src/RenamedNested2.g.dart
+++ b/feature_tests/dart/lib/src/RenamedNested2.g.dart
@@ -19,7 +19,7 @@ final class RenamedNested2 implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_Nested2_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_Nested2_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedOpaqueIterable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedOpaqueIterable.g.dart
@@ -19,7 +19,7 @@ final class RenamedOpaqueIterable with core.Iterable<AttrOpaque1Renamed> impleme
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_OpaqueIterable_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_OpaqueIterable_destroy));
 

--- a/feature_tests/dart/lib/src/RenamedOpaqueIterable.g.dart
+++ b/feature_tests/dart/lib/src/RenamedOpaqueIterable.g.dart
@@ -19,7 +19,8 @@ final class RenamedOpaqueIterable with core.Iterable<AttrOpaque1Renamed> impleme
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_OpaqueIterable_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_OpaqueIterable_destroy));
 
   RenamedOpaqueIterator get iterator {

--- a/feature_tests/dart/lib/src/RenamedOpaqueIterator.g.dart
+++ b/feature_tests/dart/lib/src/RenamedOpaqueIterator.g.dart
@@ -21,7 +21,8 @@ final class RenamedOpaqueIterator implements ffi.Finalizable, core.Iterator<Attr
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_OpaqueIterator_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_OpaqueIterator_destroy));
 
   AttrOpaque1Renamed? _current;

--- a/feature_tests/dart/lib/src/RenamedOpaqueIterator.g.dart
+++ b/feature_tests/dart/lib/src/RenamedOpaqueIterator.g.dart
@@ -21,7 +21,7 @@ final class RenamedOpaqueIterator implements ffi.Finalizable, core.Iterator<Attr
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_OpaqueIterator_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_OpaqueIterator_destroy));
 

--- a/feature_tests/dart/lib/src/ResultOpaque.g.dart
+++ b/feature_tests/dart/lib/src/ResultOpaque.g.dart
@@ -19,7 +19,7 @@ final class ResultOpaque implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('ResultOpaque_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_ResultOpaque_destroy));
 

--- a/feature_tests/dart/lib/src/ResultOpaque.g.dart
+++ b/feature_tests/dart/lib/src/ResultOpaque.g.dart
@@ -19,7 +19,8 @@ final class ResultOpaque implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('ResultOpaque_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_ResultOpaque_destroy));
 
   ///

--- a/feature_tests/dart/lib/src/Two.g.dart
+++ b/feature_tests/dart/lib/src/Two.g.dart
@@ -23,7 +23,7 @@ final class Two implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('Two_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Two_destroy));
 

--- a/feature_tests/dart/lib/src/Two.g.dart
+++ b/feature_tests/dart/lib/src/Two.g.dart
@@ -23,7 +23,8 @@ final class Two implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('Two_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Two_destroy));
 
 }

--- a/feature_tests/dart/lib/src/Unnamespaced.g.dart
+++ b/feature_tests/dart/lib/src/Unnamespaced.g.dart
@@ -19,7 +19,8 @@ final class Unnamespaced implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('namespace_Unnamespaced_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_Unnamespaced_destroy));
 
   factory Unnamespaced.make(RenamedAttrEnum e) {

--- a/feature_tests/dart/lib/src/Unnamespaced.g.dart
+++ b/feature_tests/dart/lib/src/Unnamespaced.g.dart
@@ -19,7 +19,7 @@ final class Unnamespaced implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('namespace_Unnamespaced_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_Unnamespaced_destroy));
 

--- a/feature_tests/dart/lib/src/Utf16Wrap.g.dart
+++ b/feature_tests/dart/lib/src/Utf16Wrap.g.dart
@@ -19,7 +19,7 @@ final class Utf16Wrap implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('Utf16Wrap_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Utf16Wrap_destroy));
 

--- a/feature_tests/dart/lib/src/Utf16Wrap.g.dart
+++ b/feature_tests/dart/lib/src/Utf16Wrap.g.dart
@@ -19,7 +19,8 @@ final class Utf16Wrap implements ffi.Finalizable {
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('Utf16Wrap_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_Utf16Wrap_destroy));
 
   factory Utf16Wrap(String input) {

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -64,7 +64,8 @@ part 'UnimportedEnum.g.dart';
 part 'Unnamespaced.g.dart';
 part 'Utf16Wrap.g.dart';
 
-class _DiplomatFfiUse extends meta.RecordUse {
+@meta.RecordUse()
+class _DiplomatFfiUse {
   final String symbol;
 
   const _DiplomatFfiUse(@meta.mustBeConst this.symbol);
@@ -91,13 +92,19 @@ final _callocFree = core.Finalizer(ffi2.calloc.free);
 final _nopFree = core.Finalizer((nothing) => {});
 
 // ignore: unused_element
-final _rustFree = core.Finalizer((({ffi.Pointer<ffi.Void> pointer, int bytes, int align}) record) => _diplomat_free(record.pointer, record.bytes, record.align));
+final _rustFree = core.Finalizer(
+  (({ffi.Pointer<ffi.Void> pointer, int bytes, int align}) record) =>
+      _diplomat_free(record.pointer, record.bytes, record.align),
+);
 
 // ignore: unused_element
 final class _RustAlloc implements ffi.Allocator {
   @override
-  ffi.Pointer<T> allocate<T extends ffi.NativeType>(int byteCount, {int? alignment}) {
-      return _diplomat_alloc(byteCount, alignment ?? 1).cast();
+  ffi.Pointer<T> allocate<T extends ffi.NativeType>(
+    int byteCount, {
+    int? alignment,
+  }) {
+    return _diplomat_alloc(byteCount, alignment ?? 1).cast();
   }
 
   @override
@@ -107,20 +114,27 @@ final class _RustAlloc implements ffi.Allocator {
 }
 
 @_DiplomatFfiUse('diplomat_alloc')
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(
+  symbol: 'diplomat_alloc',
+  isLeaf: true,
+)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
 @_DiplomatFfiUse('diplomat_free')
-@ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
+@ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(
+  symbol: 'diplomat_free',
+  isLeaf: true,
+)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);
-
 
 // ignore: unused_element
 class _FinalizedArena {
   final ffi2.Arena arena;
-  static final core.Finalizer<ffi2.Arena> _finalizer = core.Finalizer((arena) => arena.releaseAll());
+  static final core.Finalizer<ffi2.Arena> _finalizer = core.Finalizer(
+    (arena) => arena.releaseAll(),
+  );
 
   // ignore: unused_element
   _FinalizedArena() : arena = ffi2.Arena() {
@@ -128,14 +142,14 @@ class _FinalizedArena {
   }
 
   // ignore: unused_element
-  _FinalizedArena.withLifetime(core.List<core.List<Object>> lifetimeAppendArray) : arena = ffi2.Arena() {
+  _FinalizedArena.withLifetime(core.List<core.List<Object>> lifetimeAppendArray)
+    : arena = ffi2.Arena() {
     _finalizer.attach(this, arena);
     for (final edge in lifetimeAppendArray) {
       edge.add(this);
     }
   }
 }
-
 
 final class _ResultCyclicStructAFfiVoidUnion extends ffi.Union {
   external _CyclicStructAFfi ok;

--- a/tool/templates/dart/init.dart
+++ b/tool/templates/dart/init.dart
@@ -1,4 +1,5 @@
-class _DiplomatFfiUse extends meta.RecordUse {
+@meta.RecordUse()
+class _DiplomatFfiUse {
   final String symbol;
 
   const _DiplomatFfiUse(@meta.mustBeConst this.symbol);
@@ -25,13 +26,19 @@ final _callocFree = core.Finalizer(ffi2.calloc.free);
 final _nopFree = core.Finalizer((nothing) => {});
 
 // ignore: unused_element
-final _rustFree = core.Finalizer((({ffi.Pointer<ffi.Void> pointer, int bytes, int align}) record) => _diplomat_free(record.pointer, record.bytes, record.align));
+final _rustFree = core.Finalizer(
+  (({ffi.Pointer<ffi.Void> pointer, int bytes, int align}) record) =>
+      _diplomat_free(record.pointer, record.bytes, record.align),
+);
 
 // ignore: unused_element
 final class _RustAlloc implements ffi.Allocator {
   @override
-  ffi.Pointer<T> allocate<T extends ffi.NativeType>(int byteCount, {int? alignment}) {
-      return _diplomat_alloc(byteCount, alignment ?? 1).cast();
+  ffi.Pointer<T> allocate<T extends ffi.NativeType>(
+    int byteCount, {
+    int? alignment,
+  }) {
+    return _diplomat_alloc(byteCount, alignment ?? 1).cast();
   }
 
   @override
@@ -41,20 +48,27 @@ final class _RustAlloc implements ffi.Allocator {
 }
 
 @_DiplomatFfiUse('diplomat_alloc')
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(symbol: 'diplomat_alloc', isLeaf: true)
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(
+  symbol: 'diplomat_alloc',
+  isLeaf: true,
+)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
 @_DiplomatFfiUse('diplomat_free')
-@ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(symbol: 'diplomat_free', isLeaf: true)
+@ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(
+  symbol: 'diplomat_free',
+  isLeaf: true,
+)
 // ignore: non_constant_identifier_names
 external int _diplomat_free(ffi.Pointer<ffi.Void> ptr, int len, int align);
-
 
 // ignore: unused_element
 class _FinalizedArena {
   final ffi2.Arena arena;
-  static final core.Finalizer<ffi2.Arena> _finalizer = core.Finalizer((arena) => arena.releaseAll());
+  static final core.Finalizer<ffi2.Arena> _finalizer = core.Finalizer(
+    (arena) => arena.releaseAll(),
+  );
 
   // ignore: unused_element
   _FinalizedArena() : arena = ffi2.Arena() {
@@ -62,11 +76,11 @@ class _FinalizedArena {
   }
 
   // ignore: unused_element
-  _FinalizedArena.withLifetime(core.List<core.List<Object>> lifetimeAppendArray) : arena = ffi2.Arena() {
+  _FinalizedArena.withLifetime(core.List<core.List<Object>> lifetimeAppendArray)
+    : arena = ffi2.Arena() {
     _finalizer.attach(this, arena);
     for (final edge in lifetimeAppendArray) {
       edge.add(this);
     }
   }
 }
-

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -25,7 +25,7 @@ final class {{type_name}}
       _finalizer.attach(this, _ffi.cast());
     }
   }
-  
+
   @_DiplomatFfiUse('{{destructor}}')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_{{destructor}}));
 

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -25,7 +25,8 @@ final class {{type_name}}
       _finalizer.attach(this, _ffi.cast());
     }
   }
-
+  
+  @_DiplomatFfiUse('{{destructor}}')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_{{destructor}}));
 
   {%- if let Some(it) = special.iterator %}


### PR DESCRIPTION
The first commit has the changes, the second the regeneration of generated files.