### PR TITLE
Replace Option<Borrow> with MaybeOwn

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -636,10 +636,13 @@ impl Attrs {
                                         }
 
                                         if p.owner
-                                            .map(|b| b.mutability != Mutability::Immutable)
+                                            .as_borrowed()
+                                            .map(|o| !o.mutability.is_immutable())
                                             .unwrap_or(false)
-                                            || p.owner
-                                                .map(|b| b.mutability != Mutability::Immutable)
+                                            || p2
+                                                .owner
+                                                .as_borrowed()
+                                                .map(|o| !o.mutability.is_immutable())
                                                 .unwrap_or(false)
                                         {
                                             errors.push(LoweringError::Other(

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -702,7 +702,11 @@ impl<'ast> LoweringContext<'ast> {
                         let lifetimes =
                             ltl.lower_generics(&path.lifetimes[..], &strct.lifetimes, ty.is_self());
 
-                        Ok(Type::Struct(StructPath::new(lifetimes, tcx_id, None)))
+                        Ok(Type::Struct(StructPath::new(
+                            lifetimes,
+                            tcx_id,
+                            MaybeOwn::Own,
+                        )))
                     } else if self.lookup_id.resolve_out_struct(strct).is_some() {
                         self.errors.push(LoweringError::Other(format!("found struct in input that is marked with #[diplomat::out]: {ty} in {path}")));
                         Err(())
@@ -778,7 +782,7 @@ impl<'ast> LoweringContext<'ast> {
                                 Ok(Type::Struct(StructPath::new(
                                     lifetimes,
                                     tcx_id,
-                                    Some(borrow),
+                                    MaybeOwn::Borrow(borrow),
                                 )))
                             } else {
                                 self.errors.push(LoweringError::Other("found &T in input where T is a struct. The backend must support struct_refs.".to_string()));
@@ -939,7 +943,7 @@ impl<'ast> LoweringContext<'ast> {
                 }
 
                 Ok(Type::Slice(Slice::Primitive(
-                    new_lifetime,
+                    new_lifetime.into(),
                     PrimitiveType::from_ast(*prim),
                 )))
             }
@@ -983,7 +987,7 @@ impl<'ast> LoweringContext<'ast> {
                             let inner = self.lower_type::<P>(type_name, ltl, in_struct, in_path)?;
                             match inner {
                                 Type::Struct(st) => {
-                                    Ok(Type::Slice(Slice::Struct(new_lifetime, st)))
+                                    Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
                                 }
                                 _ => unreachable!(),
                             }
@@ -1079,11 +1083,11 @@ impl<'ast> LoweringContext<'ast> {
 
                         if let Some(tcx_id) = self.lookup_id.resolve_struct(strct) {
                             Ok(OutType::Struct(ReturnableStructPath::Struct(
-                                StructPath::new(lifetimes, tcx_id, None),
+                                StructPath::new(lifetimes, tcx_id, MaybeOwn::Own),
                             )))
                         } else if let Some(tcx_id) = self.lookup_id.resolve_out_struct(strct) {
                             Ok(OutType::Struct(ReturnableStructPath::OutStruct(
-                                OutStructPath::new(lifetimes, tcx_id, None),
+                                OutStructPath::new(lifetimes, tcx_id, MaybeOwn::Own),
                             )))
                         } else {
                             unreachable!("struct `{}` wasn't found in the set of structs or out-structs, this is a bug.", strct.name);
@@ -1311,7 +1315,7 @@ impl<'ast> LoweringContext<'ast> {
             }
             ast::TypeName::PrimitiveSlice(Some((lt, m)), prim, _stdlib) => {
                 Ok(OutType::Slice(Slice::Primitive(
-                    Some(Borrow::new(ltl.lower_lifetime(lt), *m)),
+                    MaybeOwn::Borrow(Borrow::new(ltl.lower_lifetime(lt), *m)),
                     PrimitiveType::from_ast(*prim),
                 )))
             }
@@ -1342,7 +1346,7 @@ impl<'ast> LoweringContext<'ast> {
                             )?;
                             match inner {
                                 Type::Struct(st) => {
-                                    Ok(Type::Slice(Slice::Struct(new_lifetime, st)))
+                                    Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
                                 }
                                 _ => unreachable!(),
                             }
@@ -1399,13 +1403,13 @@ impl<'ast> LoweringContext<'ast> {
                             let (borrow_lt, param_ltl) = self_param_ltl.lower_self_ref(lt);
                             let borrow = Borrow::new(borrow_lt, *mt);
 
-                            (Some(borrow), param_ltl)
+                            (MaybeOwn::Borrow(borrow), param_ltl)
                         } else {
                             self.errors.push(LoweringError::Other(format!("Method `{method_full_path}` takes a reference to a struct as a self parameter, which isn't allowed. Backend must support struct_refs.")));
                             return Err(());
                         }
                     } else {
-                        (None, self_param_ltl.no_self_ref())
+                        (MaybeOwn::Own, self_param_ltl.no_self_ref())
                     };
 
                     let attrs = self.attr_validator.attr_from_ast(

--- a/core/src/hir/paths.rs
+++ b/core/src/hir/paths.rs
@@ -1,7 +1,7 @@
 use super::lifetimes::{Lifetimes, LinkedLifetimes};
 use super::{
-    Borrow, EnumDef, EnumId, Everywhere, OpaqueDef, OpaqueId, OpaqueOwner, OutStructDef,
-    OutputOnly, ReturnableStructDef, StructDef, TraitId, TyPosition, TypeContext,
+    Borrow, EnumDef, EnumId, Everywhere, Mutability, OpaqueDef, OpaqueId, OpaqueOwner,
+    OutStructDef, OutputOnly, ReturnableStructDef, StructDef, TraitId, TyPosition, TypeContext,
 };
 
 /// Path to a struct that may appear as an output.
@@ -21,7 +21,7 @@ pub type OutStructPath = StructPath<OutputOnly>;
 pub struct StructPath<P: TyPosition = Everywhere> {
     pub lifetimes: Lifetimes,
     pub tcx_id: P::StructId,
-    pub owner: Option<Borrow>,
+    pub owner: MaybeOwn,
 }
 
 #[derive(Debug, Clone)]
@@ -107,9 +107,10 @@ pub struct EnumPath {
     pub tcx_id: EnumId,
 }
 
-/// Determine whether a pointer to an opaque type is owned or borrowed.
+/// Determine whether a type is owned or borrowed.
 ///
-/// Since owned opaques cannot be used as inputs, this only appears in output types.
+/// Ownership in the case of opaques is `Box<Opaque>`, in the case of structs is
+/// `Struct`, and in the case of slices is `Box<[T]>`.
 #[derive(Copy, Clone, Debug)]
 #[allow(clippy::exhaustive_enums)] // only two answers to this question
 pub enum MaybeOwn {
@@ -124,8 +125,27 @@ impl MaybeOwn {
             MaybeOwn::Borrow(borrow) => Some(borrow),
         }
     }
+
+    pub fn is_owned(&self) -> bool {
+        matches!(*self, Self::Own)
+    }
+
+    /// Returns the mutability of this potential-borrow
+    ///
+    /// Owned types are mutable
+    pub fn mutability(&self) -> Mutability {
+        match *self {
+            Self::Own => Mutability::Mutable,
+            Self::Borrow(b) => b.mutability,
+        }
+    }
 }
 
+impl From<Option<Borrow>> for MaybeOwn {
+    fn from(other: Option<Borrow>) -> Self {
+        other.map(Self::Borrow).unwrap_or(Self::Own)
+    }
+}
 impl ReturnableStructPath {
     pub fn resolve<'tcx>(&self, tcx: &'tcx TypeContext) -> ReturnableStructDef<'tcx> {
         match self {
@@ -146,7 +166,7 @@ impl ReturnableStructPath {
 
 impl<P: TyPosition> StructPath<P> {
     /// Returns a new [`EnumPath`].
-    pub(super) fn new(lifetimes: Lifetimes, tcx_id: P::StructId, owner: Option<Borrow>) -> Self {
+    pub(super) fn new(lifetimes: Lifetimes, tcx_id: P::StructId, owner: MaybeOwn) -> Self {
         Self {
             lifetimes,
             tcx_id,

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -142,7 +142,7 @@ TypeContext {
                                         tcx_id: OutStructId(
                                             0,
                                         ),
-                                        owner: None,
+                                        owner: Own,
                                     },
                                 ),
                             ),
@@ -304,7 +304,7 @@ TypeContext {
                                     tcx_id: StructId(
                                         0,
                                     ),
-                                    owner: None,
+                                    owner: Own,
                                 },
                             ),
                             attrs: Attrs {

--- a/core/src/hir/ty_position.rs
+++ b/core/src/hir/ty_position.rs
@@ -211,7 +211,7 @@ impl TyPosition for InputOnly {
 pub trait StructPathLike {
     fn lifetimes(&self) -> &Lifetimes;
     fn id(&self) -> TypeId;
-    fn owner(&self) -> Option<Borrow>;
+    fn owner(&self) -> MaybeOwn;
 
     /// Get a map of lifetimes used on this path to lifetimes as named in the def site. See [`LinkedLifetimes`]
     /// for more information.
@@ -229,7 +229,7 @@ impl StructPathLike for StructPath {
         self.tcx_id.into()
     }
 
-    fn owner(&self) -> Option<Borrow> {
+    fn owner(&self) -> MaybeOwn {
         self.owner
     }
 
@@ -254,8 +254,8 @@ impl StructPathLike for ReturnableStructPath {
         }
     }
 
-    fn owner(&self) -> Option<Borrow> {
-        None
+    fn owner(&self) -> MaybeOwn {
+        MaybeOwn::Own
     }
 
     fn link_lifetimes<'def, 'tcx>(

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -3,8 +3,8 @@
 use super::lowering::{ErrorAndContext, ErrorStore, ItemAndInfo};
 use super::ty_position::StructPathLike;
 use super::{
-    AttributeValidator, Attrs, EnumDef, LoweringContext, LoweringError, MaybeStatic, OpaqueDef,
-    OutStructDef, StructDef, TraitDef, TypeDef,
+    AttributeValidator, Attrs, EnumDef, LoweringContext, LoweringError, MaybeOwn, MaybeStatic,
+    OpaqueDef, OutStructDef, StructDef, TraitDef, TypeDef,
 };
 use crate::ast::attrs::AttrInheritContext;
 #[allow(unused_imports)] // use in docs links
@@ -390,7 +390,7 @@ impl TypeContext {
                     attrs: _attrs,
                 }) = &method.param_self
                 {
-                    if let Some(b) = s.owner {
+                    if let MaybeOwn::Borrow(b) = s.owner {
                         if let MaybeStatic::NonStatic(ns) = b.lifetime {
                             struct_ref_lifetimes.insert(ns);
                         }
@@ -399,7 +399,7 @@ impl TypeContext {
 
                 for param in &method.params {
                     if let super::Type::Struct(ref st) = &param.ty {
-                        if let Some(b) = st.owner {
+                        if let MaybeOwn::Borrow(b) = st.owner {
                             if let MaybeStatic::NonStatic(ns) = b.lifetime {
                                 struct_ref_lifetimes.insert(ns);
                             }

--- a/tool/src/c/formatter.rs
+++ b/tool/src/c/formatter.rs
@@ -1,8 +1,8 @@
 //! This module contains functions for formatting types
 
 use diplomat_core::hir::{
-    self, DocsTypeReferenceSyntax, DocsUrlGenerator, StringEncoding, SymbolId, TraitId, TyPosition,
-    TypeContext, TypeId,
+    self, DocsTypeReferenceSyntax, DocsUrlGenerator, MaybeOwn, StringEncoding, SymbolId, TraitId,
+    TyPosition, TypeContext, TypeId,
 };
 use std::borrow::Cow;
 use std::sync::LazyLock;
@@ -103,7 +103,7 @@ impl<'tcx> CFormatter<'tcx> {
             hir::Type::Slice(hir::Slice::Primitive(borrow, prim)) => {
                 let prim = self.fmt_primitive_name_for_derived_type(*prim);
                 let mtb = match borrow {
-                    Some(borrow) if borrow.mutability.is_immutable() => "",
+                    MaybeOwn::Borrow(borrow) if borrow.mutability.is_immutable() => "",
                     _ => "Mut",
                 };
                 self.diplomat_namespace(format!("Option{prim}View{mtb}").into()).to_string()
@@ -242,12 +242,12 @@ impl<'tcx> CFormatter<'tcx> {
     /// Get the primitive type as a C type
     pub fn fmt_primitive_slice_name(
         &self,
-        borrow: Option<hir::Borrow>,
+        borrow: MaybeOwn,
         prim: hir::PrimitiveType,
     ) -> Cow<'tcx, str> {
         let prim = self.fmt_primitive_name_for_derived_type(prim);
         let mtb = match borrow {
-            Some(borrow) if borrow.mutability.is_immutable() => "",
+            MaybeOwn::Borrow(borrow) if borrow.mutability.is_immutable() => "",
             _ => "Mut",
         };
         self.diplomat_namespace(format!("Diplomat{prim}View{mtb}").into())
@@ -255,7 +255,7 @@ impl<'tcx> CFormatter<'tcx> {
 
     pub fn fmt_struct_slice_name<P: TyPosition>(
         &self,
-        borrow: Option<hir::Borrow>,
+        borrow: MaybeOwn,
         st_ty: &P::StructPath,
     ) -> Cow<'tcx, str> {
         let st_id = hir::StructPathLike::id(st_ty);
@@ -266,7 +266,7 @@ impl<'tcx> CFormatter<'tcx> {
         let ns = def.attrs().namespace.clone();
 
         let mtb = match borrow {
-            Some(borrow) if borrow.mutability.is_immutable() => "",
+            MaybeOwn::Borrow(borrow) if borrow.mutability.is_immutable() => "",
             _ => "Mut",
         };
 

--- a/tool/src/c/ty.rs
+++ b/tool/src/c/ty.rs
@@ -4,8 +4,8 @@ use crate::ErrorStore;
 use askama::Template;
 use diplomat_core::hir::TypeContext;
 use diplomat_core::hir::{
-    self, CallbackInstantiationFunctionality, OpaqueOwner, ReturnableStructDef, StructPathLike,
-    SymbolId, TraitIdGetter, TyPosition, Type, TypeDef, TypeId,
+    self, CallbackInstantiationFunctionality, MaybeOwn, OpaqueOwner, ReturnableStructDef,
+    StructPathLike, SymbolId, TraitIdGetter, TyPosition, Type, TypeDef, TypeId,
 };
 use std::borrow::Cow;
 
@@ -464,7 +464,7 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
                 let header_path = self.formatter.fmt_decl_header_path(st_id.into());
                 header.includes.insert(header_path);
 
-                if let Some(borrow) = st.owner() {
+                if let MaybeOwn::Borrow(borrow) = st.owner() {
                     let mt = borrow.mutability;
                     self.formatter.fmt_ptr(&ty_name, mt).into_owned().into()
                 } else {

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -339,7 +339,7 @@ impl<'cx> TyGenContext<'_, 'cx> {
                     .into()
             }
             Type::Enum(_) => format!("{name}.toNative()").into(),
-            Type::Slice(Slice::Str(None, _)) | Type::Slice(Slice::Primitive(None, _)) => {
+            Type::Slice(Slice::Str(None, _)) | Type::Slice(Slice::Primitive(MaybeOwn::Own, _)) => {
                 format!("{name}Slice").into()
             }
             Type::Slice(_) => format!("{name}Slice").into(),
@@ -623,11 +623,11 @@ return string{return_type_modifier}"#
                 }
                 _ => todo!(),
             },
-            Slice::Primitive(Some(_), prim_ty) => {
+            Slice::Primitive(MaybeOwn::Borrow(_), prim_ty) => {
                 let prim_ty = self.formatter.fmt_primitive_as_kt(*prim_ty);
                 format!("    return PrimitiveArrayTools.get{prim_ty}Array({val_name}){return_type_modifier}")
             }
-            Slice::Primitive(None, prim_ty) => {
+            Slice::Primitive(MaybeOwn::Own, prim_ty) => {
                 let prim_ty = self.formatter.fmt_primitive_as_kt(*prim_ty);
                 let prim_ty_array = format!("{prim_ty}Array");
                 Self::boxed_slice_return(prim_ty_array.as_str(), val_name, return_type_modifier)
@@ -985,7 +985,7 @@ returnVal.option() ?: return null
             Slice::Str(None, StringEncoding::UnvalidatedUtf16) => ("moveUtf16".into(), true),
             Slice::Str(Some(_), _) => ("borrowUtf8".into(), true),
             Slice::Str(None, _) => ("moveUtf8".into(), true),
-            Slice::Primitive(Some(_), _) => ("borrow".into(), true),
+            Slice::Primitive(MaybeOwn::Borrow(_), _) => ("borrow".into(), true),
             Slice::Primitive(_, _) => ("move".into(), true),
             Slice::Strs(StringEncoding::UnvalidatedUtf16) => ("borrowUtf16s".into(), true),
             Slice::Strs(_) => ("borrowUtf8s".into(), true),
@@ -1016,7 +1016,7 @@ returnVal.option() ?: return null
                 Some(format!("if ({param_name}Mem != null) {param_name}Mem.close()").into())
             }
             Slice::Str(_, _) => None,
-            Slice::Primitive(Some(_), _) => {
+            Slice::Primitive(MaybeOwn::Borrow(_), _) => {
                 Some(format!("if ({param_name}Mem != null) {param_name}Mem.close()").into())
             }
             Slice::Primitive(_, _) => None,

--- a/tool/src/nanobind/ty.rs
+++ b/tool/src/nanobind/ty.rs
@@ -522,10 +522,7 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx> {
             }
             Type::Slice(hir::Slice::Primitive(b, p)) => {
                 let ret = self.formatter.cxx.fmt_primitive_as_c(p);
-                let ret = self.formatter.cxx.fmt_borrowed_slice(
-                    &ret,
-                    b.map(|b| b.mutability).unwrap_or(hir::Mutability::Mutable),
-                );
+                let ret = self.formatter.cxx.fmt_borrowed_slice(&ret, b.mutability());
                 ret.into_owned().into()
             }
             Type::Slice(hir::Slice::Strs(encoding)) => format!(


### PR DESCRIPTION
This makes ownership clearer in other sections of the code; we shouldn't have to rely on having to figure out what an Option represents.