### PR TITLE
Add [T;X] support for C/C++

### DIFF
--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -451,6 +451,8 @@ pub enum TypeName {
         PrimitiveType,
         StdlibOrDiplomat,
     ),
+    /// A `[T; usize]` type, where `T` is a primitive.
+    PrimitiveArray(PrimitiveType, usize),
     /// `&[DiplomatStrSlice]`, etc. Equivalent to `&[&str]`
     ///
     /// If StdlibOrDiplomat::Stdlib, it's specified as `&[&DiplomatFoo]`, if StdlibOrDiplomat::Diplomat it's specified
@@ -576,7 +578,7 @@ impl TypeName {
     pub fn is_ffi_safe(&self) -> bool {
         match self {
             TypeName::Primitive(..) | TypeName::Named(_) | TypeName::SelfType(_) | TypeName::Reference(..) |
-            TypeName::Box(..) |
+            TypeName::Box(..) | TypeName::PrimitiveArray(..) |
             // can only be passed across the FFI boundary; callbacks and traits are input-only
             TypeName::Function(..) | TypeName::ImplTrait(..) |
             // These are specified using FFI-safe diplomat_runtime types
@@ -698,6 +700,10 @@ impl TypeName {
                     primitive.get_diplomat_slice_type(ltmt)
                 }
             }
+            TypeName::PrimitiveArray(ty, count) => {
+                let syn_ty = ty.to_ident();
+                syn::parse_quote_spanned!(Span::call_site() => &[#syn_ty; #count])
+            }
             TypeName::CustomTypeSlice(ltmt, type_name) => {
                 let inner = type_name.to_syn();
                 if let Some((ref lt, ref mtbl)) = ltmt {
@@ -768,6 +774,30 @@ impl TypeName {
                         );
                     }
                 }
+
+                if let syn::Type::Array(arr) = &*r.elem {
+                    let len = match &arr.len {
+                        syn::Expr::Lit(syn::ExprLit {
+                            attrs: _,
+                            lit: syn::Lit::Int(i),
+                        }) => i.base10_parse::<usize>().expect("Expected usize integer."),
+                        _ => unreachable!(
+                            "Expected a literal integer expression for array length in {arr:?}"
+                        ),
+                    };
+
+                    if let syn::Type::Path(p) = &*arr.elem {
+                        if let Some(primitive) = p
+                            .path
+                            .get_ident()
+                            .and_then(|i| PrimitiveType::from_str(i.to_string().as_str()).ok())
+                        {
+                            return TypeName::PrimitiveArray(primitive, len);
+                        }
+                    }
+                    panic!("Unsupported array type {:?}", arr.to_token_stream());
+                }
+
                 if let syn::Type::Slice(slice) = &*r.elem {
                     if let syn::Type::Path(p) = &*slice.elem {
                         if let Some(primitive) = p
@@ -1105,6 +1135,12 @@ impl TypeName {
                 }
                 ret_type.expect("No valid traits found")
             }
+            syn::Type::Array(a) => {
+                panic!(
+                    "Array {0} must be behind a reference (&{0})",
+                    a.to_token_stream()
+                );
+            }
             other => panic!("Unsupported type: {}", other.to_token_stream()),
         }
     }
@@ -1315,6 +1351,7 @@ impl fmt::Display for TypeName {
                 write!(f, "DiplomatSlice{maybemut}<{lt}{typ}>")
             }
             TypeName::PrimitiveSlice(None, typ, _) => write!(f, "Box<[{typ}]>"),
+            TypeName::PrimitiveArray(ty, size) => write!(f, "&[{ty}; {size}]"),
             TypeName::CustomTypeSlice(Some((lifetime, mutability)), type_name) => {
                 write!(f, "{}[{type_name}]", ReferenceDisplay(lifetime, mutability))
             }

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1006,6 +1006,8 @@ pub struct BackendAttrSupport {
     pub abi_compatibles: bool,
     /// Whether or not the language supports &Struct or &mut Struct
     pub struct_refs: bool,
+    /// Whether or not the language supports [T; usize] fixed-size arrays
+    pub arrays: bool,
 }
 
 impl BackendAttrSupport {
@@ -1041,6 +1043,7 @@ impl BackendAttrSupport {
             generate_mocking_interface: true,
             abi_compatibles: true,
             struct_refs: true,
+            arrays: true,
         }
     }
 
@@ -1072,6 +1075,7 @@ impl BackendAttrSupport {
             "traits_are_sync" => Some(self.traits_are_sync),
             "abi_compatibles" => Some(self.abi_compatibles),
             "struct_refs" => Some(self.struct_refs),
+            "arrays" => Some(self.arrays),
             _ => None,
         }
     }
@@ -1214,6 +1218,7 @@ impl AttributeValidator for BasicAttributeValidator {
                 generate_mocking_interface,
                 abi_compatibles,
                 struct_refs,
+                arrays,
             } = self.support;
             match value {
                 "namespacing" => namespacing,
@@ -1245,6 +1250,7 @@ impl AttributeValidator for BasicAttributeValidator {
                 "generate_mocking_interface" => generate_mocking_interface,
                 "abi_compatibles" => abi_compatibles,
                 "struct_refs" => struct_refs,
+                "arrays" => arrays,
                 _ => {
                     return Err(LoweringError::Other(format!(
                         "Unknown supports = value found: {value}"

--- a/core/src/hir/types.rs
+++ b/core/src/hir/types.rs
@@ -24,6 +24,8 @@ pub enum Type<P: TyPosition = Everywhere> {
     ImplTrait(P::TraitPath),
     Enum(EnumPath),
     Slice(Slice<P>),
+    /// A primitive array of a fixed size.
+    Array(PrimitiveType, usize),
     Callback(P::CallbackInstantiation), // only a Callback if P == InputOnly
     /// `DiplomatOption<T>`, for  a primitive, struct, or enum `T`.
     ///
@@ -110,7 +112,7 @@ impl<P: TyPosition<StructPath = StructPath>> Type<P> {
                 (acc.0 + inner.0, acc.1 + inner.1)
             }),
             Type::Opaque(_) | Type::Slice(_) | Type::Callback(_) | Type::ImplTrait(_) => (1, 1),
-            Type::Primitive(_) | Type::Enum(_) => (0, 0),
+            Type::Primitive(_) | Type::Enum(_) | Type::Array(..) => (0, 0),
             Type::DiplomatOption(ty) => ty.field_leaf_lifetime_counts(tcx),
         }
     }

--- a/feature_tests/c/include/CallbackWrapper.h
+++ b/feature_tests/c/include/CallbackWrapper.h
@@ -59,6 +59,11 @@ typedef struct DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f {
     void (*run_callback)(const void*, DiplomatU8View );
     void (*destructor)(const void*);
 } DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f;
+typedef struct DiplomatCallback_CallbackWrapper_test_array_cb_arg_f {
+    const void* data;
+    void (*run_callback)(const void*, const uint8_t* /*2*/ );
+    void (*destructor)(const void*);
+} DiplomatCallback_CallbackWrapper_test_array_cb_arg_f;
 typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t_result { bool is_ok;} DiplomatCallback_CallbackWrapper_test_result_output_t_result;
 
 typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t {
@@ -155,6 +160,8 @@ int32_t CallbackWrapper_test_str_cb_arg(DiplomatCallback_CallbackWrapper_test_st
 void CallbackWrapper_test_opaque_cb_arg(DiplomatCallback_CallbackWrapper_test_opaque_cb_arg_cb cb_cb_wrap, MyString* a);
 
 void CallbackWrapper_test_slice_cb_arg(DiplomatU8View arg, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f f_cb_wrap);
+
+void CallbackWrapper_test_array_cb_arg(const uint8_t* /*2*/ arg, DiplomatCallback_CallbackWrapper_test_array_cb_arg_f f_cb_wrap);
 
 void CallbackWrapper_test_result_output(DiplomatCallback_CallbackWrapper_test_result_output_t t_cb_wrap);
 

--- a/feature_tests/c/include/Float64Vec.h
+++ b/feature_tests/c/include/Float64Vec.h
@@ -19,6 +19,8 @@ Float64Vec* Float64Vec_new(DiplomatF64View v);
 
 Float64Vec* Float64Vec_new_bool(DiplomatBoolView v);
 
+Float64Vec* Float64Vec_new_int_arr(const int32_t* /*12*/ v, const bool* /*3*/ _other, const double* /*2*/ _other_other);
+
 Float64Vec* Float64Vec_new_i16(DiplomatI16View v);
 
 Float64Vec* Float64Vec_new_u16(DiplomatU16View v);

--- a/feature_tests/cpp/include/CallbackWrapper.d.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.d.hpp
@@ -48,6 +48,8 @@ struct CallbackWrapper {
 
   inline static void test_slice_cb_arg(diplomat::span<const uint8_t> arg, std::function<void(diplomat::span<const uint8_t>)> f);
 
+  inline static void test_array_cb_arg(const std::array<uint8_t,2>& arg, std::function<void(const std::array<uint8_t,2>&)> f);
+
   inline static void test_result_output(std::function<diplomat::result<std::monostate, std::monostate>()> t);
 
   inline static void test_result_usize_output(std::function<diplomat::result<size_t, std::monostate>()> t);

--- a/feature_tests/cpp/include/CallbackWrapper.hpp
+++ b/feature_tests/cpp/include/CallbackWrapper.hpp
@@ -62,6 +62,11 @@ namespace capi {
         void (*run_callback)(const void*, diplomat::capi::DiplomatU8View );
         void (*destructor)(const void*);
     } DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f;
+    typedef struct DiplomatCallback_CallbackWrapper_test_array_cb_arg_f {
+        const void* data;
+        void (*run_callback)(const void*, const uint8_t* /*2*/ );
+        void (*destructor)(const void*);
+    } DiplomatCallback_CallbackWrapper_test_array_cb_arg_f;
     typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t_result { bool is_ok;} DiplomatCallback_CallbackWrapper_test_result_output_t_result;
 
     typedef struct DiplomatCallback_CallbackWrapper_test_result_output_t {
@@ -159,6 +164,8 @@ namespace capi {
 
     void CallbackWrapper_test_slice_cb_arg(diplomat::capi::DiplomatU8View arg, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_f f_cb_wrap);
 
+    void CallbackWrapper_test_array_cb_arg(const uint8_t* /*2*/ arg, DiplomatCallback_CallbackWrapper_test_array_cb_arg_f f_cb_wrap);
+
     void CallbackWrapper_test_result_output(DiplomatCallback_CallbackWrapper_test_result_output_t t_cb_wrap);
 
     void CallbackWrapper_test_result_usize_output(DiplomatCallback_CallbackWrapper_test_result_usize_output_t t_cb_wrap);
@@ -221,6 +228,11 @@ inline void CallbackWrapper::test_opaque_cb_arg(std::function<void(MyString&)> c
 
 inline void CallbackWrapper::test_slice_cb_arg(diplomat::span<const uint8_t> arg, std::function<void(diplomat::span<const uint8_t>)> f) {
     diplomat::capi::CallbackWrapper_test_slice_cb_arg({arg.data(), arg.size()},
+        {new decltype(f)(std::move(f)), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
+}
+
+inline void CallbackWrapper::test_array_cb_arg(const std::array<uint8_t,2>& arg, std::function<void(const std::array<uint8_t,2>&)> f) {
+    diplomat::capi::CallbackWrapper_test_array_cb_arg(arg.data(),
         {new decltype(f)(std::move(f)), diplomat::fn_traits(f).c_run_callback, diplomat::fn_traits(f).c_delete});
 }
 

--- a/feature_tests/cpp/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp/include/Float64Vec.d.hpp
@@ -25,6 +25,8 @@ public:
 
   inline static std::unique_ptr<Float64Vec> new_bool(diplomat::span<const bool> v);
 
+  inline static std::unique_ptr<Float64Vec> new_int_arr(const std::array<int32_t,12>& v, const std::array<bool,3>& _other, const std::array<double,2>& _other_other);
+
   inline static std::unique_ptr<Float64Vec> new_i16(diplomat::span<const int16_t> v);
 
   inline static std::unique_ptr<Float64Vec> new_u16(diplomat::span<const uint16_t> v);

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -22,6 +22,8 @@ namespace capi {
 
     diplomat::capi::Float64Vec* Float64Vec_new_bool(diplomat::capi::DiplomatBoolView v);
 
+    diplomat::capi::Float64Vec* Float64Vec_new_int_arr(const int32_t* /*12*/ v, const bool* /*3*/ _other, const double* /*2*/ _other_other);
+
     diplomat::capi::Float64Vec* Float64Vec_new_i16(diplomat::capi::DiplomatI16View v);
 
     diplomat::capi::Float64Vec* Float64Vec_new_u16(diplomat::capi::DiplomatU16View v);
@@ -58,6 +60,13 @@ inline std::unique_ptr<Float64Vec> Float64Vec::new_(diplomat::span<const double>
 
 inline std::unique_ptr<Float64Vec> Float64Vec::new_bool(diplomat::span<const bool> v) {
     auto result = diplomat::capi::Float64Vec_new_bool({v.data(), v.size()});
+    return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
+}
+
+inline std::unique_ptr<Float64Vec> Float64Vec::new_int_arr(const std::array<int32_t,12>& v, const std::array<bool,3>& _other, const std::array<double,2>& _other_other) {
+    auto result = diplomat::capi::Float64Vec_new_int_arr(v.data(),
+        _other.data(),
+        _other_other.data());
     return std::unique_ptr<Float64Vec>(Float64Vec::FromFFI(result));
 }
 

--- a/feature_tests/cpp/tests/attrs.cpp
+++ b/feature_tests/cpp/tests/attrs.cpp
@@ -47,6 +47,13 @@ int main(int argc, char* argv[]) {
     simple_assert_eq("vector indexer", (*vec)[1].value(), 1.6);
     simple_assert_eq("vector indexer", (*vec)[2].has_value(), false);
 
+    std::array<bool, 3> fixed_bool = {true, true, false};
+    std::array<int32_t, 12> fixed_int = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    std::array<double, 2> fixed_float = {0., 0.1};
+    auto vec_from_fixed = Float64Vec::new_int_arr(fixed_int, fixed_bool, fixed_float);
+    simple_assert_eq("bool array", (*vec_from_fixed)[0].value(), 0);
+    simple_assert_eq("bool array", (*vec_from_fixed)[11].value(), 11);
+
 
     auto uintVec = std::vector<uint8_t>{ 1, 2, 3, 4 };
     auto myIterable = ns::RenamedMyIterable::new_(diplomat::span<const uint8_t>{uintVec.data(), uintVec.size()});

--- a/feature_tests/cpp/tests/callback.cpp
+++ b/feature_tests/cpp/tests/callback.cpp
@@ -57,6 +57,12 @@ int main(int argc, char *argv[])
         });
     }
     {
+        std::array<uint8_t,2> arr = {1, 2};
+        o.test_array_cb_arg(arr, [](const std::array<uint8_t,2>& a) {
+            simple_assert_eq("test_cb_arr", a[0], 1);
+        });
+    }
+    {
         int copied = 0;
         // TODO: Make C++ reject this by using move_only_function in c++23.
         // We cannot reject this in earlier standards due to a defect in std::function.

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -41,6 +41,11 @@ mod ffi {
             f(arg);
         }
 
+        #[diplomat::attr(not(supports = arrays), disable)]
+        pub fn test_array_cb_arg(arg: &[u8; 2], f: impl Fn(&[u8; 2])) {
+            f(arg);
+        }
+
         #[diplomat::attr(kotlin, disable)]
         pub fn test_result_output(t: impl Fn() -> Result<(), ()>) {
             assert_eq!(t(), Ok(()));

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -63,6 +63,15 @@ pub mod ffi {
             Box::new(Self(v.iter().map(|&x| x as u8 as f64).collect()))
         }
 
+        #[diplomat::attr(not(supports = arrays), disable)]
+        pub fn new_int_arr(
+            v: &[i32; 12],
+            _other: &[bool; 3],
+            _other_other: &[f64; 2],
+        ) -> Box<Float64Vec> {
+            Box::new(Self(v.iter().map(|x| (*x).into()).collect()))
+        }
+
         #[diplomat::attr(auto, named_constructor = "i16")]
         pub fn new_i16(v: &[i16]) -> Box<Float64Vec> {
             Box::new(Self(v.iter().map(|&x| x as f64).collect()))

--- a/tool/src/c/formatter.rs
+++ b/tool/src/c/formatter.rs
@@ -253,6 +253,19 @@ impl<'tcx> CFormatter<'tcx> {
         self.diplomat_namespace(format!("Diplomat{prim}View{mtb}").into())
     }
 
+    pub fn fmt_primitive_array_name(
+        &self,
+        prim: hir::PrimitiveType,
+        size: usize,
+    ) -> Cow<'tcx, str> {
+        // C arrays cannot actually be passed directly, and depending on context
+        // int a[4] might be a real array or just a pointer. So, at least for C,
+        // fixed sized arrays are just pointers with comments.
+        // Otherwise, we'd have to use different notation depending on if the type
+        // appeared as a function parameter or inside a struct (like for a callback's state struct)
+        format!("const {}* /*{size}*/", self.fmt_primitive_as_c(prim)).into()
+    }
+
     pub fn fmt_struct_slice_name<P: TyPosition>(
         &self,
         borrow: MaybeOwn,

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -42,6 +42,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.generate_mocking_interface = false;
     a.abi_compatibles = true;
     a.struct_refs = true;
+    a.arrays = true;
 
     a
 }

--- a/tool/src/c/ty.rs
+++ b/tool/src/c/ty.rs
@@ -588,6 +588,12 @@ impl<'tcx> TyGenContext<'_, 'tcx> {
                 header.includes.insert(header_path);
                 ret
             }
+            Type::Array(ref p, size) => {
+                // We use a BTreeSet, even though the C compiler won't complain about duplicates
+                // (if someone includes other header files, for instance.):
+                let out_ty = self.formatter.fmt_primitive_array_name(*p, size);
+                out_ty
+            }
             _ => unreachable!("{}", format!("unknown AST/HIR variant: {:?}", ty)),
         };
 

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -165,6 +165,21 @@ impl<'tcx> Cpp2Formatter<'tcx> {
         "std::string".into()
     }
 
+    pub fn fmt_primitive_array_name(
+        &self,
+        prim: hir::PrimitiveType,
+        size: usize,
+    ) -> Cow<'tcx, str> {
+        // C++ provides us the std::array type, which is bitwise identical to a T[N],
+        // but doesn't have the syntactic drawbacks of the definition meaning different things
+        // depending on context and having the type split across both sides of the identifier.
+        format!(
+            "const std::array<{},{size}>&",
+            self.fmt_primitive_as_c(prim)
+        )
+        .into()
+    }
+
     pub fn fmt_docs(&self, docs: &hir::Docs, attrs: &hir::Attrs) -> String {
         let mut docs = self.c.fmt_docs(docs);
         if let Some(deprecated) = attrs.deprecated.as_ref() {

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -42,6 +42,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.generate_mocking_interface = false;
     a.abi_compatibles = true;
     a.struct_refs = true;
+    a.arrays = true;
 
     a
 }

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -228,7 +228,6 @@ private:
 #endif // __cplusplus >= 202002L
 
 // Interop between std::function & our C Callback wrapper type
-
 template <typename T, typename = void>
 struct as_ffi {
   using type = T;
@@ -278,9 +277,31 @@ MAKE_SLICE_CONVERTERS(String16, char16_t)
 template<typename T>
 using diplomat_c_span_convert_t = typename diplomat_c_span_convert<T>::type;
 
-/// Replace the argument types from the std::function with the argument types for th function pointer
 template<typename T>
-using replace_fn_t = diplomat_c_span_convert_t<replace_string_view_t<as_ffi_t<T>>>;
+struct is_std_array : std::false_type {};
+
+template<typename T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template<typename T>
+constexpr bool is_const_std_array_ref_v = std::is_reference_v<T> && is_std_array<std::remove_const_t<std::remove_reference_t<T>>>::value;
+
+template<typename T, typename = void>
+struct diplomat_array_ref_convert {
+  using type = T;
+};
+
+template<typename T>
+struct diplomat_array_ref_convert<T, std::enable_if_t<is_const_std_array_ref_v<T>>> {
+  using type = const typename std::remove_const_t<std::remove_reference_t<T>>::value_type*;
+};
+
+template<typename T>
+using diplomat_array_ref_convert_t = typename diplomat_array_ref_convert<T>::type;
+
+/// Replace the argument types from the std::function with the argument types for the function pointer
+template<typename T>
+using replace_fn_t = diplomat_array_ref_convert_t<diplomat_c_span_convert_t<replace_string_view_t<as_ffi_t<T>>>>;
 
 template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Args...)>> {
     using fn_ptr_t = Ret(Args...);
@@ -291,10 +312,13 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
     template<typename T>
     static T replace(replace_fn_t<T> val) {
       if constexpr(std::is_same_v<T, std::string_view>)   {
-          return std::string_view{val.data, val.len};
+        return std::string_view{val.data, val.len};
       } else if constexpr (!std::is_same_v<T, diplomat_c_span_convert_t<T>>) {
         return T{ val.data, val.len };
-      } else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
+      } else if constexpr(!std::is_same_v<T, diplomat_array_ref_convert_t<T>>) {
+        return reinterpret_cast<T>(*val);
+      }
+      else if constexpr (!std::is_same_v<T, as_ffi_t<T>>) {
         if constexpr (std::is_lvalue_reference_v<T>) {
           return *std::remove_reference_t<T>::FromFFI(val);
         }


### PR DESCRIPTION
Most work originally credit to @tyler-zeromatter/@ambiguousname 
I've made some edits/revisions. 
In C, fixed sized arrays are just passed as T*, with comments in the source indicating to end users their known size.
In C++, we convert to using const std::array<T,N>&, which is functionally the same as a pointer, just with extra info.

All this is done to avoid having to declare types as `T <identifier>[N]`, which means different things in different contexts in both C & C++ as well as being the only type where the type is split across both sides of the identifier. Specifically, the C ABI does not actually have any way to pass T[N] as a parameter - it is always interpreted as just a pointer.