### PR TITLE
Add fix for callbacks with slice arguments

### DIFF
--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -287,12 +287,42 @@ using as_ffi_t = typename as_ffi<T>::type;
 template<typename T>
 using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
 
+template<typename T, typename = void>
+struct diplomat_c_span_convert {
+  using type = T;
+};
+
+#define MAKE_SLICE_CONVERTERS(name, c_ty) \
+  template<typename T> \
+  struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<const c_ty>>>> { \
+    using type = diplomat::capi::Diplomat##name##View; \
+  }; \
+  template<typename T> \
+  struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<c_ty>>>> { \
+    using type = diplomat::capi::Diplomat##name##ViewMut; \
+  }; \
+
+MAKE_SLICE_CONVERTERS(I8, int8_t)
+MAKE_SLICE_CONVERTERS(U8, uint8_t)
+MAKE_SLICE_CONVERTERS(I16, int16_t)
+MAKE_SLICE_CONVERTERS(U16, uint16_t)
+MAKE_SLICE_CONVERTERS(I32, int32_t)
+MAKE_SLICE_CONVERTERS(U32, uint32_t)
+MAKE_SLICE_CONVERTERS(I64, int64_t)
+MAKE_SLICE_CONVERTERS(U64, uint64_t)
+MAKE_SLICE_CONVERTERS(F32, float)
+MAKE_SLICE_CONVERTERS(F64, double)
+MAKE_SLICE_CONVERTERS(Bool, bool)
+MAKE_SLICE_CONVERTERS(Char, char32_t)
+MAKE_SLICE_CONVERTERS(String, char)
+MAKE_SLICE_CONVERTERS(String16, char16_t)
+
 template<typename T>
-using replace_ref_with_ptr_t = std::conditional_t<std::is_reference_v<T>, std::add_pointer_t<std::remove_reference_t<T>>, T>;
+using diplomat_c_span_convert_t = typename diplomat_c_span_convert<T>::type;
 
 /// Replace the argument types from the std::function with the argument types for th function pointer
 template<typename T>
-using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+using replace_fn_t = diplomat_c_span_convert_t<replace_string_view_t<as_ffi_t<T>>>;
 
 template <typename T> struct fn_traits;
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
@@ -305,6 +335,8 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
     static T replace(replace_fn_t<T> val) {
       if constexpr(std::is_same_v<T, std::string_view>)   {
           return std::string_view{val.data, val.len};
+      } else if constexpr (!std::is_same_v<T, diplomat_c_span_convert_t<T>>) {
+        return T{ val.data, val.len };
       } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
         if constexpr (std::is_lvalue_reference_v<T>) {
           return *std::remove_reference_t<T>::FromFFI(val);

--- a/feature_tests/c/include/CallbackWrapper.h
+++ b/feature_tests/c/include/CallbackWrapper.h
@@ -51,6 +51,11 @@ typedef struct DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb {
     void (*run_callback)(const void*, MyString* );
     void (*destructor)(const void*);
 } DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb;
+typedef struct DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f {
+    const void* data;
+    void (*run_callback)(const void*, DiplomatU8View );
+    void (*destructor)(const void*);
+} DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f;
 
 int32_t CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f f_cb_wrap, int32_t x);
 
@@ -63,6 +68,8 @@ int32_t CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_t
 int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_str_cb_arg_f f_cb_wrap);
 
 void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb cb_cb_wrap, MyString* a);
+
+void CallbackWrapper_test_slice_cb_arg(DiplomatU8View arg, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f f_cb_wrap);
 
 
 

--- a/feature_tests/cpp/include/CallbackWrapper.d.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.d.hpp
@@ -42,6 +42,8 @@ struct CallbackWrapper {
 
   inline static void test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a);
 
+  inline static void test_slice_cb_arg(diplomat::span<const uint8_t> arg, std::function<void(diplomat::span<const uint8_t>)> f);
+
   inline diplomat::capi::CallbackWrapper AsFFI() const;
   inline static CallbackWrapper FromFFI(diplomat::capi::CallbackWrapper c_struct);
 };

--- a/feature_tests/cpp/include/CallbackWrapper.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.hpp
@@ -54,6 +54,11 @@ namespace capi {
         void (*run_callback)(const void*, diplomat::capi::MyString* );
         void (*destructor)(const void*);
     } DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb;
+    typedef struct DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f {
+        const void* data;
+        void (*run_callback)(const void*, diplomat::capi::DiplomatU8View );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f;
 
     int32_t CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f f_cb_wrap, int32_t x);
 
