### PR TITLE
Add stable ABI C++ type for string view in slice

### DIFF
--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -282,6 +282,68 @@ private:
 
 #endif // __cplusplus >= 202002L
 
+// An ABI stable std::basic_string_view equivalent for the case of string
+// views in slices
+template <class CharT, class Traits = std::char_traits<CharT>>
+class basic_string_view_for_slice {
+public:
+  using std_string_view           = std::basic_string_view<CharT, Traits>;
+  using traits_type               = typename std_string_view::traits_type;
+  using value_type                = typename std_string_view::value_type;
+  using pointer                   = typename std_string_view::pointer;
+  using const_pointer             = typename std_string_view::const_pointer;
+  using size_type                 = typename std_string_view::size_type;
+  using difference_type           = typename std_string_view::difference_type;
+
+  constexpr basic_string_view_for_slice() noexcept
+    : basic_string_view_for_slice{std_string_view{}} {}
+
+  constexpr basic_string_view_for_slice(const basic_string_view_for_slice& other) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const const_pointer s, const size_type count)
+    : basic_string_view_for_slice{std_string_view{s, count}} {}
+
+  constexpr basic_string_view_for_slice(const const_pointer s)
+    : basic_string_view_for_slice{std_string_view{s}} {}
+
+  constexpr basic_string_view_for_slice& operator=(const basic_string_view_for_slice& view) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const std_string_view& s) noexcept
+    : data_{s.data(), s.size()} {}
+
+  constexpr basic_string_view_for_slice& operator=(const std_string_view& s) noexcept {
+    data_ = {s.data(), s.size()};
+    return *this;
+  }
+
+  constexpr operator std_string_view() const noexcept { return {data(), size()}; }
+  constexpr std_string_view as_sv() const noexcept { return *this; }
+
+  constexpr const_pointer data() const noexcept { return data_.data; }
+  constexpr size_type size() const noexcept { return data_.len; }
+
+private:
+  using capi_type =
+    std::conditional_t<std::is_same_v<value_type, char>,
+      capi::DiplomatStringView,
+    std::conditional_t<std::is_same_v<value_type, char16_t>,
+      capi::DiplomatString16View,
+      void>>;
+
+  static_assert(!std::is_void_v<capi_type>,
+    "ABI compatible string_views are only supported for char and char16_t");
+
+  capi_type data_;
+};
+
+// We only implement these specialisations as diplomat doesn't provide c abi
+// types for others
+using string_view_for_slice = basic_string_view_for_slice<char>;
+using u16string_view_for_slice = basic_string_view_for_slice<char16_t>;
+
+using string_view_span = span<const string_view_for_slice>;
+using u16string_view_span = span<const u16string_view_for_slice>;
+
 // Interop between std::function & our C Callback wrapper type
 
 template <typename T, typename = void>

--- a/feature_tests/cpp/include/MyString.d.hpp
+++ b/feature_tests/cpp/include/MyString.d.hpp
@@ -33,7 +33,7 @@ public:
 
   inline static std::unique_ptr<somelib::MyString> new_owned(std::string_view v);
 
