### PR TITLE
Add `dir` attribute for backends with namespaces

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -29,9 +29,9 @@ pub struct Attrs {
     pub namespace: Option<String>,
     /// For changing the directory of a namespaced item, if you want the directory to be different from the namespace
     /// (for backends that support it). None is equivalent to the root directory.
-    /// 
+    ///
     /// This attribute is inherited to types (and is not allowed elsewhere)
-    pub dir : Option<String>,
+    pub dir: Option<String>,
     /// Rename this item/method/variant
     ///
     /// This attribute is inherited except through methods and variants (and is not allowed on variants)
@@ -363,16 +363,14 @@ impl Attrs {
                             }
                         },
                         "dir" => match StandardAttribute::from_meta(&attr.meta) {
-                            Ok(StandardAttribute::String(s)) if s.is_empty() => {
-                                this.dir = None
-                            }
+                            Ok(StandardAttribute::String(s)) if s.is_empty() => this.dir = None,
                             Ok(StandardAttribute::String(s)) => this.dir = Some(s),
                             Ok(_) | Err(_) => {
                                 errors.push(LoweringError::Other(
                                     "`dir` must have a single string parameter".to_string(),
                                 ));
                             }
-                        }
+                        },
                         "error" => {
                             this.custom_errors = true;
                         }
@@ -921,7 +919,10 @@ impl Attrs {
             None
         };
 