@@ -66,6 +71,8 @@ namespace capi {
     int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_str_cb_arg_f f_cb_wrap);
 
     void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb cb_cb_wrap, diplomat::capi::MyString* a);
+
+    void CallbackWrapper_test_slice_cb_arg(diplomat::capi::DiplomatU8View arg, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f f_cb_wrap);
 
     } // extern "C"
 } // namespace capi
@@ -101,6 +108,11 @@ inline int32_t CallbackWrapper::test_str_cb_arg(std::function<int32_t(std::strin
 inline void CallbackWrapper::test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a) {
   diplomat::capi::CallbackWrapper_test_opaque_cb_arg({new decltype(cb)(std::move(cb)), diplomat::fn_traits(cb).c_run_callback, diplomat::fn_traits(cb).c_delete},
     a.AsFFI());
+}
+
+inline void CallbackWrapper::test_slice_cb_arg(diplomat::span<const uint8_t> arg, std::function<void(diplomat::span<const uint8_t>)> f) {
+  diplomat::capi::CallbackWrapper_test_slice_cb_arg({arg.data(), arg.size()},
+    {new decltype(f)(std::move(f)), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
 }
 
 

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -287,12 +287,42 @@ using as_ffi_t = typename as_ffi<T>::type;
 template<typename T>
 using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
 
+template<typename T, typename = void>
+struct diplomat_c_span_convert {
+  using type = T;
+};
+
+#define MAKE_SLICE_CONVERTERS(name, c_ty) \
+  template<typename T> \
+  struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<const c_ty>>>> { \
+    using type = diplomat::capi::Diplomat##name##View; \
+  }; \
+  template<typename T> \
+  struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<c_ty>>>> { \
+    using type = diplomat::capi::Diplomat##name##ViewMut; \
+  }; \
+
+MAKE_SLICE_CONVERTERS(I8, int8_t)
+MAKE_SLICE_CONVERTERS(U8, uint8_t)
+MAKE_SLICE_CONVERTERS(I16, int16_t)
+MAKE_SLICE_CONVERTERS(U16, uint16_t)
+MAKE_SLICE_CONVERTERS(I32, int32_t)
+MAKE_SLICE_CONVERTERS(U32, uint32_t)
+MAKE_SLICE_CONVERTERS(I64, int64_t)
+MAKE_SLICE_CONVERTERS(U64, uint64_t)
+MAKE_SLICE_CONVERTERS(F32, float)
+MAKE_SLICE_CONVERTERS(F64, double)
+MAKE_SLICE_CONVERTERS(Bool, bool)
+MAKE_SLICE_CONVERTERS(Char, char32_t)
+MAKE_SLICE_CONVERTERS(String, char)
+MAKE_SLICE_CONVERTERS(String16, char16_t)
+
 template<typename T>
-using replace_ref_with_ptr_t = std::conditional_t<std::is_reference_v<T>, std::add_pointer_t<std::remove_reference_t<T>>, T>;
+using diplomat_c_span_convert_t = typename diplomat_c_span_convert<T>::type;
 
 /// Replace the argument types from the std::function with the argument types for th function pointer
 template<typename T>
-using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+using replace_fn_t = diplomat_c_span_convert_t<replace_string_view_t<as_ffi_t<T>>>;
 
 template <typename T> struct fn_traits;
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
@@ -305,6 +335,8 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
     static T replace(replace_fn_t<T> val) {
       if constexpr(std::is_same_v<T, std::string_view>)   {
           return std::string_view{val.data, val.len};
+      } else if constexpr (!std::is_same_v<T, diplomat_c_span_convert_t<T>>) {
+        return T{ val.data, val.len };
       } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
         if constexpr (std::is_lvalue_reference_v<T>) {
           return *std::remove_reference_t<T>::FromFFI(val);

--- a/feature_tests/cpp/tests/callback.cpp
+++ b/feature_tests/cpp/tests/callback.cpp
@@ -46,6 +46,14 @@ int main(int argc, char *argv[])
         simple_assert_eq("test_str_cb_arg output", out, 7);
     }
     {
+        std::vector<uint8_t> vector {1,2,3,4};
+
+        o.test_slice_cb_arg(diplomat::span<const uint8_t>(vector.data(), vector.size()), [](diplomat::span<const uint8_t> sp){
+            simple_assert_eq("test_cb_size", sp.size(), 4);
+            simple_assert_eq("test_cb_entry", sp.data()[3], 4);
+        });
+    }
+    {
         int copied = 0;
         // TODO: Make C++ reject this by using move_only_function in c++23.
         // We cannot reject this in earlier standards due to a defect in std::function.

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
@@ -11,6 +11,7 @@ internal interface CallbackWrapperLib: Library {
     fun CallbackWrapper_test_no_args(h: DiplomatCallback_CallbackWrapper_test_no_args_diplomatCallback_h_Native): Int
     fun CallbackWrapper_test_cb_with_struct(f: DiplomatCallback_CallbackWrapper_test_cb_with_struct_diplomatCallback_f_Native): Int
     fun CallbackWrapper_test_multiple_cb_args(f: DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f_Native, g: DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g_Native): Int
+    fun CallbackWrapper_test_slice_cb_arg(arg: Slice, f: DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f_Native): Unit
 }
 
 internal class CallbackWrapperNative: Structure(), Structure.ByValue {
@@ -269,6 +270,55 @@ internal class DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCa
         }
     }
 }
+internal interface Runner_DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f: Callback {
+    fun invoke(lang_specific_context: Pointer?, arg0: Slice ): Unit
+}
+
+internal class DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f_Native: Structure(), Structure.ByValue {
+    @JvmField
+    internal var data_: Pointer = Pointer(0L);
+    @JvmField
+    internal var run_callback: Runner_DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f
+        = object :  Runner_DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Slice ): Unit {
+                    throw Exception("Default callback runner -- should be replaced.")
+                }
+            }
+    @JvmField
+    internal var destructor: Callback = object : Callback {
+        fun invoke(obj_pointer: Pointer) {
+            DiplomatJVMRuntime.dropRustCookie(obj_pointer);
+        }
+    };
+
+    // Define the fields of the struct
+    override fun getFieldOrder(): List<String> {
+        return listOf("data_", "run_callback", "destructor")
+    }
+}
+
+internal class DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f internal constructor (
+    internal val nativeStruct: DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f_Native) {
+    val data_: Pointer = nativeStruct.data_
+    val run_callback: Callback = nativeStruct.run_callback
+    val destructor: Callback = nativeStruct.destructor
+
+    companion object {
+        val NATIVESIZE: Long = Native.getNativeSize(DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f_Native::class.java).toLong()
+
+        fun fromCallback(cb: (UByteArray)->Unit): DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f {
+            val callback: Runner_DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f = object :  Runner_DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f {
+                override fun invoke(lang_specific_context: Pointer?, arg0: Slice ): Unit {
+                    return cb(PrimitiveArrayTools.getUByteArray(arg0));
+                }
+            }
+            val cb_wrap = DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f_Native()
+            cb_wrap.run_callback = callback;
+            cb_wrap.data_ = DiplomatJVMRuntime.buildRustCookie(cb_wrap as Object);
+            return DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f(cb_wrap)
+        }
+    }
+}
 class CallbackWrapper internal constructor (
     internal val nativeStruct: CallbackWrapperNative) {
     val cantBeEmpty: Boolean = nativeStruct.cantBeEmpty > 0
@@ -304,6 +354,14 @@ class CallbackWrapper internal constructor (
             
             val returnVal = lib.CallbackWrapper_test_multiple_cb_args(DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_f.fromCallback(f).nativeStruct, DiplomatCallback_CallbackWrapper_test_multiple_cb_args_diplomatCallback_g.fromCallback(g).nativeStruct);
             return (returnVal)
+        }
+        @JvmStatic
+        
+        fun testSliceCbArg(arg: UByteArray, f: (UByteArray)->Unit): Unit {
+            val (argMem, argSlice) = PrimitiveArrayTools.borrow(arg)
+            
+            val returnVal = lib.CallbackWrapper_test_slice_cb_arg(argSlice, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f.fromCallback(f).nativeStruct);
+            
         }
     }
 

--- a/feature_tests/nanobind/src/include/CallbackWrapper.d.hpp
+++ b/feature_tests/nanobind/src/include/CallbackWrapper.d.hpp
@@ -42,6 +42,8 @@ struct CallbackWrapper {
 
   inline static void test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a);
 
+  inline static void test_slice_cb_arg(diplomat::span<const uint8_t> arg, std::function<void(diplomat::span<const uint8_t>)> f);
+
   inline diplomat::capi::CallbackWrapper AsFFI() const;
   inline static CallbackWrapper FromFFI(diplomat::capi::CallbackWrapper c_struct);
 };

