### PR TITLE
Diplomat Macros

### DIFF
--- a/core/src/ast/macros.rs
+++ b/core/src/ast/macros.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeMap;
+
+use proc_macro2::TokenStream;
+use syn::{braced, bracketed, buffer::{Cursor, TokenBuffer}, parenthesized, parse::{self, Parse}, parse_macro_input, token::{self, Token}, Error, Expr, ExprParen, Ident, Item, ItemMacro, PatParen, Path, Token};
+
+pub struct Macros {
+    defs : BTreeMap<Path, Macro>,
+}
+
+impl Macros {
+    pub fn new() -> Macros {
+        Macros {
+            defs: BTreeMap::new()
+        }
+    }
+
+    pub fn read_item_macro(&mut self, input : &ItemMacro) -> Option<TokenStream> {
+        let mac = Macro::from_syn(input);
+        if let Ok((pth, mac)) = mac {
+            println!("{:?}", pth);
+            // m.body
+            // self.defs.insert(m.ident.clone(), m);
+            None
+        } else {
+            // FIXME:
+            // panic!("{:?}", mac.unwrap_err());
+            None
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Macro {
+    MacroRules(MacroRules),
+    MacroMatch(MacroMatch)
+}
+
+impl Macro {
+    pub fn from_syn(input : &ItemMacro) -> Result<(Path, Macro), syn::Error> {
+        // Are we macro_rules!
+        if let Some(_) = &input.ident {
+            Ok((input.mac.path.clone(), Macro::MacroRules(input.mac.parse_body()?)))
+        } else {
+            let m = input.mac.parse_body()?;
+            Ok((input.mac.path.clone(), Macro::MacroMatch(m)))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MacroIdent {
+    pub ident : Ident,
+    pub ty : Ident
+}
+
+impl Parse for MacroIdent {
+    fn parse(input: parse::ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![$]>()?;
+        let ident : Ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+        let ty : Ident = input.parse()?;
+        Ok(Self{ident, ty})
+    }
+}
+
+#[derive(Debug)]
+pub struct MacroRules {
+    pub match_tokens : Vec<MacroIdent>,
+    pub body : TokenStream
+}
+
+impl Parse for MacroRules {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        
+        // Read the matcher:
+        let arm;
+        if lookahead.peek(token::Paren) {
+            parenthesized!(arm in input);
+        } else if lookahead.peek(token::Brace) {
+            braced!(arm in input);
+        } else if lookahead.peek(token::Bracket) {
+            bracketed!(arm in input);
+        } else {
+            return Err(Error::new(input.span(), "Expected {}, (), or []"))
+        }
+
+        let punc = arm.parse_terminated(MacroIdent::parse, Token![,])?;
+
+        let match_tokens = punc.iter().map(|i| { i.clone() }).collect();
+
+        let _arrow = input.parse::<Token![=>]>()?;
+
+        // Now the expansion:
+        let arm_body;
+        braced!(arm_body in input);
+
+        let body = arm_body.cursor().token_stream();
+
+        
+        // We don't support any other rules, so we ignore them.
+
+        Ok(Self {
+            match_tokens,
+            body
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct MacroMatch {
+    pub args : Vec<Expr>,
+}
+
+impl Parse for MacroMatch {
+    fn parse(input: parse::ParseStream) -> syn::Result<Self> {
+        let mut args = Vec::new();
+
+        // TODO: Need some custom logic based on the parent macro definition.
+        let args_p = input.parse_terminated(Expr::parse, Token![,])?;
+        for a in args_p {
+            args.push(a);
+        }
+
+        Ok(Self {
+            args
+        })
+    }
+}

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -44,3 +44,8 @@ pub use docs::{
     DocType, Docs, DocsUrlGenerator, RustLink, RustLinkDisplay,
     TypeReferenceSyntax as DocsTypeReferenceSyntax,
 };
+
+mod macros;
+pub use macros::{
+    Macros, Macro
+};

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -7,7 +7,7 @@ use syn::{ImplItem, Item, ItemMod, UseTree, Visibility};
 
 use super::{
     AttrInheritContext, Attrs, CustomType, Enum, Ident, Method, ModSymbol, Mutability, OpaqueType,
-    Path, PathType, RustLink, Struct, Trait,
+    Path, PathType, RustLink, Struct, Trait, Macros,
 };
 use crate::environment::*;
 
@@ -172,6 +172,8 @@ impl Module {
             mod_attrs.attrs_for_inheritance(AttrInheritContext::MethodOrImplFromModule);
         let type_parent_attrs: Attrs = mod_attrs.attrs_for_inheritance(AttrInheritContext::Type);
 
+        let mut mod_macros = Macros::new();
+
         input
             .content
             .as_ref()
@@ -276,6 +278,9 @@ impl Module {
                         custom_traits_by_name
                             .insert(ident, trt);
                     }
+                }
+                Item::Macro(mac) => {
+                    let read = mod_macros.read_item_macro(mac);
                 }
                 _ => {}
             });

--- a/feature_tests/cpp/include/ns/RenamedVectorTest.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedVectorTest.d.hpp
@@ -1,0 +1,41 @@
+#ifndef ns_RenamedVectorTest_D_HPP
+#define ns_RenamedVectorTest_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+namespace ns {
+struct RenamedVectorTest;
+}
+
+
+namespace ns {
+namespace capi {
+    struct RenamedVectorTest {
+      double test;
+    };
+
+    typedef struct RenamedVectorTest_option {union { RenamedVectorTest ok; }; bool is_ok; } RenamedVectorTest_option;
+} // namespace capi
+} // namespace
+
+
+namespace ns {
+struct RenamedVectorTest {
+  double test;
+
+  inline static ns::RenamedVectorTest new_();
+
+  inline ns::capi::RenamedVectorTest AsFFI() const;
+  inline static ns::RenamedVectorTest FromFFI(ns::capi::RenamedVectorTest c_struct);
+};
+
+} // namespace
+#endif // ns_RenamedVectorTest_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedVectorTest.hpp
+++ b/feature_tests/cpp/include/ns/RenamedVectorTest.hpp
@@ -1,0 +1,46 @@
+#ifndef ns_RenamedVectorTest_HPP
+#define ns_RenamedVectorTest_HPP
+
+#include "RenamedVectorTest.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+
+    ns::capi::RenamedVectorTest namespace_VectorTest_new(void);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline ns::RenamedVectorTest ns::RenamedVectorTest::new_() {
+  auto result = ns::capi::namespace_VectorTest_new();
+  return ns::RenamedVectorTest::FromFFI(result);
+}
+
+
+inline ns::capi::RenamedVectorTest ns::RenamedVectorTest::AsFFI() const {
+  return ns::capi::RenamedVectorTest {
+    /* .test = */ test,
+  };
+}
+
+inline ns::RenamedVectorTest ns::RenamedVectorTest::FromFFI(ns::capi::RenamedVectorTest c_struct) {
+  return ns::RenamedVectorTest {
+    /* .test = */ c_struct.test,
+  };
+}
+
+
+#endif // ns_RenamedVectorTest_HPP

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -7,12 +7,12 @@ pub mod ffi {
     macro_rules! create_vec {
         ($vec_name:ident) => {
             pub struct $vec_name {
-
+                pub test: f64,
             }
 
             impl $vec_name {
-                pub fn new(&self) -> Self {
-                    Self {}
+                pub fn new() -> Self {
+                    Self { test: 0.0 }
                 }
             }
         };

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -3,6 +3,22 @@
 #[diplomat::attr(not(any(c, kotlin)), rename = "Renamed{0}")]
 #[diplomat::attr(auto, namespace = "ns")]
 pub mod ffi {
+    macro_rules! create_vec {
+        ($vec_name:ident) => {
+            pub struct $vec_name {
+
+            }
+
+            impl $vec_name {
+                pub fn new(&self) -> Self {
+                    Self {}
+                }
+            }
+        }
+    }
+
+    create_vec!(VectorTest);
+
     #[derive(Clone)]
     #[diplomat::opaque]
     // Attr for generating mocking interface in kotlin backend to enable JVM test fakes.

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -3,6 +3,7 @@
 #[diplomat::attr(not(any(c, kotlin)), rename = "Renamed{0}")]
 #[diplomat::attr(auto, namespace = "ns")]
 pub mod ffi {
+    #[diplomat::macro_rules]
     macro_rules! create_vec {
         ($vec_name:ident) => {
             pub struct $vec_name {
@@ -14,7 +15,7 @@ pub mod ffi {
                     Self {}
                 }
             }
-        }
+        };
     }
 
     create_vec!(VectorTest);

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -687,7 +687,7 @@ pub fn macro_rules(
     // (otherwise that will cause more errors) so we hold on to it and we tack it in
     // with no modifications below
     let input_cached: proc_macro2::TokenStream = input.clone().into();
-    let expanded = diplomat_core::ast::Macros::read_item_macro(parse_macro_input!(input));
+    let expanded = diplomat_core::ast::Macro::validate(parse_macro_input!(input));
     let full = quote! {
         #expanded
         #input_cached

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -677,6 +677,24 @@ pub fn transparent_convert(
     proc_macro::TokenStream::from(full.to_token_stream())
 }
 
+#[proc_macro_attribute]
+pub fn macro_rules(
+        _attr: proc_macro::TokenStream,
+        input: proc_macro::TokenStream,
+    ) -> proc_macro::TokenStream {
+    // proc macros handle compile errors by using special error tokens.
+    // In case of an error, we don't want the original code to go away too
+    // (otherwise that will cause more errors) so we hold on to it and we tack it in
+    // with no modifications below
+    let input_cached: proc_macro2::TokenStream = input.clone().into();
+    let expanded = diplomat_core::ast::Macros::read_item_macro(parse_macro_input!(input));
+    let full = quote! {
+        #expanded
+        #input_cached
+    };
+    proc_macro::TokenStream::from(full.to_token_stream())
+}
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
Implements #752.

This is currently very barebones, but there is a working example in feature_tests! So the TODOs:

- [ ] Fix macro matcher reading (and add errors for when inputs don't match). So things like `macro!($var:tt asdkfja $other_var:expr)` aren't supported yet.
- [ ] Add validation for location of macros
- [ ] Add support for macro usage in Item impl
- [ ] Write a working test for macros