### PR TITLE
Fix GCC template error & behavioral error with Result types

### DIFF
--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -127,10 +127,11 @@ template<> struct WriteTrait<std::string> {
 template<class T> struct Ok {
   T inner;
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
-  template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Ok(T i): inner(i) {}
+  // We don't want to expose an lvalue-capable constructor in general,
+  // and universal referencing rules exist, so we have to delete the l-value overload.
+  // This is allowed for trivially copyable types, so we only do it conditionally
+  template<typename X = T, typename = typename std::enable_if<!std::is_trivially_copyable<X>::value>::type>
+  Ok(T& i) = delete;
   Ok() = default;
   Ok(Ok&&) noexcept = default;
   Ok(const Ok &) = default;
@@ -141,10 +142,11 @@ template<class T> struct Ok {
 template<class T> struct Err {
   T inner;
   Err(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
-  template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Err(T i): inner(i) {}
+  // We don't want to expose an lvalue-capable constructor in general,
+  // and universal referencing rules exist, so we have to delete the l-value overload.
+  // This is allowed for trivially copyable types, so we only do it conditionally
+  template<typename X = T, typename = typename std::enable_if<!std::is_trivially_copyable<X>::value>::type>
+  Err(T& i) = delete;
   Err() = default;
   Err(Err&&) noexcept = default;
   Err(const Err &) = default;

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -127,10 +127,11 @@ template<> struct WriteTrait<std::string> {
 template<class T> struct Ok {
   T inner;
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
-  template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Ok(T i): inner(i) {}
+  // We don't want to expose an lvalue-capable constructor in general,
+  // and universal referencing rules exist, so we have to delete the l-value overload.
+  // This is allowed for trivially copyable types, so we only do it conditionally
+  template<typename X = T, typename = typename std::enable_if<!std::is_trivially_copyable<X>::value>::type>
+  Ok(T& i) = delete;
   Ok() = default;
   Ok(Ok&&) noexcept = default;
   Ok(const Ok &) = default;
@@ -141,10 +142,11 @@ template<class T> struct Ok {
 template<class T> struct Err {
   T inner;
   Err(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
-  template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Err(T i): inner(i) {}
+  // We don't want to expose an lvalue-capable constructor in general,
+  // and universal referencing rules exist, so we have to delete the l-value overload.
+  // This is allowed for trivially copyable types, so we only do it conditionally
+  template<typename X = T, typename = typename std::enable_if<!std::is_trivially_copyable<X>::value>::type>
+  Err(T& i) = delete;
   Err() = default;
   Err(Err&&) noexcept = default;
   Err(const Err &) = default;

--- a/feature_tests/cpp/tests/result.cpp
+++ b/feature_tests/cpp/tests/result.cpp
@@ -4,6 +4,11 @@
 #include "../include/ErrorStruct.hpp"
 #include "assert.hpp"
 
+struct NonTrivial{
+    explicit NonTrivial(int i) {}
+    NonTrivial(const NonTrivial&) = delete;
+};
+
 int main(int argc, char *argv[])
 {
     std::unique_ptr<ResultOpaque> r;
@@ -32,4 +37,13 @@ int main(int argc, char *argv[])
 
     auto str_result = r2->takes_str("fish").ok();
     simple_assert_eq("Did not return a chaining value correctly", &str_result.value().get(), r2.get());
+
+    // check r and l value construction
+    auto trivial_lvalue = diplomat::Ok(std::monostate());
+    auto trivial_v = std::monostate();
+    auto trivial_rvalue = diplomat::Ok(trivial_v);
+    
+    auto complex_lvalue = diplomat::Ok(NonTrivial(1));
+    auto complex_v = NonTrivial(2);
+    //auto complex_rvalue = diplomat::Ok(complex_v); // This is expected to fail compilation
 }

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -127,10 +127,11 @@ template<> struct WriteTrait<std::string> {
 template<class T> struct Ok {
   T inner;
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
-  template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Ok(T i): inner(i) {}
+  // We don't want to expose an lvalue-capable constructor in general,
+  // and universal referencing rules exist, so we have to delete the l-value overload.
+  // This is allowed for trivially copyable types, so we only do it conditionally
+  template<typename X = T, typename = typename std::enable_if<!std::is_trivially_copyable<X>::value>::type>
+  Ok(T& i) = delete;
   Ok() = default;
   Ok(Ok&&) noexcept = default;
   Ok(const Ok &) = default;
@@ -141,10 +142,11 @@ template<class T> struct Ok {
 template<class T> struct Err {
   T inner;
   Err(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
-  template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Err(T i): inner(i) {}
+  // We don't want to expose an lvalue-capable constructor in general,
+  // and universal referencing rules exist, so we have to delete the l-value overload.
+  // This is allowed for trivially copyable types, so we only do it conditionally
+  template<typename X = T, typename = typename std::enable_if<!std::is_trivially_copyable<X>::value>::type>
+  Err(T& i) = delete;
   Err() = default;
   Err(Err&&) noexcept = default;
   Err(const Err &) = default;

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -73,10 +73,11 @@ template<> struct WriteTrait<std::string> {
 template<class T> struct Ok {
   T inner;
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
-  template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Ok(T i): inner(i) {}
+  // We don't want to expose an lvalue-capable constructor in general,
+  // and universal referencing rules exist, so we have to delete the l-value overload.
+  // This is allowed for trivially copyable types, so we only do it conditionally
+  template<typename X = T, typename = typename std::enable_if<!std::is_trivially_copyable<X>::value>::type>
+  Ok(T& i) = delete;
   Ok() = default;
   Ok(Ok&&) noexcept = default;
   Ok(const Ok &) = default;
@@ -87,10 +88,11 @@ template<class T> struct Ok {
 template<class T> struct Err {
   T inner;
   Err(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
-  template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Err(T i): inner(i) {}
+  // We don't want to expose an lvalue-capable constructor in general,
+  // and universal referencing rules exist, so we have to delete the l-value overload.
+  // This is allowed for trivially copyable types, so we only do it conditionally
+  template<typename X = T, typename = typename std::enable_if<!std::is_trivially_copyable<X>::value>::type>
+  Err(T& i) = delete;
   Err() = default;
   Err(Err&&) noexcept = default;
   Err(const Err &) = default;


### PR DESCRIPTION
In GCC 14.2.0, the OK & Err types type show an underspecified template error when passing a trivially copiable R-value, such as the common std::monostate.
This pointed out to me that due to universal referencing rules, we were actually defining the T& constructor *twice*, one explicitly as the T& constructor, and another implicitly with T&& due to the universal referencing template rules.

As a fix, instead of defining the T& constructor for trivially copyable types, we instead delete it for *non* trivially copiable types.

This is more correct, shows proper behavior, and fixes the GCC error