### PR TITLE
Nanobind: Keep Owned Non-Self References Alive

### DIFF
--- a/feature_tests/c/include/OpaqueThin.h
+++ b/feature_tests/c/include/OpaqueThin.h
@@ -19,6 +19,8 @@ int32_t OpaqueThin_a(const OpaqueThin* self);
 
 float OpaqueThin_b(const OpaqueThin* self);
 
+void OpaqueThin_c(const OpaqueThin* self, DiplomatWrite* write);
+
 void OpaqueThin_destroy(OpaqueThin* self);
 
 

--- a/feature_tests/c/include/OpaqueThinVec.h
+++ b/feature_tests/c/include/OpaqueThinVec.h
@@ -17,7 +17,7 @@
 
 
 
-OpaqueThinVec* OpaqueThinVec_create(DiplomatI32View a, DiplomatF32View b);
+OpaqueThinVec* OpaqueThinVec_create(DiplomatI32View a, DiplomatF32View b, DiplomatStringView c);
 
 OpaqueThinIter* OpaqueThinVec_iter(const OpaqueThinVec* self);
 

--- a/feature_tests/cpp/include/OpaqueThin.d.hpp
+++ b/feature_tests/cpp/include/OpaqueThin.d.hpp
@@ -25,6 +25,10 @@ public:
 
   inline float b() const;
 
+  inline std::string c() const;
+  template<typename W>
+  inline void c_write(W& writeable_output) const;
+
   inline const diplomat::capi::OpaqueThin* AsFFI() const;
   inline diplomat::capi::OpaqueThin* AsFFI();
   inline static const OpaqueThin* FromFFI(const diplomat::capi::OpaqueThin* ptr);

--- a/feature_tests/cpp/include/OpaqueThin.hpp
+++ b/feature_tests/cpp/include/OpaqueThin.hpp
@@ -22,6 +22,8 @@ namespace capi {
 
     float OpaqueThin_b(const diplomat::capi::OpaqueThin* self);
 
+    void OpaqueThin_c(const diplomat::capi::OpaqueThin* self, diplomat::capi::DiplomatWrite* write);
+
     void OpaqueThin_destroy(OpaqueThin* self);
 
     } // extern "C"