-  inline static std::unique_ptr<somelib::MyString> new_from_first(somelib::diplomat::span<const std::string_view> v);
+  inline static std::unique_ptr<somelib::MyString> new_from_first(somelib::diplomat::span<const diplomat::string_view_for_slice> v);
 
   inline void set_str(std::string_view new_str);
 

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -60,7 +60,7 @@ inline std::unique_ptr<somelib::MyString> somelib::MyString::new_owned(std::stri
     return std::unique_ptr<somelib::MyString>(somelib::MyString::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::MyString> somelib::MyString::new_from_first(somelib::diplomat::span<const std::string_view> v) {
+inline std::unique_ptr<somelib::MyString> somelib::MyString::new_from_first(somelib::diplomat::span<const diplomat::string_view_for_slice> v) {
     auto result = somelib::capi::MyString_new_from_first({reinterpret_cast<const somelib::diplomat::capi::DiplomatStringView*>(v.data()), v.size()});
     return std::unique_ptr<somelib::MyString>(somelib::MyString::FromFFI(result));
 }

--- a/feature_tests/cpp/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.d.hpp
@@ -68,7 +68,7 @@ public:
 
   inline static size_t accepts_option_str(std::optional<std::string_view> arg, uint8_t sentinel);
 
-  inline static bool accepts_option_str_slice(std::optional<somelib::diplomat::span<const std::string_view>> arg, uint8_t sentinel);
+  inline static bool accepts_option_str_slice(std::optional<somelib::diplomat::span<const diplomat::string_view_for_slice>> arg, uint8_t sentinel);
 
   inline static int64_t accepts_option_primitive(std::optional<somelib::diplomat::span<const uint32_t>> arg, uint8_t sentinel);
 

--- a/feature_tests/cpp/include/OptionOpaque.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.hpp
@@ -181,7 +181,7 @@ inline size_t somelib::OptionOpaque::accepts_option_str(std::optional<std::strin
     return result;
 }
 
-inline bool somelib::OptionOpaque::accepts_option_str_slice(std::optional<somelib::diplomat::span<const std::string_view>> arg, uint8_t sentinel) {
+inline bool somelib::OptionOpaque::accepts_option_str_slice(std::optional<somelib::diplomat::span<const diplomat::string_view_for_slice>> arg, uint8_t sentinel) {
     auto result = somelib::capi::OptionOpaque_accepts_option_str_slice(arg.has_value() ? (somelib::diplomat::capi::OptionStringsView{ { {reinterpret_cast<const somelib::diplomat::capi::DiplomatStringView*>(arg.value().data()), arg.value().size()} }, true }) : (somelib::diplomat::capi::OptionStringsView{ {}, false }),
         sentinel);
     return result;

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -282,6 +282,68 @@ private:
 
 #endif // __cplusplus >= 202002L
 
+// An ABI stable std::basic_string_view equivalent for the case of string
+// views in slices
+template <class CharT, class Traits = std::char_traits<CharT>>
+class basic_string_view_for_slice {
+public:
+  using std_string_view           = std::basic_string_view<CharT, Traits>;
+  using traits_type               = typename std_string_view::traits_type;
+  using value_type                = typename std_string_view::value_type;
+  using pointer                   = typename std_string_view::pointer;
+  using const_pointer             = typename std_string_view::const_pointer;
+  using size_type                 = typename std_string_view::size_type;
+  using difference_type           = typename std_string_view::difference_type;
+
+  constexpr basic_string_view_for_slice() noexcept
+    : basic_string_view_for_slice{std_string_view{}} {}
+
+  constexpr basic_string_view_for_slice(const basic_string_view_for_slice& other) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const const_pointer s, const size_type count)
+    : basic_string_view_for_slice{std_string_view{s, count}} {}
+
+  constexpr basic_string_view_for_slice(const const_pointer s)
+    : basic_string_view_for_slice{std_string_view{s}} {}
+
+  constexpr basic_string_view_for_slice& operator=(const basic_string_view_for_slice& view) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const std_string_view& s) noexcept
+    : data_{s.data(), s.size()} {}
+
+  constexpr basic_string_view_for_slice& operator=(const std_string_view& s) noexcept {
+    data_ = {s.data(), s.size()};
+    return *this;
+  }
+
+  constexpr operator std_string_view() const noexcept { return {data(), size()}; }
+  constexpr std_string_view as_sv() const noexcept { return *this; }
+
+  constexpr const_pointer data() const noexcept { return data_.data; }
+  constexpr size_type size() const noexcept { return data_.len; }
+
+private:
+  using capi_type =
+    std::conditional_t<std::is_same_v<value_type, char>,
+      capi::DiplomatStringView,
+    std::conditional_t<std::is_same_v<value_type, char16_t>,
+      capi::DiplomatString16View,
+      void>>;
+
+  static_assert(!std::is_void_v<capi_type>,
+    "ABI compatible string_views are only supported for char and char16_t");
+
+  capi_type data_;
+};
+
+// We only implement these specialisations as diplomat doesn't provide c abi
+// types for others
+using string_view_for_slice = basic_string_view_for_slice<char>;
+using u16string_view_for_slice = basic_string_view_for_slice<char16_t>;
+
+using string_view_span = span<const string_view_for_slice>;
+using u16string_view_span = span<const u16string_view_for_slice>;
+
 // Interop between std::function & our C Callback wrapper type
 
 template <typename T, typename = void>

--- a/feature_tests/cpp/tests/callback.cpp
+++ b/feature_tests/cpp/tests/callback.cpp
@@ -81,6 +81,11 @@ int main(int argc, char *argv[])
         }, *opaque);
         simple_assert_eq("opaque cb arg", opaque->borrow(), "split");
     }
