### PR TITLE
Fix GCC underspecified template error

### DIFF
--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -129,7 +129,7 @@ template<class T> struct Ok {
 
   // Move constructor always allowed
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  
+
   //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
   Ok(const T& i) : inner(i) {}
@@ -144,7 +144,7 @@ template<class T> struct Ok {
 
 template<class T> struct Err {
   T inner;
-  
+
   // Move constructor always allowed
   Err(T&& i): inner(std::forward<T>(i)) {}
 

--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -126,11 +126,14 @@ template<> struct WriteTrait<std::string> {
 
 template<class T> struct Ok {
   T inner;
+
+  // Move constructor always allowed
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
+  
+  //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Ok(T i): inner(i) {}
+  Ok(const T& i) : inner(i) {}
+
   Ok() = default;
   Ok(Ok&&) noexcept = default;
   Ok(const Ok &) = default;
@@ -138,13 +141,17 @@ template<class T> struct Ok {
   Ok& operator=(Ok&&) noexcept = default;
 };
 
+
 template<class T> struct Err {
   T inner;
+  
+  // Move constructor always allowed
   Err(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
+
+  //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Err(T i): inner(i) {}
+  Err(const T& i) : inner(i) {}
+
   Err() = default;
   Err(Err&&) noexcept = default;
   Err(const Err &) = default;

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -129,7 +129,7 @@ template<class T> struct Ok {
 
   // Move constructor always allowed
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  
+
   //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
   Ok(const T& i) : inner(i) {}
@@ -144,7 +144,7 @@ template<class T> struct Ok {
 
 template<class T> struct Err {
   T inner;
-  
+
   // Move constructor always allowed
   Err(T&& i): inner(std::forward<T>(i)) {}
 

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -126,11 +126,14 @@ template<> struct WriteTrait<std::string> {
 
 template<class T> struct Ok {
   T inner;
+
+  // Move constructor always allowed
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
+  
+  //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Ok(T i): inner(i) {}
+  Ok(const T& i) : inner(i) {}
+
   Ok() = default;
   Ok(Ok&&) noexcept = default;
   Ok(const Ok &) = default;
@@ -138,13 +141,17 @@ template<class T> struct Ok {
   Ok& operator=(Ok&&) noexcept = default;
 };
 
+
 template<class T> struct Err {
   T inner;
+  
+  // Move constructor always allowed
   Err(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
+
+  //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Err(T i): inner(i) {}
+  Err(const T& i) : inner(i) {}
+
   Err() = default;
   Err(Err&&) noexcept = default;
   Err(const Err &) = default;

--- a/feature_tests/cpp/tests/result.cpp
+++ b/feature_tests/cpp/tests/result.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     auto trivial_lvalue = diplomat::Ok(std::monostate());
     auto trivial_v = std::monostate();
     auto trivial_rvalue = diplomat::Ok(trivial_v); //trivial type, implicit copy allowed
-    
+
     auto complex_lvalue = diplomat::Ok(NonTrivial(1));
     auto complex_v = NonTrivial(2);
     // non-trivial type, copying not allowed

--- a/feature_tests/cpp/tests/result.cpp
+++ b/feature_tests/cpp/tests/result.cpp
@@ -4,6 +4,12 @@
 #include "../include/ErrorStruct.hpp"
 #include "assert.hpp"
 
+struct NonTrivial{
+    explicit NonTrivial(int i) {}
+    NonTrivial(const NonTrivial&) {}; // non-default, but still callable
+    NonTrivial(NonTrivial&&) = default;
+};
+
 int main(int argc, char *argv[])
 {
     std::unique_ptr<ResultOpaque> r;
@@ -32,4 +38,14 @@ int main(int argc, char *argv[])
 
     auto str_result = r2->takes_str("fish").ok();
     simple_assert_eq("Did not return a chaining value correctly", &str_result.value().get(), r2.get());
+
+    // check r and l value construction
+    auto trivial_lvalue = diplomat::Ok(std::monostate());
+    auto trivial_v = std::monostate();
+    auto trivial_rvalue = diplomat::Ok(trivial_v); //trivial type, implicit copy allowed
+    
+    auto complex_lvalue = diplomat::Ok(NonTrivial(1));
+    auto complex_v = NonTrivial(2);
+    // non-trivial type, copying not allowed
+    //auto complex_rvalue = diplomat::Ok(complex_v); // This is expected to fail compilation
 }

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -129,7 +129,7 @@ template<class T> struct Ok {
 
   // Move constructor always allowed
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  
+
   //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
   Ok(const T& i) : inner(i) {}
@@ -144,7 +144,7 @@ template<class T> struct Ok {
 
 template<class T> struct Err {
   T inner;
-  
+
   // Move constructor always allowed
   Err(T&& i): inner(std::forward<T>(i)) {}
 

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -126,11 +126,14 @@ template<> struct WriteTrait<std::string> {
 
 template<class T> struct Ok {
   T inner;
+
+  // Move constructor always allowed
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
+  
+  //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Ok(T i): inner(i) {}
+  Ok(const T& i) : inner(i) {}
+
   Ok() = default;
   Ok(Ok&&) noexcept = default;
   Ok(const Ok &) = default;
@@ -138,13 +141,17 @@ template<class T> struct Ok {
   Ok& operator=(Ok&&) noexcept = default;
 };
 
+
 template<class T> struct Err {
   T inner;
+  
+  // Move constructor always allowed
   Err(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
+
+  //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Err(T i): inner(i) {}
+  Err(const T& i) : inner(i) {}
+
   Err() = default;
   Err(Err&&) noexcept = default;
   Err(const Err &) = default;

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -75,7 +75,7 @@ template<class T> struct Ok {
 
   // Move constructor always allowed
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  
+
   //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
   Ok(const T& i) : inner(i) {}
@@ -90,7 +90,7 @@ template<class T> struct Ok {
 
 template<class T> struct Err {
   T inner;
-  
+
   // Move constructor always allowed
   Err(T&& i): inner(std::forward<T>(i)) {}
 

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -72,11 +72,14 @@ template<> struct WriteTrait<std::string> {
 
 template<class T> struct Ok {
   T inner;
+
+  // Move constructor always allowed
   Ok(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
+  
+  //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Ok(T i): inner(i) {}
+  Ok(const T& i) : inner(i) {}
+
   Ok() = default;
   Ok(Ok&&) noexcept = default;
   Ok(const Ok &) = default;
@@ -84,13 +87,17 @@ template<class T> struct Ok {
   Ok& operator=(Ok&&) noexcept = default;
 };
 
+
 template<class T> struct Err {
   T inner;
+  
+  // Move constructor always allowed
   Err(T&& i): inner(std::forward<T>(i)) {}
-  // We don't want to expose an lvalue-capable constructor in general
-  // however there is no problem doing this for trivially copyable types
+
+  //  copy constructor allowed only for trivially copyable types
   template<typename X = T, typename = typename std::enable_if<std::is_trivially_copyable<X>::value>::type>
-  Err(T i): inner(i) {}
+  Err(const T& i) : inner(i) {}
+
   Err() = default;
   Err(Err&&) noexcept = default;
   Err(const Err &) = default;


### PR DESCRIPTION
We identified a compilation error when using std::monostate() with result types in GCC 14.2.0.
Some fiddling in godbolt later, this fix was identified as still maintaining all the properties we want while not throwing warnings under any compiler.