@@ -36,6 +38,20 @@ inline int32_t OpaqueThin::a() const {
 inline float OpaqueThin::b() const {
   auto result = diplomat::capi::OpaqueThin_b(this->AsFFI());
   return result;
+}
+
+inline std::string OpaqueThin::c() const {
+  std::string output;
+  diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  diplomat::capi::OpaqueThin_c(this->AsFFI(),
+    &write);
+  return output;
+}
+template<typename W>
+inline void OpaqueThin::c_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::OpaqueThin_c(this->AsFFI(),
+    &write);
 }
 
 inline const diplomat::capi::OpaqueThin* OpaqueThin::AsFFI() const {

--- a/feature_tests/cpp/include/OpaqueThinVec.d.hpp
+++ b/feature_tests/cpp/include/OpaqueThinVec.d.hpp
@@ -26,7 +26,7 @@ namespace capi {
 class OpaqueThinVec {
 public:
 
-  inline static std::unique_ptr<OpaqueThinVec> create(diplomat::span<const int32_t> a, diplomat::span<const float> b);
+  inline static std::unique_ptr<OpaqueThinVec> create(diplomat::span<const int32_t> a, diplomat::span<const float> b, std::string_view c);
 
   inline std::unique_ptr<OpaqueThinIter> iter() const;
   inline diplomat::next_to_iter_helper<OpaqueThinIter> begin() const;

--- a/feature_tests/cpp/include/OpaqueThinVec.hpp
+++ b/feature_tests/cpp/include/OpaqueThinVec.hpp
@@ -20,7 +20,7 @@ namespace diplomat {
 namespace capi {
     extern "C" {
 
-    diplomat::capi::OpaqueThinVec* OpaqueThinVec_create(diplomat::capi::DiplomatI32View a, diplomat::capi::DiplomatF32View b);
+    diplomat::capi::OpaqueThinVec* OpaqueThinVec_create(diplomat::capi::DiplomatI32View a, diplomat::capi::DiplomatF32View b, diplomat::capi::DiplomatStringView c);
 
     diplomat::capi::OpaqueThinIter* OpaqueThinVec_iter(const diplomat::capi::OpaqueThinVec* self);
 
@@ -36,9 +36,10 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<OpaqueThinVec> OpaqueThinVec::create(diplomat::span<const int32_t> a, diplomat::span<const float> b) {
+inline std::unique_ptr<OpaqueThinVec> OpaqueThinVec::create(diplomat::span<const int32_t> a, diplomat::span<const float> b, std::string_view c) {
   auto result = diplomat::capi::OpaqueThinVec_create({a.data(), a.size()},
-    {b.data(), b.size()});
+    {b.data(), b.size()},
+    {c.data(), c.size()});
   return std::unique_ptr<OpaqueThinVec>(OpaqueThinVec::FromFFI(result));
 }
 

--- a/feature_tests/dart/lib/src/OpaqueThin.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueThin.g.dart
@@ -33,6 +33,12 @@ final class OpaqueThin implements ffi.Finalizable {
     return result;
   }
 
+  String get c {
+    final write = _Write();
+    _OpaqueThin_c(_ffi, write._ffi);
+    return write.finalize();
+  }
+
 }
 
 @_DiplomatFfiUse('OpaqueThin_destroy')
@@ -49,5 +55,10 @@ external int _OpaqueThin_a(ffi.Pointer<ffi.Opaque> self);
 @ffi.Native<ffi.Float Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueThin_b')
 // ignore: non_constant_identifier_names
 external double _OpaqueThin_b(ffi.Pointer<ffi.Opaque> self);
+
+@_DiplomatFfiUse('OpaqueThin_c')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueThin_c')
+// ignore: non_constant_identifier_names
+external void _OpaqueThin_c(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
 // dart format on

--- a/feature_tests/dart/lib/src/OpaqueThinVec.g.dart
+++ b/feature_tests/dart/lib/src/OpaqueThinVec.g.dart
@@ -23,9 +23,9 @@ final class OpaqueThinVec with core.Iterable<OpaqueThin> implements ffi.Finaliza
   @_DiplomatFfiUse('OpaqueThinVec_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_OpaqueThinVec_destroy));
 
-  factory OpaqueThinVec(core.List<int> a, core.List<double> b) {
+  factory OpaqueThinVec(core.List<int> a, core.List<double> b, String c) {
     final temp = _FinalizedArena();
-    final result = _OpaqueThinVec_create(a._int32AllocIn(temp.arena), b._float32AllocIn(temp.arena));
+    final result = _OpaqueThinVec_create(a._int32AllocIn(temp.arena), b._float32AllocIn(temp.arena), c._utf8AllocIn(temp.arena));
     return OpaqueThinVec._fromFfi(result, []);
   }
 
@@ -63,9 +63,9 @@ final class OpaqueThinVec with core.Iterable<OpaqueThin> implements ffi.Finaliza
 external void _OpaqueThinVec_destroy(ffi.Pointer<ffi.Void> self);
 
 @_DiplomatFfiUse('OpaqueThinVec_create')
-@ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceInt32, _SliceFloat)>(isLeaf: true, symbol: 'OpaqueThinVec_create')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceInt32, _SliceFloat, _SliceUtf8)>(isLeaf: true, symbol: 'OpaqueThinVec_create')
 // ignore: non_constant_identifier_names
-external ffi.Pointer<ffi.Opaque> _OpaqueThinVec_create(_SliceInt32 a, _SliceFloat b);
+external ffi.Pointer<ffi.Opaque> _OpaqueThinVec_create(_SliceInt32 a, _SliceFloat b, _SliceUtf8 c);
 
 @_DiplomatFfiUse('OpaqueThinVec_iter')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'OpaqueThinVec_iter')

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -278,10 +278,10 @@ let termini = Object.assign({
     },
 
     "OpaqueThinVec.len": {
-        func: (selfA, selfB) => new somelib.OpaqueThinVec(selfA, selfB).len(),
+        func: (selfA, selfB, selfC) => new somelib.OpaqueThinVec(selfA, selfB, selfC).len(),
         // For avoiding webpacking minifying issues:
         funcName: "OpaqueThinVec.len",
-        expr: (selfA, selfB) => "new somelib.OpaqueThinVec(selfA, selfB).len()".replace(/([\( ])selfA([,\) \n])/, '$1' + selfA + '$2').replace(/([\( ])selfB([,\) \n])/, '$1' + selfB + '$2'),
+        expr: (selfA, selfB, selfC) => "new somelib.OpaqueThinVec(selfA, selfB, selfC).len()".replace(/([\( ])selfA([,\) \n])/, '$1' + selfA + '$2').replace(/([\( ])selfB([,\) \n])/, '$1' + selfB + '$2').replace(/([\( ])selfC([,\) \n])/, '$1' + selfC + '$2'),
         parameters: [
             
             {
@@ -294,6 +294,12 @@ let termini = Object.assign({
                 name: "self_b",
                 type: "Array<number>",
                 typeUse: "Array<number>"
+            },
+            
+            {
+                name: "self_c",
+                type: "string",
+                typeUse: "string"
             }
             
         ]

--- a/feature_tests/js/api/OpaqueThin.d.ts
+++ b/feature_tests/js/api/OpaqueThin.d.ts
@@ -13,4 +13,6 @@ export class OpaqueThin {
     get a(): number;
 
     get b(): number;
+
+    get c(): string;
 }

--- a/feature_tests/js/api/OpaqueThin.mjs
+++ b/feature_tests/js/api/OpaqueThin.mjs
@@ -59,6 +59,20 @@ export class OpaqueThin {
         }
     }
 
+    get c() {
+        const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
+
+    wasm.OpaqueThin_c(this.ffiValue, write.buffer);
+
+        try {
+            return write.readString8();
+        }
+
+        finally {
+            write.free();
+        }
+    }
+
     constructor(symbol, ptr, selfEdge) {
         return this.#internalConstructor(...arguments)
     }

--- a/feature_tests/js/api/OpaqueThinVec.d.ts
+++ b/feature_tests/js/api/OpaqueThinVec.d.ts
@@ -18,5 +18,5 @@ export class OpaqueThinVec {
 
     get first(): OpaqueThin | null;
 
-    constructor(a: Array<number>, b: Array<number>);
+    constructor(a: Array<number>, b: Array<number>, c: string);
 }

--- a/feature_tests/js/api/OpaqueThinVec.mjs
+++ b/feature_tests/js/api/OpaqueThinVec.mjs
@@ -37,13 +37,14 @@ export class OpaqueThinVec {
     }
 
 
-    #defaultConstructor(a, b) {
+    #defaultConstructor(a, b, c) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const aSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.slice(wasm, a, "i32")));
         const bSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.slice(wasm, b, "f32")));
+        const cSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, c)));
 
-        const result = wasm.OpaqueThinVec_create(aSlice.ptr, bSlice.ptr);
+        const result = wasm.OpaqueThinVec_create(aSlice.ptr, bSlice.ptr, cSlice.ptr);
 
         try {
             return new OpaqueThinVec(diplomatRuntime.internalConstructor, result, []);
@@ -112,7 +113,7 @@ export class OpaqueThinVec {
         }
     }
 
-    constructor(a, b) {
+    constructor(a, b, c) {
         if (arguments[0] === diplomatRuntime.exposeConstructor) {
             return this.#internalConstructor(...Array.prototype.slice.call(arguments, 1));
         } else if (arguments[0] === diplomatRuntime.internalConstructor) {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueThin.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueThin.kt
@@ -9,6 +9,7 @@ internal interface OpaqueThinLib: Library {
     fun OpaqueThin_destroy(handle: Pointer)
     fun OpaqueThin_a(handle: Pointer): Int
     fun OpaqueThin_b(handle: Pointer): Float
+    fun OpaqueThin_c(handle: Pointer, write: Pointer): Unit
 }
 
 class OpaqueThin internal constructor (
@@ -39,6 +40,14 @@ class OpaqueThin internal constructor (
         
         val returnVal = lib.OpaqueThin_b(handle);
         return (returnVal)
+    }
+    
+    fun c(): String {
+        val write = DW.lib.diplomat_buffer_write_create(0)
+        val returnVal = lib.OpaqueThin_c(handle, write);
+        
+        val returnString = DW.writeToString(write)
+        return returnString
     }
 
 }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueThinVec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueThinVec.kt
@@ -7,7 +7,7 @@ import com.sun.jna.Structure
 
 internal interface OpaqueThinVecLib: Library {
     fun OpaqueThinVec_destroy(handle: Pointer)
-    fun OpaqueThinVec_create(a: Slice, b: Slice): Pointer
+    fun OpaqueThinVec_create(a: Slice, b: Slice, c: Slice): Pointer
     fun OpaqueThinVec_iter(handle: Pointer): Pointer
     fun OpaqueThinVec_len(handle: Pointer): FFISizet
     fun OpaqueThinVec_get(handle: Pointer, idx: FFISizet): Pointer?
@@ -32,17 +32,19 @@ class OpaqueThinVec internal constructor (
         internal val lib: OpaqueThinVecLib = Native.load("somelib", libClass)
         @JvmStatic
         
-        fun create(a: IntArray, b: FloatArray): OpaqueThinVec {
+        fun create(a: IntArray, b: FloatArray, c: String): OpaqueThinVec {
             val (aMem, aSlice) = PrimitiveArrayTools.borrow(a)
             val (bMem, bSlice) = PrimitiveArrayTools.borrow(b)
+            val (cMem, cSlice) = PrimitiveArrayTools.borrowUtf8(c)
             
-            val returnVal = lib.OpaqueThinVec_create(aSlice, bSlice);
+            val returnVal = lib.OpaqueThinVec_create(aSlice, bSlice, cSlice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = OpaqueThinVec(handle, selfEdges)
             CLEANER.register(returnOpaque, OpaqueThinVec.OpaqueThinVecCleaner(handle, OpaqueThinVec.lib));
             if (aMem != null) aMem.close()
             if (bMem != null) bMem.close()
+            if (cMem != null) cMem.close()
             return returnOpaque
         }
     }

--- a/feature_tests/nanobind/src/include/OpaqueThin.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThin.d.hpp
@@ -25,6 +25,10 @@ public:
 
   inline float b() const;
 
+  inline std::string c() const;
+  template<typename W>
+  inline void c_write(W& writeable_output) const;
+
   inline const diplomat::capi::OpaqueThin* AsFFI() const;
   inline diplomat::capi::OpaqueThin* AsFFI();
   inline static const OpaqueThin* FromFFI(const diplomat::capi::OpaqueThin* ptr);

--- a/feature_tests/nanobind/src/include/OpaqueThin.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThin.hpp
@@ -22,6 +22,8 @@ namespace capi {
 
     float OpaqueThin_b(const diplomat::capi::OpaqueThin* self);
 
+    void OpaqueThin_c(const diplomat::capi::OpaqueThin* self, diplomat::capi::DiplomatWrite* write);
+
     void OpaqueThin_destroy(OpaqueThin* self);
 
     } // extern "C"
@@ -36,6 +38,20 @@ inline int32_t OpaqueThin::a() const {
 inline float OpaqueThin::b() const {
   auto result = diplomat::capi::OpaqueThin_b(this->AsFFI());
   return result;
+}
+
+inline std::string OpaqueThin::c() const {
+  std::string output;
+  diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
+  diplomat::capi::OpaqueThin_c(this->AsFFI(),
+    &write);
+  return output;
+}
+template<typename W>
+inline void OpaqueThin::c_write(W& writeable) const {
+  diplomat::capi::DiplomatWrite write = diplomat::WriteTrait<W>::Construct(writeable);
+  diplomat::capi::OpaqueThin_c(this->AsFFI(),
+    &write);
 }
 
 inline const diplomat::capi::OpaqueThin* OpaqueThin::AsFFI() const {

--- a/feature_tests/nanobind/src/include/OpaqueThinVec.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinVec.d.hpp
@@ -26,7 +26,7 @@ namespace capi {
 class OpaqueThinVec {
 public:
 
-  inline static std::unique_ptr<OpaqueThinVec> create(diplomat::span<const int32_t> a, diplomat::span<const float> b);
+  inline static std::unique_ptr<OpaqueThinVec> create(diplomat::span<const int32_t> a, diplomat::span<const float> b, std::string_view c);
 
   inline std::unique_ptr<OpaqueThinIter> iter() const;
   inline diplomat::next_to_iter_helper<OpaqueThinIter> begin() const;

--- a/feature_tests/nanobind/src/include/OpaqueThinVec.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinVec.hpp
@@ -20,7 +20,7 @@ namespace diplomat {
 namespace capi {
     extern "C" {
 
-    diplomat::capi::OpaqueThinVec* OpaqueThinVec_create(diplomat::capi::DiplomatI32View a, diplomat::capi::DiplomatF32View b);
+    diplomat::capi::OpaqueThinVec* OpaqueThinVec_create(diplomat::capi::DiplomatI32View a, diplomat::capi::DiplomatF32View b, diplomat::capi::DiplomatStringView c);
 
     diplomat::capi::OpaqueThinIter* OpaqueThinVec_iter(const diplomat::capi::OpaqueThinVec* self);
 
@@ -36,9 +36,10 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<OpaqueThinVec> OpaqueThinVec::create(diplomat::span<const int32_t> a, diplomat::span<const float> b) {
+inline std::unique_ptr<OpaqueThinVec> OpaqueThinVec::create(diplomat::span<const int32_t> a, diplomat::span<const float> b, std::string_view c) {
   auto result = diplomat::capi::OpaqueThinVec_create({a.data(), a.size()},
-    {b.data(), b.size()});
+    {b.data(), b.size()},
+    {c.data(), c.size()});
   return std::unique_ptr<OpaqueThinVec>(OpaqueThinVec::FromFFI(result));
 }
 

--- a/feature_tests/nanobind/src/sub_modules/OpaqueMutexedString_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OpaqueMutexedString_binding.cpp
@@ -11,9 +11,9 @@ void add_OpaqueMutexedString_binding(nb::handle mod) {
         {0, nullptr}};
     
     nb::class_<OpaqueMutexedString>(mod, "OpaqueMutexedString", nb::type_slots(OpaqueMutexedString_slots))
-    	.def("borrow", &OpaqueMutexedString::borrow, nb::rv_policy::reference)
+    	.def("borrow", &OpaqueMutexedString::borrow, nb::rv_policy::reference_internal)
     	.def_static("borrow_other", &OpaqueMutexedString::borrow_other, "other"_a, nb::rv_policy::reference)
-    	.def("borrow_self_or_other", &OpaqueMutexedString::borrow_self_or_other, "other"_a, nb::rv_policy::reference)
+    	.def("borrow_self_or_other", &OpaqueMutexedString::borrow_self_or_other, "other"_a, nb::rv_policy::reference_internal)
     	.def("change", &OpaqueMutexedString::change, "number"_a)
     	.def("dummy_str", &OpaqueMutexedString::dummy_str)
     	.def_static("from_usize", &OpaqueMutexedString::from_usize, "number"_a)

--- a/feature_tests/nanobind/src/sub_modules/OpaqueThinIter_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OpaqueThinIter_binding.cpp
@@ -17,7 +17,7 @@ void add_OpaqueThinIter_binding(nb::handle mod) {
     				throw nb::stop_iteration();
     			}
     			return next_inner_extractor<decltype(next)>::get(std::move(next));
-    		}, nb::keep_alive<0, 1>(), nb::rv_policy::reference)
+    		}, nb::keep_alive<0, 1>(), nb::rv_policy::reference_internal)
     		.def("__iter__", [](nb::handle self) { return self; });
 }
 

--- a/feature_tests/nanobind/src/sub_modules/OpaqueThinVec_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OpaqueThinVec_binding.cpp
@@ -12,7 +12,7 @@ void add_OpaqueThinVec_binding(nb::handle mod) {
     
     nb::class_<OpaqueThinVec>(mod, "OpaqueThinVec", nb::type_slots(OpaqueThinVec_slots))
     	.def("__len__", &OpaqueThinVec::__len__)
-    	.def(nb::new_(&OpaqueThinVec::create), "a"_a, "b"_a)
+    	.def(nb::new_(&OpaqueThinVec::create), "a"_a, "b"_a, "c"_a)
     	.def_prop_ro("first", &OpaqueThinVec::first)
     	.def("__getitem__", &OpaqueThinVec::operator[], "idx"_a, nb::rv_policy::reference)
     	.def("__iter__", &OpaqueThinVec::iter, nb::keep_alive<0, 1>());

--- a/feature_tests/nanobind/src/sub_modules/OpaqueThinVec_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OpaqueThinVec_binding.cpp
@@ -14,7 +14,7 @@ void add_OpaqueThinVec_binding(nb::handle mod) {
     	.def("__len__", &OpaqueThinVec::__len__)
     	.def(nb::new_(&OpaqueThinVec::create), "a"_a, "b"_a, "c"_a)
     	.def_prop_ro("first", &OpaqueThinVec::first)
-    	.def("__getitem__", &OpaqueThinVec::operator[], "idx"_a, nb::rv_policy::reference)
+    	.def("__getitem__", &OpaqueThinVec::operator[], "idx"_a, nb::rv_policy::reference_internal)
     	.def("__iter__", &OpaqueThinVec::iter, nb::keep_alive<0, 1>());
 }
 

--- a/feature_tests/nanobind/src/sub_modules/OpaqueThin_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OpaqueThin_binding.cpp
@@ -12,6 +12,7 @@ void add_OpaqueThin_binding(nb::handle mod) {
     
     nb::class_<OpaqueThin>(mod, "OpaqueThin", nb::type_slots(OpaqueThin_slots))
     	.def_prop_ro("a", &OpaqueThin::a)
-    	.def_prop_ro("b", &OpaqueThin::b);
+    	.def_prop_ro("b", &OpaqueThin::b)
+    	.def_prop_ro("c", &OpaqueThin::c);
 }
 

--- a/feature_tests/nanobind/src/sub_modules/OptionOpaque_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OptionOpaque_binding.cpp
@@ -28,8 +28,8 @@ void add_OptionOpaque_binding(nb::handle mod) {
     	.def("option_u32", &OptionOpaque::option_u32)
     	.def("option_usize", &OptionOpaque::option_usize)
     	.def_static("returns", &OptionOpaque::returns)
-    	.def("returns_none_self", &OptionOpaque::returns_none_self, nb::rv_policy::reference)
+    	.def("returns_none_self", &OptionOpaque::returns_none_self, nb::rv_policy::reference_internal)
     	.def_static("returns_option_input_struct", &OptionOpaque::returns_option_input_struct)
-    	.def("returns_some_self", &OptionOpaque::returns_some_self, nb::rv_policy::reference);
+    	.def("returns_some_self", &OptionOpaque::returns_some_self, nb::rv_policy::reference_internal);
 }
 

--- a/feature_tests/nanobind/src/sub_modules/ResultOpaque_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/ResultOpaque_binding.cpp
@@ -20,6 +20,6 @@ void add_ResultOpaque_binding(nb::handle mod) {
     	.def_static("new_in_enum_err", &ResultOpaque::new_in_enum_err, "i"_a)
     	.def_static("new_in_err", &ResultOpaque::new_in_err, "i"_a)
     	.def_static("new_int", &ResultOpaque::new_int, "i"_a)
-    	.def("takes_str", &ResultOpaque::takes_str, "_v"_a, nb::rv_policy::reference);
+    	.def("takes_str", &ResultOpaque::takes_str, "_v"_a, nb::rv_policy::reference_internal);
 }
 

--- a/feature_tests/nanobind/test/test_lifetimes.py
+++ b/feature_tests/nanobind/test/test_lifetimes.py
@@ -31,7 +31,8 @@ def test_fill_lifetimes():
     c = f[0]
     gc.collect()
     
-    # Not sure why this works, but this fools the GC into collecting the inner data for f above (even though we still need a reference):
+    # Not sure why this works, but this fools the GC into collecting the inner data for f above (even though we still need a reference).
+    # We need to check against a string since that takes up more memory than the other fields.
     for i in range(0, 10000):
         f = somelib.OpaqueThinVec([120, 2], [.1, .2], "This is adifferent test")
     gc.collect()

--- a/feature_tests/nanobind/test/test_lifetimes.py
+++ b/feature_tests/nanobind/test/test_lifetimes.py
@@ -11,7 +11,7 @@ def test_lifetimes():
 
     assert a.as_returning().bytes == "fananna"
 
-    it = somelib.OpaqueThinVec([1,2,3,4], [.1, .2, .3, .4])
+    it = somelib.OpaqueThinVec([1,2,3,4], [.1, .2, .3, .4], "")
     for i, o in enumerate(it):
         assert o.a == i+1, "Iteraton over thin vec didn't work"
 
@@ -24,3 +24,16 @@ def test_lifetimes():
     
     del a
     assert b.a == 1
+
+def test_fill_lifetimes():
+    
+    f = somelib.OpaqueThinVec([120, 2], [.1, .2], "This is a test")
+    c = f[0]
+    gc.collect()
+    
+    # Not sure why this works, but this fools the GC into collecting the inner data for f above (even though we still need a reference):
+    for i in range(0, 10000):
+        f = somelib.OpaqueThinVec([120, 2], [.1, .2], "This is adifferent test")
+    gc.collect()
+
+    assert c.c == "This is a test"

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -314,7 +314,7 @@ pub mod ffi {
         }
 
         #[diplomat::attr(auto, getter)]
-        pub fn c(&self, w : &mut DiplomatWrite) {
+        pub fn c(&self, w: &mut DiplomatWrite) {
             w.write_str(&self.0.c).unwrap();
         }
     }
@@ -334,12 +334,16 @@ pub mod ffi {
 
     impl OpaqueThinVec {
         #[diplomat::attr(auto, constructor)]
-        pub fn create(a: &[i32], b: &[f32], c: &DiplomatStr ) -> Box<Self> {
+        pub fn create(a: &[i32], b: &[f32], c: &DiplomatStr) -> Box<Self> {
             assert!(a.len() == b.len(), "arrays must be of equal size");
             Box::new(Self(
                 a.iter()
                     .zip(b.iter())
-                    .map(|(a, b)| crate::lifetimes::Internal { a: *a, b: *b, c: String::from_utf8(c.to_vec()).unwrap() })
+                    .map(|(a, b)| crate::lifetimes::Internal {
+                        a: *a,
+                        b: *b,
+                        c: String::from_utf8(c.to_vec()).unwrap(),
+                    })
                     .collect(),
             ))
         }

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -1,5 +1,7 @@
 #[diplomat::bridge]
 pub mod ffi {
+    use std::fmt::Write;
+
     use diplomat_runtime::DiplomatStr16;
 
     #[diplomat::opaque]
@@ -310,6 +312,11 @@ pub mod ffi {
         pub fn b(&self) -> f32 {
             self.0.b
         }
+
+        #[diplomat::attr(auto, getter)]
+        pub fn c(&self, w : &mut DiplomatWrite) {
+            w.write_str(&self.0.c).unwrap();
+        }
     }
 
     #[diplomat::opaque]
@@ -327,12 +334,12 @@ pub mod ffi {
 
     impl OpaqueThinVec {
         #[diplomat::attr(auto, constructor)]
-        pub fn create(a: &[i32], b: &[f32]) -> Box<Self> {
+        pub fn create(a: &[i32], b: &[f32], c: &DiplomatStr ) -> Box<Self> {
             assert!(a.len() == b.len(), "arrays must be of equal size");
             Box::new(Self(
                 a.iter()
                     .zip(b.iter())
-                    .map(|(a, b)| crate::lifetimes::Internal { a: *a, b: *b })
+                    .map(|(a, b)| crate::lifetimes::Internal { a: *a, b: *b, c: String::from_utf8(c.to_vec()).unwrap() })
                     .collect(),
             ))
         }
@@ -371,4 +378,5 @@ pub struct Two<'a, 'b>(&'a (), &'b ());
 pub struct Internal {
     a: i32,
     b: f32,
+    c: String,
 }

--- a/tool/src/nanobind/ty.rs
+++ b/tool/src/nanobind/ty.rs
@@ -352,7 +352,10 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
         // Collect all the relevant borrowed params, with self in position 1 if present
         let mut param_borrows = Vec::new();
 
-        let self_borrow = method.param_self.as_ref().map(|s| visitor.visit_param(&s.ty.clone().into(), "self"));
+        let self_borrow = method
+            .param_self
+            .as_ref()
+            .map(|s| visitor.visit_param(&s.ty.clone().into(), "self"));
 
         if let Some(b) = self_borrow.as_ref() {
             param_borrows.push(b.clone());

--- a/tool/src/nanobind/ty.rs
+++ b/tool/src/nanobind/ty.rs
@@ -352,11 +352,7 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
         // Collect all the relevant borrowed params, with self in position 1 if present
         let mut param_borrows = Vec::new();
 
-        let self_borrow = if let Some(s) = &method.param_self {
-            Some(visitor.visit_param(&s.ty.clone().into(), "self"))
-        } else {
-            None
-        };
+        let self_borrow = method.param_self.as_ref().map(|s| visitor.visit_param(&s.ty.clone().into(), "self"));
 
         if let Some(b) = self_borrow.as_ref() {
             param_borrows.push(b.clone());

--- a/tool/src/nanobind/ty.rs
+++ b/tool/src/nanobind/ty.rs
@@ -349,10 +349,9 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
 
         let mut visitor = method.borrowing_param_visitor(self.c2.tcx, false);
 
-
         // Collect all the relevant borrowed params, with self in position 1 if present
         let mut param_borrows = Vec::new();
-        
+
         let self_borrow = if let Some(s) = &method.param_self {
             Some(visitor.visit_param(&s.ty.clone().into(), "self"))
         } else {
@@ -421,8 +420,10 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
             //  Because `rv_policy` is only applied to unknown types (i.e., newly created references), then we can apply `reference_internal` to any of the cases above, without worrying about unnecessarily increasing the reference count for when we return `self` (since `self` is an already known type to Nanobind).
             let str = match self_borrow.as_ref() {
                 // For non-borrowed &self however, we can just return a standard reference that has no attachment to &self:
-                Some(hir::borrowing_param::ParamBorrowInfo::NotBorrowed) | None => "nb::rv_policy::reference",
-                _ => "nb::rv_policy::reference_internal"
+                Some(hir::borrowing_param::ParamBorrowInfo::NotBorrowed) | None => {
+                    "nb::rv_policy::reference"
+                }
+                _ => "nb::rv_policy::reference_internal",
             };
             lifetime_args.push(str.to_owned());
         }

--- a/tool/src/nanobind/ty.rs
+++ b/tool/src/nanobind/ty.rs
@@ -349,12 +349,20 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
 
         let mut visitor = method.borrowing_param_visitor(self.c2.tcx, false);
 
+
         // Collect all the relevant borrowed params, with self in position 1 if present
-        let mut param_borrows = method
-            .param_self
-            .iter()
-            .map(|s| visitor.visit_param(&s.ty.clone().into(), "self"))
-            .collect::<Vec<_>>();
+        let mut param_borrows = Vec::new();
+        
+        let self_borrow = if let Some(s) = &method.param_self {
+            Some(visitor.visit_param(&s.ty.clone().into(), "self"))
+        } else {
+            None
+        };
+
+        if let Some(b) = self_borrow.as_ref() {
+            param_borrows.push(b.clone());
+        };
+
         // Must be a separate call *after* collect to avoid double-borrowing visitor
         param_borrows.extend(
             method
@@ -376,7 +384,7 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
 
         // Only returned values that are either created on return or return addresses previously unknown
         // to nanobind require additional annotation with keep_alive per: https://nanobind.readthedocs.io/en/latest/api_core.html#_CPPv4N8nanobind9rv_policyE
-        // For any return of a reference to an existing object, nanobind is smart enough to locate it's python wrapper object & correctly increment it's refcount
+        // For any return of a reference to an existing object, nanobind is smart enough to locate its python wrapper object & correctly increment its refcount
         // No keep_alive for even borrowed string outputs, the type conversion always involves a copy
         if matches!(
             method.attrs.special_method,
@@ -409,7 +417,14 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
         // This won't make a difference for methods that return a reference to an already created value.
         if matches!(method.output.success_type(), hir::SuccessType::OutType(hir::Type::Opaque(path)) if !path.is_owned())
         {
-            lifetime_args.push("nb::rv_policy::reference".to_owned());
+            // For any type -> `Type<'a>`, as long as our self reference `&'a self` has the same lifetime (`'a`), we can assume that `&'a`` self has some kind of ownership of the returned type.
+            //  Because `rv_policy` is only applied to unknown types (i.e., newly created references), then we can apply `reference_internal` to any of the cases above, without worrying about unnecessarily increasing the reference count for when we return `self` (since `self` is an already known type to Nanobind).
+            let str = match self_borrow.as_ref() {
+                // For non-borrowed &self however, we can just return a standard reference that has no attachment to &self:
+                Some(hir::borrowing_param::ParamBorrowInfo::NotBorrowed) | None => "nb::rv_policy::reference",
+                _ => "nb::rv_policy::reference_internal"
+            };
+            lifetime_args.push(str.to_owned());
         }
 
         Some(MethodInfo {


### PR DESCRIPTION
Currently this is just a failing test, I'm still working out what the fix needs to be.

You can fool the garbage collector in Python into collecting data that's still being used elsewehere (like say, a reference to an inner vec). This can be fixed with a `nb::keep_alive<0, 1>()` on the returned reference to the inner data, but I still need to research what scenarios we want to implement `keep_alive` for.