+    {
+        std::array<diplomat::string_view_for_slice, 2> names{"Banana", "Apple"};
+        auto opaque = MyString::new_from_first(names);
+        simple_assert_eq("opaque cb arg", opaque->borrow(), "Banana");
+    }
 
     {
         o.test_result_output([]() {

--- a/feature_tests/cpp/tests/option.cpp
+++ b/feature_tests/cpp/tests/option.cpp
@@ -49,8 +49,8 @@ int main(int argc, char *argv[])
 
     using namespace std::string_view_literals;
 
-    std::array<std::string_view, 2> string_array{"string1"sv, "string2"sv};
-    diplomat::span<const std::string_view> arg{string_array};
+    std::array<diplomat::string_view_for_slice, 2> string_array{"string1"sv, "string2"sv};
+    diplomat::string_view_span arg{string_array};
     auto str_slice_result = OptionOpaque::accepts_option_str_slice(std::make_optional(std::move(arg)), 123);
     simple_assert("option_str_slice functions", str_slice_result);
 

--- a/feature_tests/nanobind/src/include/MyString.d.hpp
+++ b/feature_tests/nanobind/src/include/MyString.d.hpp
@@ -27,7 +27,7 @@ public:
 
   inline static std::unique_ptr<MyString> new_owned(std::string_view v);
 
-  inline static std::unique_ptr<MyString> new_from_first(diplomat::span<const std::string_view> v);
+  inline static std::unique_ptr<MyString> new_from_first(diplomat::span<const diplomat::string_view_for_slice> v);
 
   inline void set_str(std::string_view new_str);
 

--- a/feature_tests/nanobind/src/include/MyString.hpp
+++ b/feature_tests/nanobind/src/include/MyString.hpp
@@ -60,7 +60,7 @@ inline std::unique_ptr<MyString> MyString::new_owned(std::string_view v) {
     return std::unique_ptr<MyString>(MyString::FromFFI(result));
 }
 
-inline std::unique_ptr<MyString> MyString::new_from_first(diplomat::span<const std::string_view> v) {
+inline std::unique_ptr<MyString> MyString::new_from_first(diplomat::span<const diplomat::string_view_for_slice> v) {
     auto result = diplomat::capi::MyString_new_from_first({reinterpret_cast<const diplomat::capi::DiplomatStringView*>(v.data()), v.size()});
     return std::unique_ptr<MyString>(MyString::FromFFI(result));
 }

--- a/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
@@ -65,7 +65,7 @@ public:
 
   inline static size_t accepts_option_str(std::optional<std::string_view> arg, uint8_t sentinel);
 
-  inline static bool accepts_option_str_slice(std::optional<diplomat::span<const std::string_view>> arg, uint8_t sentinel);
+  inline static bool accepts_option_str_slice(std::optional<diplomat::span<const diplomat::string_view_for_slice>> arg, uint8_t sentinel);
 
   inline static int64_t accepts_option_primitive(std::optional<diplomat::span<const uint32_t>> arg, uint8_t sentinel);
 

--- a/feature_tests/nanobind/src/include/OptionOpaque.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.hpp
@@ -181,7 +181,7 @@ inline size_t OptionOpaque::accepts_option_str(std::optional<std::string_view> a
     return result;
 }
 
-inline bool OptionOpaque::accepts_option_str_slice(std::optional<diplomat::span<const std::string_view>> arg, uint8_t sentinel) {
+inline bool OptionOpaque::accepts_option_str_slice(std::optional<diplomat::span<const diplomat::string_view_for_slice>> arg, uint8_t sentinel) {
     auto result = diplomat::capi::OptionOpaque_accepts_option_str_slice(arg.has_value() ? (diplomat::capi::OptionStringsView{ { {reinterpret_cast<const diplomat::capi::DiplomatStringView*>(arg.value().data()), arg.value().size()} }, true }) : (diplomat::capi::OptionStringsView{ {}, false }),
         sentinel);
     return result;

--- a/feature_tests/nanobind/src/include/diplomat_nanobind_common.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_nanobind_common.hpp
@@ -266,6 +266,26 @@ namespace nanobind::detail
             }
         }
     };
+
+    template <>
+    struct type_caster<diplomat::string_view_for_slice> {
+        NB_TYPE_CASTER(diplomat::string_view_for_slice, const_name("str"))
+
+        bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+            Py_ssize_t size;
+            const char *str = PyUnicode_AsUTF8AndSize(src.ptr(), &size);
+            if (!str) {
+                PyErr_Clear();
+                return false;
+            }
+            value = diplomat::string_view_for_slice(str, (size_t) size);
+            return true;
+        }
+
+        static handle from_cpp(diplomat::string_view_for_slice value, rv_policy, cleanup_list *) noexcept {
+            return PyUnicode_FromStringAndSize(value.data(), value.size());
+        }
+    };
 }
 
 // Return the inner type from next()

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -282,6 +282,68 @@ private:
 
 #endif // __cplusplus >= 202002L
 
+// An ABI stable std::basic_string_view equivalent for the case of string
+// views in slices
+template <class CharT, class Traits = std::char_traits<CharT>>
+class basic_string_view_for_slice {
+public:
+  using std_string_view           = std::basic_string_view<CharT, Traits>;
+  using traits_type               = typename std_string_view::traits_type;
+  using value_type                = typename std_string_view::value_type;
+  using pointer                   = typename std_string_view::pointer;
+  using const_pointer             = typename std_string_view::const_pointer;
+  using size_type                 = typename std_string_view::size_type;
+  using difference_type           = typename std_string_view::difference_type;
+
+  constexpr basic_string_view_for_slice() noexcept
+    : basic_string_view_for_slice{std_string_view{}} {}
+
+  constexpr basic_string_view_for_slice(const basic_string_view_for_slice& other) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const const_pointer s, const size_type count)
+    : basic_string_view_for_slice{std_string_view{s, count}} {}
+
+  constexpr basic_string_view_for_slice(const const_pointer s)
+    : basic_string_view_for_slice{std_string_view{s}} {}
+
+  constexpr basic_string_view_for_slice& operator=(const basic_string_view_for_slice& view) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const std_string_view& s) noexcept
+    : data_{s.data(), s.size()} {}
+
+  constexpr basic_string_view_for_slice& operator=(const std_string_view& s) noexcept {
+    data_ = {s.data(), s.size()};
+    return *this;
+  }
+
+  constexpr operator std_string_view() const noexcept { return {data(), size()}; }
+  constexpr std_string_view as_sv() const noexcept { return *this; }
+
+  constexpr const_pointer data() const noexcept { return data_.data; }
+  constexpr size_type size() const noexcept { return data_.len; }
+
+private:
+  using capi_type =
+    std::conditional_t<std::is_same_v<value_type, char>,
+      capi::DiplomatStringView,
+    std::conditional_t<std::is_same_v<value_type, char16_t>,
+      capi::DiplomatString16View,
+      void>>;
+
+  static_assert(!std::is_void_v<capi_type>,
+    "ABI compatible string_views are only supported for char and char16_t");
+
+  capi_type data_;
+};
+
+// We only implement these specialisations as diplomat doesn't provide c abi
+// types for others
+using string_view_for_slice = basic_string_view_for_slice<char>;
+using u16string_view_for_slice = basic_string_view_for_slice<char16_t>;
+
+using string_view_span = span<const string_view_for_slice>;
+using u16string_view_span = span<const u16string_view_for_slice>;
+
 // Interop between std::function & our C Callback wrapper type
 
 template <typename T, typename = void>