-        let dir = if matches!(context, AttrInheritContext::Module | AttrInheritContext::Type) {
+        let dir = if matches!(
+            context,
+            AttrInheritContext::Module | AttrInheritContext::Type
+        ) {
             self.dir.clone()
         } else {
             None

--- a/feature_tests/cpp/include/test_directory/RenamedDifferentDirectory.d.hpp
+++ b/feature_tests/cpp/include/test_directory/RenamedDifferentDirectory.d.hpp
@@ -1,0 +1,40 @@
+#ifndef test_directory_RenamedDifferentDirectory_D_HPP
+#define test_directory_RenamedDifferentDirectory_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    struct RenamedDifferentDirectory;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedDifferentDirectory {
+public:
+
+  inline const ns::capi::RenamedDifferentDirectory* AsFFI() const;
+  inline ns::capi::RenamedDifferentDirectory* AsFFI();
+  inline static const ns::RenamedDifferentDirectory* FromFFI(const ns::capi::RenamedDifferentDirectory* ptr);
+  inline static ns::RenamedDifferentDirectory* FromFFI(ns::capi::RenamedDifferentDirectory* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  RenamedDifferentDirectory() = delete;
+  RenamedDifferentDirectory(const ns::RenamedDifferentDirectory&) = delete;
+  RenamedDifferentDirectory(ns::RenamedDifferentDirectory&&) noexcept = delete;
+  RenamedDifferentDirectory operator=(const ns::RenamedDifferentDirectory&) = delete;
+  RenamedDifferentDirectory operator=(ns::RenamedDifferentDirectory&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // test_directory_RenamedDifferentDirectory_D_HPP

--- a/feature_tests/cpp/include/test_directory/RenamedDifferentDirectory.hpp
+++ b/feature_tests/cpp/include/test_directory/RenamedDifferentDirectory.hpp
@@ -1,0 +1,48 @@
+#ifndef test_directory_RenamedDifferentDirectory_HPP
+#define test_directory_RenamedDifferentDirectory_HPP
+
+#include "RenamedDifferentDirectory.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+
+    void namespace_DifferentDirectory_destroy(RenamedDifferentDirectory* self);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline const ns::capi::RenamedDifferentDirectory* ns::RenamedDifferentDirectory::AsFFI() const {
+  return reinterpret_cast<const ns::capi::RenamedDifferentDirectory*>(this);
+}
+
+inline ns::capi::RenamedDifferentDirectory* ns::RenamedDifferentDirectory::AsFFI() {
+  return reinterpret_cast<ns::capi::RenamedDifferentDirectory*>(this);
+}
+
+inline const ns::RenamedDifferentDirectory* ns::RenamedDifferentDirectory::FromFFI(const ns::capi::RenamedDifferentDirectory* ptr) {
+  return reinterpret_cast<const ns::RenamedDifferentDirectory*>(ptr);
+}
+
+inline ns::RenamedDifferentDirectory* ns::RenamedDifferentDirectory::FromFFI(ns::capi::RenamedDifferentDirectory* ptr) {
+  return reinterpret_cast<ns::RenamedDifferentDirectory*>(ptr);
+}
+
+inline void ns::RenamedDifferentDirectory::operator delete(void* ptr) {
+  ns::capi::namespace_DifferentDirectory_destroy(reinterpret_cast<ns::capi::RenamedDifferentDirectory*>(ptr));
+}
+
+
+#endif // test_directory_RenamedDifferentDirectory_HPP

--- a/feature_tests/nanobind/src/include/test_directory/RenamedDifferentDirectory.d.hpp
+++ b/feature_tests/nanobind/src/include/test_directory/RenamedDifferentDirectory.d.hpp
@@ -1,0 +1,40 @@
+#ifndef test_directory_RenamedDifferentDirectory_D_HPP
+#define test_directory_RenamedDifferentDirectory_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    struct RenamedDifferentDirectory;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedDifferentDirectory {
+public:
+
+  inline const ns::capi::RenamedDifferentDirectory* AsFFI() const;
+  inline ns::capi::RenamedDifferentDirectory* AsFFI();
+  inline static const ns::RenamedDifferentDirectory* FromFFI(const ns::capi::RenamedDifferentDirectory* ptr);
+  inline static ns::RenamedDifferentDirectory* FromFFI(ns::capi::RenamedDifferentDirectory* ptr);
+  inline static void operator delete(void* ptr);
+private:
+  RenamedDifferentDirectory() = delete;
+  RenamedDifferentDirectory(const ns::RenamedDifferentDirectory&) = delete;
+  RenamedDifferentDirectory(ns::RenamedDifferentDirectory&&) noexcept = delete;
+  RenamedDifferentDirectory operator=(const ns::RenamedDifferentDirectory&) = delete;
+  RenamedDifferentDirectory operator=(ns::RenamedDifferentDirectory&&) noexcept = delete;
+  static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // test_directory_RenamedDifferentDirectory_D_HPP

--- a/feature_tests/nanobind/src/include/test_directory/RenamedDifferentDirectory.hpp
+++ b/feature_tests/nanobind/src/include/test_directory/RenamedDifferentDirectory.hpp
@@ -1,0 +1,48 @@
+#ifndef test_directory_RenamedDifferentDirectory_HPP
+#define test_directory_RenamedDifferentDirectory_HPP
+
+#include "RenamedDifferentDirectory.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+
+    void namespace_DifferentDirectory_destroy(RenamedDifferentDirectory* self);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline const ns::capi::RenamedDifferentDirectory* ns::RenamedDifferentDirectory::AsFFI() const {
+  return reinterpret_cast<const ns::capi::RenamedDifferentDirectory*>(this);
+}
+
+inline ns::capi::RenamedDifferentDirectory* ns::RenamedDifferentDirectory::AsFFI() {
+  return reinterpret_cast<ns::capi::RenamedDifferentDirectory*>(this);
+}
+
+inline const ns::RenamedDifferentDirectory* ns::RenamedDifferentDirectory::FromFFI(const ns::capi::RenamedDifferentDirectory* ptr) {
+  return reinterpret_cast<const ns::RenamedDifferentDirectory*>(ptr);
+}
+
+inline ns::RenamedDifferentDirectory* ns::RenamedDifferentDirectory::FromFFI(ns::capi::RenamedDifferentDirectory* ptr) {
+  return reinterpret_cast<ns::RenamedDifferentDirectory*>(ptr);
+}
+
+inline void ns::RenamedDifferentDirectory::operator delete(void* ptr) {
+  ns::capi::namespace_DifferentDirectory_destroy(reinterpret_cast<ns::capi::RenamedDifferentDirectory*>(ptr));
+}
+
+
+#endif // test_directory_RenamedDifferentDirectory_HPP

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -68,6 +68,7 @@ void add_RenamedTestMacroStruct_binding(nb::handle);
 void add_AttrOpaque1Renamed_binding(nb::handle);
 void add_RenamedAttrOpaque2_binding(nb::handle);
 void add_RenamedComparable_binding(nb::handle);
+void add_RenamedDifferentDirectory_binding(nb::handle);
 void add_RenamedMyIndexer_binding(nb::handle);
 void add_RenamedMyIterable_binding(nb::handle);
 void add_RenamedMyIterator_binding(nb::handle);
@@ -199,6 +200,7 @@ NB_MODULE(somelib, somelib_mod)
     ns::add_AttrOpaque1Renamed_binding(somelib_ns_mod);
     ns::add_RenamedAttrOpaque2_binding(somelib_ns_mod);
     ns::add_RenamedComparable_binding(somelib_ns_mod);
+    ns::add_RenamedDifferentDirectory_binding(somelib_ns_mod);
     ns::add_RenamedMyIndexer_binding(somelib_ns_mod);
     ns::add_RenamedMyIterable_binding(somelib_ns_mod);
     ns::add_RenamedMyIterator_binding(somelib_ns_mod);

--- a/feature_tests/nanobind/src/sub_modules/ns/RenamedDifferentDirectory_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/ns/RenamedDifferentDirectory_binding.cpp
@@ -1,0 +1,19 @@
+#include "diplomat_nanobind_common.hpp"
+
+
+#include "test_directory/RenamedDifferentDirectory.hpp"
+
+
+namespace ns{
+
+void add_RenamedDifferentDirectory_binding(nb::handle mod) {
+    PyType_Slot ns_RenamedDifferentDirectory_slots[] = {
+        {Py_tp_free, (void *)ns::RenamedDifferentDirectory::operator delete },
+        {Py_tp_dealloc, (void *)diplomat_tp_dealloc},
+        {0, nullptr}};
+    
+    nb::class_<ns::RenamedDifferentDirectory>(mod, "RenamedDifferentDirectory", nb::type_slots(ns_RenamedDifferentDirectory_slots));
+}
+
+
+}

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -349,4 +349,9 @@ pub mod ffi {
     } [EXPR 0, IDENT TestMacroStruct] LT 'a literal "Testing" <=> diplomat::attr(auto, constructor) std::fmt::Write; {
         fn hello() {}
     } f64, pub, const IT:usize = 0;}
+
+    #[diplomat::attr(not(supports=namespacing), disable)]
+    #[diplomat::attr(supports=namespacing, dir="test_directory")]
+    #[diplomat::opaque]
+    pub struct DifferentDirectory(f32);
 }

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -58,7 +58,12 @@ impl<'tcx> Cpp2Formatter<'tcx> {
             .rename
             .apply(resolved.name().as_str().into());
         if let Some(ref ns) = resolved.attrs().namespace {
-            let ns = ns.replace("::", "/");
+            let ns = if let Some(ref d) = resolved.attrs().dir {
+                d.clone()
+            } else {
+                ns.replace("::", "/")
+            };
+
             format!("{ns}/{type_name}.d.hpp")
         } else {
             format!("{type_name}.d.hpp")
@@ -73,7 +78,11 @@ impl<'tcx> Cpp2Formatter<'tcx> {
             .rename
             .apply(resolved.name().as_str().into());
         if let Some(ref ns) = resolved.attrs().namespace {
-            let ns = ns.replace("::", "/");
+            let ns = if let Some(ref d) = resolved.attrs().dir {
+                d.clone()
+            } else {
+                ns.replace("::", "/")
+            };
             format!("{ns}/{type_name}.hpp")
         } else {
             format!("{type_name}.hpp")


### PR DESCRIPTION
We're trying to shuffle around namespaced items to different folders than their namespaces for organizational purposes. This quickly adds an attribute for namespaced items that allows you to specify a different directory (if supported). Currently I've only implemented for C++, since that's the only backend that we really need this for right now.

Until we have per-backend attributes (or something like that), I think this will have to do for anyone trying to do something similar.