--- a/feature_tests/nanobind/src/include/CallbackWrapper.hpp
+++ b/feature_tests/nanobind/src/include/CallbackWrapper.hpp
@@ -54,6 +54,11 @@ namespace capi {
         void (*run_callback)(const void*, diplomat::capi::MyString* );
         void (*destructor)(const void*);
     } DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb;
+    typedef struct DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f {
+        const void* data;
+        void (*run_callback)(const void*, diplomat::capi::DiplomatU8View );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f;
 
     int32_t CallbackWrapper_test_multi_arg_callback(DiplomatCallback_CallbackWrapper_test_multi_arg_callback_f f_cb_wrap, int32_t x);
 
@@ -66,6 +71,8 @@ namespace capi {
     int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_str_cb_arg_f f_cb_wrap);
 
     void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb cb_cb_wrap, diplomat::capi::MyString* a);
+
+    void CallbackWrapper_test_slice_cb_arg(diplomat::capi::DiplomatU8View arg, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f f_cb_wrap);
 
     } // extern "C"
 } // namespace capi
@@ -101,6 +108,11 @@ inline int32_t CallbackWrapper::test_str_cb_arg(std::function<int32_t(std::strin
 inline void CallbackWrapper::test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a) {
   diplomat::capi::CallbackWrapper_test_opaque_cb_arg({new decltype(cb)(std::move(cb)), diplomat::fn_traits(cb).c_run_callback, diplomat::fn_traits(cb).c_delete},
     a.AsFFI());
+}
+
+inline void CallbackWrapper::test_slice_cb_arg(diplomat::span<const uint8_t> arg, std::function<void(diplomat::span<const uint8_t>)> f) {
+  diplomat::capi::CallbackWrapper_test_slice_cb_arg({arg.data(), arg.size()},
+    {new decltype(f)(std::move(f)), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
 }
 
 

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -287,12 +287,42 @@ using as_ffi_t = typename as_ffi<T>::type;
 template<typename T>
 using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
 
+template<typename T, typename = void>
+struct diplomat_c_span_convert {
+  using type = T;
+};
+
+#define MAKE_SLICE_CONVERTERS(name, c_ty) \
+  template<typename T> \
+  struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<const c_ty>>>> { \
+    using type = diplomat::capi::Diplomat##name##View; \
+  }; \
+  template<typename T> \
+  struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<c_ty>>>> { \
+    using type = diplomat::capi::Diplomat##name##ViewMut; \
+  }; \
+
+MAKE_SLICE_CONVERTERS(I8, int8_t)
+MAKE_SLICE_CONVERTERS(U8, uint8_t)
+MAKE_SLICE_CONVERTERS(I16, int16_t)
+MAKE_SLICE_CONVERTERS(U16, uint16_t)
+MAKE_SLICE_CONVERTERS(I32, int32_t)
+MAKE_SLICE_CONVERTERS(U32, uint32_t)
+MAKE_SLICE_CONVERTERS(I64, int64_t)
+MAKE_SLICE_CONVERTERS(U64, uint64_t)
+MAKE_SLICE_CONVERTERS(F32, float)
+MAKE_SLICE_CONVERTERS(F64, double)
+MAKE_SLICE_CONVERTERS(Bool, bool)
+MAKE_SLICE_CONVERTERS(Char, char32_t)
+MAKE_SLICE_CONVERTERS(String, char)
+MAKE_SLICE_CONVERTERS(String16, char16_t)
+
 template<typename T>
-using replace_ref_with_ptr_t = std::conditional_t<std::is_reference_v<T>, std::add_pointer_t<std::remove_reference_t<T>>, T>;
+using diplomat_c_span_convert_t = typename diplomat_c_span_convert<T>::type;
 
 /// Replace the argument types from the std::function with the argument types for th function pointer
 template<typename T>
-using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+using replace_fn_t = diplomat_c_span_convert_t<replace_string_view_t<as_ffi_t<T>>>;
 
 template <typename T> struct fn_traits;
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
@@ -305,6 +335,8 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
     static T replace(replace_fn_t<T> val) {
       if constexpr(std::is_same_v<T, std::string_view>)   {
           return std::string_view{val.data, val.len};
+      } else if constexpr (!std::is_same_v<T, diplomat_c_span_convert_t<T>>) {
+        return T{ val.data, val.len };
       } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
         if constexpr (std::is_lvalue_reference_v<T>) {
           return *std::remove_reference_t<T>::FromFFI(val);

--- a/feature_tests/nanobind/src/sub_modules/CallbackWrapper_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/CallbackWrapper_binding.cpp
@@ -14,6 +14,7 @@ void add_CallbackWrapper_binding(nb::handle mod) {
     	.def_static("test_multiple_cb_args", &CallbackWrapper::test_multiple_cb_args, "f"_a, "g"_a)
     	.def_static("test_no_args", &CallbackWrapper::test_no_args, "h"_a)
     	.def_static("test_opaque_cb_arg", &CallbackWrapper::test_opaque_cb_arg, "cb"_a, "a"_a)
+    	.def_static("test_slice_cb_arg", &CallbackWrapper::test_slice_cb_arg, "arg"_a, "f"_a)
     	.def_static("test_str_cb_arg", &CallbackWrapper::test_str_cb_arg, "f"_a);
 }
 

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -36,6 +36,10 @@ mod ffi {
         pub fn test_opaque_cb_arg<'a>(cb: impl Fn(&mut MyString), a: &'a mut MyString) {
             cb(a);
         }
+
+        pub fn test_slice_cb_arg(arg: &[u8], f: impl Fn(&[u8])) {
+            f(arg);
+        }
     }
 
     #[diplomat::attr(not(supports = "callbacks"), disable)]

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -233,12 +233,42 @@ using as_ffi_t = typename as_ffi<T>::type;
 template<typename T>
 using replace_string_view_t = std::conditional_t<std::is_same_v<T, std::string_view>, capi::DiplomatStringView, T>;
 
+template<typename T, typename = void>
+struct diplomat_c_span_convert {
+  using type = T;
+};
+
+#define MAKE_SLICE_CONVERTERS(name, c_ty) \
+  template<typename T> \
+  struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<const c_ty>>>> { \
+    using type = diplomat::capi::Diplomat##name##View; \
+  }; \
+  template<typename T> \
+  struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<c_ty>>>> { \
+    using type = diplomat::capi::Diplomat##name##ViewMut; \
+  }; \
+
+MAKE_SLICE_CONVERTERS(I8, int8_t)
+MAKE_SLICE_CONVERTERS(U8, uint8_t)
+MAKE_SLICE_CONVERTERS(I16, int16_t)
+MAKE_SLICE_CONVERTERS(U16, uint16_t)
+MAKE_SLICE_CONVERTERS(I32, int32_t)
+MAKE_SLICE_CONVERTERS(U32, uint32_t)
+MAKE_SLICE_CONVERTERS(I64, int64_t)
+MAKE_SLICE_CONVERTERS(U64, uint64_t)
+MAKE_SLICE_CONVERTERS(F32, float)
+MAKE_SLICE_CONVERTERS(F64, double)
+MAKE_SLICE_CONVERTERS(Bool, bool)
+MAKE_SLICE_CONVERTERS(Char, char32_t)
+MAKE_SLICE_CONVERTERS(String, char)
+MAKE_SLICE_CONVERTERS(String16, char16_t)
+
 template<typename T>
-using replace_ref_with_ptr_t = std::conditional_t<std::is_reference_v<T>, std::add_pointer_t<std::remove_reference_t<T>>, T>;
+using diplomat_c_span_convert_t = typename diplomat_c_span_convert<T>::type;
 
 /// Replace the argument types from the std::function with the argument types for th function pointer
 template<typename T>
-using replace_fn_t = replace_string_view_t<as_ffi_t<T>>;
+using replace_fn_t = diplomat_c_span_convert_t<replace_string_view_t<as_ffi_t<T>>>;
 
 template <typename T> struct fn_traits;
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
@@ -251,6 +281,8 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
     static T replace(replace_fn_t<T> val) {
       if constexpr(std::is_same_v<T, std::string_view>)   {
           return std::string_view{val.data, val.len};
+      } else if constexpr (!std::is_same_v<T, diplomat_c_span_convert_t<T>>) {
+        return T{ val.data, val.len };
       } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
         if constexpr (std::is_lvalue_reference_v<T>) {
           return *std::remove_reference_t<T>::FromFFI(val);


### PR DESCRIPTION
C++ bindings for callbacks would fail due to the lack of conversion between `span<T>` and the CFFI safe Diplomat*View types.
This adds support for that conversion & tests it.