--- a/feature_tests/src/option.rs
+++ b/feature_tests/src/option.rs
@@ -185,7 +185,11 @@ pub mod ffi {
         #[diplomat::attr(any(not(supports = option), not(any(c, cpp, nanobind))), disable)]
         pub fn accepts_option_str_slice(arg: Option<&[DiplomatStrSlice]>, sentinel: u8) -> bool {
             assert_eq!(sentinel, 123);
-            arg.is_some()
+            if let Some([a, _]) = arg {
+                std::str::from_utf8(a).unwrap_or("").contains("string")
+            } else {
+                false
+            }
         }
 
         #[diplomat::attr(any(not(supports = option), not(any(c, cpp, nanobind))), disable)]

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -221,6 +221,14 @@ impl<'tcx> Cpp2Formatter<'tcx> {
         }
     }
 
+    pub fn fmt_borrowed_str_in_slice(&self, encoding: StringEncoding) -> Cow<'static, str> {
+        match encoding {
+            StringEncoding::Utf8 | StringEncoding::UnvalidatedUtf8 => "diplomat::string_view_for_slice".into(),
+            StringEncoding::UnvalidatedUtf16 => "diplomat::u16string_view_for_slice".into(),
+            _ => unreachable!(),
+        }
+    }
+
     pub fn fmt_owned_str(&self) -> Cow<'static, str> {
         "std::string".into()
     }

