### PR TITLE
Better docstring alignment

### DIFF
--- a/example/cpp/include/DataProvider.d.hpp
+++ b/example/cpp/include/DataProvider.d.hpp
@@ -32,14 +32,14 @@ namespace icu4x {
 class DataProvider {
 public:
 
-    /**
-     * See the [Rust documentation for `get_static_provider`](https://docs.rs/icu_testdata/latest/icu_testdata/fn.get_static_provider.html) for more information.
-     */
+  /**
+   * See the [Rust documentation for `get_static_provider`](https://docs.rs/icu_testdata/latest/icu_testdata/fn.get_static_provider.html) for more information.
+   */
   inline static std::unique_ptr<icu4x::DataProvider> new_static();
 
-    /**
-     * This exists as a regression test for https://github.com/rust-diplomat/diplomat/issues/155
-     */
+  /**
+   * This exists as a regression test for https://github.com/rust-diplomat/diplomat/issues/155
+   */
   inline static icu4x::diplomat::result<std::monostate, std::monostate> returns_result();
 
     inline const icu4x::capi::DataProvider* AsFFI() const;

--- a/example/cpp/include/FixedDecimal.d.hpp
+++ b/example/cpp/include/FixedDecimal.d.hpp
@@ -30,23 +30,23 @@ namespace icu4x {
 class FixedDecimal {
 public:
 
-    /**
-     * Construct an {@link FixedDecimal} from an integer.
-     */
+  /**
+   * Construct an {@link FixedDecimal} from an integer.
+   */
   inline static std::unique_ptr<icu4x::FixedDecimal> new_(int32_t v);
 
-    /**
-     * Multiply the {@link FixedDecimal} by a given power of ten.
-     *
-     * See the [Rust documentation for `multiply_pow10`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.multiply_pow10) for more information.
-     */
+  /**
+   * Multiply the {@link FixedDecimal} by a given power of ten.
+   *
+   * See the [Rust documentation for `multiply_pow10`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.multiply_pow10) for more information.
+   */
   inline void multiply_pow10(int16_t power);
 
-    /**
-     * Format the {@link FixedDecimal} as a string.
-     *
-     * See the [Rust documentation for `write_to`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.write_to) for more information.
-     */
+  /**
+   * Format the {@link FixedDecimal} as a string.
+   *
+   * See the [Rust documentation for `write_to`](https://docs.rs/fixed_decimal/latest/fixed_decimal/struct.FixedDecimal.html#method.write_to) for more information.
+   */
   inline icu4x::diplomat::result<std::string, std::monostate> to_string() const;
   template<typename W>
   inline icu4x::diplomat::result<std::monostate, std::monostate> to_string_write(W& writeable_output) const;

--- a/example/cpp/include/FixedDecimalFormatter.d.hpp
+++ b/example/cpp/include/FixedDecimalFormatter.d.hpp
@@ -39,18 +39,18 @@ namespace icu4x {
 class FixedDecimalFormatter {
 public:
 
-    /**
-     * Creates a new {@link FixedDecimalFormatter} from locale data.
-     *
-     * See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new) for more information.
-     */
+  /**
+   * Creates a new {@link FixedDecimalFormatter} from locale data.
+   *
+   * See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/decimal/struct.FixedDecimalFormatter.html#method.try_new) for more information.
+   */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::FixedDecimalFormatter>, std::monostate> try_new(const icu4x::Locale& locale, const icu4x::DataProvider& provider, icu4x::FixedDecimalFormatterOptions options);
 
-    /**
-     * Formats a {@link FixedDecimal} to a string.
-     *
-     * See the [Rust documentation for `format`](https://docs.rs/icu/latest/icu/decimal/struct.FixedDecimalFormatter.html#method.format) for more information.
-     */
+  /**
+   * Formats a {@link FixedDecimal} to a string.
+   *
+   * See the [Rust documentation for `format`](https://docs.rs/icu/latest/icu/decimal/struct.FixedDecimalFormatter.html#method.format) for more information.
+   */
   inline std::string format_write(const icu4x::FixedDecimal& value) const;
   template<typename W>
   inline void format_write_write(const icu4x::FixedDecimal& value, W& writeable_output) const;

--- a/example/cpp/include/Locale.d.hpp
+++ b/example/cpp/include/Locale.d.hpp
@@ -32,9 +32,9 @@ namespace icu4x {
 class Locale {
 public:
 
-    /**
-     * Construct an {@link Locale} from a locale identifier represented as a string.
-     */
+  /**
+   * Construct an {@link Locale} from a locale identifier represented as a string.
+   */
   inline static std::unique_ptr<icu4x::Locale> new_(std::string_view name);
 
     inline const icu4x::capi::Locale* AsFFI() const;

--- a/feature_tests/cpp/include/Foo.d.hpp
+++ b/feature_tests/cpp/include/Foo.d.hpp
@@ -42,9 +42,9 @@ public:
 
   inline static std::unique_ptr<somelib::Foo> extract_from_fields(somelib::BorrowedFields fields);
 
-    /**
-     * Test that the extraction logic correctly pins the right fields
-     */
+  /**
+   * Test that the extraction logic correctly pins the right fields
+   */
   inline static std::unique_ptr<somelib::Foo> extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds, std::string_view another_string);
 
     inline const somelib::capi::Foo* AsFFI() const;

--- a/feature_tests/cpp/include/Opaque.d.hpp
+++ b/feature_tests/cpp/include/Opaque.d.hpp
@@ -39,13 +39,13 @@ public:
   template<typename W>
   inline void get_debug_str_write(W& writeable_output) const;
 
-    /**
-     * See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.
-     *
-     * See the [Rust documentation for `something_else`](https://docs.rs/Something/latest/struct.Something.html#method.something_else) for more information.
-     *
-     * Additional information: [1](https://docs.rs/Something/latest/struct.Something.html#method.something_small), [2](https://docs.rs/SomethingElse/latest/struct.SomethingElse.html#method.something)
-     */
+  /**
+   * See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.
+   *
+   * See the [Rust documentation for `something_else`](https://docs.rs/Something/latest/struct.Something.html#method.something_else) for more information.
+   *
+   * Additional information: [1](https://docs.rs/Something/latest/struct.Something.html#method.something_small), [2](https://docs.rs/SomethingElse/latest/struct.SomethingElse.html#method.something)
+   */
   inline void assert_struct(somelib::MyStruct s) const;
 
   inline static size_t returns_usize();

--- a/feature_tests/cpp/include/ResultOpaque.d.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.d.hpp
@@ -45,10 +45,10 @@ public:
 
   inline static somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::ResultOpaque>> new_in_enum_err(int32_t i);
 
-    /**
-     * When we take &str, the return type becomes a Result
-     * Test that this interacts gracefully with returning a reference type
-     */
+  /**
+   * When we take &str, the return type becomes a Result
+   * Test that this interacts gracefully with returning a reference type
+   */
   inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> takes_str(std::string_view _v);
 
   inline void assert_integer(int32_t i) const;

--- a/feature_tests/cpp/include/ns/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp/include/ns/AttrOpaque1Renamed.d.hpp
@@ -37,9 +37,9 @@ namespace somelib::ns {
 class AttrOpaque1Renamed {
 public:
 
-    /**
-     * More example docs
-     */
+  /**
+   * More example docs
+   */
   inline static std::unique_ptr<somelib::ns::AttrOpaque1Renamed> totally_not_new();
 
   inline static void test_namespaced_callback(std::function<somelib::diplomat::result<std::monostate, std::monostate>()> _t);

--- a/feature_tests/cpp/include/ns/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/cpp/include/ns/AttrOpaque1Renamed.d.hpp
@@ -31,9 +31,15 @@ namespace capi {
 } // namespace
 
 namespace somelib::ns {
+/**
+ * Some example docs
+ */
 class AttrOpaque1Renamed {
 public:
 
+    /**
+     * More example docs
+     */
   inline static std::unique_ptr<somelib::ns::AttrOpaque1Renamed> totally_not_new();
 
   inline static void test_namespaced_callback(std::function<somelib::diplomat::result<std::monostate, std::monostate>()> _t);

--- a/feature_tests/cpp/include/ns/RenamedStructWithAttrs.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedStructWithAttrs.d.hpp
@@ -48,9 +48,9 @@ struct RenamedStructWithAttrs {
 
   inline uint32_t c() const;
 
-    /**
-     * \deprecated use Foo
-     */
+  /**
+   * \deprecated use Foo
+   */
   [[deprecated("use Foo")]]
   inline void deprecated() const;
 

--- a/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
+++ b/feature_tests/dart/lib/src/AttrOpaque1Renamed.g.dart
@@ -3,6 +3,7 @@
 
 part of 'lib.g.dart';
 
+/// Some example docs
 final class AttrOpaque1Renamed implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -23,6 +24,7 @@ final class AttrOpaque1Renamed implements ffi.Finalizable {
   @_DiplomatFfiUse('namespace_AttrOpaque1_destroy')
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_namespace_AttrOpaque1_destroy));
 
+  /// More example docs
   factory AttrOpaque1Renamed() {
     final result = _namespace_AttrOpaque1_new();
     return AttrOpaque1Renamed._fromFfi(result, []);

--- a/feature_tests/js/api/AttrOpaque1Renamed.d.ts
+++ b/feature_tests/js/api/AttrOpaque1Renamed.d.ts
@@ -5,6 +5,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 
+/**
+ * Some example docs
+ */
 export class AttrOpaque1Renamed {
     /** @internal */
     get ffiValue(): pointer;
@@ -22,5 +25,8 @@ export class AttrOpaque1Renamed {
 
     useNamespaced(n: RenamedAttrEnum): void;
 
+    /**
+     * More example docs
+     */
     constructor();
 }

--- a/feature_tests/js/api/AttrOpaque1Renamed.mjs
+++ b/feature_tests/js/api/AttrOpaque1Renamed.mjs
@@ -8,6 +8,9 @@ const AttrOpaque1Renamed_box_destroy_registry = new FinalizationRegistry((ptr) =
     wasm.namespace_AttrOpaque1_destroy(ptr);
 });
 
+/**
+ * Some example docs
+ */
 export class AttrOpaque1Renamed {
     // Internal ptr reference:
     #ptr = null;
@@ -37,6 +40,9 @@ export class AttrOpaque1Renamed {
     }
 
 
+    /**
+     * More example docs
+     */
     #defaultConstructor() {
 
         const result = wasm.namespace_AttrOpaque1_new();
@@ -115,6 +121,9 @@ export class AttrOpaque1Renamed {
         }
     }
 
+    /**
+     * More example docs
+     */
     constructor() {
         if (arguments[0] === diplomatRuntime.exposeConstructor) {
             return this.#internalConstructor(...Array.prototype.slice.call(arguments, 1));

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/AttrOpaque1.kt
@@ -21,7 +21,8 @@ internal interface AttrOpaque1Interface {
     fun useUnnamespaced(un: Unnamespaced): Unit
     fun useNamespaced(n: AttrEnum): Unit
 }
-
+/** Some example docs
+*/
 class AttrOpaque1 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,6 +41,8 @@ class AttrOpaque1 internal constructor (
         internal val lib: AttrOpaque1Lib = Native.load("somelib", libClass)
         @JvmStatic
         
+        /** More example docs
+        */
         fun new_(): AttrOpaque1 {
             
             val returnVal = lib.namespace_AttrOpaque1_new();

--- a/feature_tests/nanobind/src/include/Foo.d.hpp
+++ b/feature_tests/nanobind/src/include/Foo.d.hpp
@@ -39,9 +39,9 @@ public:
 
   inline static std::unique_ptr<Foo> extract_from_fields(BorrowedFields fields);
 
-    /**
-     * Test that the extraction logic correctly pins the right fields
-     */
+  /**
+   * Test that the extraction logic correctly pins the right fields
+   */
   inline static std::unique_ptr<Foo> extract_from_bounds(BorrowedFieldsWithBounds bounds, std::string_view another_string);
 
     inline const diplomat::capi::Foo* AsFFI() const;

--- a/feature_tests/nanobind/src/include/Opaque.d.hpp
+++ b/feature_tests/nanobind/src/include/Opaque.d.hpp
@@ -36,13 +36,13 @@ public:
   template<typename W>
   inline void get_debug_str_write(W& writeable_output) const;
 
-    /**
-     * See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.
-     *
-     * See the [Rust documentation for `something_else`](https://docs.rs/Something/latest/struct.Something.html#method.something_else) for more information.
-     *
-     * Additional information: [1](https://docs.rs/Something/latest/struct.Something.html#method.something_small), [2](https://docs.rs/SomethingElse/latest/struct.SomethingElse.html#method.something)
-     */
+  /**
+   * See the [Rust documentation for `something`](https://docs.rs/Something/latest/struct.Something.html#method.something) for more information.
+   *
+   * See the [Rust documentation for `something_else`](https://docs.rs/Something/latest/struct.Something.html#method.something_else) for more information.
+   *
+   * Additional information: [1](https://docs.rs/Something/latest/struct.Something.html#method.something_small), [2](https://docs.rs/SomethingElse/latest/struct.SomethingElse.html#method.something)
+   */
   inline void assert_struct(MyStruct s) const;
 
   inline static size_t returns_usize();

--- a/feature_tests/nanobind/src/include/ResultOpaque.d.hpp
+++ b/feature_tests/nanobind/src/include/ResultOpaque.d.hpp
@@ -42,10 +42,10 @@ public:
 
   inline static diplomat::result<ErrorEnum, std::unique_ptr<ResultOpaque>> new_in_enum_err(int32_t i);
 
-    /**
-     * When we take &str, the return type becomes a Result
-     * Test that this interacts gracefully with returning a reference type
-     */
+  /**
+   * When we take &str, the return type becomes a Result
+   * Test that this interacts gracefully with returning a reference type
+   */
   inline diplomat::result<ResultOpaque&, diplomat::Utf8Error> takes_str(std::string_view _v);
 
   inline void assert_integer(int32_t i) const;

--- a/feature_tests/nanobind/src/include/ns/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/AttrOpaque1Renamed.d.hpp
@@ -37,9 +37,9 @@ namespace ns {
 class AttrOpaque1Renamed {
 public:
 
-    /**
-     * More example docs
-     */
+  /**
+   * More example docs
+   */
   inline static std::unique_ptr<ns::AttrOpaque1Renamed> totally_not_new();
 
   inline static void test_namespaced_callback(std::function<diplomat::result<std::monostate, std::monostate>()> _t);

--- a/feature_tests/nanobind/src/include/ns/AttrOpaque1Renamed.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/AttrOpaque1Renamed.d.hpp
@@ -31,9 +31,15 @@ namespace capi {
 } // namespace
 
 namespace ns {
+/**
+ * Some example docs
+ */
 class AttrOpaque1Renamed {
 public:
 
+    /**
+     * More example docs
+     */
   inline static std::unique_ptr<ns::AttrOpaque1Renamed> totally_not_new();
 
   inline static void test_namespaced_callback(std::function<diplomat::result<std::monostate, std::monostate>()> _t);

--- a/feature_tests/nanobind/src/include/ns/RenamedStructWithAttrs.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedStructWithAttrs.d.hpp
@@ -48,9 +48,9 @@ struct RenamedStructWithAttrs {
 
   inline uint32_t c() const;
 
-    /**
-     * \deprecated use Foo
-     */
+  /**
+   * \deprecated use Foo
+   */
   [[deprecated("use Foo")]]
   inline void deprecated() const;
 

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -54,11 +54,13 @@ pub mod ffi {
     // Attr for generating mocking interface in kotlin backend to enable JVM test fakes.
     #[diplomat::attr(kotlin, generate_mocking_interface)]
     #[diplomat::attr(not(kotlin), rename = "AttrOpaque1Renamed")]
+    /// Some example docs
     pub struct AttrOpaque1;
 
     impl AttrOpaque1 {
         #[diplomat::attr(not(kotlin), rename = "totally_not_{0}")]
         #[diplomat::attr(auto, constructor)]
+        /// More example docs
         pub fn new() -> Box<AttrOpaque1> {
             Box::new(AttrOpaque1)
         }

--- a/tool/templates/cpp/function_defs/method_decl_base.h.jinja
+++ b/tool/templates/cpp/function_defs/method_decl_base.h.jinja
@@ -1,8 +1,8 @@
 {%- block pre_func %}{%- endblock -%}
 {% if !m.docs.is_empty() %}
-    /**
-     {{~ m.docs|prefix_trimmed("     * ")}}
-     */
+  /**
+   {{~ m.docs|prefix_trimmed("   * ")}}
+   */
 {%- endif -%}
 {%- if let Some(deprecated) = m.deprecated %}
   [[deprecated("{{ deprecated }}")]]


### PR DESCRIPTION
Follows the examples in https://www.doxygen.nl/manual/docblocks.html: The beginning `/` is aligned with the method name, subsequent lines are aligned with the *first* asterisk and have a space before the docs, the last `*/` is also aligned with the first asterisk.