### PR TITLE
Fix bug with handling optionals in JS

### DIFF
--- a/feature_tests/c/include/OptionEnum.d.h
+++ b/feature_tests/c/include/OptionEnum.d.h
@@ -14,6 +14,7 @@
 typedef enum OptionEnum {
   OptionEnum_Foo = 0,
   OptionEnum_Bar = 1,
+  OptionEnum_Baz = 2,
 } OptionEnum;
 
 typedef struct OptionEnum_option {union { OptionEnum ok; }; bool is_ok; } OptionEnum_option;

--- a/feature_tests/c/include/OptionOpaque.h
+++ b/feature_tests/c/include/OptionOpaque.h
@@ -55,6 +55,9 @@ OptionOpaque_accepts_option_u8_result OptionOpaque_accepts_option_u8(OptionU8 ar
 typedef struct OptionOpaque_accepts_option_enum_result {union {OptionEnum ok; }; bool is_ok;} OptionOpaque_accepts_option_enum_result;
 OptionOpaque_accepts_option_enum_result OptionOpaque_accepts_option_enum(OptionEnum_option arg, uint8_t sentinel);
 
+typedef struct OptionOpaque_accepts_multiple_option_enum_result {union {OptionEnum ok; }; bool is_ok;} OptionOpaque_accepts_multiple_option_enum_result;
+OptionOpaque_accepts_multiple_option_enum_result OptionOpaque_accepts_multiple_option_enum(uint8_t sentinel1, OptionEnum_option arg1, OptionEnum_option arg2, OptionEnum_option arg3, uint8_t sentinel2);
+
 typedef struct OptionOpaque_accepts_option_input_struct_result {union {OptionInputStruct ok; }; bool is_ok;} OptionOpaque_accepts_option_input_struct_result;
 OptionOpaque_accepts_option_input_struct_result OptionOpaque_accepts_option_input_struct(OptionInputStruct_option arg, uint8_t sentinel);
 

--- a/feature_tests/cpp/include/OptionEnum.d.hpp
+++ b/feature_tests/cpp/include/OptionEnum.d.hpp
@@ -17,6 +17,7 @@ namespace capi {
     enum OptionEnum {
       OptionEnum_Foo = 0,
       OptionEnum_Bar = 1,
+      OptionEnum_Baz = 2,
     };
 
     typedef struct OptionEnum_option {union { OptionEnum ok; }; bool is_ok; } OptionEnum_option;
@@ -28,6 +29,7 @@ public:
     enum Value {
         Foo = 0,
         Bar = 1,
+        Baz = 2,
     };
 
     OptionEnum(): value(Value::Foo) {}

--- a/feature_tests/cpp/include/OptionEnum.hpp
+++ b/feature_tests/cpp/include/OptionEnum.hpp
@@ -30,6 +30,7 @@ inline OptionEnum OptionEnum::FromFFI(diplomat::capi::OptionEnum c_enum) {
     switch (c_enum) {
         case diplomat::capi::OptionEnum_Foo:
         case diplomat::capi::OptionEnum_Bar:
+        case diplomat::capi::OptionEnum_Baz:
             return static_cast<OptionEnum::Value>(c_enum);
         default:
             std::abort();

--- a/feature_tests/cpp/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.d.hpp
@@ -55,6 +55,8 @@ public:
 
   inline static std::optional<OptionEnum> accepts_option_enum(std::optional<OptionEnum> arg, uint8_t sentinel);
 
+  inline static std::optional<OptionEnum> accepts_multiple_option_enum(uint8_t sentinel1, std::optional<OptionEnum> arg1, std::optional<OptionEnum> arg2, std::optional<OptionEnum> arg3, uint8_t sentinel2);
+
   inline static std::optional<OptionInputStruct> accepts_option_input_struct(std::optional<OptionInputStruct> arg, uint8_t sentinel);
 
   inline static OptionInputStruct returns_option_input_struct();

--- a/feature_tests/cpp/include/OptionOpaque.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.hpp
@@ -58,6 +58,9 @@ namespace capi {
     typedef struct OptionOpaque_accepts_option_enum_result {union {diplomat::capi::OptionEnum ok; }; bool is_ok;} OptionOpaque_accepts_option_enum_result;
     OptionOpaque_accepts_option_enum_result OptionOpaque_accepts_option_enum(diplomat::capi::OptionEnum_option arg, uint8_t sentinel);
 
+    typedef struct OptionOpaque_accepts_multiple_option_enum_result {union {diplomat::capi::OptionEnum ok; }; bool is_ok;} OptionOpaque_accepts_multiple_option_enum_result;
+    OptionOpaque_accepts_multiple_option_enum_result OptionOpaque_accepts_multiple_option_enum(uint8_t sentinel1, diplomat::capi::OptionEnum_option arg1, diplomat::capi::OptionEnum_option arg2, diplomat::capi::OptionEnum_option arg3, uint8_t sentinel2);
+
     typedef struct OptionOpaque_accepts_option_input_struct_result {union {diplomat::capi::OptionInputStruct ok; }; bool is_ok;} OptionOpaque_accepts_option_input_struct_result;
     OptionOpaque_accepts_option_input_struct_result OptionOpaque_accepts_option_input_struct(diplomat::capi::OptionInputStruct_option arg, uint8_t sentinel);
 
@@ -149,6 +152,15 @@ inline std::optional<uint8_t> OptionOpaque::accepts_option_u8(std::optional<uint
 inline std::optional<OptionEnum> OptionOpaque::accepts_option_enum(std::optional<OptionEnum> arg, uint8_t sentinel) {
     auto result = diplomat::capi::OptionOpaque_accepts_option_enum(arg.has_value() ? (diplomat::capi::OptionEnum_option{ { arg.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
         sentinel);
+    return result.is_ok ? std::optional<OptionEnum>(OptionEnum::FromFFI(result.ok)) : std::nullopt;
+}
+
+inline std::optional<OptionEnum> OptionOpaque::accepts_multiple_option_enum(uint8_t sentinel1, std::optional<OptionEnum> arg1, std::optional<OptionEnum> arg2, std::optional<OptionEnum> arg3, uint8_t sentinel2) {
+    auto result = diplomat::capi::OptionOpaque_accepts_multiple_option_enum(sentinel1,
+        arg1.has_value() ? (diplomat::capi::OptionEnum_option{ { arg1.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
+        arg2.has_value() ? (diplomat::capi::OptionEnum_option{ { arg2.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
+        arg3.has_value() ? (diplomat::capi::OptionEnum_option{ { arg3.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
+        sentinel2);
     return result.is_ok ? std::optional<OptionEnum>(OptionEnum::FromFFI(result.ok)) : std::nullopt;
 }
 

--- a/feature_tests/dart/lib/src/OptionEnum.g.dart
+++ b/feature_tests/dart/lib/src/OptionEnum.g.dart
@@ -7,7 +7,9 @@ enum OptionEnum {
 
   foo,
 
-  bar;
+  bar,
+
+  baz;
 
 }
 

--- a/feature_tests/dart/lib/src/OptionOpaque.g.dart
+++ b/feature_tests/dart/lib/src/OptionOpaque.g.dart
@@ -122,6 +122,14 @@ final class OptionOpaque implements ffi.Finalizable {
     return OptionEnum.values[result.union.ok];
   }
 
+  static OptionEnum? acceptsMultipleOptionEnum(int sentinel1, int sentinel2, {OptionEnum? arg1, OptionEnum? arg2, OptionEnum? arg3}) {
+    final result = _OptionOpaque_accepts_multiple_option_enum(sentinel1, arg1 != null ? _ResultInt32Void.ok(arg1.index) : _ResultInt32Void.err(), arg2 != null ? _ResultInt32Void.ok(arg2.index) : _ResultInt32Void.err(), arg3 != null ? _ResultInt32Void.ok(arg3.index) : _ResultInt32Void.err(), sentinel2);
+    if (!result.isOk) {
+      return null;
+    }
+    return OptionEnum.values[result.union.ok];
+  }
+
   static OptionInputStruct? acceptsOptionInputStruct(int sentinel, [OptionInputStruct? arg]) {
     final temp = _FinalizedArena();
     final result = _OptionOpaque_accepts_option_input_struct(arg != null ? _ResultOptionInputStructFfiVoid.ok(arg._toFfi(temp.arena)) : _ResultOptionInputStructFfiVoid.err(), sentinel);
@@ -217,6 +225,11 @@ external _ResultUint8Void _OptionOpaque_accepts_option_u8(_ResultUint8Void arg, 
 @ffi.Native<_ResultInt32Void Function(_ResultInt32Void, ffi.Uint8)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_enum')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _OptionOpaque_accepts_option_enum(_ResultInt32Void arg, int sentinel);
+
+@_DiplomatFfiUse('OptionOpaque_accepts_multiple_option_enum')
+@ffi.Native<_ResultInt32Void Function(ffi.Uint8, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, ffi.Uint8)>(isLeaf: true, symbol: 'OptionOpaque_accepts_multiple_option_enum')
+// ignore: non_constant_identifier_names
+external _ResultInt32Void _OptionOpaque_accepts_multiple_option_enum(int sentinel1, _ResultInt32Void arg1, _ResultInt32Void arg2, _ResultInt32Void arg3, int sentinel2);
 
 @_DiplomatFfiUse('OptionOpaque_accepts_option_input_struct')
 @ffi.Native<_ResultOptionInputStructFfiVoid Function(_ResultOptionInputStructFfiVoid, ffi.Uint8)>(isLeaf: true, symbol: 'OptionOpaque_accepts_option_input_struct')

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -430,11 +430,55 @@ let termini = Object.assign({
                 name: "arg",
                 type: "OptionEnum",
                 typeUse: "enumerator",
-                values: ["Foo", "Bar"]
+                values: ["Foo", "Bar", "Baz"]
             },
             
             {
                 name: "sentinel",
+                type: "number",
+                typeUse: "number"
+            }
+            
+        ]
+    },
+
+    "OptionOpaque.acceptsMultipleOptionEnum": {
+        func: (sentinel1, arg1, arg2, arg3, sentinel2) => somelib.OptionOpaque.acceptsMultipleOptionEnum(sentinel1, arg1, arg2, arg3, sentinel2),
+        // For avoiding webpacking minifying issues:
+        funcName: "OptionOpaque.acceptsMultipleOptionEnum",
+        expr: (sentinel1, arg1, arg2, arg3, sentinel2) => "somelib.OptionOpaque.acceptsMultipleOptionEnum(sentinel1, arg1, arg2, arg3, sentinel2)".replace(/([\( ])sentinel1([,\) \n])/, '$1' + sentinel1 + '$2').replace(/([\( ])arg1([,\) \n])/, '$1' + arg1 + '$2').replace(/([\( ])arg2([,\) \n])/, '$1' + arg2 + '$2').replace(/([\( ])arg3([,\) \n])/, '$1' + arg3 + '$2').replace(/([\( ])sentinel2([,\) \n])/, '$1' + sentinel2 + '$2'),
+        display: displayOptionalEnum,
+        parameters: [
+            
+            {
+                name: "sentinel1",
+                type: "number",
+                typeUse: "number"
+            },
+            
+            {
+                name: "arg1",
+                type: "OptionEnum",
+                typeUse: "enumerator",
+                values: ["Foo", "Bar", "Baz"]
+            },
+            
+            {
+                name: "arg2",
+                type: "OptionEnum",
+                typeUse: "enumerator",
+                values: ["Foo", "Bar", "Baz"]
+            },
+            
+            {
+                name: "arg3",
+                type: "OptionEnum",
+                typeUse: "enumerator",
+                values: ["Foo", "Bar", "Baz"]
+            },
+            
+            {
+                name: "sentinel2",
                 type: "number",
                 typeUse: "number"
             }

--- a/feature_tests/js/api/OptionEnum.d.ts
+++ b/feature_tests/js/api/OptionEnum.d.ts
@@ -15,6 +15,7 @@ export class OptionEnum {
 
     static Foo : OptionEnum;
     static Bar : OptionEnum;
+    static Baz : OptionEnum;
 
 
     constructor(value: OptionEnum | string );

--- a/feature_tests/js/api/OptionEnum.mjs
+++ b/feature_tests/js/api/OptionEnum.mjs
@@ -9,7 +9,8 @@ export class OptionEnum {
 
     static #values = new Map([
         ["Foo", 0],
-        ["Bar", 1]
+        ["Bar", 1],
+        ["Baz", 2]
     ]);
 
     static getAllEntries() {
@@ -57,10 +58,12 @@ export class OptionEnum {
     static #objectValues = [
         new OptionEnum(diplomatRuntime.internalConstructor, diplomatRuntime.internalConstructor, 0),
         new OptionEnum(diplomatRuntime.internalConstructor, diplomatRuntime.internalConstructor, 1),
+        new OptionEnum(diplomatRuntime.internalConstructor, diplomatRuntime.internalConstructor, 2),
     ];
 
     static Foo = OptionEnum.#objectValues[0];
     static Bar = OptionEnum.#objectValues[1];
+    static Baz = OptionEnum.#objectValues[2];
 
 
     constructor(value) {

--- a/feature_tests/js/api/OptionOpaque.d.ts
+++ b/feature_tests/js/api/OptionOpaque.d.ts
@@ -43,6 +43,8 @@ export class OptionOpaque {
 
     static acceptsOptionEnum(arg: OptionEnum | null, sentinel: number): OptionEnum | null;
 
+    static acceptsMultipleOptionEnum(sentinel1: number, arg1: OptionEnum | null, arg2: OptionEnum | null, arg3: OptionEnum | null, sentinel2: number): OptionEnum | null;
+
     static acceptsOptionInputStruct(arg: OptionInputStruct | null, sentinel: number): OptionInputStruct | null;
 
     static returnsOptionInputStruct(): OptionInputStruct;

--- a/feature_tests/js/api/OptionOpaque.mjs
+++ b/feature_tests/js/api/OptionOpaque.mjs
@@ -277,6 +277,28 @@ export class OptionOpaque {
         }
     }
 
+    static acceptsMultipleOptionEnum(sentinel1, arg1, arg2, arg3, sentinel2) {
+        let functionCleanupArena = new diplomatRuntime.CleanupArena();
+
+        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+
+
+        const result = wasm.OptionOpaque_accepts_multiple_option_enum(diplomatReceive.buffer, sentinel1, diplomatRuntime.optionToBufferForCalling(wasm, arg1, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), diplomatRuntime.optionToBufferForCalling(wasm, arg2, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), diplomatRuntime.optionToBufferForCalling(wasm, arg3, 4, 4, functionCleanupArena, (arrayBuffer, offset, jsValue) => [diplomatRuntime.writeToArrayBuffer(arrayBuffer, offset + 0, jsValue.ffiValue, Int32Array)]), sentinel2);
+
+        try {
+            if (!diplomatReceive.resultFlag) {
+                return null;
+            }
+            return new OptionEnum(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
+        }
+
+        finally {
+            functionCleanupArena.free();
+
+            diplomatReceive.free();
+        }
+    }
+
     static acceptsOptionInputStruct(arg, sentinel) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 

--- a/feature_tests/js/test/option.mts
+++ b/feature_tests/js/test/option.mts
@@ -51,3 +51,9 @@ test("DiplomatOption test struct", t => {
     t.is(struct.c.value, OptionEnum.Bar.value);
 
 });
+
+test("DiplomatOption multiple args regression", t => {
+    let maybe = OptionOpaque.acceptsMultipleOptionEnum(123, OptionEnum.Foo, OptionEnum.Bar, OptionEnum.Baz, 200);
+    t.assert(maybe === OptionEnum.Baz);
+
+});

--- a/feature_tests/nanobind/src/include/OptionEnum.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionEnum.d.hpp
@@ -17,6 +17,7 @@ namespace capi {
     enum OptionEnum {
       OptionEnum_Foo = 0,
       OptionEnum_Bar = 1,
+      OptionEnum_Baz = 2,
     };
 
     typedef struct OptionEnum_option {union { OptionEnum ok; }; bool is_ok; } OptionEnum_option;
@@ -28,6 +29,7 @@ public:
     enum Value {
         Foo = 0,
         Bar = 1,
+        Baz = 2,
     };
 
     OptionEnum(): value(Value::Foo) {}

--- a/feature_tests/nanobind/src/include/OptionEnum.hpp
+++ b/feature_tests/nanobind/src/include/OptionEnum.hpp
@@ -30,6 +30,7 @@ inline OptionEnum OptionEnum::FromFFI(diplomat::capi::OptionEnum c_enum) {
     switch (c_enum) {
         case diplomat::capi::OptionEnum_Foo:
         case diplomat::capi::OptionEnum_Bar:
+        case diplomat::capi::OptionEnum_Baz:
             return static_cast<OptionEnum::Value>(c_enum);
         default:
             std::abort();

--- a/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
@@ -55,6 +55,8 @@ public:
 
   inline static std::optional<OptionEnum> accepts_option_enum(std::optional<OptionEnum> arg, uint8_t sentinel);
 
+  inline static std::optional<OptionEnum> accepts_multiple_option_enum(uint8_t sentinel1, std::optional<OptionEnum> arg1, std::optional<OptionEnum> arg2, std::optional<OptionEnum> arg3, uint8_t sentinel2);
+
   inline static std::optional<OptionInputStruct> accepts_option_input_struct(std::optional<OptionInputStruct> arg, uint8_t sentinel);
 
   inline static OptionInputStruct returns_option_input_struct();

--- a/feature_tests/nanobind/src/include/OptionOpaque.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.hpp
@@ -58,6 +58,9 @@ namespace capi {
     typedef struct OptionOpaque_accepts_option_enum_result {union {diplomat::capi::OptionEnum ok; }; bool is_ok;} OptionOpaque_accepts_option_enum_result;
     OptionOpaque_accepts_option_enum_result OptionOpaque_accepts_option_enum(diplomat::capi::OptionEnum_option arg, uint8_t sentinel);
 
+    typedef struct OptionOpaque_accepts_multiple_option_enum_result {union {diplomat::capi::OptionEnum ok; }; bool is_ok;} OptionOpaque_accepts_multiple_option_enum_result;
+    OptionOpaque_accepts_multiple_option_enum_result OptionOpaque_accepts_multiple_option_enum(uint8_t sentinel1, diplomat::capi::OptionEnum_option arg1, diplomat::capi::OptionEnum_option arg2, diplomat::capi::OptionEnum_option arg3, uint8_t sentinel2);
+
     typedef struct OptionOpaque_accepts_option_input_struct_result {union {diplomat::capi::OptionInputStruct ok; }; bool is_ok;} OptionOpaque_accepts_option_input_struct_result;
     OptionOpaque_accepts_option_input_struct_result OptionOpaque_accepts_option_input_struct(diplomat::capi::OptionInputStruct_option arg, uint8_t sentinel);
 
@@ -149,6 +152,15 @@ inline std::optional<uint8_t> OptionOpaque::accepts_option_u8(std::optional<uint
 inline std::optional<OptionEnum> OptionOpaque::accepts_option_enum(std::optional<OptionEnum> arg, uint8_t sentinel) {
     auto result = diplomat::capi::OptionOpaque_accepts_option_enum(arg.has_value() ? (diplomat::capi::OptionEnum_option{ { arg.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
         sentinel);
+    return result.is_ok ? std::optional<OptionEnum>(OptionEnum::FromFFI(result.ok)) : std::nullopt;
+}
+
+inline std::optional<OptionEnum> OptionOpaque::accepts_multiple_option_enum(uint8_t sentinel1, std::optional<OptionEnum> arg1, std::optional<OptionEnum> arg2, std::optional<OptionEnum> arg3, uint8_t sentinel2) {
+    auto result = diplomat::capi::OptionOpaque_accepts_multiple_option_enum(sentinel1,
+        arg1.has_value() ? (diplomat::capi::OptionEnum_option{ { arg1.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
+        arg2.has_value() ? (diplomat::capi::OptionEnum_option{ { arg2.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
+        arg3.has_value() ? (diplomat::capi::OptionEnum_option{ { arg3.value().AsFFI() }, true }) : (diplomat::capi::OptionEnum_option{ {}, false }),
+        sentinel2);
     return result.is_ok ? std::optional<OptionEnum>(OptionEnum::FromFFI(result.ok)) : std::nullopt;
 }
 

--- a/feature_tests/nanobind/src/sub_modules/OptionEnum_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OptionEnum_binding.cpp
@@ -10,6 +10,7 @@ void add_OptionEnum_binding(nb::handle mod) {
         nb::enum_<OptionEnum::Value>(e_class, "OptionEnum")
             .value("Foo", OptionEnum::Foo)
             .value("Bar", OptionEnum::Bar)
+            .value("Baz", OptionEnum::Baz)
             .export_values();
     
         e_class

--- a/feature_tests/nanobind/src/sub_modules/OptionOpaque_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/OptionOpaque_binding.cpp
@@ -13,6 +13,7 @@ void add_OptionOpaque_binding(nb::handle mod) {
         {0, nullptr}};
     
     nb::class_<OptionOpaque>(mod, "OptionOpaque", nb::type_slots(OptionOpaque_slots))
+        .def_static("accepts_multiple_option_enum", &OptionOpaque::accepts_multiple_option_enum, "sentinel1"_a, "arg1"_a= nb::none(), "arg2"_a= nb::none(), "arg3"_a= nb::none(), "sentinel2"_a)
         .def_static("accepts_option_enum", &OptionOpaque::accepts_option_enum, "arg"_a= nb::none(), "sentinel"_a)
         .def_static("accepts_option_input_struct", &OptionOpaque::accepts_option_input_struct, "arg"_a= nb::none(), "sentinel"_a)
         .def_static("accepts_option_primitive", &OptionOpaque::accepts_option_primitive, "arg"_a= nb::none(), "sentinel"_a)

--- a/feature_tests/src/option.rs
+++ b/feature_tests/src/option.rs
@@ -61,10 +61,11 @@ pub mod ffi {
     }
 
     #[diplomat::attr(not(supports = option), disable)]
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum OptionEnum {
         Foo,
         Bar,
+        Baz,
     }
 
     impl OptionOpaque {
@@ -142,6 +143,22 @@ pub mod ffi {
             assert_eq!(sentinel, 123, "{arg:?}");
             arg
         }
+
+        #[diplomat::attr(not(supports = option), disable)]
+        pub fn accepts_multiple_option_enum(
+            sentinel1: u8,
+            arg1: Option<OptionEnum>,
+            arg2: Option<OptionEnum>,
+            arg3: Option<OptionEnum>,
+            sentinel2: u8,
+        ) -> Option<OptionEnum> {
+            assert_eq!(sentinel1, 123);
+            assert_eq!(arg1, Some(OptionEnum::Foo));
+            assert_eq!(arg2, Some(OptionEnum::Bar));
+            assert_eq!(sentinel2, 200);
+            arg3
+        }
+
         #[diplomat::attr(not(supports = option), disable)]
         pub fn accepts_option_input_struct(
             arg: Option<OptionInputStruct>,


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/6688

The core problem is the distinction between TypedArray and ArrayBuffer: TypedArrays are views into an ArrayBuffer, whereas an ArrayBuffer is often a very large list of bytes. When working with wasm, we typically work with the underlying ArrayBuffer and use offset "pointers".

The source of the bug was two separate bugs cancelling each other out.

Firstly, we were accidentally giving Rust a pointer value 0 because we forgot to return anything from `optionToBufferForCalling()` and were passing it `undefined`. Rust was reading from the beginning of Wasm memory.

Secondly, we were accidentally writing data to pointer value 0 because we were passing down the ArrayBuffer with offset 0 to the callback, thinking we had already offset it when making a TypedArray, except `TypedArray.buffer` returns the original full buffer, not some slice view. So we were writing to the beginning of Wasm memory as well. Furthermore, when we made the TypedArray, we passed it `buf` as the offset which also probably turned into 0, so the Option discriminant got written to the beginning of wasm memory (but offset a bit).

These cancel out so it worked as long as we only passed one optional parameter, using the beginning of wasm memory as "scratch space".

We should probably be more consistent about "buffer" terminology in this code.