### PR TITLE
Prefer TypeDef/SymbolDef over TypeID in formatter

### DIFF
--- a/book/src/developer.md
+++ b/book/src/developer.md
@@ -35,9 +35,9 @@ create a module `tool/src/{backend}/mod.rs`  (make sure you add a line `pub mod 
 `tool/src/lib.rs`). Add the following to it
 
 ```rs
-use diplomat_core::hir::{OpaqueDef, TypeContext, TypeId};
+use diplomat_core::hir::{OpaqueDef, TypeContext};
 
-fn gen_opaque_def(ctx: &TypeContext, type_id: TypeId, opaque_path: &OpaqueDef) -> String {
+fn gen_opaque_def(ctx: &TypeContext, opaque_path: &OpaqueDef) -> String {
     "We'll get to it".into()
 }
 
@@ -76,16 +76,16 @@ mod test {
             }
         };
 
-        let (type_id, opaque_def) = match context
+        let opaque_def = match context
             .all_types()
             .next()
             .expect("Failed to generate first opaque def")
         {
-            (type_id, TypeDef::Opaque(opaque_def)) => (type_id, opaque_def),
+            TypeDef::Opaque(opaque_def) => opaque_def,
             _ => panic!("Failed to find opaque type from AST"),
         };
 
-        let generated = super::gen_opaque_def(&context, type_id, opaque_def);
+        let generated = super::gen_opaque_def(&context, opaque_def);
 
         insta::assert_snapshot!(generated)
     }
