### PR TITLE
Nanobind: Raise IndexError for Result<...> and Option<...> Indexer types

### DIFF
--- a/feature_tests/nanobind/src/include/Float64VecError.d.hpp
+++ b/feature_tests/nanobind/src/include/Float64VecError.d.hpp
@@ -1,0 +1,43 @@
+#ifndef Float64VecError_D_HPP
+#define Float64VecError_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    struct Float64VecError;
+} // namespace capi
+} // namespace
+
+class Float64VecError {
+public:
+
+  inline static std::unique_ptr<Float64VecError> new_(diplomat::span<const double> v);
+
+  inline diplomat::result<double, std::monostate> operator[](size_t i) const;
+
+  inline const diplomat::capi::Float64VecError* AsFFI() const;
+  inline diplomat::capi::Float64VecError* AsFFI();
+  inline static const Float64VecError* FromFFI(const diplomat::capi::Float64VecError* ptr);
+  inline static Float64VecError* FromFFI(diplomat::capi::Float64VecError* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  Float64VecError() = delete;
+  Float64VecError(const Float64VecError&) = delete;
+  Float64VecError(Float64VecError&&) noexcept = delete;
+  Float64VecError operator=(const Float64VecError&) = delete;
+  Float64VecError operator=(Float64VecError&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+
+#endif // Float64VecError_D_HPP

--- a/feature_tests/nanobind/src/include/Float64VecError.hpp
+++ b/feature_tests/nanobind/src/include/Float64VecError.hpp
@@ -1,0 +1,64 @@
+#ifndef Float64VecError_HPP
+#define Float64VecError_HPP
+
+#include "Float64VecError.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "diplomat_runtime.hpp"
+
+
+namespace diplomat {
+namespace capi {
+    extern "C" {
+
+    diplomat::capi::Float64VecError* Float64VecError_new(diplomat::capi::DiplomatF64View v);
+
+    typedef struct Float64VecError_get_result {union {double ok; }; bool is_ok;} Float64VecError_get_result;
+    Float64VecError_get_result Float64VecError_get(const diplomat::capi::Float64VecError* self, size_t i);
+
+    void Float64VecError_destroy(Float64VecError* self);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<Float64VecError> Float64VecError::new_(diplomat::span<const double> v) {
+  auto result = diplomat::capi::Float64VecError_new({v.data(), v.size()});
+  return std::unique_ptr<Float64VecError>(Float64VecError::FromFFI(result));
+}
+
+inline diplomat::result<double, std::monostate> Float64VecError::operator[](size_t i) const {
+  auto result = diplomat::capi::Float64VecError_get(this->AsFFI(),
+    i);
+  return result.is_ok ? diplomat::result<double, std::monostate>(diplomat::Ok<double>(result.ok)) : diplomat::result<double, std::monostate>(diplomat::Err<std::monostate>());
+}
+
+inline const diplomat::capi::Float64VecError* Float64VecError::AsFFI() const {
+  return reinterpret_cast<const diplomat::capi::Float64VecError*>(this);
+}
+
+inline diplomat::capi::Float64VecError* Float64VecError::AsFFI() {
+  return reinterpret_cast<diplomat::capi::Float64VecError*>(this);
+}
+
+inline const Float64VecError* Float64VecError::FromFFI(const diplomat::capi::Float64VecError* ptr) {
+  return reinterpret_cast<const Float64VecError*>(ptr);
+}
+
+inline Float64VecError* Float64VecError::FromFFI(diplomat::capi::Float64VecError* ptr) {
+  return reinterpret_cast<Float64VecError*>(ptr);
+}
+
+inline void Float64VecError::operator delete(void* ptr) {
+  diplomat::capi::Float64VecError_destroy(reinterpret_cast<diplomat::capi::Float64VecError*>(ptr));
+}
+
+
+#endif // Float64VecError_HPP

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -41,6 +41,7 @@ void add_ResultOpaque_binding(nb::handle);
 void add_RefList_binding(nb::handle);
 void add_RefListParameter_binding(nb::handle);
 void add_Float64Vec_binding(nb::handle);
+void add_Float64VecError_binding(nb::handle);
 void add_MyString_binding(nb::handle);
 void add_MyOpaqueEnum_binding(nb::handle);
 void add_Opaque_binding(nb::handle);
@@ -173,6 +174,7 @@ NB_MODULE(somelib, somelib_mod)
     add_RefList_binding(somelib_mod);
     add_RefListParameter_binding(somelib_mod);
     add_Float64Vec_binding(somelib_mod);
+    add_Float64VecError_binding(somelib_mod);
     add_MyString_binding(somelib_mod);
     add_MyOpaqueEnum_binding(somelib_mod);
     add_Opaque_binding(somelib_mod);

--- a/feature_tests/nanobind/src/sub_modules/Float64VecError_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/Float64VecError_binding.cpp
@@ -1,0 +1,29 @@
+#include "diplomat_nanobind_common.hpp"
+
+
+#include "Float64VecError.hpp"
+
+
+void add_Float64VecError_binding(nb::handle mod) {
+    PyType_Slot Float64VecError_slots[] = {
+        {Py_tp_free, (void *)Float64VecError::operator delete },
+        {Py_tp_dealloc, (void *)diplomat_tp_dealloc},
+        {0, nullptr}};
+    
+    nb::class_<Float64VecError>(mod, "Float64VecError", nb::type_slots(Float64VecError_slots))
+    	.def("__getitem__", [](Float64VecError* self, size_t index) {
+    			auto out = self->operator[] (index);if (!out.is_ok()) {
+    				auto errorPyV = nb::cast(std::move(std::move(out).err().value()));
+    				if (errorPyV.is_valid())
+    				{
+    					throw nb::index_error(nb::str(errorPyV).c_str());
+    				} else {
+    					throw nb::index_error("Indexing error. Could not convert error type to string.");
+    				}
+    			} else {
+    				return out;
+    			}
+    		}, "i"_a)
+    	.def_static("new", &Float64VecError::new_, "v"_a);
+}
+

--- a/feature_tests/nanobind/src/sub_modules/Float64Vec_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/Float64Vec_binding.cpp
@@ -14,7 +14,14 @@ void add_Float64Vec_binding(nb::handle mod) {
     	.def_prop_ro("asSlice", &Float64Vec::as_slice)
     	.def("borrow", &Float64Vec::borrow)
     	.def("fill_slice", &Float64Vec::fill_slice, "v"_a)
-    	.def("__getitem__", &Float64Vec::operator[], "i"_a)
+    	.def("__getitem__", [](Float64Vec* self, size_t index) {
+    			auto out = self->operator[] (index);
+    			if (!out.has_value()) {
+    				throw nb::index_error("Could not get index.");
+    			} else {
+    				return out;
+    			}
+    		}, "i"_a)
     	.def_static("new", &Float64Vec::new_, "v"_a)
     	.def_static("new_bool", &Float64Vec::new_bool, "v"_a ) // unsupported special method NamedConstructor(Some("bool"))
     	.def_static("new_f64_be_bytes", &Float64Vec::new_f64_be_bytes, "v"_a ) // unsupported special method NamedConstructor(Some("f64BeBytes"))

--- a/feature_tests/nanobind/src/sub_modules/OpaqueThinVec_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OpaqueThinVec_binding.cpp
@@ -14,7 +14,8 @@ void add_OpaqueThinVec_binding(nb::handle mod) {
     	.def("__len__", &OpaqueThinVec::__len__)
     	.def(nb::new_(&OpaqueThinVec::create), "a"_a, "b"_a)
     	.def_prop_ro("first", &OpaqueThinVec::first)
-    	.def("__getitem__", &OpaqueThinVec::operator[], "idx"_a, nb::rv_policy::reference)
+    	.def("__getitem__", &OpaqueThinVec::operator[]
+    		, "idx"_a, nb::rv_policy::reference)
     	.def("__iter__", &OpaqueThinVec::iter, nb::keep_alive<0, 1>());
 }
 

--- a/feature_tests/nanobind/src/sub_modules/ns/RenamedMyIndexer_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/ns/RenamedMyIndexer_binding.cpp
@@ -13,7 +13,14 @@ void add_RenamedMyIndexer_binding(nb::handle mod) {
         {0, nullptr}};
     
     nb::class_<ns::RenamedMyIndexer>(mod, "RenamedMyIndexer", nb::type_slots(ns_RenamedMyIndexer_slots))
-    	.def("__getitem__", &ns::RenamedMyIndexer::operator[], "i"_a);
+    	.def("__getitem__", [](ns::RenamedMyIndexer* self, size_t index) {
+    			auto out = self->operator[] (index);
+    			if (!out.has_value()) {
+    				throw nb::index_error("Could not get index.");
+    			} else {
+    				return out;
+    			}
+    		}, "i"_a);
 }
 
 

--- a/feature_tests/nanobind/src/sub_modules/ns/RenamedVectorTest_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/ns/RenamedVectorTest_binding.cpp
@@ -13,7 +13,14 @@ void add_RenamedVectorTest_binding(nb::handle mod) {
         {0, nullptr}};
     
     nb::class_<ns::RenamedVectorTest>(mod, "RenamedVectorTest", nb::type_slots(ns_RenamedVectorTest_slots))
-    	.def("__getitem__", &ns::RenamedVectorTest::operator[], "idx"_a)
+    	.def("__getitem__", [](ns::RenamedVectorTest* self, size_t index) {
+    			auto out = self->operator[] (index);
+    			if (!out.has_value()) {
+    				throw nb::index_error("Could not get index.");
+    			} else {
+    				return out;
+    			}
+    		}, "idx"_a)
     	.def_prop_ro("len", &ns::RenamedVectorTest::len)
     	.def(nb::new_(&ns::RenamedVectorTest::new_))
     	.def("push", &ns::RenamedVectorTest::push, "value"_a);

--- a/feature_tests/nanobind/test/test_slices.py
+++ b/feature_tests/nanobind/test/test_slices.py
@@ -1,5 +1,8 @@
 import somelib
 import somelib.somelib
+
+import pytest
+
 def test_slices():
     sl = somelib.Float64Vec.new([.1, .2, .3]).asSlice
     b = somelib.Float64Vec.new([.1, .2, .3]).borrow()
@@ -11,3 +14,6 @@ def test_slices():
     assert s == "hello"
     assert b == "banannas"
     assert s is not b
+    
+    with pytest.raises(IndexError):
+        sl[4]

--- a/feature_tests/nanobind/test/test_slices.py
+++ b/feature_tests/nanobind/test/test_slices.py
@@ -14,6 +14,10 @@ def test_slices():
     assert s == "hello"
     assert b == "banannas"
     assert s is not b
+
+    c = somelib.Float64Vec.new([.1, .2, .3])
+    d = somelib.Float64VecError.new([.1, .2, .3])
     
     with pytest.raises(IndexError):
-        sl[4]
+        c[4]
+        d[4]

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -127,8 +127,9 @@ pub mod ffi {
         }
     }
 
-    
+    // For testing throwing IndexError:
     #[diplomat::opaque]
+    #[diplomat::attr(not(nanobind), disable)]
     struct Float64VecError(Vec<f64>);
 
     impl Float64VecError {

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -141,7 +141,7 @@ pub mod ffi {
         #[diplomat::attr(auto, indexer)]
         pub fn get(&self, i: usize) -> Result<f64, ()> {
             if let Some(i) = self.0.get(i) {
-                Ok(i.clone())
+                Ok(*i)
             } else {
                 Err(())
             }

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -139,7 +139,7 @@ pub mod ffi {
         }
 
         #[diplomat::attr(auto, indexer)]
-        pub fn get(&self, i : usize) -> Result<f64, ()> {
+        pub fn get(&self, i: usize) -> Result<f64, ()> {
             if let Some(i) = self.0.get(i) {
                 Ok(i.clone())
             } else {

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -126,4 +126,24 @@ pub mod ffi {
             self.0.get(i).copied()
         }
     }
+
+    
+    #[diplomat::opaque]
+    struct Float64VecError(Vec<f64>);
+
+    impl Float64VecError {
+        #[diplomat::attr(not(supports = memory_sharing), disable)]
+        pub fn new(v: &[f64]) -> Box<Float64VecError> {
+            Box::new(Self(v.to_vec()))
+        }
+
+        #[diplomat::attr(auto, indexer)]
+        pub fn get(&self, i : usize) -> Result<f64, ()> {
+            if let Some(i) = self.0.get(i) {
+                Ok(i.clone())
+            } else {
+                Err(())
+            }
+        }
+    }
 }

--- a/tool/src/nanobind/ty.rs
+++ b/tool/src/nanobind/ty.rs
@@ -324,7 +324,10 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
         }
 
         let param_decls = {
-            if matches!(method.attrs.special_method, Some(hir::SpecialMethod::Indexer)) || (matches!(
+            if matches!(
+                method.attrs.special_method,
+                Some(hir::SpecialMethod::Indexer)
+            ) || (matches!(
                 method.attrs.special_method,
                 Some(hir::SpecialMethod::Constructor) | Some(hir::SpecialMethod::Setter(_)) // We only need type info for constructors or certain setters
             ) && !matches!(

--- a/tool/src/nanobind/ty.rs
+++ b/tool/src/nanobind/ty.rs
@@ -324,14 +324,14 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
         }
 
         let param_decls = {
-            if matches!(
+            if matches!(method.attrs.special_method, Some(hir::SpecialMethod::Indexer)) || (matches!(
                 method.attrs.special_method,
                 Some(hir::SpecialMethod::Constructor) | Some(hir::SpecialMethod::Setter(_)) // We only need type info for constructors or certain setters
             ) && !matches!(
                 // and even then, only when the type isn't opaque
                 id,
                 TypeId::Opaque(_)
-            ) {
+            )) {
                 Some(
                     method
                         .params

--- a/tool/templates/nanobind/method_impl.cpp.jinja
+++ b/tool/templates/nanobind/method_impl.cpp.jinja
@@ -93,7 +93,7 @@
 		}
 		{%- when crate::hir::ReturnType::Infallible(..) -%}
 		&{{- type_name }}::operator[]
-		{% endmatch -%}
+		{%- endmatch -%}
 
 		{%- include "method_params.cpp.jinja" %})
 	{%- when _ -%}

--- a/tool/templates/nanobind/method_impl.cpp.jinja
+++ b/tool/templates/nanobind/method_impl.cpp.jinja
@@ -72,7 +72,29 @@
 		{%- endif -%}
 		{%- include "method_params.cpp.jinja" %})
 	{%- when crate::hir::SpecialMethod::Indexer -%}
-		("__getitem__", &{{- type_name }}::operator[]
+		("__getitem__", {% match m.method.output -%}
+		{%- when crate::hir::ReturnType::Nullable(..) | crate::hir::ReturnType::Fallible(..) -%}
+		[]({{type_name}}* self, {{m.param_decls.as_ref().unwrap()[0].type_name}} index) {
+			auto out = self->operator[] (index);
+			{%- if let crate::hir::ReturnType::Nullable(..) = m.method.output %}
+			if (!out.has_value()) {
+				throw nb::index_error("Could not get index.");
+			} {% else -%} if (!out.is_ok()) {
+				auto errorPyV = nb::cast(std::move(std::move(out).err().value()));
+				if (errorPyV.is_valid())
+				{
+					throw nb::index_error(nb::str(errorPyV).c_str());
+				} else {
+					throw nb::index_error("Indexing error. Could not convert error type to string.");
+				}
+			} {% endif -%} else {
+				return out;
+			}
+		}
+		{%- when crate::hir::ReturnType::Infallible(..) -%}
+		&{{- type_name }}::operator[]
+		{% endmatch -%}
+
 		{%- include "method_params.cpp.jinja" %})
 	{%- when _ -%}
 		("{{m.method_name}}", &{{- type_name }}::{{ m.cpp_method_name -}} 


### PR DESCRIPTION
To avoid implicit conversion errors like `list(type)` which will continually expand infinitely unless an `IndexError` is raised.