### PR TITLE
Primitive Fixed Size Array Support (`&[T; usize]`)

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1113,22 +1113,22 @@ impl TypeName {
             }
             syn::Type::Array(arr) => {
                 let len = match &arr.len {
-                    syn::Expr::Lit(syn::ExprLit { attrs: _, lit: syn::Lit::Int(i)}) => {
-                        i.base10_parse::<usize>().expect("Expected usize integer.")
-                    },
-                    _ => unreachable!("Expected a literal integer expression for array length in {arr:?}")
+                    syn::Expr::Lit(syn::ExprLit {
+                        attrs: _,
+                        lit: syn::Lit::Int(i),
+                    }) => i.base10_parse::<usize>().expect("Expected usize integer."),
+                    _ => unreachable!(
+                        "Expected a literal integer expression for array length in {arr:?}"
+                    ),
                 };
-                
+
                 if let syn::Type::Path(p) = &*arr.elem {
                     if let Some(primitive) = p
                         .path
                         .get_ident()
                         .and_then(|i| PrimitiveType::from_str(i.to_string().as_str()).ok())
                     {
-                        return TypeName::PrimitiveArray(
-                            primitive,
-                            len
-                        );
+                        return TypeName::PrimitiveArray(primitive, len);
                     }
                 }
                 panic!("Unsupported array type {:?}", arr.to_token_stream());

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -774,8 +774,8 @@ impl TypeName {
                         );
                     }
                 }
-                
-                if let syn::Type::Array(arr) =  &*r.elem {
+
+                if let syn::Type::Array(arr) = &*r.elem {
                     let len = match &arr.len {
                         syn::Expr::Lit(syn::ExprLit {
                             attrs: _,
@@ -797,7 +797,7 @@ impl TypeName {
                     }
                     panic!("Unsupported array type {:?}", arr.to_token_stream());
                 }
-                
+
                 if let syn::Type::Slice(slice) = &*r.elem {
                     if let syn::Type::Path(p) = &*slice.elem {
                         if let Some(primitive) = p
@@ -1136,7 +1136,10 @@ impl TypeName {
                 ret_type.expect("No valid traits found")
             }
             syn::Type::Array(a) => {
-                panic!("Array {0} must be behind a reference (&{0})", a.to_token_stream());
+                panic!(
+                    "Array {0} must be behind a reference (&{0})",
+                    a.to_token_stream()
+                );
             }
             other => panic!("Unsupported type: {}", other.to_token_stream()),
         }

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1000,6 +1000,8 @@ pub struct BackendAttrSupport {
     pub abi_compatibles: bool,
     /// Whether or not the language supports &Struct or &mut Struct
     pub struct_refs: bool,
+    /// Whether or not the language supports [T; usize] fixed-size arrays
+    pub arrays : bool,
 }
 
 impl BackendAttrSupport {
@@ -1035,6 +1037,7 @@ impl BackendAttrSupport {
             generate_mocking_interface: true,
             abi_compatibles: true,
             struct_refs: true,
+            arrays: true,
         }
     }
 
@@ -1066,6 +1069,7 @@ impl BackendAttrSupport {
             "traits_are_sync" => Some(self.traits_are_sync),
             "abi_compatibles" => Some(self.abi_compatibles),
             "struct_refs" => Some(self.struct_refs),
+            "arrays" => Some(self.arrays),
             _ => None,
         }
     }
@@ -1208,6 +1212,7 @@ impl AttributeValidator for BasicAttributeValidator {
                 generate_mocking_interface,
                 abi_compatibles,
                 struct_refs,
+                arrays,
             } = self.support;
             match value {
                 "namespacing" => namespacing,
@@ -1239,6 +1244,7 @@ impl AttributeValidator for BasicAttributeValidator {
                 "generate_mocking_interface" => generate_mocking_interface,
                 "abi_compatibles" => abi_compatibles,
                 "struct_refs" => struct_refs,
+                "arrays" => arrays,
                 _ => {
                     return Err(LoweringError::Other(format!(
                         "Unknown supports = value found: {value}"

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1001,7 +1001,7 @@ pub struct BackendAttrSupport {
     /// Whether or not the language supports &Struct or &mut Struct
     pub struct_refs: bool,
     /// Whether or not the language supports [T; usize] fixed-size arrays
-    pub arrays : bool,
+    pub arrays: bool,
 }
 
 impl BackendAttrSupport {

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -992,10 +992,7 @@ impl<'ast> LoweringContext<'ast> {
                             "Arrays not supported in this backend. Try using #[diplomat::attr(not(supports = arrays), disable)].".into()
                         ));
                 }
-                Ok(Type::Array(
-                    PrimitiveType::from_ast(*ty),
-                    *size,
-                ))
+                Ok(Type::Array(PrimitiveType::from_ast(*ty), *size))
             }
             ast::TypeName::CustomTypeSlice(lm, type_name) => {
                 match type_name.as_ref() {
@@ -1362,10 +1359,7 @@ impl<'ast> LoweringContext<'ast> {
             }
             ast::TypeName::PrimitiveArray(ty, size) => {
                 if let TypeLoweringContext::Callback = context {
-                    Ok(OutType::Array(
-                        PrimitiveType::from_ast(*ty),
-                        *size,
-                    ))
+                    Ok(OutType::Array(PrimitiveType::from_ast(*ty), *size))
                 } else {
                     self.errors.push(LoweringError::Other(
                         "Owned arrays cannot be returned".into(),

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -987,6 +987,9 @@ impl<'ast> LoweringContext<'ast> {
                 )))
             }
             ast::TypeName::PrimitiveArray(ty, size) => {
+                if !self.attr_validator.attrs_supported().arrays {
+                    panic!("Arrays not supported in this backend. Try using #[diplomat::attr(not(supports = arrays), disable)].")
+                }
                 Ok(Type::Array(Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)), *size))
             }
             ast::TypeName::CustomTypeSlice(lm, type_name) => {

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1358,7 +1358,14 @@ impl<'ast> LoweringContext<'ast> {
                 Err(())
             }
             ast::TypeName::PrimitiveArray(ty, size) => {
-                Ok(OutType::Array(Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)), *size))
+                if let TypeLoweringContext::Callback = context {
+                    Ok(OutType::Array(Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)), *size))
+                } else {
+                    self.errors.push(LoweringError::Other(
+                        "Owned arrays cannot be returned".into(),
+                    ));
+                    Err(())
+                }
             }
             ast::TypeName::StrReference(Some(l), encoding, _stdlib) => Ok(OutType::Slice(
                 Slice::Str(Some(ltl.lower_lifetime(l)), *encoding),

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -993,7 +993,7 @@ impl<'ast> LoweringContext<'ast> {
                         ));
                 }
                 Ok(Type::Array(
-                    Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)),
+                    PrimitiveType::from_ast(*ty),
                     *size,
                 ))
             }
@@ -1363,7 +1363,7 @@ impl<'ast> LoweringContext<'ast> {
             ast::TypeName::PrimitiveArray(ty, size) => {
                 if let TypeLoweringContext::Callback = context {
                     Ok(OutType::Array(
-                        Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)),
+                        PrimitiveType::from_ast(*ty),
                         *size,
                     ))
                 } else {

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -986,6 +986,9 @@ impl<'ast> LoweringContext<'ast> {
                     PrimitiveType::from_ast(*prim),
                 )))
             }
+            ast::TypeName::PrimitiveArray(ty, size) => {
+                Ok(Type::Array(Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)), *size))
+            }
             ast::TypeName::CustomTypeSlice(lm, type_name) => {
                 match type_name.as_ref() {
                     ast::TypeName::Named(path) => match path.resolve(in_path, self.env) {
@@ -1348,6 +1351,9 @@ impl<'ast> LoweringContext<'ast> {
                     "Owned slices cannot be returned".into(),
                 ));
                 Err(())
+            }
+            ast::TypeName::PrimitiveArray(ty, size) => {
+                Ok(OutType::Array(Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)), *size))
             }
             ast::TypeName::StrReference(Some(l), encoding, _stdlib) => Ok(OutType::Slice(
                 Slice::Str(Some(ltl.lower_lifetime(l)), *encoding),

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -992,7 +992,10 @@ impl<'ast> LoweringContext<'ast> {
                             "Arrays not supported in this backend. Try using #[diplomat::attr(not(supports = arrays), disable)].".into()
                         ));
                 }