@@ -158,13 +158,13 @@ symbol for your new impl method:
 ```rust
 use crate::c2::CFormatter;
 
-fn gen_opaque_def(ctx: &TypeContext, type_id: TypeId, opaque_path: &OpaqueDef) -> String {
+fn gen_opaque_def(ctx: &TypeContext, opaque_path: &OpaqueDef) -> String {
     let c_formatter = CFormatter::new(ctx);
 
     opaque_def
         .methods
         .iter()
-        .map(|method| c_formatter.fmt_method_name(type_id, method))
+        .map(|method| c_formatter.fmt_method_name(method))
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -22,6 +22,9 @@ pub struct Method {
     /// The `self` param of the method, if any.
     pub self_param: Option<SelfParam>,
 
+    // the 'Self' type of the method, if any.
+    pub self_type: Option<PathType>,
+
     /// All non-`self` params taken by the method.
     pub params: Vec<Param>,
 
@@ -78,7 +81,7 @@ impl Method {
                 // support it so we can insert the expanded explicit lifetimes.
                 Some(TypeName::from_syn(
                     return_typ.as_ref(),
-                    Some(self_path_type),
+                    Some(self_path_type.clone()),
                 ))
             }
             syn::ReturnType::Default => None,
@@ -97,6 +100,7 @@ impl Method {
             docs: Docs::from_attrs(&m.attrs),
             abi_name: Ident::from(&extern_ident),
             self_param,
+            self_type: Some(self_path_type),
             params: all_params,
             return_type: return_ty,
             lifetime_env,

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__cfged_method.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__cfged_method.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                #[doc = r\" Some docs.\"]\n                #[diplomat::rust_link(foo::Bar::batz, FnInStruct)]\n                #[cfg(any(feature = \"foo\", not(feature = \"bar\")))] fn\n                foo(x: u64, y: MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
+expression: "Method::from_syn(&syn::parse_quote!\n{\n    #[doc = r\" Some docs.\"] #[diplomat::rust_link(foo::Bar::batz, FnInStruct)]\n    #[cfg(any(feature = \"foo\", not(feature = \"bar\")))] fn\n    foo(x: u64, y: MyCustomStruct) {}\n},\nPathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\nNone, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -14,6 +14,11 @@ docs:
       display: Normal
 abi_name: MyStructContainingMethod_foo
 self_param: ~
+self_type:
+  path:
+    elements:
+      - MyStructContainingMethod
+  lifetimes: []
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                #[diplomat::rust_link(foo::Bar::batz, FnInStruct)] fn\n                foo(&mut self, x: u64, y: MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
+expression: "Method::from_syn(&syn::parse_quote!\n{\n    #[diplomat::rust_link(foo::Bar::batz, FnInStruct)] fn\n    foo(&mut self, x: u64, y: MyCustomStruct) -> u64 { x }\n},\nPathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\nNone, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -23,6 +23,11 @@ self_param:
         - MyStructContainingMethod
     lifetimes: []
   attrs: {}
+self_type:
+  path:
+    elements:
+      - MyStructContainingMethod
+  lifetimes: []
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__nonstatic_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                fn foo(&self, x: u64, y: MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
+expression: "Method::from_syn(&syn::parse_quote!\n{ fn foo(&self, x: u64, y: MyCustomStruct) {} },\nPathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\nNone, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -17,6 +17,11 @@ self_param:
         - MyStructContainingMethod
     lifetimes: []
   attrs: {}
+self_type:
+  path:
+    elements:
+      - MyStructContainingMethod
+  lifetimes: []
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods-2.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                #[doc = r\" Some docs.\"] #[doc = r\" Some more docs.\"]\n                #[doc = r\"\"] #[doc = r\" Even more docs.\"]\n                #[diplomat::rust_link(foo::Bar::batz, FnInEnum)] fn\n                foo(x: u64, y: MyCustomStruct) -> u64 { x }\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
+expression: "Method::from_syn(&syn::parse_quote!\n{\n    #[doc = r\" Some docs.\"] #[doc = r\" Some more docs.\"] #[doc = r\"\"]\n    #[doc = r\" Even more docs.\"]\n    #[diplomat::rust_link(foo::Bar::batz, FnInEnum)] fn\n    foo(x: u64, y: MyCustomStruct) -> u64 { x }\n},\nPathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\nNone, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -14,6 +14,11 @@ docs:
       display: Normal
 abi_name: MyStructContainingMethod_foo
 self_param: ~
+self_type:
+  path:
+    elements:
+      - MyStructContainingMethod
+  lifetimes: []
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__methods__tests__static_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/ast/methods.rs
-expression: "Method::from_syn(&syn::parse_quote! {\n                #[doc = r\" Some docs.\"]\n                #[diplomat::rust_link(foo::Bar::batz, FnInStruct)] fn\n                foo(x: u64, y: MyCustomStruct) {}\n            },\n    PathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\n    None, &Attrs::default())"
+expression: "Method::from_syn(&syn::parse_quote!\n{\n    #[doc = r\" Some docs.\"] #[diplomat::rust_link(foo::Bar::batz, FnInStruct)]\n    fn foo(x: u64, y: MyCustomStruct) {}\n},\nPathType::new(Path::empty().sub_path(Ident::from(\"MyStructContainingMethod\"))),\nNone, &Attrs::default())"
 ---
 name: foo
 docs:
@@ -14,6 +14,11 @@ docs:
       display: Normal
 abi_name: MyStructContainingMethod_foo
 self_param: ~
+self_type:
+  path:
+    elements:
+      - MyStructContainingMethod
+  lifetimes: []
 params:
   - name: x
     ty:

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__method_visibility.snap
@@ -20,6 +20,11 @@ declared_types:
             - []
           abi_name: Foo_pub_fn
           self_param: ~
+          self_type:
+            path:
+              elements:
+                - Foo
+            lifetimes: []
           params: []
           return_type: ~
           lifetime_env: {}

--- a/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
+++ b/core/src/ast/snapshots/diplomat_core__ast__modules__tests__simple_mod.snap
@@ -35,6 +35,11 @@ declared_types:
             - []
           abi_name: NonOpaqueStruct_new
           self_param: ~
+          self_type:
+            path:
+              elements:
+                - NonOpaqueStruct
+            lifetimes: []
           params:
             - name: x
               ty:
@@ -63,6 +68,11 @@ declared_types:
                   - NonOpaqueStruct
               lifetimes: []
             attrs: {}
+          self_type:
+            path:
+              elements:
+                - NonOpaqueStruct
+            lifetimes: []
           params:
             - name: new_a
               ty:
@@ -87,6 +97,11 @@ declared_types:
             - []
           abi_name: OpaqueStruct_new
           self_param: ~
+          self_type:
+            path:
+              elements:
+                - OpaqueStruct
+            lifetimes: []
           params: []
           return_type:
             Box:
@@ -112,6 +127,11 @@ declared_types:
                   - OpaqueStruct
               lifetimes: []
             attrs: {}
+          self_type:
+            path:
+              elements:
+                - OpaqueStruct
+            lifetimes: []
           params: []
           return_type:
             Named:

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -228,7 +228,7 @@ pub enum AttributeContext<'a, 'b> {
     Type(TypeDef<'a>),
     Trait(&'a TraitDef),
     EnumVariant(&'a EnumVariant),
-    Method(&'a Method, TypeId, &'b mut SpecialMethodPresence),
+    Method(&'a Method, Option<TypeId>, &'b mut SpecialMethodPresence),
     Function(&'a Method),
     Module,
     Param,
@@ -547,7 +547,7 @@ impl Attrs {
                         }
 
                         if let SuccessType::OutType(t) = &output {
-                            if t.id() != Some(self_id) {
+                            if t.id() != self_id || self_id.is_none() {
                                 errors.push(LoweringError::Other(
                                     "Constructors must return Self!".to_string(),
                                 ));

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -22,6 +22,17 @@ pub enum TypeDef<'tcx> {
     Enum(&'tcx EnumDef),
 }
 
+#[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
+pub enum SymbolDef<'tcx> {
+    Struct(&'tcx StructDef),
+    OutStruct(&'tcx OutStructDef),
+    Opaque(&'tcx OpaqueDef),
+    Enum(&'tcx EnumDef),
+    Trait(&'tcx TraitDef),
+    Method(&'tcx Method),
+}
+
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct TraitDef {
@@ -248,6 +259,79 @@ impl<'tcx> TypeDef<'tcx> {
             Self::OutStruct(ty) => &ty.special_method_presence,
             Self::Opaque(ty) => &ty.special_method_presence,
             Self::Enum(ty) => &ty.special_method_presence,
+        }
+    }
+}
+
+impl<'a, P: TyPosition> From<&'a StructDef<P>> for SymbolDef<'a> {
+    fn from(x: &'a StructDef<P>) -> Self {
+        P::wrap_struct_def(x).into()
+    }
+}
+
+impl<'a> From<&'a OpaqueDef> for SymbolDef<'a> {
+    fn from(x: &'a OpaqueDef) -> Self {
+        SymbolDef::Opaque(x)
+    }
+}
+impl<'a> From<TypeDef<'a>> for SymbolDef<'a> {
+    fn from(x: TypeDef<'a>) -> Self {
+        match x {
+            TypeDef::Struct(ty) => SymbolDef::Struct(ty),
+            TypeDef::OutStruct(ty) => SymbolDef::OutStruct(ty),
+            TypeDef::Opaque(ty) => SymbolDef::Opaque(ty),
+            TypeDef::Enum(ty) => SymbolDef::Enum(ty),
+        }
+    }
+}
+
+impl<'a> From<&'a EnumDef> for SymbolDef<'a> {
+    fn from(x: &'a EnumDef) -> Self {
+        SymbolDef::Enum(x)
+    }
+}
+
+impl<'a> From<&'a TraitDef> for SymbolDef<'a> {
+    fn from(x: &'a TraitDef) -> Self {
+        SymbolDef::Trait(x)
+    }
+}
+
+impl<'a> From<&'a Method> for SymbolDef<'a> {
+    fn from(x: &'a Method) -> Self {
+        SymbolDef::Method(x)
+    }
+}
+
+impl<'tcx> SymbolDef<'tcx> {
+    pub fn name(&self) -> &'tcx IdentBuf {
+        match *self {
+            Self::Struct(ty) => &ty.name,
+            Self::OutStruct(ty) => &ty.name,
+            Self::Opaque(ty) => &ty.name,
+            Self::Enum(ty) => &ty.name,
+            Self::Trait(t) => &t.name,
+            Self::Method(m) => &m.name,
+        }
+    }
+    pub fn attrs(&self) -> &'tcx Attrs {
+        match *self {
+            Self::Struct(ty) => &ty.attrs,
+            Self::OutStruct(ty) => &ty.attrs,
+            Self::Opaque(ty) => &ty.attrs,
+            Self::Enum(ty) => &ty.attrs,
+            Self::Trait(t) => &t.attrs,
+            Self::Method(m) => &m.attrs,
+        }
+    }
+    pub fn docs(&self) -> &'tcx Docs {
+        match *self {
+            Self::Struct(ty) => &ty.docs,
+            Self::OutStruct(ty) => &ty.docs,
+            Self::Opaque(ty) => &ty.docs,
+            Self::Enum(ty) => &ty.docs,
+            Self::Trait(t) => &t.docs,
+            Self::Method(m) => &m.docs,
         }
     }
 }

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -69,14 +69,6 @@ pub enum TypeId {
     Enum(EnumId),
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[non_exhaustive]
-pub enum SymbolId {
-    TypeId(TypeId),
-    TraitId(TraitId),
-    FunctionId(FunctionId),
-}
-
 enum Param<'a> {
     Input(&'a str),
     Return,
@@ -233,17 +225,11 @@ impl TypeContext {
                 match sym {
                     ast::ModSymbol::CustomType(custom_type) => match custom_type {
                         ast::CustomType::Struct(strct) => {
-                            let id = if strct.output_only {
-                                TypeId::OutStruct(OutStructId(ast_out_structs.len()))
-                            } else {
-                                TypeId::Struct(StructId(ast_structs.len()))
-                            };
                             let item = ItemAndInfo {
                                 item: strct,
                                 in_path: path,
                                 ty_parent_attrs: ty_attrs.clone(),
                                 method_parent_attrs: method_attrs.clone(),
-                                id: id.into(),
                             };
                             if strct.output_only {
                                 ast_out_structs.push(item);
@@ -257,7 +243,6 @@ impl TypeContext {
                                 in_path: path,
                                 ty_parent_attrs: ty_attrs.clone(),
                                 method_parent_attrs: method_attrs.clone(),
-                                id: TypeId::Opaque(OpaqueId(ast_opaques.len())).into(),
                             };
                             ast_opaques.push(item)
                         }
@@ -267,7 +252,6 @@ impl TypeContext {
                                 in_path: path,
                                 ty_parent_attrs: ty_attrs.clone(),
                                 method_parent_attrs: method_attrs.clone(),
-                                id: TypeId::Enum(EnumId(ast_enums.len())).into(),
                             };
                             ast_enums.push(item)
                         }
@@ -278,7 +262,6 @@ impl TypeContext {
                             in_path: path,
                             ty_parent_attrs: ty_attrs.clone(),
                             method_parent_attrs: method_attrs.clone(),
-                            id: TraitId(ast_traits.len()).into(),
                         };
                         ast_traits.push(item)
                     }
@@ -288,7 +271,6 @@ impl TypeContext {
                             in_path: path,
                             ty_parent_attrs: ty_attrs.clone(),
                             method_parent_attrs: method_attrs.clone(),
-                            id: FunctionId(ast_functions.len()).into(),
                         };
                         ast_functions.push(item)
                     }
@@ -703,68 +685,6 @@ impl From<OpaqueId> for TypeId {
 impl From<EnumId> for TypeId {
     fn from(x: EnumId) -> Self {
         TypeId::Enum(x)
-    }
-}
-
-impl From<TypeId> for SymbolId {
-    fn from(x: TypeId) -> Self {
-        SymbolId::TypeId(x)
-    }
-}
-
-impl From<TraitId> for SymbolId {
-    fn from(x: TraitId) -> Self {
-        SymbolId::TraitId(x)
-    }
-}
-
-impl From<FunctionId> for SymbolId {
-    fn from(x: FunctionId) -> Self {
-        SymbolId::FunctionId(x)
-    }
-}
-
-impl From<StructId> for SymbolId {
-    fn from(x: StructId) -> Self {
-        SymbolId::TypeId(x.into())
-    }
-}
-
-impl From<OutStructId> for SymbolId {
-    fn from(x: OutStructId) -> Self {
-        SymbolId::TypeId(x.into())
-    }
-}
-
-impl From<OpaqueId> for SymbolId {
-    fn from(x: OpaqueId) -> Self {
-        SymbolId::TypeId(x.into())
-    }
-}
-
-impl From<EnumId> for SymbolId {
-    fn from(x: EnumId) -> Self {
-        SymbolId::TypeId(x.into())
-    }
-}
-
-impl TryInto<TypeId> for SymbolId {
-    type Error = ();
-    fn try_into(self) -> Result<TypeId, Self::Error> {
-        match self {
-            SymbolId::TypeId(id) => Ok(id),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryInto<TraitId> for SymbolId {
-    type Error = ();
-    fn try_into(self) -> Result<TraitId, Self::Error> {
-        match self {
-            SymbolId::TraitId(id) => Ok(id),
-            _ => Err(()),
-        }
     }
 }
 

--- a/tool/src/c/gen.rs
+++ b/tool/src/c/gen.rs
@@ -3,8 +3,8 @@ use super::header::Header;
 use crate::ErrorStore;
 use askama::Template;
 use diplomat_core::hir::{
-    self, CallbackInstantiationFunctionality, MaybeOwn, OpaqueOwner, StructPathLike, SymbolId,
-    TraitIdGetter, TyPosition, Type, TypeDef,
+    self, CallbackInstantiationFunctionality, MaybeOwn, OpaqueOwner, StructPathLike, TraitIdGetter,
+    TyPosition, Type, TypeDef,
 };
 use diplomat_core::hir::{ReturnType, SuccessType, TypeContext};
 use std::borrow::Cow;
@@ -79,7 +79,6 @@ pub struct ItemGenContext<'cx, 'tcx, 'header> {
     pub formatter: &'cx CFormatter<'tcx>,
     pub errors: &'cx ErrorStore<'tcx, String>,
     pub is_for_cpp: bool,
-    pub id: SymbolId,
     pub decl_header_path: &'header str,
     pub impl_header_path: &'header str,
 }

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -57,7 +57,7 @@ pub(crate) fn run<'tcx>(
     docs_url_gen: &'tcx DocsUrlGenerator,
 ) -> (FileMap, ErrorStore<'tcx, String>) {
     let files = FileMap::default();
-    let formatter = CFormatter::new(tcx, false, config, docs_url_gen);
+    let formatter = CFormatter::new(false, config, docs_url_gen);
     let errors = ErrorStore::default();
 
     files.add_file("diplomat_runtime.h".into(), Runtime.to_string());
@@ -68,8 +68,8 @@ pub(crate) fn run<'tcx>(
             continue;
         }
 
-        let decl_header_path = formatter.fmt_decl_header_path(id.into());
-        let impl_header_path = formatter.fmt_impl_header_path(id.into());
+        let decl_header_path = formatter.fmt_decl_header_path(ty.into());
+        let impl_header_path = formatter.fmt_impl_header_path(ty.into());
 
         let _guard = errors.set_context_ty(ty.name().as_str().into());
         let context = ItemGenContext {
@@ -90,7 +90,7 @@ pub(crate) fn run<'tcx>(
             _ => unreachable!("unknown AST/HIR variant"),
         };
 
-        let impl_header = context.gen_impl(id);
+        let impl_header = context.gen_impl(ty);
 
         files.add_file(decl_header_path, decl_header.to_string());
         files.add_file(impl_header_path, impl_header.to_string());
@@ -102,8 +102,8 @@ pub(crate) fn run<'tcx>(
             continue;
         }
 
-        let decl_header_path = formatter.fmt_decl_header_path(id.into());
-        let impl_header_path = formatter.fmt_impl_header_path(id.into());
+        let decl_header_path = formatter.fmt_decl_header_path(trt.into());
+        let impl_header_path = formatter.fmt_impl_header_path(trt.into());
 
         let _guard = errors.set_context_ty(trt.name.as_str().into());
         let context = ItemGenContext {

--- a/tool/src/c/mod.rs
+++ b/tool/src/c/mod.rs
@@ -62,7 +62,7 @@ pub(crate) fn run<'tcx>(
 
     files.add_file("diplomat_runtime.h".into(), Runtime.to_string());
 
-    for (id, ty) in tcx.all_types() {
+    for ty in tcx.all_types() {
         if ty.attrs().disable {
             // Skip type if disabled
             continue;
@@ -76,7 +76,6 @@ pub(crate) fn run<'tcx>(
             tcx,
             formatter: &formatter,
             errors: &errors,
-            id: id.into(),
             is_for_cpp: false,
             decl_header_path: &decl_header_path,
             impl_header_path: &impl_header_path,
@@ -96,7 +95,7 @@ pub(crate) fn run<'tcx>(
         files.add_file(impl_header_path, impl_header.to_string());
     }
 
-    for (id, trt) in tcx.all_traits() {
+    for trt in tcx.all_traits() {
         if trt.attrs.disable {
             // Skip type if disabled
             continue;
@@ -110,7 +109,6 @@ pub(crate) fn run<'tcx>(
             tcx,
             formatter: &formatter,
             errors: &errors,
-            id: id.into(),
             is_for_cpp: false,
             decl_header_path: &decl_header_path,
             impl_header_path: &impl_header_path,
@@ -123,23 +121,19 @@ pub(crate) fn run<'tcx>(
 
     let impl_header_path = "free_functions.h".to_string();
 
-    if let Some((first_func_id, _)) = tcx.all_free_functions().next() {
-        let context = ItemGenContext {
-            tcx,
-            formatter: &formatter,
-            errors: &errors,
-            id: first_func_id.into(),
-            is_for_cpp: false,
-            decl_header_path: "",
-            impl_header_path: &impl_header_path,
-        };
+    let context = ItemGenContext {
+        tcx,
+        formatter: &formatter,
+        errors: &errors,
+        is_for_cpp: false,
+        decl_header_path: "",
+        impl_header_path: &impl_header_path,
+    };
 
-        let impl_header =
-            context.gen_function_impls(None, tcx.all_free_functions().map(|(_, m)| m));
+    let impl_header = context.gen_function_impls(None, tcx.all_free_functions());
 
-        if !impl_header.body.is_empty() {
-            files.add_file(impl_header.path.clone(), impl_header.to_string());
-        }
+    if !impl_header.body.is_empty() {
+        files.add_file(impl_header.path.clone(), impl_header.to_string());
     }
 
     (files, errors)

--- a/tool/src/cpp/gen.rs
+++ b/tool/src/cpp/gen.rs
@@ -390,7 +390,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
         let method_name = self.formatter.fmt_method_name(method);
         let abi_name = self
             .formatter
-            .namespace_c_name(associated_symbol.into(), method.abi_name.as_str());
+            .namespace_c_name(associated_symbol, method.abi_name.as_str());
         let mut param_decls = Vec::new();
         let mut cpp_to_c_params = Vec::new();
 
@@ -672,7 +672,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
                 self.impl_header
                     .includes
                     .insert(self.formatter.fmt_impl_header_path(def.into()));
-                type_name.into()
+                type_name
             }
             Type::Slice(hir::Slice::Str(_, encoding)) => self.formatter.fmt_borrowed_str(encoding),
             Type::Slice(hir::Slice::Primitive(b, p)) => {
@@ -729,7 +729,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
             .into_owned()
             .into()
         } else {
-            type_name.into()
+            type_name
         }
     }
 

--- a/tool/src/dart/formatter.rs
+++ b/tool/src/dart/formatter.rs
@@ -1,6 +1,6 @@
 //! This module contains functions for formatting types
 
-use diplomat_core::hir::{self, DocsTypeReferenceSyntax, DocsUrlGenerator, TypeContext, TypeId};
+use diplomat_core::hir::{self, DocsTypeReferenceSyntax, DocsUrlGenerator, TypeDef};
 use heck::ToLowerCamelCase;
 use std::borrow::Cow;
 
@@ -14,7 +14,6 @@ use std::borrow::Cow;
 /// This type may be used by other backends attempting to figure out the names
 /// of C types and methods.
 pub(super) struct DartFormatter<'tcx> {
-    tcx: &'tcx TypeContext,
     docs_url_gen: &'tcx DocsUrlGenerator,
 }
 
@@ -23,8 +22,8 @@ const INVALID_FIELD_NAMES: &[&str] = &["new", "static", "default"];
 const DISALLOWED_CORE_TYPES: &[&str] = &["Object", "String"];
 
 impl<'tcx> DartFormatter<'tcx> {
-    pub fn new(tcx: &'tcx TypeContext, docs_url_gen: &'tcx DocsUrlGenerator) -> Self {
-        Self { tcx, docs_url_gen }
+    pub fn new(docs_url_gen: &'tcx DocsUrlGenerator) -> Self {
+        Self { docs_url_gen }
     }
 
     pub fn fmt_lifetime_edge_array(
@@ -74,16 +73,14 @@ impl<'tcx> DartFormatter<'tcx> {
     }
 
     /// Resolve and format a named type for use in code
-    pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
-        let resolved = self.tcx.resolve_type(id);
-
-        let candidate = resolved.name().as_str();
+    pub fn fmt_type_name(&self, def: TypeDef<'tcx>) -> Cow<'tcx, str> {
+        let candidate = def.name().as_str();
 
         if DISALLOWED_CORE_TYPES.contains(&candidate) {
             panic!("{candidate:?} is not a valid Dart type name. Please rename.");
         }
 
-        resolved.attrs().rename.apply(candidate.into())
+        def.attrs().rename.apply(candidate.into())
     }
 
     /// Format an enum variant.

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -11,7 +11,7 @@ use diplomat_core::hir::{
     },
     BackendAttrSupport, DocsUrlGenerator, Lifetime, LifetimeEnv, MaybeStatic, OpaqueOwner,
     ReturnType, SelfType, SpecialMethod, SpecialMethodPresence, StructPathLike, SuccessType,
-    TyPosition, Type, TypeContext, TypeDef, TypeId,
+    TyPosition, Type, TypeContext, TypeDef,
 };
 
 use askama::Template;
@@ -69,12 +69,12 @@ pub(crate) fn run<'cx>(
         formatter: &formatter,
     };
 
-    for (id, ty) in tcx.all_types() {
+    for ty in tcx.all_types() {
         if ty.attrs().disable {
             continue;
         }
 
-        let (file_name, body) = context.gen(id);
+        let (file_name, body) = context.gen(ty);
 
         directives.insert(formatter.fmt_part(&file_name));
 
@@ -151,9 +151,7 @@ struct ItemGenContext<'a, 'cx> {
 }
 
 impl<'cx> ItemGenContext<'_, 'cx> {
-    fn gen(&mut self, id: TypeId) -> (String, String) {
-        let ty = self.tcx.resolve_type(id);
-
+    fn gen(&mut self, ty: TypeDef<'cx>) -> (String, String) {
         let _guard = self.errors.set_context_ty(ty.name().as_str().into());
 
         let name = self.formatter.fmt_type_name(ty);

--- a/tool/src/demo_gen/mod.rs
+++ b/tool/src/demo_gen/mod.rs
@@ -115,7 +115,7 @@ pub(crate) fn run<'tcx>(
 
     let is_explicit = unwrapped_conf.explicit_generation.unwrap_or(false);
 
-    for (_id, ty) in tcx.all_types() {
+    for ty in tcx.all_types() {
         let _guard = errors.set_context_ty(ty.name().as_str().into());
 
         let methods = ty.methods();

--- a/tool/src/demo_gen/mod.rs
+++ b/tool/src/demo_gen/mod.rs
@@ -72,7 +72,7 @@ pub(crate) fn run<'tcx>(
     docs: &'tcx diplomat_core::ast::DocsUrlGenerator,
     conf: Config,
 ) -> (FileMap, ErrorStore<'tcx, String>) {
-    let formatter = JSFormatter::new(tcx, docs);
+    let formatter = JSFormatter::new(docs);
     let errors = ErrorStore::default();
     let files = FileMap::default();
 
@@ -115,7 +115,7 @@ pub(crate) fn run<'tcx>(
 
     let is_explicit = unwrapped_conf.explicit_generation.unwrap_or(false);
 
-    for (id, ty) in tcx.all_types() {
+    for (_id, ty) in tcx.all_types() {
         let _guard = errors.set_context_ty(ty.name().as_str().into());
 
         let methods = ty.methods();
@@ -123,10 +123,8 @@ pub(crate) fn run<'tcx>(
         let mut termini = Vec::new();
 
         {
-            let ty_name = formatter.fmt_type_name(id);
+            let ty_name = formatter.fmt_type_name(ty);
             let type_name: String = ty_name.into();
-
-            let ty = tcx.resolve_type(id);
 
             let attrs = ty.attrs();
             if attrs.disable {

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, fmt::Write};
 
 use diplomat_core::hir::{
     self, Attrs, Docs, DocsTypeReferenceSyntax, DocsUrlGenerator, EnumVariant, SpecialMethod,
-    TypeContext, TypeId,
+    TypeDef,
 };
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 
@@ -59,21 +59,17 @@ const RESERVED_TYPES: &[&str] = &["Infinity", "NaN"];
 /// Helper class for us to format JS identifiers from the HIR.
 pub(crate) struct JSFormatter<'tcx> {
     /// Per [`CFormatter`]'s documentation we use it for support.
-    tcx: &'tcx TypeContext,
-
     /// For generating doc.rs links
     docs_url_gen: &'tcx DocsUrlGenerator,
 }
 
 impl<'tcx> JSFormatter<'tcx> {
-    pub fn new(tcx: &'tcx TypeContext, docs_url_gen: &'tcx DocsUrlGenerator) -> Self {
-        Self { tcx, docs_url_gen }
+    pub fn new(docs_url_gen: &'tcx DocsUrlGenerator) -> Self {
+        Self { docs_url_gen }
     }
 
     /// Given a [`TypeId`] that we're reading, make sure to rename it appropriately, or throw an error if it's reserved.
-    pub fn fmt_type_name(&self, id: TypeId) -> Cow<'tcx, str> {
-        let type_def = self.tcx.resolve_type(id);
-
+    pub fn fmt_type_name(&self, type_def: TypeDef<'tcx>) -> Cow<'tcx, str> {
         let name = type_def
             .attrs()
             .rename

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -68,7 +68,7 @@ impl<'tcx> JSFormatter<'tcx> {
         Self { docs_url_gen }
     }
 
-    /// Given a [`TypeId`] that we're reading, make sure to rename it appropriately, or throw an error if it's reserved.
+    /// Given a [`TypeDef`] that we're reading, make sure to rename it appropriately, or throw an error if it's reserved.
     pub fn fmt_type_name(&self, type_def: TypeDef<'tcx>) -> Cow<'tcx, str> {
         let name = type_def
             .attrs()

--- a/tool/src/js/mod.rs
+++ b/tool/src/js/mod.rs
@@ -81,7 +81,7 @@ pub(crate) fn run<'tcx>(
     config: Config,
     docs: &'tcx DocsUrlGenerator,
 ) -> (FileMap, ErrorStore<'tcx, String>) {
-    let formatter = JSFormatter::new(tcx, docs);
+    let formatter = JSFormatter::new(docs);
     let errors = ErrorStore::default();
     let files = FileMap::default();
     let mut exports = Vec::new();
@@ -108,10 +108,11 @@ pub(crate) fn run<'tcx>(
         }
 
         let type_def = tcx.resolve_type(id);
+        assert_eq!(type_def.name(), ty.name());
 
         let _guard = errors.set_context_ty(type_def.name().as_str().into());
 
-        let type_name = formatter.fmt_type_name(id);
+        let type_name = formatter.fmt_type_name(type_def);
 
         let context = ItemGenContext {
             tcx,

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -363,7 +363,7 @@ impl<'tcx> KotlinFormatter<'tcx> {
             }
             Type::Struct(p) => {
                 let op_def = self.tcx.resolve_type(p.id());
-                self.fmt_type_name(op_def.into())
+                self.fmt_type_name(op_def)
             }
             Type::Enum(e) => {
                 let e_def = self.tcx.resolve_enum(e.tcx_id);
@@ -513,11 +513,11 @@ pub mod test {
         let opaques = tcx.opaques();
         assert!(!opaques.is_empty());
         let mut all_types = tcx.all_types();
-        let (_, ty) = all_types.next().expect("Failed to get next type");
+        let ty = all_types.next().expect("Failed to get next type");
 
         assert_eq!(Cow::from("MyOpaqueStruct"), formatter.fmt_type_name(ty));
 
-        let (_, ty) = all_types.next().expect("Failed to get next type");
+        let ty = all_types.next().expect("Failed to get next type");
 
         assert_eq!(Cow::from("StringWrapper"), formatter.fmt_type_name(ty));
     }

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -111,7 +111,7 @@ pub(crate) fn run<'tcx>(
         callback_params: &mut callback_params,
     };
 
-    for (_id, ty) in tcx.all_types() {
+    for ty in tcx.all_types() {
         ty_gen_cx.callback_params.clear(); // specific to each type in a file
         let _guard = ty_gen_cx.errors.set_context_ty(ty.name().as_str().into());
         if ty.attrs().disable {
@@ -177,7 +177,7 @@ pub(crate) fn run<'tcx>(
         }
     }
 
-    for (_id, trt_def) in tcx.all_traits() {
+    for trt_def in tcx.all_traits() {
         ty_gen_cx.callback_params.clear(); // specific to each type in a file
         let _guard = ty_gen_cx
             .errors
@@ -1984,7 +1984,7 @@ returnVal.option() ?: return null
             }
             Type::Struct(ref st) => {
                 let def = self.tcx.resolve_type(st.id());
-                self.formatter.fmt_type_name(def.into())
+                self.formatter.fmt_type_name(def)
             }
             Type::ImplTrait(ref trt) => {
                 let def = self.tcx.resolve_trait(trt.id());
@@ -2199,7 +2199,7 @@ mod test {
 
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (_id, TypeDef::Enum(enum_def)) = all_types
+        if let TypeDef::Enum(enum_def) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {
@@ -2287,7 +2287,7 @@ mod test {
 
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (_id, TypeDef::Struct(strct)) = all_types
+        if let TypeDef::Struct(strct) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {
@@ -2339,7 +2339,7 @@ mod test {
         };
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (_id, TypeDef::Opaque(opaque_def)) = all_types
+        if let TypeDef::Opaque(opaque_def) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {
@@ -2453,7 +2453,7 @@ mod test {
         };
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (_id, TypeDef::Opaque(opaque_def)) = all_types
+        if let TypeDef::Opaque(opaque_def) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {
@@ -2509,7 +2509,7 @@ mod test {
         };
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (_id, TypeDef::Opaque(opaque_def)) = all_types
+        if let TypeDef::Opaque(opaque_def) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {
@@ -2582,7 +2582,7 @@ mod test {
         };
         let tcx = new_tcx(tk_stream);
         let mut all_traits = tcx.all_traits();
-        let (_id, trait_def) = all_traits.next().expect("Failed to generate trait");
+        let trait_def = all_traits.next().expect("Failed to generate trait");
         let error_store = ErrorStore::default();
         let docs_urls = HashMap::new();
         let docs_generator = diplomat_core::hir::DocsUrlGenerator::with_base_urls(None, docs_urls);
@@ -2629,7 +2629,7 @@ mod test {
         };
         let tcx = new_tcx(tk_stream);
         let mut all_types = tcx.all_types();
-        if let (_id, TypeDef::Opaque(opaque_def)) = all_types
+        if let TypeDef::Opaque(opaque_def) = all_types
             .next()
             .expect("Failed to generate first opaque def")
         {

--- a/tool/src/nanobind/formatter.rs
+++ b/tool/src/nanobind/formatter.rs
@@ -1,7 +1,7 @@
 //! This module contains functions for formatting types
 
 use crate::cpp::Cpp2Formatter;
-use diplomat_core::hir::{DocsUrlGenerator, Method, SymbolId, TypeContext, TypeId};
+use diplomat_core::hir::{DocsUrlGenerator, Method, SymbolDef, TypeDef};
 use std::{borrow::Cow, sync::LazyLock};
 
 /// This type mediates all formatting
@@ -18,42 +18,26 @@ pub(crate) struct PyFormatter<'tcx> {
 }
 
 impl<'tcx> PyFormatter<'tcx> {
-    pub fn new(
-        tcx: &'tcx TypeContext,
-        config_for_cpp: &crate::Config,
-        docs_url_gen: &'tcx DocsUrlGenerator,
-    ) -> Self {
+    pub fn new(config_for_cpp: &crate::Config, docs_url_gen: &'tcx DocsUrlGenerator) -> Self {
         Self {
-            cxx: Cpp2Formatter::new(tcx, config_for_cpp, docs_url_gen),
+            cxx: Cpp2Formatter::new(config_for_cpp, docs_url_gen),
         }
     }
 
-    pub fn fmt_binding_fn(&self, id: TypeId) -> String {
-        let def = self.cxx.c.tcx().resolve_type(id);
+    pub fn fmt_binding_fn(&self, def: TypeDef) -> String {
         let type_name = def.attrs().rename.apply(def.name().as_str().into());
         format!("add_{type_name}_binding")
     }
 
-    pub fn fmt_binding_impl_path(&self, id: TypeId) -> String {
-        self.cxx.fmt_type_name(id).replace("::", "/") + "_binding.cpp"
+    pub fn fmt_binding_impl_path(&self, def: TypeDef) -> String {
+        self.cxx.fmt_symbol_name(def.into()).replace("::", "/") + "_binding.cpp"
     }
 
     /// Resolve and format the nested module names for this type
     /// Returns an iterator to the namespaces. Will always have at least one entry
-    pub fn fmt_namespaces(&self, id: SymbolId) -> impl Iterator<Item = &'tcx str> {
-        let namespace = match id {
-            SymbolId::FunctionId(f) => self
-                .cxx
-                .c
-                .tcx()
-                .resolve_function(f)
-                .attrs
-                .namespace
-                .as_ref(),
-            SymbolId::TypeId(ty) => self.cxx.c.tcx().resolve_type(ty).attrs().namespace.as_ref(),
-            _ => panic!("Unsupported SymbolId {id:?}"),
-        };
-        namespace
+    pub fn fmt_namespaces(&self, def: SymbolDef<'tcx>) -> impl Iterator<Item = &'tcx str> {
+        def.attrs()
+            .namespace
             .as_ref()
             .map(|v| v.split("::"))
             .into_iter()

--- a/tool/src/nanobind/gen.rs
+++ b/tool/src/nanobind/gen.rs
@@ -377,7 +377,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx> {
                     .impl_header
                     .includes
                     .insert(self.formatter.cxx.fmt_impl_header_path(def));
-                type_name.into()
+                type_name
             }
             Type::Enum(ref e) => {
                 let def = self.cpp.c.tcx.resolve_enum(e.tcx_id);
@@ -391,7 +391,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx> {
                     .impl_header
                     .includes
                     .insert(self.formatter.cxx.fmt_impl_header_path(def.into()));
-                type_name.into()
+                type_name
             }
             Type::Slice(hir::Slice::Str(_, encoding)) => {
                 self.formatter.cxx.fmt_borrowed_str(encoding)

--- a/tool/src/nanobind/mod.rs
+++ b/tool/src/nanobind/mod.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{cpp::Header, nanobind::gen::MethodInfo, Config, ErrorStore, FileMap};
 use askama::Template;
-use diplomat_core::hir::{self, BackendAttrSupport, DocsUrlGenerator, FunctionId};
+use diplomat_core::hir::{self, BackendAttrSupport, DocsUrlGenerator};
 use formatter::PyFormatter;
 use gen::ItemGenContext;
 use itertools::Itertools;
@@ -112,7 +112,7 @@ pub(crate) fn run<'cx>(
     root_module.module_name = lib_name.into();
 
     let mut submodules = BTreeMap::new();
-    for (id, ty) in tcx.all_types() {
+    for ty in tcx.all_types() {
         if ty.attrs().disable {
             // Skip type if disabled
             continue;
@@ -130,7 +130,6 @@ pub(crate) fn run<'cx>(
                     tcx,
                     formatter: &formatter.cxx.c,
                     errors: &errors,
-                    id: id.into(),
                     decl_header_path: &cpp_decl_path,
                     impl_header_path: &cpp_impl_path,
                     is_for_cpp: false,
@@ -194,7 +193,6 @@ pub(crate) fn run<'cx>(
                 tcx,
                 formatter: &formatter.cxx.c,
                 is_for_cpp: false,
-                id: FunctionId::default().into(), // This is a junk value
                 errors: &errors,
                 decl_header_path: "",
                 impl_header_path: "",
@@ -221,7 +219,7 @@ pub(crate) fn run<'cx>(
 
     let mut func_map = BTreeMap::new();
 
-    for (_, func) in tcx.all_free_functions() {
+    for func in tcx.all_free_functions() {
         let Some(func_info) = ty_context.gen_method_info(func.into(), func) else {
             continue;
         };
@@ -360,12 +358,12 @@ mod test {
             }
         };
 
-        let (type_id, opaque_def) = match tcx
+        let opaque_def = match tcx
             .all_types()
             .next()
             .expect("Failed to generate first opaque def")
         {
-            (type_id, TypeDef::Opaque(opaque_def)) => (type_id, opaque_def),
+            TypeDef::Opaque(opaque_def) => opaque_def,
             _ => panic!("Failed to find opaque type from AST"),
         };
 
@@ -389,7 +387,6 @@ mod test {
                     formatter: &formatter.cxx.c,
                     errors: &errors,
                     is_for_cpp: false,
-                    id: type_id.into(),
                     decl_header_path: &decl_header_path,
                     impl_header_path: &impl_file_path,
                 },
@@ -439,12 +436,12 @@ mod test {
             }
         };
 
-        let (type_id, enum_def) = match tcx
+        let enum_def = match tcx
             .all_types()
             .next()
             .expect("Failed to generate first opaque def")
         {
-            (type_id, TypeDef::Enum(enum_def)) => (type_id, enum_def),
+            TypeDef::Enum(enum_def) => enum_def,
             _ => panic!("Failed to find opaque type from AST"),
         };
 
@@ -468,7 +465,6 @@ mod test {
                     formatter: &formatter.cxx.c,
                     errors: &errors,
                     is_for_cpp: false,
-                    id: type_id.into(),
                     decl_header_path: &decl_header_path,
                     impl_header_path: &impl_file_path,
                 },
@@ -517,12 +513,12 @@ mod test {
             }
         };
 
-        let (type_id, struct_def) = match tcx
+        let struct_def = match tcx
             .all_types()
             .next()
             .expect("Failed to generate first opaque def")
         {
-            (type_id, TypeDef::Struct(struct_def)) => (type_id, struct_def),
+            TypeDef::Struct(struct_def) => struct_def,
             _ => panic!("Failed to find opaque type from AST"),
         };
 
@@ -546,7 +542,6 @@ mod test {
                     formatter: &formatter.cxx.c,
                     errors: &errors,
                     is_for_cpp: false,
-                    id: type_id.into(),
                     decl_header_path: &decl_header_path,
                     impl_header_path: &impl_file_path,
                 },


### PR DESCRIPTION
This is a pure refactor, with 0 changes to the generated code.

There are a variety of places where TypeIDs are passed instead of/alongside resolved TypeDefs. This causes a chunk of unnessecary complexity & repeated lookups.

By removing TypeIDs from all the formatters, I was able to remove a number of places where the ID was being stored, and simplify the TypeContext methods such that most methods no longer need to return TypeIDs, only Defs.

Ids are still used & need to be resolved in the hir lowering pass where the arrays of defs are still being built, but in situations where the TypeContext is taken by `&`, the set of types is fixed and once resolved the `&[Opaque|Enum|...]Def`s should be used

Going through this process uncovered many places where 
 - defs were already available at the callsite, but 'resolve' was being called anyways
 - functions taking IDs would do immediate lookups, then the calling function would *also* do a lookup immediately after
  