--- a/tool/src/cpp/ty.rs
+++ b/tool/src/cpp/ty.rs
@@ -403,7 +403,7 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx, '_> {
             }
             Type::Slice(hir::Slice::Strs(encoding)) => format!(
                 "{lib_name_ns_prefix}diplomat::span<const {}>",
-                self.formatter.fmt_borrowed_str(encoding)
+                self.formatter.fmt_borrowed_str_in_slice(encoding)
             )
             .into(),
             Type::Slice(hir::Slice::Struct(b, ref st_ty)) => {
@@ -567,7 +567,7 @@ impl<'ccx, 'tcx: 'ccx> TyGenContext<'ccx, 'tcx, '_> {
             },
             Type::Enum(..) => format!("{cpp_name}.AsFFI()").into(),
             Type::Slice(Slice::Strs(..)) => format!(
-                // Layout of DiplomatStringView and std::string_view are guaranteed to be identical, otherwise this would be terrible
+                // This cast is valid as diplomat::string_view_for_slice is used to ensure correct layout
                 "{{reinterpret_cast<const {lib_name_ns_prefix}diplomat::capi::DiplomatStringView*>({cpp_name}.data()), {cpp_name}.size()}}"
             ).into(),
             Type::Slice(Slice::Struct(b, ref st)) => format!("{{reinterpret_cast<{}{}*>({cpp_name}.data()), {cpp_name}.size()}}",

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -228,6 +228,68 @@ private:
 
 #endif // __cplusplus >= 202002L
 
+// An ABI stable std::basic_string_view equivalent for the case of string
+// views in slices
+template <class CharT, class Traits = std::char_traits<CharT>>
+class basic_string_view_for_slice {
+public:
+  using std_string_view           = std::basic_string_view<CharT, Traits>;
+  using traits_type               = typename std_string_view::traits_type;
+  using value_type                = typename std_string_view::value_type;
+  using pointer                   = typename std_string_view::pointer;
+  using const_pointer             = typename std_string_view::const_pointer;
+  using size_type                 = typename std_string_view::size_type;
+  using difference_type           = typename std_string_view::difference_type;
+
+  constexpr basic_string_view_for_slice() noexcept
+    : basic_string_view_for_slice{std_string_view{}} {}
+
+  constexpr basic_string_view_for_slice(const basic_string_view_for_slice& other) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const const_pointer s, const size_type count)
+    : basic_string_view_for_slice{std_string_view{s, count}} {}
+
+  constexpr basic_string_view_for_slice(const const_pointer s)
+    : basic_string_view_for_slice{std_string_view{s}} {}
+
+  constexpr basic_string_view_for_slice& operator=(const basic_string_view_for_slice& view) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const std_string_view& s) noexcept
+    : data_{s.data(), s.size()} {}
+
+  constexpr basic_string_view_for_slice& operator=(const std_string_view& s) noexcept {
+    data_ = {s.data(), s.size()};
+    return *this;
+  }
+
+  constexpr operator std_string_view() const noexcept { return {data(), size()}; }
+  constexpr std_string_view as_sv() const noexcept { return *this; }
+
+  constexpr const_pointer data() const noexcept { return data_.data; }
+  constexpr size_type size() const noexcept { return data_.len; }
+
+private:
+  using capi_type =
+    std::conditional_t<std::is_same_v<value_type, char>,
+      capi::DiplomatStringView,
+    std::conditional_t<std::is_same_v<value_type, char16_t>,
+      capi::DiplomatString16View,
+      void>>;
+
+  static_assert(!std::is_void_v<capi_type>,
+    "ABI compatible string_views are only supported for char and char16_t");
+
+  capi_type data_;
+};
+
+// We only implement these specialisations as diplomat doesn't provide c abi
+// types for others
+using string_view_for_slice = basic_string_view_for_slice<char>;
+using u16string_view_for_slice = basic_string_view_for_slice<char16_t>;
+
+using string_view_span = span<const string_view_for_slice>;
+using u16string_view_span = span<const u16string_view_for_slice>;
+
 // Interop between std::function & our C Callback wrapper type
 
 template <typename T, typename = void>

--- a/tool/templates/nanobind/common.h.jinja
+++ b/tool/templates/nanobind/common.h.jinja
@@ -266,6 +266,26 @@ namespace nanobind::detail
             }
         }
     };
+
+    template <>
+    struct type_caster<diplomat::string_view_for_slice> {
+        NB_TYPE_CASTER(diplomat::string_view_for_slice, const_name("str"))
+
+        bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+            Py_ssize_t size;
+            const char *str = PyUnicode_AsUTF8AndSize(src.ptr(), &size);
+            if (!str) {
+                PyErr_Clear();
+                return false;
+            }
+            value = diplomat::string_view_for_slice(str, (size_t) size);
+            return true;
+        }
+
+        static handle from_cpp(diplomat::string_view_for_slice value, rv_policy, cleanup_list *) noexcept {
+            return PyUnicode_FromStringAndSize(value.data(), value.size());
+        }
+    };
 }
 
 // Return the inner type from next()


### PR DESCRIPTION
Fixes #963 

This adds `diplomat::string_view_for_slice` to the c++ runtime which internally contains `DiplomatStringView` so has the right layout to pass over the ABI in a slice, at the downside of needing to use this type instead of `std::string_view` for this case.

This also adds an appropriate adapter to nanobind and updates the tests.