-                Ok(Type::Array(Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)), *size))
+                Ok(Type::Array(
+                    Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)),
+                    *size,
+                ))
             }
             ast::TypeName::CustomTypeSlice(lm, type_name) => {
                 match type_name.as_ref() {
@@ -1359,7 +1362,10 @@ impl<'ast> LoweringContext<'ast> {
             }
             ast::TypeName::PrimitiveArray(ty, size) => {
                 if let TypeLoweringContext::Callback = context {
-                    Ok(OutType::Array(Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)), *size))
+                    Ok(OutType::Array(
+                        Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)),
+                        *size,
+                    ))
                 } else {
                     self.errors.push(LoweringError::Other(
                         "Owned arrays cannot be returned".into(),

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -988,7 +988,9 @@ impl<'ast> LoweringContext<'ast> {
             }
             ast::TypeName::PrimitiveArray(ty, size) => {
                 if !self.attr_validator.attrs_supported().arrays {
-                    panic!("Arrays not supported in this backend. Try using #[diplomat::attr(not(supports = arrays), disable)].")
+                    self.errors.push(LoweringError::Other(
+                            "Arrays not supported in this backend. Try using #[diplomat::attr(not(supports = arrays), disable)].".into()
+                        ));
                 }
                 Ok(Type::Array(Slice::Primitive(MaybeOwn::Own, PrimitiveType::from_ast(*ty)), *size))
             }

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -24,6 +24,8 @@ pub enum Type<P: TyPosition = Everywhere> {
     ImplTrait(P::TraitPath),
     Enum(EnumPath),
     Slice(Slice<P>),
+    /// A slice of a fixed size.
+    Array(Slice<P>, usize),
     Callback(P::CallbackInstantiation), // only a Callback if P == InputOnly
     /// `DiplomatOption<T>`, for  a primitive, struct, or enum `T`.
     ///
@@ -110,7 +112,7 @@ impl<P: TyPosition<StructPath = StructPath>> Type<P> {
                 (acc.0 + inner.0, acc.1 + inner.1)
             }),
             Type::Opaque(_) | Type::Slice(_) | Type::Callback(_) | Type::ImplTrait(_) => (1, 1),
-            Type::Primitive(_) | Type::Enum(_) => (0, 0),
+            Type::Primitive(_) | Type::Enum(_) | Type::Array(..) => (0, 0),
             Type::DiplomatOption(ty) => ty.field_leaf_lifetime_counts(tcx),
         }
     }

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -24,8 +24,8 @@ pub enum Type<P: TyPosition = Everywhere> {
     ImplTrait(P::TraitPath),
     Enum(EnumPath),
     Slice(Slice<P>),
-    /// A slice of a fixed size.
-    Array(Slice<P>, usize),
+    /// A primitive array of a fixed size.
+    Array(PrimitiveType, usize),
     Callback(P::CallbackInstantiation), // only a Callback if P == InputOnly
     /// `DiplomatOption<T>`, for  a primitive, struct, or enum `T`.
     ///

--- a/example/c/include/DataProvider.d.h
+++ b/example/c/include/DataProvider.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct DataProvider DataProvider;
-
-
 
 
 #endif // DataProvider_D_H

--- a/example/c/include/DataProvider.h
+++ b/example/c/include/DataProvider.h
@@ -14,15 +14,12 @@
 
 
 
-
 DataProvider* icu4x_DataProvider_new_static_mv1(void);
 
 typedef struct icu4x_DataProvider_returns_result_mv1_result { bool is_ok;} icu4x_DataProvider_returns_result_mv1_result;
 icu4x_DataProvider_returns_result_mv1_result icu4x_DataProvider_returns_result_mv1(void);
 
 void icu4x_DataProvider_destroy_mv1(DataProvider* self);
-
-
 
 
 

--- a/example/c/include/FixedDecimal.d.h
+++ b/example/c/include/FixedDecimal.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct FixedDecimal FixedDecimal;
-
-
 
 
 #endif // FixedDecimal_D_H

--- a/example/c/include/FixedDecimal.h
+++ b/example/c/include/FixedDecimal.h
@@ -14,7 +14,6 @@
 
 
 
-
 FixedDecimal* icu4x_FixedDecimal_new_mv1(int32_t v);
 
 void icu4x_FixedDecimal_multiply_pow10_mv1(FixedDecimal* self, int16_t power);
@@ -23,8 +22,6 @@ typedef struct icu4x_FixedDecimal_to_string_mv1_result { bool is_ok;} icu4x_Fixe
 icu4x_FixedDecimal_to_string_mv1_result icu4x_FixedDecimal_to_string_mv1(const FixedDecimal* self, DiplomatWrite* write);
 
 void icu4x_FixedDecimal_destroy_mv1(FixedDecimal* self);
-
-
 
 
 

--- a/example/c/include/FixedDecimalFormatter.d.h
+++ b/example/c/include/FixedDecimalFormatter.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct FixedDecimalFormatter FixedDecimalFormatter;
-
-
 
 
 #endif // FixedDecimalFormatter_D_H

--- a/example/c/include/FixedDecimalFormatter.h
+++ b/example/c/include/FixedDecimalFormatter.h
@@ -18,15 +18,12 @@
 
 
 
-
 typedef struct icu4x_FixedDecimalFormatter_try_new_mv1_result {union {FixedDecimalFormatter* ok; }; bool is_ok;} icu4x_FixedDecimalFormatter_try_new_mv1_result;
 icu4x_FixedDecimalFormatter_try_new_mv1_result icu4x_FixedDecimalFormatter_try_new_mv1(const Locale* locale, const DataProvider* provider, FixedDecimalFormatterOptions options);
 
 void icu4x_FixedDecimalFormatter_format_write_mv1(const FixedDecimalFormatter* self, const FixedDecimal* value, DiplomatWrite* write);
 
 void icu4x_FixedDecimalFormatter_destroy_mv1(FixedDecimalFormatter* self);
-
-
 
 
 

--- a/example/c/include/FixedDecimalFormatterOptions.d.h
+++ b/example/c/include/FixedDecimalFormatterOptions.d.h
@@ -11,14 +11,11 @@
 
 
 
-
 typedef struct FixedDecimalFormatterOptions {
   FixedDecimalGroupingStrategy grouping_strategy;
   bool some_other_config;
 } FixedDecimalFormatterOptions;
 
 typedef struct FixedDecimalFormatterOptions_option {union { FixedDecimalFormatterOptions ok; }; bool is_ok; } FixedDecimalFormatterOptions_option;
-
-
 
 #endif // FixedDecimalFormatterOptions_D_H

--- a/example/c/include/FixedDecimalFormatterOptions.h
+++ b/example/c/include/FixedDecimalFormatterOptions.h
@@ -14,10 +14,7 @@
 
 
 
-
 FixedDecimalFormatterOptions icu4x_FixedDecimalFormatterOptions_default_mv1(void);
-
-
 
 
 

--- a/example/c/include/FixedDecimalGroupingStrategy.d.h
+++ b/example/c/include/FixedDecimalGroupingStrategy.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef enum FixedDecimalGroupingStrategy {
   FixedDecimalGroupingStrategy_Auto = 0,
   FixedDecimalGroupingStrategy_Never = 1,
@@ -19,7 +18,5 @@ typedef enum FixedDecimalGroupingStrategy {
 } FixedDecimalGroupingStrategy;
 
 typedef struct FixedDecimalGroupingStrategy_option {union { FixedDecimalGroupingStrategy ok; }; bool is_ok; } FixedDecimalGroupingStrategy_option;
-
-
 
 #endif // FixedDecimalGroupingStrategy_D_H

--- a/example/c/include/FixedDecimalGroupingStrategy.h
+++ b/example/c/include/FixedDecimalGroupingStrategy.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // FixedDecimalGroupingStrategy_H

--- a/example/c/include/Locale.d.h
+++ b/example/c/include/Locale.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Locale Locale;
-
-
 
 
 #endif // Locale_D_H

--- a/example/c/include/Locale.h
+++ b/example/c/include/Locale.h
@@ -14,12 +14,9 @@
 
 
 
-
 Locale* icu4x_Locale_new_mv1(DiplomatStringView name);
 
 void icu4x_Locale_destroy_mv1(Locale* self);
-
-
 
 
 

--- a/feature_tests/c/include/AttrEnum.d.h
+++ b/feature_tests/c/include/AttrEnum.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef enum AttrEnum {
   AttrEnum_A = 0,
   AttrEnum_B = 1,
@@ -18,7 +17,5 @@ typedef enum AttrEnum {
 } AttrEnum;
 
 typedef struct AttrEnum_option {union { AttrEnum ok; }; bool is_ok; } AttrEnum_option;
-
-
 
 #endif // AttrEnum_D_H

--- a/feature_tests/c/include/AttrEnum.h
+++ b/feature_tests/c/include/AttrEnum.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // AttrEnum_H

--- a/feature_tests/c/include/AttrOpaque1.d.h
+++ b/feature_tests/c/include/AttrOpaque1.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct AttrOpaque1 AttrOpaque1;
-
-
 
 
 #endif // AttrOpaque1_D_H

--- a/feature_tests/c/include/AttrOpaque1.h
+++ b/feature_tests/c/include/AttrOpaque1.h
@@ -15,7 +15,6 @@
 
 
 
-
 typedef struct DiplomatCallback_namespace_AttrOpaque1_test_namespaced_callback__t_result { bool is_ok;} DiplomatCallback_namespace_AttrOpaque1_test_namespaced_callback__t_result;
 
 typedef struct DiplomatCallback_namespace_AttrOpaque1_test_namespaced_callback__t {
@@ -41,8 +40,6 @@ void namespace_AttrOpaque1_use_unnamespaced(const AttrOpaque1* self, const Unnam
 void namespace_AttrOpaque1_use_namespaced(const AttrOpaque1* self, AttrEnum _n);
 
 void namespace_AttrOpaque1_destroy(AttrOpaque1* self);
-
-
 
 
 

--- a/feature_tests/c/include/AttrOpaque2.d.h
+++ b/feature_tests/c/include/AttrOpaque2.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct AttrOpaque2 AttrOpaque2;
-
-
 
 
 #endif // AttrOpaque2_D_H

--- a/feature_tests/c/include/AttrOpaque2.h
+++ b/feature_tests/c/include/AttrOpaque2.h
@@ -14,10 +14,7 @@
 
 
 
-
 void namespace_AttrOpaque2_destroy(AttrOpaque2* self);
-
-
 
 
 

--- a/feature_tests/c/include/Bar.d.h
+++ b/feature_tests/c/include/Bar.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Bar Bar;
-
-
 
 
 #endif // Bar_D_H

--- a/feature_tests/c/include/Bar.h
+++ b/feature_tests/c/include/Bar.h
@@ -15,12 +15,9 @@
 
 
 
-
 const Foo* Bar_foo(const Bar* self);
 
 void Bar_destroy(Bar* self);
-
-
 
 
 

--- a/feature_tests/c/include/BigStructWithStuff.d.h
+++ b/feature_tests/c/include/BigStructWithStuff.d.h
@@ -11,7 +11,6 @@
 
 
 
-
 typedef struct BigStructWithStuff {
   uint8_t first;
   uint16_t second;
@@ -30,8 +29,6 @@ typedef struct DiplomatBigStructWithStuffViewMut {
   BigStructWithStuff* data;
   size_t len;
 } DiplomatBigStructWithStuffViewMut;
-
-
 
 
 #endif // BigStructWithStuff_D_H

--- a/feature_tests/c/include/BigStructWithStuff.h
+++ b/feature_tests/c/include/BigStructWithStuff.h
@@ -14,12 +14,9 @@
 
 
 
-
 void BigStructWithStuff_assert_value(BigStructWithStuff self, uint16_t extra_val);
 
 void BigStructWithStuff_assert_slice(DiplomatBigStructWithStuffView slice, uint16_t second_value);
-
-
 
 
 

--- a/feature_tests/c/include/BorrowedFields.d.h
+++ b/feature_tests/c/include/BorrowedFields.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef struct BorrowedFields {
   DiplomatString16View a;
   DiplomatStringView b;
@@ -18,7 +17,5 @@ typedef struct BorrowedFields {
 } BorrowedFields;
 
 typedef struct BorrowedFields_option {union { BorrowedFields ok; }; bool is_ok; } BorrowedFields_option;
-
-
 
 #endif // BorrowedFields_D_H

--- a/feature_tests/c/include/BorrowedFields.h
+++ b/feature_tests/c/include/BorrowedFields.h
@@ -15,10 +15,7 @@
 
 
 
-
 BorrowedFields BorrowedFields_from_bar_and_strings(const Bar* bar, DiplomatString16View dstr16, DiplomatStringView utf8_str);
-
-
 
 
 

--- a/feature_tests/c/include/BorrowedFieldsReturning.d.h
+++ b/feature_tests/c/include/BorrowedFieldsReturning.d.h
@@ -10,13 +10,10 @@
 
 
 
-
 typedef struct BorrowedFieldsReturning {
   DiplomatStringView bytes;
 } BorrowedFieldsReturning;
 
 typedef struct BorrowedFieldsReturning_option {union { BorrowedFieldsReturning ok; }; bool is_ok; } BorrowedFieldsReturning_option;
-
-
 
 #endif // BorrowedFieldsReturning_D_H

--- a/feature_tests/c/include/BorrowedFieldsReturning.h
+++ b/feature_tests/c/include/BorrowedFieldsReturning.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // BorrowedFieldsReturning_H

--- a/feature_tests/c/include/BorrowedFieldsWithBounds.d.h
+++ b/feature_tests/c/include/BorrowedFieldsWithBounds.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef struct BorrowedFieldsWithBounds {
   DiplomatString16View field_a;
   DiplomatStringView field_b;
@@ -18,7 +17,5 @@ typedef struct BorrowedFieldsWithBounds {
 } BorrowedFieldsWithBounds;
 
 typedef struct BorrowedFieldsWithBounds_option {union { BorrowedFieldsWithBounds ok; }; bool is_ok; } BorrowedFieldsWithBounds_option;
-
-
 
 #endif // BorrowedFieldsWithBounds_D_H

--- a/feature_tests/c/include/BorrowedFieldsWithBounds.h
+++ b/feature_tests/c/include/BorrowedFieldsWithBounds.h
@@ -15,10 +15,7 @@
 
 
 
-
 BorrowedFieldsWithBounds BorrowedFieldsWithBounds_from_foo_and_strings(const Foo* foo, DiplomatString16View dstr16_x, DiplomatStringView utf8_str_z);
-
-
 
 
 

--- a/feature_tests/c/include/CallbackHolder.d.h
+++ b/feature_tests/c/include/CallbackHolder.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct CallbackHolder CallbackHolder;
-
-
 
 
 #endif // CallbackHolder_D_H

--- a/feature_tests/c/include/CallbackHolder.h
+++ b/feature_tests/c/include/CallbackHolder.h
@@ -13,7 +13,6 @@
 
 
 
-
 typedef struct DiplomatCallback_CallbackHolder_new_func {
     const void* data;
     int32_t (*run_callback)(const void*, int32_t );
@@ -25,8 +24,6 @@ CallbackHolder* CallbackHolder_new(DiplomatCallback_CallbackHolder_new_func func
 int32_t CallbackHolder_call(const CallbackHolder* self, int32_t a);
 
 void CallbackHolder_destroy(CallbackHolder* self);
-
-
 
 
 

--- a/feature_tests/c/include/CallbackTestingStruct.d.h
+++ b/feature_tests/c/include/CallbackTestingStruct.d.h
@@ -10,14 +10,11 @@
 
 
 
-
 typedef struct CallbackTestingStruct {
   int32_t x;
   int32_t y;
 } CallbackTestingStruct;
 
 typedef struct CallbackTestingStruct_option {union { CallbackTestingStruct ok; }; bool is_ok; } CallbackTestingStruct_option;
-
-
 
 #endif // CallbackTestingStruct_D_H

--- a/feature_tests/c/include/CallbackTestingStruct.h
+++ b/feature_tests/c/include/CallbackTestingStruct.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // CallbackTestingStruct_H

--- a/feature_tests/c/include/CallbackWrapper.d.h
+++ b/feature_tests/c/include/CallbackWrapper.d.h
@@ -10,13 +10,10 @@
 
 
 
-
 typedef struct CallbackWrapper {
   bool cant_be_empty;
 } CallbackWrapper;
 
 typedef struct CallbackWrapper_option {union { CallbackWrapper ok; }; bool is_ok; } CallbackWrapper_option;
-
-
 
 #endif // CallbackWrapper_D_H

--- a/feature_tests/c/include/CallbackWrapper.h
+++ b/feature_tests/c/include/CallbackWrapper.h
@@ -14,7 +14,6 @@
 #include "PrimitiveStruct.d.h"
 
 #include "CallbackWrapper.d.h"
-
 typedef uint8_t U8Array_2[2];
 
 
@@ -187,8 +186,6 @@ void CallbackWrapper_test_slice_conversion(DiplomatCallback_CallbackWrapper_test
 void CallbackWrapper_test_struct_slice_conversion(DiplomatCallback_CallbackWrapper_test_struct_slice_conversion_t t_cb_wrap);
 
 void CallbackWrapper_test_opaque_result_error(DiplomatCallback_CallbackWrapper_test_opaque_result_error_t t_cb_wrap, DiplomatWrite* write);
-
-
 
 
 

--- a/feature_tests/c/include/CallbackWrapper.h
+++ b/feature_tests/c/include/CallbackWrapper.h
@@ -62,7 +62,7 @@ typedef struct DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f {
 } DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f;
 typedef struct DiplomatCallback_CallbackWrapper_test_array_cb_arg_f {
     const void* data;
-    U8Array_2 (*run_callback)(const void*, U8Array_2 );
+    void (*run_callback)(const void*, U8Array_2 );
     void (*destructor)(const void*);
 } DiplomatCallback_CallbackWrapper_test_array_cb_arg_f;
 typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t_result { bool is_ok;} DiplomatCallback_CallbackWrapper_test_result_output_t_result;
@@ -162,7 +162,7 @@ void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_op
 
 void CallbackWrapper_test_slice_cb_arg(DiplomatU8View arg, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f f_cb_wrap);
 
-U8Array_2 CallbackWrapper_test_array_cb_arg(U8Array_2 arg, DiplomatCallback_CallbackWrapper_test_array_cb_arg_f f_cb_wrap);
+void CallbackWrapper_test_array_cb_arg(U8Array_2 arg, DiplomatCallback_CallbackWrapper_test_array_cb_arg_f f_cb_wrap);
 
 void CallbackWrapper_test_result_output(DiplomatCallback_CallbackWrapper_test_result_output_t t_cb_wrap);
 

--- a/feature_tests/c/include/CallbackWrapper.h
+++ b/feature_tests/c/include/CallbackWrapper.h
@@ -15,6 +15,7 @@
 
 #include "CallbackWrapper.d.h"
 
+typedef uint8_t U8Array_2[2];
 
 
 
@@ -59,6 +60,11 @@ typedef struct DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f {
     void (*run_callback)(const void*, DiplomatU8View );
     void (*destructor)(const void*);
 } DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f;
+typedef struct DiplomatCallback_CallbackWrapper_test_array_cb_arg_f {
+    const void* data;
+    U8Array_2 (*run_callback)(const void*, U8Array_2 );
+    void (*destructor)(const void*);
+} DiplomatCallback_CallbackWrapper_test_array_cb_arg_f;
 typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t_result { bool is_ok;} DiplomatCallback_CallbackWrapper_test_result_output_t_result;
 
 typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t {
@@ -155,6 +161,8 @@ int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_st
 void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb cb_cb_wrap, MyString* a);
 
 void CallbackWrapper_test_slice_cb_arg(DiplomatU8View arg, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f f_cb_wrap);
+
+U8Array_2 CallbackWrapper_test_array_cb_arg(U8Array_2 arg, DiplomatCallback_CallbackWrapper_test_array_cb_arg_f f_cb_wrap);
 
 void CallbackWrapper_test_result_output(DiplomatCallback_CallbackWrapper_test_result_output_t t_cb_wrap);
 

--- a/feature_tests/c/include/ContiguousEnum.d.h
+++ b/feature_tests/c/include/ContiguousEnum.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef enum ContiguousEnum {
   ContiguousEnum_C = 0,
   ContiguousEnum_D = 1,
@@ -19,7 +18,5 @@ typedef enum ContiguousEnum {
 } ContiguousEnum;
 
 typedef struct ContiguousEnum_option {union { ContiguousEnum ok; }; bool is_ok; } ContiguousEnum_option;
-
-
 
 #endif // ContiguousEnum_D_H

--- a/feature_tests/c/include/ContiguousEnum.h
+++ b/feature_tests/c/include/ContiguousEnum.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // ContiguousEnum_H

--- a/feature_tests/c/include/CyclicStructA.d.h
+++ b/feature_tests/c/include/CyclicStructA.d.h
@@ -11,7 +11,6 @@
 
 
 
-
 typedef struct CyclicStructA {
   CyclicStructB a;
 } CyclicStructA;
@@ -26,8 +25,6 @@ typedef struct DiplomatCyclicStructAViewMut {
   CyclicStructA* data;
   size_t len;
 } DiplomatCyclicStructAViewMut;
-
-
 
 
 #endif // CyclicStructA_D_H

--- a/feature_tests/c/include/CyclicStructA.h
+++ b/feature_tests/c/include/CyclicStructA.h
@@ -15,7 +15,6 @@
 
 
 
-
 CyclicStructB CyclicStructA_get_b(void);
 
 void CyclicStructA_cyclic_out(CyclicStructA self, DiplomatWrite* write);
@@ -25,8 +24,6 @@ uint8_t CyclicStructA_nested_slice(DiplomatCyclicStructAView sl);
 void CyclicStructA_double_cyclic_out(CyclicStructA self, CyclicStructA cyclic_struct_a, DiplomatWrite* write);
 
 void CyclicStructA_getter_out(CyclicStructA self, DiplomatWrite* write);
-
-
 
 
 

--- a/feature_tests/c/include/CyclicStructB.d.h
+++ b/feature_tests/c/include/CyclicStructB.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef struct CyclicStructB {
   uint8_t field;
 } CyclicStructB;
@@ -25,8 +24,6 @@ typedef struct DiplomatCyclicStructBViewMut {
   CyclicStructB* data;
   size_t len;
 } DiplomatCyclicStructBViewMut;
-
-
 
 
 #endif // CyclicStructB_D_H

--- a/feature_tests/c/include/CyclicStructB.h
+++ b/feature_tests/c/include/CyclicStructB.h
@@ -15,13 +15,10 @@
 
 
 
-
 CyclicStructA CyclicStructB_get_a(void);
 
 typedef struct CyclicStructB_get_a_option_result {union {CyclicStructA ok; }; bool is_ok;} CyclicStructB_get_a_option_result;
 CyclicStructB_get_a_option_result CyclicStructB_get_a_option(void);
-
-
 
 
 

--- a/feature_tests/c/include/CyclicStructC.d.h
+++ b/feature_tests/c/include/CyclicStructC.d.h
@@ -11,13 +11,10 @@
 
 
 
-
 typedef struct CyclicStructC {
   CyclicStructA a;
 } CyclicStructC;
 
 typedef struct CyclicStructC_option {union { CyclicStructC ok; }; bool is_ok; } CyclicStructC_option;
-
-
 
 #endif // CyclicStructC_D_H

--- a/feature_tests/c/include/CyclicStructC.h
+++ b/feature_tests/c/include/CyclicStructC.h
@@ -14,12 +14,9 @@
 
 
 
-
 CyclicStructC CyclicStructC_takes_nested_parameters(CyclicStructC c);
 
 void CyclicStructC_cyclic_out(CyclicStructC self, DiplomatWrite* write);
-
-
 
 
 

--- a/feature_tests/c/include/DefaultEnum.d.h
+++ b/feature_tests/c/include/DefaultEnum.d.h
@@ -10,14 +10,11 @@
 
 
 
-
 typedef enum DefaultEnum {
   DefaultEnum_A = 0,
   DefaultEnum_B = 1,
 } DefaultEnum;
 
 typedef struct DefaultEnum_option {union { DefaultEnum ok; }; bool is_ok; } DefaultEnum_option;
-
-
 
 #endif // DefaultEnum_D_H

--- a/feature_tests/c/include/DefaultEnum.h
+++ b/feature_tests/c/include/DefaultEnum.h
@@ -14,10 +14,7 @@
 
 
 
-
 DefaultEnum DefaultEnum_new(void);
-
-
 
 
 

--- a/feature_tests/c/include/ErrorEnum.d.h
+++ b/feature_tests/c/include/ErrorEnum.d.h
@@ -10,14 +10,11 @@
 
 
 
-
 typedef enum ErrorEnum {
   ErrorEnum_Foo = 0,
   ErrorEnum_Bar = 1,
 } ErrorEnum;
 
 typedef struct ErrorEnum_option {union { ErrorEnum ok; }; bool is_ok; } ErrorEnum_option;
-
-
 
 #endif // ErrorEnum_D_H

--- a/feature_tests/c/include/ErrorEnum.h
+++ b/feature_tests/c/include/ErrorEnum.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // ErrorEnum_H

--- a/feature_tests/c/include/ErrorStruct.d.h
+++ b/feature_tests/c/include/ErrorStruct.d.h
@@ -10,14 +10,11 @@
 
 
 
-
 typedef struct ErrorStruct {
   int32_t i;
   int32_t j;
 } ErrorStruct;
 
 typedef struct ErrorStruct_option {union { ErrorStruct ok; }; bool is_ok; } ErrorStruct_option;
-
-
 
 #endif // ErrorStruct_D_H

--- a/feature_tests/c/include/ErrorStruct.h
+++ b/feature_tests/c/include/ErrorStruct.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // ErrorStruct_H

--- a/feature_tests/c/include/Float64Vec.d.h
+++ b/feature_tests/c/include/Float64Vec.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Float64Vec Float64Vec;
-
-
 
 
 #endif // Float64Vec_D_H

--- a/feature_tests/c/include/Float64Vec.h
+++ b/feature_tests/c/include/Float64Vec.h
@@ -10,6 +10,7 @@
 
 #include "Float64Vec.d.h"
 typedef bool BoolArray_3[3];
+typedef double F64Array_2[2];
 typedef int32_t I32Array_12[12];
 
 
@@ -20,7 +21,7 @@ Float64Vec* Float64Vec_new(DiplomatF64View v);
 
 Float64Vec* Float64Vec_new_bool(DiplomatBoolView v);
 
-Float64Vec* Float64Vec_new_bool_arr(BoolArray_3 v, BoolArray_3 _other, I32Array_12 _other_other);
+Float64Vec* Float64Vec_new_int_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other);
 
 Float64Vec* Float64Vec_new_i16(DiplomatI16View v);
 

--- a/feature_tests/c/include/Float64Vec.h
+++ b/feature_tests/c/include/Float64Vec.h
@@ -10,6 +10,8 @@
 
 #include "Float64Vec.d.h"
 
+typedef bool BoolArray_3[3];
+typedef int32_t I32Array_12[12];
 
 
 
@@ -18,6 +20,8 @@
 Float64Vec* Float64Vec_new(DiplomatF64View v);
 
 Float64Vec* Float64Vec_new_bool(DiplomatBoolView v);
+
+Float64Vec* Float64Vec_new_bool_arr(BoolArray_3 v, BoolArray_3 _other, I32Array_12 _other_other);
 
 Float64Vec* Float64Vec_new_i16(DiplomatI16View v);
 

--- a/feature_tests/c/include/Float64Vec.h
+++ b/feature_tests/c/include/Float64Vec.h
@@ -11,6 +11,7 @@
 #include "Float64Vec.d.h"
 
 typedef bool BoolArray_3[3];
+typedef double F64Array_3[3];
 typedef int32_t I32Array_12[12];
 
 
@@ -34,6 +35,8 @@ Float64Vec* Float64Vec_new_usize(DiplomatUsizeView v);
 Float64Vec* Float64Vec_new_f64_be_bytes(DiplomatU8View v);
 
 DiplomatF64View Float64Vec_as_slice(const Float64Vec* self);
+
+F64Array_3 Float64Vec_get_array(const Float64Vec* self);
 
 void Float64Vec_fill_slice(const Float64Vec* self, DiplomatF64ViewMut v);
 

--- a/feature_tests/c/include/Float64Vec.h
+++ b/feature_tests/c/include/Float64Vec.h
@@ -9,7 +9,6 @@
 
 
 #include "Float64Vec.d.h"
-
 typedef bool BoolArray_3[3];
 typedef int32_t I32Array_12[12];
 
@@ -47,8 +46,6 @@ typedef struct Float64Vec_get_result {union {double ok; }; bool is_ok;} Float64V
 Float64Vec_get_result Float64Vec_get(const Float64Vec* self, size_t i);
 
 void Float64Vec_destroy(Float64Vec* self);
-
-
 
 
 

--- a/feature_tests/c/include/Float64Vec.h
+++ b/feature_tests/c/include/Float64Vec.h
@@ -11,7 +11,6 @@
 #include "Float64Vec.d.h"
 
 typedef bool BoolArray_3[3];
-typedef double F64Array_3[3];
 typedef int32_t I32Array_12[12];
 
 
@@ -35,8 +34,6 @@ Float64Vec* Float64Vec_new_usize(DiplomatUsizeView v);
 Float64Vec* Float64Vec_new_f64_be_bytes(DiplomatU8View v);
 
 DiplomatF64View Float64Vec_as_slice(const Float64Vec* self);
-
-F64Array_3 Float64Vec_get_array(const Float64Vec* self);
 
 void Float64Vec_fill_slice(const Float64Vec* self, DiplomatF64ViewMut v);
 

--- a/feature_tests/c/include/Foo.d.h
+++ b/feature_tests/c/include/Foo.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Foo Foo;
-
-
 
 
 #endif // Foo_D_H

--- a/feature_tests/c/include/Foo.h
+++ b/feature_tests/c/include/Foo.h
@@ -18,7 +18,6 @@
 
 
 
-
 Foo* Foo_new(DiplomatStringView x);
 
 Bar* Foo_get_bar(const Foo* self);
@@ -32,8 +31,6 @@ Foo* Foo_extract_from_fields(BorrowedFields fields);
 Foo* Foo_extract_from_bounds(BorrowedFieldsWithBounds bounds, DiplomatStringView another_string);
 
 void Foo_destroy(Foo* self);
-
-
 
 
 

--- a/feature_tests/c/include/ImportedStruct.d.h
+++ b/feature_tests/c/include/ImportedStruct.d.h
@@ -11,14 +11,11 @@
 
 
 
-
 typedef struct ImportedStruct {
   UnimportedEnum foo;
   uint8_t count;
 } ImportedStruct;
 
 typedef struct ImportedStruct_option {union { ImportedStruct ok; }; bool is_ok; } ImportedStruct_option;
-
-
 
 #endif // ImportedStruct_D_H

--- a/feature_tests/c/include/ImportedStruct.h
+++ b/feature_tests/c/include/ImportedStruct.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // ImportedStruct_H

--- a/feature_tests/c/include/MutableCallbackHolder.d.h
+++ b/feature_tests/c/include/MutableCallbackHolder.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct MutableCallbackHolder MutableCallbackHolder;
-
-
 
 
 #endif // MutableCallbackHolder_D_H

--- a/feature_tests/c/include/MutableCallbackHolder.h
+++ b/feature_tests/c/include/MutableCallbackHolder.h
@@ -13,7 +13,6 @@
 
 
 
-
 typedef struct DiplomatCallback_MutableCallbackHolder_new_func {
     const void* data;
     int32_t (*run_callback)(const void*, int32_t );
@@ -25,8 +24,6 @@ MutableCallbackHolder* MutableCallbackHolder_new(DiplomatCallback_MutableCallbac
 int32_t MutableCallbackHolder_call(MutableCallbackHolder* self, int32_t a);
 
 void MutableCallbackHolder_destroy(MutableCallbackHolder* self);
-
-
 
 
 

--- a/feature_tests/c/include/MyEnum.d.h
+++ b/feature_tests/c/include/MyEnum.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef enum MyEnum {
   MyEnum_A = -2,
   MyEnum_B = -1,
@@ -21,7 +20,5 @@ typedef enum MyEnum {
 } MyEnum;
 
 typedef struct MyEnum_option {union { MyEnum ok; }; bool is_ok; } MyEnum_option;
-
-
 
 #endif // MyEnum_D_H

--- a/feature_tests/c/include/MyEnum.h
+++ b/feature_tests/c/include/MyEnum.h
@@ -14,12 +14,9 @@
 
 
 
-
 int8_t MyEnum_into_value(MyEnum self);
 
 MyEnum MyEnum_get_a(void);
-
-
 
 
 

--- a/feature_tests/c/include/MyOpaqueEnum.d.h
+++ b/feature_tests/c/include/MyOpaqueEnum.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct MyOpaqueEnum MyOpaqueEnum;
-
-
 
 
 #endif // MyOpaqueEnum_D_H

--- a/feature_tests/c/include/MyOpaqueEnum.h
+++ b/feature_tests/c/include/MyOpaqueEnum.h
@@ -14,14 +14,11 @@
 
 
 
-
 MyOpaqueEnum* MyOpaqueEnum_new(void);
 
 void MyOpaqueEnum_to_string(const MyOpaqueEnum* self, DiplomatWrite* write);
 
 void MyOpaqueEnum_destroy(MyOpaqueEnum* self);
-
-
 
 
 

--- a/feature_tests/c/include/MyString.d.h
+++ b/feature_tests/c/include/MyString.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct MyString MyString;
-
-
 
 
 #endif // MyString_D_H

--- a/feature_tests/c/include/MyString.h
+++ b/feature_tests/c/include/MyString.h
@@ -14,7 +14,6 @@
 
 
 
-
 MyString* MyString_new(DiplomatStringView v);
 
 MyString* MyString_new_unsafe(DiplomatStringView v);
@@ -34,8 +33,6 @@ void MyString_string_transform(DiplomatStringView foo, DiplomatWrite* write);
 DiplomatStringView MyString_borrow(const MyString* self);
 
 void MyString_destroy(MyString* self);
-
-
 
 
 

--- a/feature_tests/c/include/MyStruct.d.h
+++ b/feature_tests/c/include/MyStruct.d.h
@@ -11,7 +11,6 @@
 
 
 
-
 typedef struct MyStruct {
   uint8_t a;
   bool b;
@@ -23,7 +22,5 @@ typedef struct MyStruct {
 } MyStruct;
 
 typedef struct MyStruct_option {union { MyStruct ok; }; bool is_ok; } MyStruct_option;
-
-
 
 #endif // MyStruct_D_H

--- a/feature_tests/c/include/MyStruct.h
+++ b/feature_tests/c/include/MyStruct.h
@@ -14,7 +14,6 @@
 
 
 
-
 MyStruct MyStruct_new(void);
 
 void MyStruct_takes_mut(MyStruct* self, MyStruct* o);
@@ -28,8 +27,6 @@ MyStruct_returns_zst_result_result MyStruct_returns_zst_result(void);
 
 typedef struct MyStruct_fails_zst_result_result { bool is_ok;} MyStruct_fails_zst_result_result;
 MyStruct_fails_zst_result_result MyStruct_fails_zst_result(void);
-
-
 
 
 

--- a/feature_tests/c/include/MyStructContainingAnOption.d.h
+++ b/feature_tests/c/include/MyStructContainingAnOption.d.h
@@ -12,14 +12,11 @@
 
 
 
-
 typedef struct MyStructContainingAnOption {
   MyStruct_option a;
   DefaultEnum_option b;
 } MyStructContainingAnOption;
 
 typedef struct MyStructContainingAnOption_option {union { MyStructContainingAnOption ok; }; bool is_ok; } MyStructContainingAnOption_option;
-
-
 
 #endif // MyStructContainingAnOption_D_H

--- a/feature_tests/c/include/MyStructContainingAnOption.h
+++ b/feature_tests/c/include/MyStructContainingAnOption.h
@@ -14,12 +14,9 @@
 
 
 
-
 MyStructContainingAnOption MyStructContainingAnOption_new(void);
 
 MyStructContainingAnOption MyStructContainingAnOption_filled(void);
-
-
 
 
 

--- a/feature_tests/c/include/MyZst.d.h
+++ b/feature_tests/c/include/MyZst.d.h
@@ -14,7 +14,4 @@
 
 
 
-
-
-
 #endif // MyZst_D_H

--- a/feature_tests/c/include/MyZst.h
+++ b/feature_tests/c/include/MyZst.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // MyZst_H

--- a/feature_tests/c/include/Nested.d.h
+++ b/feature_tests/c/include/Nested.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Nested Nested;
-
-
 
 
 #endif // Nested_D_H

--- a/feature_tests/c/include/Nested.h
+++ b/feature_tests/c/include/Nested.h
@@ -14,10 +14,7 @@
 
 
 
-
 void namespace_Nested_destroy(Nested* self);
-
-
 
 
 

--- a/feature_tests/c/include/Nested2.d.h
+++ b/feature_tests/c/include/Nested2.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Nested2 Nested2;
-
-
 
 
 #endif // Nested2_D_H

--- a/feature_tests/c/include/Nested2.h
+++ b/feature_tests/c/include/Nested2.h
@@ -14,10 +14,7 @@
 
 
 
-
 void namespace_Nested2_destroy(Nested2* self);
-
-
 
 
 

--- a/feature_tests/c/include/NestedBorrowedFields.d.h
+++ b/feature_tests/c/include/NestedBorrowedFields.d.h
@@ -12,7 +12,6 @@
 
 
 
-
 typedef struct NestedBorrowedFields {
   BorrowedFields fields;
   BorrowedFieldsWithBounds bounds;
@@ -20,7 +19,5 @@ typedef struct NestedBorrowedFields {
 } NestedBorrowedFields;
 
 typedef struct NestedBorrowedFields_option {union { NestedBorrowedFields ok; }; bool is_ok; } NestedBorrowedFields_option;
-
-
 
 #endif // NestedBorrowedFields_D_H

--- a/feature_tests/c/include/NestedBorrowedFields.h
+++ b/feature_tests/c/include/NestedBorrowedFields.h
@@ -16,10 +16,7 @@
 
 
 
-
 NestedBorrowedFields NestedBorrowedFields_from_bar_and_foo_and_strings(const Bar* bar, const Foo* foo, DiplomatString16View dstr16_x, DiplomatString16View dstr16_z, DiplomatStringView utf8_str_y, DiplomatStringView utf8_str_z);
-
-
 
 
 

--- a/feature_tests/c/include/One.d.h
+++ b/feature_tests/c/include/One.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct One One;
-
-
 
 
 #endif // One_D_H

--- a/feature_tests/c/include/One.h
+++ b/feature_tests/c/include/One.h
@@ -15,7 +15,6 @@
 
 
 
-
 One* One_transitivity(const One* hold, const One* nohold);
 
 One* One_cycle(const Two* hold, const One* nohold);
@@ -39,8 +38,6 @@ One* One_implicit_bounds(const One* explicit_hold, const One* implicit_hold, con
 One* One_implicit_bounds_deep(const One* explicit_, const One* implicit_1, const One* implicit_2, const One* nohold);
 
 void One_destroy(One* self);
-
-
 
 
 

--- a/feature_tests/c/include/Opaque.d.h
+++ b/feature_tests/c/include/Opaque.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Opaque Opaque;
-
-
 
 
 #endif // Opaque_D_H

--- a/feature_tests/c/include/Opaque.h
+++ b/feature_tests/c/include/Opaque.h
@@ -16,7 +16,6 @@
 
 
 
-
 Opaque* Opaque_new(void);
 
 Opaque* Opaque_try_from_utf8(DiplomatStringView input);
@@ -34,8 +33,6 @@ ImportedStruct Opaque_returns_imported(void);
 int8_t Opaque_cmp(void);
 
 void Opaque_destroy(Opaque* self);
-
-
 
 
 

--- a/feature_tests/c/include/OpaqueMutexedString.d.h
+++ b/feature_tests/c/include/OpaqueMutexedString.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct OpaqueMutexedString OpaqueMutexedString;
-
-
 
 
 #endif // OpaqueMutexedString_D_H

--- a/feature_tests/c/include/OpaqueMutexedString.h
+++ b/feature_tests/c/include/OpaqueMutexedString.h
@@ -15,7 +15,6 @@
 
 
 
-
 OpaqueMutexedString* OpaqueMutexedString_from_usize(size_t number);
 
 void OpaqueMutexedString_change(const OpaqueMutexedString* self, size_t number);
@@ -35,8 +34,6 @@ Utf16Wrap* OpaqueMutexedString_wrapper(const OpaqueMutexedString* self);
 uint16_t OpaqueMutexedString_to_unsigned_from_unsigned(const OpaqueMutexedString* self, uint16_t input);
 
 void OpaqueMutexedString_destroy(OpaqueMutexedString* self);
-
-
 
 
 

--- a/feature_tests/c/include/OpaqueThin.d.h
+++ b/feature_tests/c/include/OpaqueThin.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct OpaqueThin OpaqueThin;
-
-
 
 
 #endif // OpaqueThin_D_H

--- a/feature_tests/c/include/OpaqueThin.h
+++ b/feature_tests/c/include/OpaqueThin.h
@@ -14,7 +14,6 @@
 
 
 
-
 int32_t OpaqueThin_a(const OpaqueThin* self);
 
 float OpaqueThin_b(const OpaqueThin* self);
@@ -22,8 +21,6 @@ float OpaqueThin_b(const OpaqueThin* self);
 void OpaqueThin_c(const OpaqueThin* self, DiplomatWrite* write);
 
 void OpaqueThin_destroy(OpaqueThin* self);
-
-
 
 
 

--- a/feature_tests/c/include/OpaqueThinIter.d.h
+++ b/feature_tests/c/include/OpaqueThinIter.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct OpaqueThinIter OpaqueThinIter;
-
-
 
 
 #endif // OpaqueThinIter_D_H

--- a/feature_tests/c/include/OpaqueThinIter.h
+++ b/feature_tests/c/include/OpaqueThinIter.h
@@ -15,12 +15,9 @@
 
 
 
-
 const OpaqueThin* OpaqueThinIter_next(OpaqueThinIter* self);
 
 void OpaqueThinIter_destroy(OpaqueThinIter* self);
-
-
 
 
 

--- a/feature_tests/c/include/OpaqueThinVec.d.h
+++ b/feature_tests/c/include/OpaqueThinVec.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct OpaqueThinVec OpaqueThinVec;
-
-
 
 
 #endif // OpaqueThinVec_D_H

--- a/feature_tests/c/include/OpaqueThinVec.h
+++ b/feature_tests/c/include/OpaqueThinVec.h
@@ -16,7 +16,6 @@
 
 
 
-
 OpaqueThinVec* OpaqueThinVec_create(DiplomatI32View a, DiplomatF32View b, DiplomatStringView c);
 
 OpaqueThinIter* OpaqueThinVec_iter(const OpaqueThinVec* self);
@@ -28,8 +27,6 @@ const OpaqueThin* OpaqueThinVec_get(const OpaqueThinVec* self, size_t idx);
 const OpaqueThin* OpaqueThinVec_first(const OpaqueThinVec* self);
 
 void OpaqueThinVec_destroy(OpaqueThinVec* self);
-
-
 
 
 

--- a/feature_tests/c/include/OptionEnum.d.h
+++ b/feature_tests/c/include/OptionEnum.d.h
@@ -10,14 +10,11 @@
 
 
 
-
 typedef enum OptionEnum {
   OptionEnum_Foo = 0,
   OptionEnum_Bar = 1,
 } OptionEnum;
 
 typedef struct OptionEnum_option {union { OptionEnum ok; }; bool is_ok; } OptionEnum_option;
-
-
 
 #endif // OptionEnum_D_H

--- a/feature_tests/c/include/OptionEnum.h
+++ b/feature_tests/c/include/OptionEnum.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // OptionEnum_H

--- a/feature_tests/c/include/OptionInputStruct.d.h
+++ b/feature_tests/c/include/OptionInputStruct.d.h
@@ -11,7 +11,6 @@
 
 
 
-
 typedef struct OptionInputStruct {
   OptionU8 a;
   OptionChar b;
@@ -19,7 +18,5 @@ typedef struct OptionInputStruct {
 } OptionInputStruct;
 
 typedef struct OptionInputStruct_option {union { OptionInputStruct ok; }; bool is_ok; } OptionInputStruct_option;
-
-
 
 #endif // OptionInputStruct_D_H

--- a/feature_tests/c/include/OptionInputStruct.h
+++ b/feature_tests/c/include/OptionInputStruct.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // OptionInputStruct_H

--- a/feature_tests/c/include/OptionOpaque.d.h
+++ b/feature_tests/c/include/OptionOpaque.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct OptionOpaque OptionOpaque;
-
-
 
 
 #endif // OptionOpaque_D_H

--- a/feature_tests/c/include/OptionOpaque.h
+++ b/feature_tests/c/include/OptionOpaque.h
@@ -17,7 +17,6 @@
 
 
 
-
 OptionOpaque* OptionOpaque_new(int32_t i);
 
 OptionOpaque* OptionOpaque_new_none(void);
@@ -67,8 +66,6 @@ bool OptionOpaque_accepts_option_str_slice(OptionStringsView arg, uint8_t sentin
 int64_t OptionOpaque_accepts_option_primitive(OptionU32View arg, uint8_t sentinel);
 
 void OptionOpaque_destroy(OptionOpaque* self);
-
-
 
 
 

--- a/feature_tests/c/include/OptionOpaqueChar.d.h
+++ b/feature_tests/c/include/OptionOpaqueChar.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct OptionOpaqueChar OptionOpaqueChar;
-
-
 
 
 #endif // OptionOpaqueChar_D_H

--- a/feature_tests/c/include/OptionOpaqueChar.h
+++ b/feature_tests/c/include/OptionOpaqueChar.h
@@ -14,12 +14,9 @@
 
 
 
-
 void OptionOpaqueChar_assert_char(const OptionOpaqueChar* self, char32_t ch);
 
 void OptionOpaqueChar_destroy(OptionOpaqueChar* self);
-
-
 
 
 

--- a/feature_tests/c/include/OptionString.d.h
+++ b/feature_tests/c/include/OptionString.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct OptionString OptionString;
-
-
 
 
 #endif // OptionString_D_H

--- a/feature_tests/c/include/OptionString.h
+++ b/feature_tests/c/include/OptionString.h
@@ -14,7 +14,6 @@
 
 
 
-
 OptionString* OptionString_new(DiplomatStringView diplomat_str);
 
 typedef struct OptionString_write_result { bool is_ok;} OptionString_write_result;
@@ -24,8 +23,6 @@ typedef struct OptionString_borrow_result {union {DiplomatStringView ok; }; bool
 OptionString_borrow_result OptionString_borrow(const OptionString* self);
 
 void OptionString_destroy(OptionString* self);
-
-
 
 
 

--- a/feature_tests/c/include/OptionStruct.d.h
+++ b/feature_tests/c/include/OptionStruct.d.h
@@ -12,7 +12,6 @@
 
 
 
-
 typedef struct OptionStruct {
   OptionOpaque* a;
   OptionOpaqueChar* b;
@@ -21,7 +20,5 @@ typedef struct OptionStruct {
 } OptionStruct;
 
 typedef struct OptionStruct_option {union { OptionStruct ok; }; bool is_ok; } OptionStruct_option;
-
-
 
 #endif // OptionStruct_D_H

--- a/feature_tests/c/include/OptionStruct.h
+++ b/feature_tests/c/include/OptionStruct.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // OptionStruct_H

--- a/feature_tests/c/include/PrimitiveStruct.d.h
+++ b/feature_tests/c/include/PrimitiveStruct.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef struct PrimitiveStruct {
   float x;
   bool a;
@@ -30,8 +29,6 @@ typedef struct DiplomatPrimitiveStructViewMut {
   PrimitiveStruct* data;
   size_t len;
 } DiplomatPrimitiveStructViewMut;
-
-
 
 
 #endif // PrimitiveStruct_D_H

--- a/feature_tests/c/include/PrimitiveStruct.h
+++ b/feature_tests/c/include/PrimitiveStruct.h
@@ -14,12 +14,9 @@
 
 
 
-
 void PrimitiveStruct_mutable_slice(DiplomatPrimitiveStructViewMut a);
 
 void PrimitiveStruct_mutable_ref(PrimitiveStruct* self, PrimitiveStruct* a);
-
-
 
 
 

--- a/feature_tests/c/include/PrimitiveStructVec.d.h
+++ b/feature_tests/c/include/PrimitiveStructVec.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct PrimitiveStructVec PrimitiveStructVec;
-
-
 
 
 #endif // PrimitiveStructVec_D_H

--- a/feature_tests/c/include/PrimitiveStructVec.h
+++ b/feature_tests/c/include/PrimitiveStructVec.h
@@ -16,7 +16,6 @@
 
 
 
-
 PrimitiveStructVec* PrimitiveStructVec_new(void);
 
 void PrimitiveStructVec_push(PrimitiveStructVec* self, PrimitiveStruct value);
@@ -32,8 +31,6 @@ PrimitiveStruct PrimitiveStructVec_get(const PrimitiveStructVec* self, size_t id
 void PrimitiveStructVec_take_slice_from_other_namespace(DiplomatStructWithAttrsView _sl);
 
 void PrimitiveStructVec_destroy(PrimitiveStructVec* self);
-
-
 
 
 

--- a/feature_tests/c/include/RefList.d.h
+++ b/feature_tests/c/include/RefList.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct RefList RefList;
-
-
 
 
 #endif // RefList_D_H

--- a/feature_tests/c/include/RefList.h
+++ b/feature_tests/c/include/RefList.h
@@ -15,12 +15,9 @@
 
 
 
-
 RefList* RefList_node(const RefListParameter* data);
 
 void RefList_destroy(RefList* self);
-
-
 
 
 

--- a/feature_tests/c/include/RefListParameter.d.h
+++ b/feature_tests/c/include/RefListParameter.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct RefListParameter RefListParameter;
-
-
 
 
 #endif // RefListParameter_D_H

--- a/feature_tests/c/include/RefListParameter.h
+++ b/feature_tests/c/include/RefListParameter.h
@@ -14,10 +14,7 @@
 
 
 
-
 void RefListParameter_destroy(RefListParameter* self);
-
-
 
 
 

--- a/feature_tests/c/include/ResultOpaque.d.h
+++ b/feature_tests/c/include/ResultOpaque.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct ResultOpaque ResultOpaque;
-
-
 
 
 #endif // ResultOpaque_D_H

--- a/feature_tests/c/include/ResultOpaque.h
+++ b/feature_tests/c/include/ResultOpaque.h
@@ -16,7 +16,6 @@
 
 
 
-
 typedef struct ResultOpaque_new_result {union {ResultOpaque* ok; ErrorEnum err;}; bool is_ok;} ResultOpaque_new_result;
 ResultOpaque_new_result ResultOpaque_new(int32_t i);
 
@@ -46,8 +45,6 @@ ResultOpaque* ResultOpaque_takes_str(ResultOpaque* self, DiplomatStringView _v);
 void ResultOpaque_assert_integer(const ResultOpaque* self, int32_t i);
 
 void ResultOpaque_destroy(ResultOpaque* self);
-
-
 
 
 

--- a/feature_tests/c/include/ScalarPairWithPadding.d.h
+++ b/feature_tests/c/include/ScalarPairWithPadding.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef struct ScalarPairWithPadding {
   uint8_t first;
   uint32_t second;
@@ -26,8 +25,6 @@ typedef struct DiplomatScalarPairWithPaddingViewMut {
   ScalarPairWithPadding* data;
   size_t len;
 } DiplomatScalarPairWithPaddingViewMut;
-
-
 
 
 #endif // ScalarPairWithPadding_D_H

--- a/feature_tests/c/include/ScalarPairWithPadding.h
+++ b/feature_tests/c/include/ScalarPairWithPadding.h
@@ -14,10 +14,7 @@
 
 
 
-
 void ScalarPairWithPadding_assert_value(ScalarPairWithPadding self);
-
-
 
 
 

--- a/feature_tests/c/include/StructWithAttrs.d.h
+++ b/feature_tests/c/include/StructWithAttrs.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef struct StructWithAttrs {
   bool a;
   uint32_t b;
@@ -26,8 +25,6 @@ typedef struct DiplomatStructWithAttrsViewMut {
   StructWithAttrs* data;
   size_t len;
 } DiplomatStructWithAttrsViewMut;
-
-
 
 
 #endif // StructWithAttrs_D_H

--- a/feature_tests/c/include/StructWithAttrs.h
+++ b/feature_tests/c/include/StructWithAttrs.h
@@ -14,13 +14,10 @@
 
 
 
-
 typedef struct namespace_StructWithAttrs_new_fallible_result {union {StructWithAttrs ok; }; bool is_ok;} namespace_StructWithAttrs_new_fallible_result;
 namespace_StructWithAttrs_new_fallible_result namespace_StructWithAttrs_new_fallible(bool a, uint32_t b);
 
 uint32_t namespace_StructWithAttrs_c(StructWithAttrs self);
-
-
 
 
 

--- a/feature_tests/c/include/StructWithSlices.d.h
+++ b/feature_tests/c/include/StructWithSlices.d.h
@@ -10,14 +10,11 @@
 
 
 
-
 typedef struct StructWithSlices {
   DiplomatStringView first;
   DiplomatU16View second;
 } StructWithSlices;
 
 typedef struct StructWithSlices_option {union { StructWithSlices ok; }; bool is_ok; } StructWithSlices_option;
-
-
 
 #endif // StructWithSlices_D_H

--- a/feature_tests/c/include/StructWithSlices.h
+++ b/feature_tests/c/include/StructWithSlices.h
@@ -14,10 +14,7 @@
 
 
 
-
 void StructWithSlices_return_last(StructWithSlices self, DiplomatWrite* write);
-
-
 
 
 

--- a/feature_tests/c/include/TestMacroStruct.d.h
+++ b/feature_tests/c/include/TestMacroStruct.d.h
@@ -10,13 +10,10 @@
 
 
 
-
 typedef struct TestMacroStruct {
   size_t a;
 } TestMacroStruct;
 
 typedef struct TestMacroStruct_option {union { TestMacroStruct ok; }; bool is_ok; } TestMacroStruct_option;
-
-
 
 #endif // TestMacroStruct_D_H

--- a/feature_tests/c/include/TestMacroStruct.h
+++ b/feature_tests/c/include/TestMacroStruct.h
@@ -14,12 +14,9 @@
 
 
 
-
 size_t namespace_TestMacroStruct_test_func(void);
 
 TestMacroStruct namespace_TestMacroStruct_test_meta(void);
-
-
 
 
 

--- a/feature_tests/c/include/TestOpaque.d.h
+++ b/feature_tests/c/include/TestOpaque.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct TestOpaque TestOpaque;
-
-
 
 
 #endif // TestOpaque_D_H

--- a/feature_tests/c/include/TestOpaque.h
+++ b/feature_tests/c/include/TestOpaque.h
@@ -14,10 +14,7 @@
 
 
 
-
 void namespace_TestOpaque_destroy(TestOpaque* self);
-
-
 
 
 

--- a/feature_tests/c/include/TesterTrait.d.h
+++ b/feature_tests/c/include/TesterTrait.d.h
@@ -12,7 +12,6 @@
 
 
 
-
 typedef struct test_result_output_result {union {uint32_t ok; }; bool is_ok;} test_result_output_result;
 typedef struct TesterTrait_VTable {
     void (*destructor)(const void*);
@@ -34,8 +33,6 @@ static void general_destructor(const void* data) {
 
 const size_t TesterTrait_DATA_SIZE = 0;
 const size_t TesterTrait_DATA_ALIGNMENT = 0;
-
-
 
 
 #endif // TesterTrait_D_H

--- a/feature_tests/c/include/TraitTestingStruct.d.h
+++ b/feature_tests/c/include/TraitTestingStruct.d.h
@@ -10,14 +10,11 @@
 
 
 
-
 typedef struct TraitTestingStruct {
   int32_t x;
   int32_t y;
 } TraitTestingStruct;
 
 typedef struct TraitTestingStruct_option {union { TraitTestingStruct ok; }; bool is_ok; } TraitTestingStruct_option;
-
-
 
 #endif // TraitTestingStruct_D_H

--- a/feature_tests/c/include/TraitTestingStruct.h
+++ b/feature_tests/c/include/TraitTestingStruct.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // TraitTestingStruct_H

--- a/feature_tests/c/include/TraitWrapper.d.h
+++ b/feature_tests/c/include/TraitWrapper.d.h
@@ -10,13 +10,10 @@
 
 
 
-
 typedef struct TraitWrapper {
   bool cant_be_empty;
 } TraitWrapper;
 
 typedef struct TraitWrapper_option {union { TraitWrapper ok; }; bool is_ok; } TraitWrapper_option;
-
-
 
 #endif // TraitWrapper_D_H

--- a/feature_tests/c/include/TraitWrapper.h
+++ b/feature_tests/c/include/TraitWrapper.h
@@ -15,14 +15,11 @@
 
 
 
-
 int32_t TraitWrapper_test_with_trait(DiplomatTraitStruct_TesterTrait t_trait_wrap, int32_t x);
 
 int32_t TraitWrapper_test_trait_with_struct(DiplomatTraitStruct_TesterTrait t_trait_wrap);
 
 void TraitWrapper_test_result_output(DiplomatTraitStruct_TesterTrait t_trait_wrap);
-
-
 
 
 

--- a/feature_tests/c/include/Two.d.h
+++ b/feature_tests/c/include/Two.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Two Two;
-
-
 
 
 #endif // Two_D_H

--- a/feature_tests/c/include/Two.h
+++ b/feature_tests/c/include/Two.h
@@ -14,10 +14,7 @@
 
 
 
-
 void Two_destroy(Two* self);
-
-
 
 
 

--- a/feature_tests/c/include/UnimportedEnum.d.h
+++ b/feature_tests/c/include/UnimportedEnum.d.h
@@ -10,7 +10,6 @@
 
 
 
-
 typedef enum UnimportedEnum {
   UnimportedEnum_A = 0,
   UnimportedEnum_B = 1,
@@ -18,7 +17,5 @@ typedef enum UnimportedEnum {
 } UnimportedEnum;
 
 typedef struct UnimportedEnum_option {union { UnimportedEnum ok; }; bool is_ok; } UnimportedEnum_option;
-
-
 
 #endif // UnimportedEnum_D_H

--- a/feature_tests/c/include/UnimportedEnum.h
+++ b/feature_tests/c/include/UnimportedEnum.h
@@ -16,7 +16,4 @@
 
 
 
-
-
-
 #endif // UnimportedEnum_H

--- a/feature_tests/c/include/Unnamespaced.d.h
+++ b/feature_tests/c/include/Unnamespaced.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Unnamespaced Unnamespaced;
-
-
 
 
 #endif // Unnamespaced_D_H

--- a/feature_tests/c/include/Unnamespaced.h
+++ b/feature_tests/c/include/Unnamespaced.h
@@ -16,14 +16,11 @@
 
 
 
-
 Unnamespaced* namespace_Unnamespaced_make(AttrEnum _e);
 
 void namespace_Unnamespaced_use_namespaced(const Unnamespaced* self, const AttrOpaque1* _n);
 
 void namespace_Unnamespaced_destroy(Unnamespaced* self);
-
-
 
 
 

--- a/feature_tests/c/include/Utf16Wrap.d.h
+++ b/feature_tests/c/include/Utf16Wrap.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct Utf16Wrap Utf16Wrap;
-
-
 
 
 #endif // Utf16Wrap_D_H

--- a/feature_tests/c/include/Utf16Wrap.h
+++ b/feature_tests/c/include/Utf16Wrap.h
@@ -14,7 +14,6 @@
 
 
 
-
 Utf16Wrap* Utf16Wrap_from_utf16(DiplomatString16View input);
 
 void Utf16Wrap_get_debug_str(const Utf16Wrap* self, DiplomatWrite* write);
@@ -22,8 +21,6 @@ void Utf16Wrap_get_debug_str(const Utf16Wrap* self, DiplomatWrite* write);
 DiplomatString16View Utf16Wrap_borrow_cont(const Utf16Wrap* self);
 
 void Utf16Wrap_destroy(Utf16Wrap* self);
-
-
 
 
 

--- a/feature_tests/c/include/VectorTest.d.h
+++ b/feature_tests/c/include/VectorTest.d.h
@@ -10,10 +10,7 @@
 
 
 
-
 typedef struct VectorTest VectorTest;
-
-
 
 
 #endif // VectorTest_D_H

--- a/feature_tests/c/include/VectorTest.h
+++ b/feature_tests/c/include/VectorTest.h
@@ -14,7 +14,6 @@
 
 
 
-
 VectorTest* namespace_VectorTest_new(void);
 
 size_t namespace_VectorTest_len(const VectorTest* self);
@@ -25,8 +24,6 @@ namespace_VectorTest_get_result namespace_VectorTest_get(const VectorTest* self,
 void namespace_VectorTest_push(VectorTest* self, double value);
 
 void namespace_VectorTest_destroy(VectorTest* self);
-
-
 
 
 

--- a/feature_tests/cpp/include/CallbackWrapper.d.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.d.hpp
@@ -20,6 +20,7 @@ struct MyStructContainingAnOption;
 struct PrimitiveStruct;
 
 
+typedef uint8_t U8Array_2[2];
 namespace diplomat {
 namespace capi {
     struct CallbackWrapper {
@@ -47,6 +48,8 @@ struct CallbackWrapper {
   inline static void test_opaque_cb_arg(std::function<void(MyString&)> cb, MyString& a);
 
   inline static void test_slice_cb_arg(diplomat::span<const uint8_t> arg, std::function<void(diplomat::span<const uint8_t>)> f);
+
+  inline static void test_array_cb_arg(U8Array_2 arg, std::function<void(U8Array_2)> f);
 
   inline static void test_result_output(std::function<diplomat::result<std::monostate, std::monostate>()> t);
 

--- a/feature_tests/cpp/include/CallbackWrapper.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.hpp
@@ -19,6 +19,7 @@
 #include "diplomat_runtime.hpp"
 
 
+typedef uint8_t U8Array_2[2];
 namespace diplomat {
 namespace capi {
     extern "C" {
@@ -62,6 +63,11 @@ namespace capi {
         void (*run_callback)(const void*, diplomat::capi::DiplomatU8View );
         void (*destructor)(const void*);
     } DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f;
+    typedef struct DiplomatCallback_CallbackWrapper_test_array_cb_arg_f {
+        const void* data;
+        void (*run_callback)(const void*, U8Array_2 );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_array_cb_arg_f;
     typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t_result { bool is_ok;} DiplomatCallback_CallbackWrapper_test_result_output_t_result;
 
     typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t {
@@ -159,6 +165,8 @@ namespace capi {
 
     void CallbackWrapper_test_slice_cb_arg(diplomat::capi::DiplomatU8View arg, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f f_cb_wrap);
 
+    void CallbackWrapper_test_array_cb_arg(U8Array_2 arg, DiplomatCallback_CallbackWrapper_test_array_cb_arg_f f_cb_wrap);
+
     void CallbackWrapper_test_result_output(DiplomatCallback_CallbackWrapper_test_result_output_t t_cb_wrap);
 
     void CallbackWrapper_test_result_usize_output(DiplomatCallback_CallbackWrapper_test_result_usize_output_t t_cb_wrap);
@@ -221,6 +229,11 @@ inline void CallbackWrapper::test_opaque_cb_arg(std::function<void(MyString&)> c
 
 inline void CallbackWrapper::test_slice_cb_arg(diplomat::span<const uint8_t> arg, std::function<void(diplomat::span<const uint8_t>)> f) {
   diplomat::capi::CallbackWrapper_test_slice_cb_arg({arg.data(), arg.size()},
+    {new decltype(f)(std::move(f)), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
+}
+
+inline void CallbackWrapper::test_array_cb_arg(U8Array_2 arg, std::function<void(U8Array_2)> f) {
+  diplomat::capi::CallbackWrapper_test_array_cb_arg(arg,
     {new decltype(f)(std::move(f)), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
 }
 

--- a/feature_tests/cpp/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp/include/Float64Vec.d.hpp
@@ -28,7 +28,7 @@ public:
 
   inline static std::unique_ptr<Float64Vec> new_bool(diplomat::span<const bool> v);
 
-  inline static std::unique_ptr<Float64Vec> new_bool_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other);
+  inline static std::unique_ptr<Float64Vec> new_int_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other);
 
   inline static std::unique_ptr<Float64Vec> new_i16(diplomat::span<const int16_t> v);
 

--- a/feature_tests/cpp/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp/include/Float64Vec.d.hpp
@@ -12,6 +12,8 @@
 #include "diplomat_runtime.hpp"
 
 
+typedef bool BoolArray_3[3];
+typedef int32_t I32Array_12[12];
 namespace diplomat {
 namespace capi {
     struct Float64Vec;
@@ -24,6 +26,8 @@ public:
   inline static std::unique_ptr<Float64Vec> new_(diplomat::span<const double> v);
 
   inline static std::unique_ptr<Float64Vec> new_bool(diplomat::span<const bool> v);
+
+  inline static std::unique_ptr<Float64Vec> new_bool_arr(BoolArray_3 v, BoolArray_3 _other, I32Array_12 _other_other);
 
   inline static std::unique_ptr<Float64Vec> new_i16(diplomat::span<const int16_t> v);
 

--- a/feature_tests/cpp/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp/include/Float64Vec.d.hpp
@@ -13,6 +13,7 @@
 
 
 typedef bool BoolArray_3[3];
+typedef double F64Array_2[2];
 typedef int32_t I32Array_12[12];
 namespace diplomat {
 namespace capi {
@@ -27,7 +28,7 @@ public:
 
   inline static std::unique_ptr<Float64Vec> new_bool(diplomat::span<const bool> v);
 
-  inline static std::unique_ptr<Float64Vec> new_bool_arr(BoolArray_3 v, BoolArray_3 _other, I32Array_12 _other_other);
+  inline static std::unique_ptr<Float64Vec> new_bool_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other);
 
   inline static std::unique_ptr<Float64Vec> new_i16(diplomat::span<const int16_t> v);
 

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -14,6 +14,8 @@
 #include "diplomat_runtime.hpp"
 
 
+typedef bool BoolArray_3[3];
+typedef int32_t I32Array_12[12];
 namespace diplomat {
 namespace capi {
     extern "C" {
@@ -21,6 +23,8 @@ namespace capi {
     diplomat::capi::Float64Vec* Float64Vec_new(diplomat::capi::DiplomatF64View v);
 
     diplomat::capi::Float64Vec* Float64Vec_new_bool(diplomat::capi::DiplomatBoolView v);
+
+    diplomat::capi::Float64Vec* Float64Vec_new_bool_arr(BoolArray_3 v, BoolArray_3 _other, I32Array_12 _other_other);
 
     diplomat::capi::Float64Vec* Float64Vec_new_i16(diplomat::capi::DiplomatI16View v);
 
@@ -58,6 +62,13 @@ inline std::unique_ptr<Float64Vec> Float64Vec::new_(diplomat::span<const double>
 
 inline std::unique_ptr<Float64Vec> Float64Vec::new_bool(diplomat::span<const bool> v) {
   auto result = diplomat::capi::Float64Vec_new_bool({v.data(), v.size()});
+  return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
+}
+
+inline std::unique_ptr<Float64Vec> Float64Vec::new_bool_arr(BoolArray_3 v, BoolArray_3 _other, I32Array_12 _other_other) {
+  auto result = diplomat::capi::Float64Vec_new_bool_arr(v,
+    _other,
+    _other_other);
   return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
 }
 

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -15,6 +15,7 @@
 
 
 typedef bool BoolArray_3[3];
+typedef double F64Array_2[2];
 typedef int32_t I32Array_12[12];
 namespace diplomat {
 namespace capi {
@@ -24,7 +25,7 @@ namespace capi {
 
     diplomat::capi::Float64Vec* Float64Vec_new_bool(diplomat::capi::DiplomatBoolView v);
 
-    diplomat::capi::Float64Vec* Float64Vec_new_bool_arr(BoolArray_3 v, BoolArray_3 _other, I32Array_12 _other_other);
+    diplomat::capi::Float64Vec* Float64Vec_new_bool_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other);
 
     diplomat::capi::Float64Vec* Float64Vec_new_i16(diplomat::capi::DiplomatI16View v);
 
@@ -65,7 +66,7 @@ inline std::unique_ptr<Float64Vec> Float64Vec::new_bool(diplomat::span<const boo
   return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
 }
 
-inline std::unique_ptr<Float64Vec> Float64Vec::new_bool_arr(BoolArray_3 v, BoolArray_3 _other, I32Array_12 _other_other) {
+inline std::unique_ptr<Float64Vec> Float64Vec::new_bool_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other) {
   auto result = diplomat::capi::Float64Vec_new_bool_arr(v,
     _other,
     _other_other);

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -25,7 +25,7 @@ namespace capi {
 
     diplomat::capi::Float64Vec* Float64Vec_new_bool(diplomat::capi::DiplomatBoolView v);
 
-    diplomat::capi::Float64Vec* Float64Vec_new_bool_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other);
+    diplomat::capi::Float64Vec* Float64Vec_new_int_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other);
 
     diplomat::capi::Float64Vec* Float64Vec_new_i16(diplomat::capi::DiplomatI16View v);
 
@@ -66,8 +66,8 @@ inline std::unique_ptr<Float64Vec> Float64Vec::new_bool(diplomat::span<const boo
   return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
 }
 
-inline std::unique_ptr<Float64Vec> Float64Vec::new_bool_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other) {
-  auto result = diplomat::capi::Float64Vec_new_bool_arr(v,
+inline std::unique_ptr<Float64Vec> Float64Vec::new_int_arr(I32Array_12 v, BoolArray_3 _other, F64Array_2 _other_other) {
+  auto result = diplomat::capi::Float64Vec_new_int_arr(v,
     _other,
     _other_other);
   return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));

--- a/feature_tests/cpp/tests/attrs.cpp
+++ b/feature_tests/cpp/tests/attrs.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
     bool fixed_bool[3] = {true, true, false};
     int32_t fixed_int[12] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
     double fixed_float[2] = {0., 0.1};
-    auto vec_from_fixed = Float64Vec::new_bool_arr(fixed_int, fixed_bool, fixed_float);
+    auto vec_from_fixed = Float64Vec::new_int_arr(fixed_int, fixed_bool, fixed_float);
     simple_assert_eq("bool array", (*vec_from_fixed)[0].value(), 0);
     simple_assert_eq("bool array", (*vec_from_fixed)[11].value(), 11);
 

--- a/feature_tests/cpp/tests/attrs.cpp
+++ b/feature_tests/cpp/tests/attrs.cpp
@@ -47,6 +47,13 @@ int main(int argc, char* argv[]) {
     simple_assert_eq("vector indexer", (*vec)[1].value(), 1.6);
     simple_assert_eq("vector indexer", (*vec)[2].has_value(), false);
 
+    bool fixed_bool[3] = {true, true, false};
+    int32_t fixed_int[12] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    double fixed_float[2] = {0., 0.1};
+    auto vec_from_fixed = Float64Vec::new_bool_arr(fixed_int, fixed_bool, fixed_float);
+    simple_assert_eq("bool array", (*vec_from_fixed)[0].value(), 0);
+    simple_assert_eq("bool array", (*vec_from_fixed)[11].value(), 11);
+
 
     auto uintVec = std::vector<uint8_t>{ 1, 2, 3, 4 };
     auto myIterable = ns::RenamedMyIterable::new_(diplomat::span<const uint8_t>{uintVec.data(), uintVec.size()});

--- a/feature_tests/cpp/tests/callback.cpp
+++ b/feature_tests/cpp/tests/callback.cpp
@@ -57,6 +57,12 @@ int main(int argc, char *argv[])
         });
     }
     {
+        uint8_t arr[2] = {1, 2};
+        o.test_array_cb_arg(arr, [](uint8_t a[2]) {
+            simple_assert_eq("test_cb_arr", a[0], 1);
+        });
+    }
+    {
         int copied = 0;
         // TODO: Make C++ reject this by using move_only_function in c++23.
         // We cannot reject this in earlier standards due to a defect in std::function.

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -42,7 +42,7 @@ mod ffi {
         }
 
         #[diplomat::attr(not(supports = arrays), disable)]
-        pub fn test_array_cb_arg(arg: [u8; 2], f: impl Fn([u8; 2])) {
+        pub fn test_array_cb_arg(arg: &[u8; 2], f: impl Fn(&[u8; 2])) {
             f(arg);
         }
 

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -41,6 +41,10 @@ mod ffi {
             f(arg);
         }
 
+        pub fn test_array_cb_arg(arg: [u8; 2], f : impl Fn([u8; 2]) -> [u8; 2]) -> [u8; 2]  {
+            f(arg)
+        }
+
         #[diplomat::attr(kotlin, disable)]
         pub fn test_result_output(t: impl Fn() -> Result<(), ()>) {
             assert_eq!(t(), Ok(()));

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -41,6 +41,7 @@ mod ffi {
             f(arg);
         }
 
+        #[diplomat::attr(not(supports = arrays), disable)]
         pub fn test_array_cb_arg(arg: [u8; 2], f : impl Fn([u8; 2]) -> [u8; 2]) -> [u8; 2]  {
             f(arg)
         }

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -42,7 +42,7 @@ mod ffi {
         }
 
         #[diplomat::attr(not(supports = arrays), disable)]
-        pub fn test_array_cb_arg(arg: [u8; 2], f : impl Fn([u8; 2]))  {
+        pub fn test_array_cb_arg(arg: [u8; 2], f: impl Fn([u8; 2])) {
             f(arg);
         }
 

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -42,8 +42,8 @@ mod ffi {
         }
 
         #[diplomat::attr(not(supports = arrays), disable)]
-        pub fn test_array_cb_arg(arg: [u8; 2], f : impl Fn([u8; 2]) -> [u8; 2]) -> [u8; 2]  {
-            f(arg)
+        pub fn test_array_cb_arg(arg: [u8; 2], f : impl Fn([u8; 2]))  {
+            f(arg);
         }
 
         #[diplomat::attr(kotlin, disable)]

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -65,11 +65,11 @@ pub mod ffi {
 
         #[diplomat::attr(not(supports = arrays), disable)]
         pub fn new_bool_arr(
-            v: [bool; 3],
+            v: [i32; 12],
             _other: [bool; 3],
-            _other_other: [i32; 12],
+            _other_other: [f64; 2],
         ) -> Box<Float64Vec> {
-            Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
+            Box::new(Self(v.iter().map(|&x| x.into()).collect()))
         }
 
         #[diplomat::attr(auto, named_constructor = "i16")]

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -107,6 +107,10 @@ pub mod ffi {
             &self.0
         }
 
+        pub fn get_array(&self) -> [f64; 3] {
+            [0., 1., 2.]
+        }
+
         pub fn fill_slice(&self, v: &mut [f64]) {
             v.copy_from_slice(&self.0)
         }

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -69,9 +69,7 @@ pub mod ffi {
             _other: &[bool; 3],
             _other_other: &[f64; 2],
         ) -> Box<Float64Vec> {
-            Box::new(Self(v.iter().map(|x| { 
-                (*x).into()
-        }).collect()))
+            Box::new(Self(v.iter().map(|x| (*x).into()).collect()))
         }
 
         #[diplomat::attr(auto, named_constructor = "i16")]

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -62,9 +62,13 @@ pub mod ffi {
         pub fn new_bool(v: &[bool]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
-        
+
         #[diplomat::attr(not(supports = arrays), disable)]
-        pub fn new_bool_arr(v : [bool; 3], _other : [bool ; 3], _other_other : [i32; 12]) -> Box<Float64Vec> {
+        pub fn new_bool_arr(
+            v: [bool; 3],
+            _other: [bool; 3],
+            _other_other: [i32; 12],
+        ) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
 

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -64,12 +64,14 @@ pub mod ffi {
         }
 
         #[diplomat::attr(not(supports = arrays), disable)]
-        pub fn new_bool_arr(
-            v: [i32; 12],
-            _other: [bool; 3],
-            _other_other: [f64; 2],
+        pub fn new_int_arr(
+            v: &[i32; 12],
+            _other: &[bool; 3],
+            _other_other: &[f64; 2],
         ) -> Box<Float64Vec> {
-            Box::new(Self(v.iter().map(|&x| x.into()).collect()))
+            Box::new(Self(v.iter().map(|x| { 
+                (*x).into()
+        }).collect()))
         }
 
         #[diplomat::attr(auto, named_constructor = "i16")]

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -63,7 +63,7 @@ pub mod ffi {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
         
-        pub fn new_bool_arr(v : [bool; 3]) -> Box<Float64Vec> {
+        pub fn new_bool_arr(v : [bool; 3], _other : [bool ; 3], _other_other : [i32; 12]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
 

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -108,11 +108,6 @@ pub mod ffi {
             &self.0
         }
 
-        #[diplomat::attr(not(supports = arrays), disable)]
-        pub fn get_array(&self) -> [f64; 3] {
-            [0., 1., 2.]
-        }
-
         pub fn fill_slice(&self, v: &mut [f64]) {
             v.copy_from_slice(&self.0)
         }

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -63,6 +63,7 @@ pub mod ffi {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
         
+        #[diplomat::attr(not(supports = arrays), disable)]
         pub fn new_bool_arr(v : [bool; 3], _other : [bool ; 3], _other_other : [i32; 12]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
@@ -107,6 +108,7 @@ pub mod ffi {
             &self.0
         }
 
+        #[diplomat::attr(not(supports = arrays), disable)]
         pub fn get_array(&self) -> [f64; 3] {
             [0., 1., 2.]
         }

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -62,6 +62,10 @@ pub mod ffi {
         pub fn new_bool(v: &[bool]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
+        
+        pub fn new_bool_arr(v : [bool; 3]) -> Box<Float64Vec> {
+            Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
+        }
 
         #[diplomat::attr(auto, named_constructor = "i16")]
         pub fn new_i16(v: &[i16]) -> Box<Float64Vec> {

--- a/tool/src/c/formatter.rs
+++ b/tool/src/c/formatter.rs
@@ -253,6 +253,18 @@ impl<'tcx> CFormatter<'tcx> {
         self.diplomat_namespace(format!("Diplomat{prim}View{mtb}").into())
     }
 
+    pub fn fmt_primitive_array_name(
+        &self,
+        prim : hir::PrimitiveType,
+        size: usize,
+    ) -> Cow<'tcx, str> {
+        format!(
+            "{}Array_{size}",
+            self.fmt_primitive_name_for_derived_type(prim)
+        )
+        .into()
+    }
+
     pub fn fmt_struct_slice_name<P: TyPosition>(
         &self,
         borrow: MaybeOwn,

--- a/tool/src/c/formatter.rs
+++ b/tool/src/c/formatter.rs
@@ -255,7 +255,7 @@ impl<'tcx> CFormatter<'tcx> {
 
     pub fn fmt_primitive_array_name(
         &self,
-        prim : hir::PrimitiveType,
+        prim: hir::PrimitiveType,
         size: usize,
     ) -> Cow<'tcx, str> {
         format!(

--- a/tool/src/c/header.rs
+++ b/tool/src/c/header.rs
@@ -82,7 +82,6 @@ struct HeaderTemplate<'a> {
     arr_typedefs: &'a BTreeSet<String>,
     includes: &'a BTreeSet<String>,
     body: Cow<'a, str>,
-    is_for_cpp: bool,
 }
 
 impl fmt::Display for Header {
@@ -102,7 +101,6 @@ impl fmt::Display for Header {
             decl_include: self.decl_include.as_ref(),
             arr_typedefs: &self.arr_typedefs,
             body,
-            is_for_cpp: self.is_for_cpp,
         }
         .render_into(f)
         .unwrap();

--- a/tool/src/c/header.rs
+++ b/tool/src/c/header.rs
@@ -29,6 +29,8 @@ pub struct Header {
     pub includes: BTreeSet<String>,
     /// The decl file corresponding to this impl file. Empty if this is not an impl file.
     pub decl_include: Option<String>,
+    /// For defining arrays with `typedef` (since writing `type var[size]` would require a major refactor of many backends).
+    pub arr_typedefs : BTreeSet<String>,
     /// The actual meat of the header: usually will contain a type definition and methods
     ///
     /// Example:
@@ -52,6 +54,7 @@ impl Header {
             path,
             includes: BTreeSet::new(),
             decl_include: None,
+            arr_typedefs: BTreeSet::new(),
             body: String::new(),
             indent_str: "  ",
             is_for_cpp,
@@ -76,6 +79,7 @@ impl fmt::Write for Header {
 struct HeaderTemplate<'a> {
     header_guard: Cow<'a, str>,
     decl_include: Option<&'a String>,
+    arr_typedefs : &'a BTreeSet<String>,
     includes: &'a BTreeSet<String>,
     body: Cow<'a, str>,
     is_for_cpp: bool,
@@ -96,6 +100,7 @@ impl fmt::Display for Header {
             header_guard: header_guard.into(),
             includes: &self.includes,
             decl_include: self.decl_include.as_ref(),
+            arr_typedefs: &self.arr_typedefs,
             body,
             is_for_cpp: self.is_for_cpp,
         }

--- a/tool/src/c/header.rs
+++ b/tool/src/c/header.rs
@@ -30,7 +30,7 @@ pub struct Header {
     /// The decl file corresponding to this impl file. Empty if this is not an impl file.
     pub decl_include: Option<String>,
     /// For defining arrays with `typedef` (since writing `type var[size]` would require a major refactor of many backends).
-    pub arr_typedefs : BTreeSet<String>,
+    pub arr_typedefs: BTreeSet<String>,
     /// The actual meat of the header: usually will contain a type definition and methods
     ///
     /// Example:
@@ -79,7 +79,7 @@ impl fmt::Write for Header {
 struct HeaderTemplate<'a> {
     header_guard: Cow<'a, str>,
     decl_include: Option<&'a String>,
-    arr_typedefs : &'a BTreeSet<String>,
+    arr_typedefs: &'a BTreeSet<String>,
     includes: &'a BTreeSet<String>,
     body: Cow<'a, str>,
     is_for_cpp: bool,

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -42,6 +42,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.generate_mocking_interface = false;
     a.abi_compatibles = true;
     a.struct_refs = true;
+    a.arrays = true;
 
     a
 }

--- a/tool/src/c/ty.rs
+++ b/tool/src/c/ty.rs
@@ -588,6 +588,18 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
                 header.includes.insert(header_path);
                 ret
             }
+            Type::Array(ref ty, size) => {
+                let (out_ty, c_ty_name) = match ty {
+                    hir::Slice::Primitive(_, p) => {
+                        (format!("{}Array_{size}", self.formatter.fmt_primitive_name_for_derived_type(*p)).into(), self.formatter.fmt_primitive_as_c(*p)) 
+                    }
+                    _ => unreachable!("Unsupported array type {ty:?}")
+                };
+                // We use a BTreeSet, even though the C compiler won't complain about duplicates
+                // (if someone includes other header files, for instance.):
+                header.arr_typedefs.insert(format!("typedef {c_ty_name} {out_ty}[{size}];"));
+                out_ty
+            }
             _ => unreachable!("{}", format!("unknown AST/HIR variant: {:?}", ty)),
         };
 

--- a/tool/src/c/ty.rs
+++ b/tool/src/c/ty.rs
@@ -589,14 +589,10 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
                 ret
             }
             Type::Array(ref p, size) => {
-                let out_ty = format!(
-                    "{}Array_{size}",
-                    self.formatter.fmt_primitive_name_for_derived_type(*p)
-                )
-                .into();
-                let c_ty_name = self.formatter.fmt_primitive_as_c(*p);
                 // We use a BTreeSet, even though the C compiler won't complain about duplicates
                 // (if someone includes other header files, for instance.):
+                let out_ty = self.formatter.fmt_primitive_array_name(*p, size);
+                let c_ty_name = self.formatter.fmt_primitive_as_c(*p);
                 header
                     .arr_typedefs
                     .insert(format!("typedef {c_ty_name} {out_ty}[{size}];"));

--- a/tool/src/c/ty.rs
+++ b/tool/src/c/ty.rs
@@ -588,18 +588,13 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
                 header.includes.insert(header_path);
                 ret
             }
-            Type::Array(ref ty, size) => {
-                let (out_ty, c_ty_name) = match ty {
-                    hir::Slice::Primitive(_, p) => (
-                        format!(
-                            "{}Array_{size}",
-                            self.formatter.fmt_primitive_name_for_derived_type(*p)
-                        )
-                        .into(),
-                        self.formatter.fmt_primitive_as_c(*p),
-                    ),
-                    _ => unreachable!("Unsupported array type {ty:?}"),
-                };
+            Type::Array(ref p, size) => {
+                let out_ty = format!(
+                    "{}Array_{size}",
+                    self.formatter.fmt_primitive_name_for_derived_type(*p)
+                )
+                .into();
+                let c_ty_name = self.formatter.fmt_primitive_as_c(*p);
                 // We use a BTreeSet, even though the C compiler won't complain about duplicates
                 // (if someone includes other header files, for instance.):
                 header

--- a/tool/src/c/ty.rs
+++ b/tool/src/c/ty.rs
@@ -590,14 +590,21 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
             }
             Type::Array(ref ty, size) => {
                 let (out_ty, c_ty_name) = match ty {
-                    hir::Slice::Primitive(_, p) => {
-                        (format!("{}Array_{size}", self.formatter.fmt_primitive_name_for_derived_type(*p)).into(), self.formatter.fmt_primitive_as_c(*p)) 
-                    }
-                    _ => unreachable!("Unsupported array type {ty:?}")
+                    hir::Slice::Primitive(_, p) => (
+                        format!(
+                            "{}Array_{size}",
+                            self.formatter.fmt_primitive_name_for_derived_type(*p)
+                        )
+                        .into(),
+                        self.formatter.fmt_primitive_as_c(*p),
+                    ),
+                    _ => unreachable!("Unsupported array type {ty:?}"),
                 };
                 // We use a BTreeSet, even though the C compiler won't complain about duplicates
                 // (if someone includes other header files, for instance.):
-                header.arr_typedefs.insert(format!("typedef {c_ty_name} {out_ty}[{size}];"));
+                header
+                    .arr_typedefs
+                    .insert(format!("typedef {c_ty_name} {out_ty}[{size}];"));
                 out_ty
             }
             _ => unreachable!("{}", format!("unknown AST/HIR variant: {:?}", ty)),

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -42,6 +42,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.generate_mocking_interface = false;
     a.abi_compatibles = true;
     a.struct_refs = true;
+    a.arrays = true;
 
     a
 }

--- a/tool/templates/c/base.h.jinja
+++ b/tool/templates/c/base.h.jinja
@@ -8,7 +8,7 @@
     {% when Some with (include) ~%}
         #include "{{ include }}"
     {%~ when None %}
-{%- endmatch %}
+{%- endmatch %} {#- TODO: At some point this whole block should be included in c_include.h.jinja somehow. Maybe as a macro? #}
 
 {%- for typedef in arr_typedefs -%}
 {{typedef}}

--- a/tool/templates/c/base.h.jinja
+++ b/tool/templates/c/base.h.jinja
@@ -9,9 +9,6 @@
         #include "{{ include }}"
     {%~ when None %}
 {%- endmatch %}
-{% if is_for_cpp -%}
-namespace capi {
-{%- endif %}
 
 {%- for typedef in arr_typedefs -%}
 {{typedef}}
@@ -19,9 +16,5 @@ namespace capi {
 
 
 {{ body }}
-
-{% if is_for_cpp -%}
-} // namespace capi
-{%- endif %}
 
 #endif // {{ header_guard }}

--- a/tool/templates/c/base.h.jinja
+++ b/tool/templates/c/base.h.jinja
@@ -13,6 +13,10 @@
 namespace capi {
 {%- endif %}
 
+{%- for typedef in arr_typedefs -%}
+{{typedef}}
+{% endfor %}
+
 
 {{ body }}
 

--- a/tool/templates/cpp/c_include.h.jinja
+++ b/tool/templates/cpp/c_include.h.jinja
@@ -1,4 +1,7 @@
-{% if let Some(ns) = namespace -%}
+{% for typedef in c_header.arr_typedefs -%}
+{{typedef}}
+{% endfor -%}
+{%- if let Some(ns) = namespace -%}
 namespace {{ns}} {
 {% else -%}
 namespace diplomat {


### PR DESCRIPTION
This was pretty easy to set up on the HIR/AST side of things, I was just able to mark Arrays as a type that used Slices, with the guarantee that they would always be owned. Currently, only primitive types are supported, since they're fairly simple to deal with.

Would like some feedback on the C implementation, since the syntax there is sort of tricky. I came up with what I think is a good enough fix, but I also noticed that there's a `Diplomat##name##Array` type that's unused. I decided to avoid using it since on the FFI side it doesn't indicate a fixed length for any would-be callers.

TODOs:

- [x] C++ support
- [x] C++ tests
- [ ] Fix ABI (I'm pretty sure for function conversions, Rust doesn't understand that it's being passed a pointer to a fixed array)