### PR TITLE
Bump to Diplomat 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "diplomat"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "diplomat_core",
  "insta",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-example"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "diplomat",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-feature-tests"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "jni",
  "log",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat_core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "displaydoc",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["core", "macro", "runtime", "tool", "example", "feature_tests"]
 [workspace.package]
 
 # Individual subcrates may choose to temporarily switch to a different version
-version = "0.12.0"
+version = "0.13.0"
 # Applies to diplomat-core, diplomat, and diplomat-runtime
 # Diplomat-tool has no MSRV for now
 rust-version = "1.81"
@@ -21,7 +21,7 @@ categories = ["development-tools", "compilers"]
 keywords = ["ffi", "codegen"]
 
 [workspace.dependencies]
-diplomat = { version = "0.12.0", path = "macro", default-features = false }
-diplomat_core = { version = "0.12.0", path = "core", default-features = false }
-diplomat-runtime = { version = "0.12.0", path = "runtime", default-features = false }
-diplomat-tool = { version = "0.12.0", path = "tool", default-features = false }
+diplomat = { version = "0.13.0", path = "macro", default-features = false }
+diplomat_core = { version = "0.13.0", path = "core", default-features = false }
+diplomat-runtime = { version = "0.13.0", path = "runtime", default-features = false }
+diplomat-tool = { version = "0.13.0", path = "tool", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diplomat_core"
 description = "Shared utilities between Diplomat macros and code generation"
-version = "0.12.1"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
Diplomat 0.13.0 brings us:

 - [A changed default for the JS WASM ABI](https://blog.rust-lang.org/2025/04/04/c-abi-changes-for-wasm32-unknown-unknown/)
 - Various improvements to the demogen, nanobind, JS and Dart APIs.
 - Struct refs and free function support for C++ and nanobind
 - `lib_name` support for C++ (if you set `lib_name`, you may need to remove namespace annotations to keep existing behavior)


This does not yet stabilize `diplomat_runtime` as is planned in https://github.com/rust-diplomat/diplomat/issues/958.

In theory we could just bump the other three crates, but I don't want to introduce more versioning confusion. We can release `diplomat_runtime` 1.0.0 whenever we like and clients can update to that as needed.