### PR TITLE
Cleanup Free function Gen Function

### DIFF
--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -57,7 +57,7 @@ pub struct EnumId(usize);
 pub struct TraitId(usize);
 
 /// Key used to index into a [`TypeContext`] representing a function.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct FunctionId(usize);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -54,10 +54,10 @@ void add_ErrorEnum_binding(nb::module_);
 void add_ContiguousEnum_binding(nb::module_);
 void add_DefaultEnum_binding(nb::module_);
 void add_MyEnum_binding(nb::module_);
-void add_diplomat_func_binding(nb::module_);
+void add_free_function_binding(nb::module_);
 namespace nested::ns {
 void add_Nested_binding(nb::module_);
-void add_nested_ns_func_binding(nb::module_);
+void add_free_function_binding(nb::module_);
 }
 
 namespace nested::ns2 {
@@ -84,7 +84,7 @@ void add_RenamedTestOpaque_binding(nb::module_);
 void add_RenamedVectorTest_binding(nb::module_);
 void add_RenamedAttrEnum_binding(nb::module_);
 void add_RenamedDeprecatedEnum_binding(nb::module_);
-void add_ns_func_binding(nb::module_);
+void add_free_function_binding(nb::module_);
 }
 
 
@@ -126,104 +126,101 @@ void diplomat_tp_dealloc(PyObject *self)
 
 struct _Dummy {};
 
-NB_MODULE(somelib, somelib_mod)
+NB_MODULE(somelib, mod)
 {
     {
-        nb::class_<_Dummy> dummy(somelib_mod, "__dummy__");
+        nb::class_<_Dummy> dummy(mod, "__dummy__");
         nb_tp_dealloc = (void (*)(void *))nb::type_get_slot(dummy, Py_tp_dealloc);
     }
 
-    nb::class_<std::monostate>(somelib_mod, "monostate")
+    nb::class_<std::monostate>(mod, "monostate")
         .def("__repr__", [](const std::monostate &)
              { return ""; })
         .def("__str__", [](const std::monostate &)
-             { return ""; });
-             
-
-    // Module declarations
-    nb::module_ somelib_nested_mod = somelib_mod.def_submodule("nested");
-    nb::module_ somelib_nested_ns_mod = somelib_nested_mod.def_submodule("ns");
-    nb::module_ somelib_nested_ns2_mod = somelib_nested_mod.def_submodule("ns2");
-    nb::module_ somelib_ns_mod = somelib_mod.def_submodule("ns");
+             { return ""; });// Module declarations
+    nb::module_ nested_mod = mod.def_submodule("nested");
+    nb::module_ nested_ns_mod = nested_mod.def_submodule("ns");
+    nb::module_ nested_ns2_mod = nested_mod.def_submodule("ns2");
+    nb::module_ ns_mod = mod.def_submodule("ns");
     // Add bindings
-    add_CallbackTestingStruct_binding(somelib_mod);
-    add_CallbackWrapper_binding(somelib_mod);
-    add_ImportedStruct_binding(somelib_mod);
-    add_BorrowedFields_binding(somelib_mod);
-    add_BorrowedFieldsReturning_binding(somelib_mod);
-    add_BorrowedFieldsWithBounds_binding(somelib_mod);
-    add_NestedBorrowedFields_binding(somelib_mod);
-    add_OptionInputStruct_binding(somelib_mod);
-    add_ErrorStruct_binding(somelib_mod);
-    add_BigStructWithStuff_binding(somelib_mod);
-    add_CyclicStructA_binding(somelib_mod);
-    add_CyclicStructB_binding(somelib_mod);
-    add_CyclicStructC_binding(somelib_mod);
-    add_MyStruct_binding(somelib_mod);
-    add_MyStructContainingAnOption_binding(somelib_mod);
-    add_MyZst_binding(somelib_mod);
-    add_PrimitiveStruct_binding(somelib_mod);
-    add_ScalarPairWithPadding_binding(somelib_mod);
-    add_StructArithmetic_binding(somelib_mod);
-    add_StructWithSlices_binding(somelib_mod);
-    add_OptionStruct_binding(somelib_mod);
-    add_Unnamespaced_binding(somelib_mod);
-    add_CallbackHolder_binding(somelib_mod);
-    add_MutableCallbackHolder_binding(somelib_mod);
-    add_Bar_binding(somelib_mod);
-    add_Foo_binding(somelib_mod);
-    add_One_binding(somelib_mod);
-    add_OpaqueThin_binding(somelib_mod);
-    add_OpaqueThinIter_binding(somelib_mod);
-    add_OpaqueThinVec_binding(somelib_mod);
-    add_Two_binding(somelib_mod);
-    add_OptionOpaque_binding(somelib_mod);
-    add_OptionOpaqueChar_binding(somelib_mod);
-    add_OptionString_binding(somelib_mod);
-    add_ResultOpaque_binding(somelib_mod);
-    add_RefList_binding(somelib_mod);
-    add_RefListParameter_binding(somelib_mod);
-    add_Float64Vec_binding(somelib_mod);
-    add_Float64VecError_binding(somelib_mod);
-    add_MyString_binding(somelib_mod);
-    add_MyOpaqueEnum_binding(somelib_mod);
-    add_Opaque_binding(somelib_mod);
-    add_OpaqueMutexedString_binding(somelib_mod);
-    add_PrimitiveStructVec_binding(somelib_mod);
-    add_Utf16Wrap_binding(somelib_mod);
-    add_UnimportedEnum_binding(somelib_mod);
-    add_OptionEnum_binding(somelib_mod);
-    add_ErrorEnum_binding(somelib_mod);
-    add_ContiguousEnum_binding(somelib_mod);
-    add_DefaultEnum_binding(somelib_mod);
-    add_MyEnum_binding(somelib_mod);
-    add_diplomat_func_binding(somelib_mod);
+    add_CallbackTestingStruct_binding(mod);
+    add_CallbackWrapper_binding(mod);
+    add_ImportedStruct_binding(mod);
+    add_BorrowedFields_binding(mod);
+    add_BorrowedFieldsReturning_binding(mod);
+    add_BorrowedFieldsWithBounds_binding(mod);
+    add_NestedBorrowedFields_binding(mod);
+    add_OptionInputStruct_binding(mod);
+    add_ErrorStruct_binding(mod);
+    add_BigStructWithStuff_binding(mod);
+    add_CyclicStructA_binding(mod);
+    add_CyclicStructB_binding(mod);
+    add_CyclicStructC_binding(mod);
+    add_MyStruct_binding(mod);
+    add_MyStructContainingAnOption_binding(mod);
+    add_MyZst_binding(mod);
+    add_PrimitiveStruct_binding(mod);
+    add_ScalarPairWithPadding_binding(mod);
+    add_StructArithmetic_binding(mod);
+    add_StructWithSlices_binding(mod);
+    add_OptionStruct_binding(mod);
+    add_Unnamespaced_binding(mod);
+    add_CallbackHolder_binding(mod);
+    add_MutableCallbackHolder_binding(mod);
+    add_Bar_binding(mod);
+    add_Foo_binding(mod);
+    add_One_binding(mod);
+    add_OpaqueThin_binding(mod);
+    add_OpaqueThinIter_binding(mod);
+    add_OpaqueThinVec_binding(mod);
+    add_Two_binding(mod);
+    add_OptionOpaque_binding(mod);
+    add_OptionOpaqueChar_binding(mod);
+    add_OptionString_binding(mod);
+    add_ResultOpaque_binding(mod);
+    add_RefList_binding(mod);
+    add_RefListParameter_binding(mod);
+    add_Float64Vec_binding(mod);
+    add_Float64VecError_binding(mod);
+    add_MyString_binding(mod);
+    add_MyOpaqueEnum_binding(mod);
+    add_Opaque_binding(mod);
+    add_OpaqueMutexedString_binding(mod);
+    add_PrimitiveStructVec_binding(mod);
+    add_Utf16Wrap_binding(mod);
+    add_UnimportedEnum_binding(mod);
+    add_OptionEnum_binding(mod);
+    add_ErrorEnum_binding(mod);
+    add_ContiguousEnum_binding(mod);
+    add_DefaultEnum_binding(mod);
+    add_MyEnum_binding(mod);
+    add_free_function_binding(mod);
     
-    nested::ns::add_Nested_binding(somelib_nested_ns_mod);
-    nested::ns::add_nested_ns_func_binding(somelib_nested_ns_mod);
+    nested::ns::add_Nested_binding(nested_ns_mod);
+    nested::ns::add_free_function_binding(nested_ns_mod);
     
-    nested::ns2::add_Nested_binding(somelib_nested_ns2_mod);
+    nested::ns2::add_Nested_binding(nested_ns2_mod);
     
-    ns::add_RenamedDeprecatedStruct_binding(somelib_ns_mod);
-    ns::add_RenamedStructWithAttrs_binding(somelib_ns_mod);
-    ns::add_RenamedTestMacroStruct_binding(somelib_ns_mod);
-    ns::add_AttrOpaque1Renamed_binding(somelib_ns_mod);
-    ns::add_RenamedAttrOpaque2_binding(somelib_ns_mod);
-    ns::add_RenamedComparable_binding(somelib_ns_mod);
-    ns::add_RenamedDeprecatedOpaque_binding(somelib_ns_mod);
-    ns::add_RenamedMyIndexer_binding(somelib_ns_mod);
-    ns::add_RenamedMyIterable_binding(somelib_ns_mod);
-    ns::add_RenamedMyIterator_binding(somelib_ns_mod);
-    ns::add_RenamedOpaqueArithmetic_binding(somelib_ns_mod);
-    ns::add_RenamedOpaqueIterable_binding(somelib_ns_mod);
-    ns::add_RenamedOpaqueIterator_binding(somelib_ns_mod);
-    ns::add_RenamedOpaqueRefIterable_binding(somelib_ns_mod);
-    ns::add_RenamedOpaqueRefIterator_binding(somelib_ns_mod);
-    ns::add_RenamedTestOpaque_binding(somelib_ns_mod);
-    ns::add_RenamedVectorTest_binding(somelib_ns_mod);
-    ns::add_RenamedAttrEnum_binding(somelib_ns_mod);
-    ns::add_RenamedDeprecatedEnum_binding(somelib_ns_mod);
-    ns::add_ns_func_binding(somelib_ns_mod);
+    ns::add_RenamedDeprecatedStruct_binding(ns_mod);
+    ns::add_RenamedStructWithAttrs_binding(ns_mod);
+    ns::add_RenamedTestMacroStruct_binding(ns_mod);
+    ns::add_AttrOpaque1Renamed_binding(ns_mod);
+    ns::add_RenamedAttrOpaque2_binding(ns_mod);
+    ns::add_RenamedComparable_binding(ns_mod);
+    ns::add_RenamedDeprecatedOpaque_binding(ns_mod);
+    ns::add_RenamedMyIndexer_binding(ns_mod);
+    ns::add_RenamedMyIterable_binding(ns_mod);
+    ns::add_RenamedMyIterator_binding(ns_mod);
+    ns::add_RenamedOpaqueArithmetic_binding(ns_mod);
+    ns::add_RenamedOpaqueIterable_binding(ns_mod);
+    ns::add_RenamedOpaqueIterator_binding(ns_mod);
+    ns::add_RenamedOpaqueRefIterable_binding(ns_mod);
+    ns::add_RenamedOpaqueRefIterator_binding(ns_mod);
+    ns::add_RenamedTestOpaque_binding(ns_mod);
+    ns::add_RenamedVectorTest_binding(ns_mod);
+    ns::add_RenamedAttrEnum_binding(ns_mod);
+    ns::add_RenamedDeprecatedEnum_binding(ns_mod);
+    ns::add_free_function_binding(ns_mod);
     
     
 }

--- a/feature_tests/nanobind/src/sub_modules/func_bindings.cpp
+++ b/feature_tests/nanobind/src/sub_modules/func_bindings.cpp
@@ -4,7 +4,7 @@
 #include "free_functions.hpp"
 
 
-void add_diplomat_func_binding(nb::module_ mod) {
+void add_free_function_binding(nb::module_ mod) {
     mod
         .def("free_callback_holder", &free_callback_holder, "f"_a);
 }

--- a/feature_tests/nanobind/src/sub_modules/nested/ns/func_bindings.cpp
+++ b/feature_tests/nanobind/src/sub_modules/nested/ns/func_bindings.cpp
@@ -6,7 +6,7 @@
 
 namespace nested::ns{
 
-void add_nested_ns_func_binding(nb::module_ mod) {
+void add_free_function_binding(nb::module_ mod) {
     mod
         .def("Renamednested_ns_fn", &Renamednested_ns_fn, "x"_a);
 }

--- a/feature_tests/nanobind/src/sub_modules/ns/func_bindings.cpp
+++ b/feature_tests/nanobind/src/sub_modules/ns/func_bindings.cpp
@@ -6,7 +6,7 @@
 
 namespace ns{
 
-void add_ns_func_binding(nb::module_ mod) {
+void add_free_function_binding(nb::module_ mod) {
     mod
         .def("Renamedfree_func_test", &Renamedfree_func_test, "x"_a);
 }

--- a/tool/src/cpp/gen.rs
+++ b/tool/src/cpp/gen.rs
@@ -78,7 +78,7 @@ struct NamedExpression<'a> {
 /// Header for the implementation of a block of functions.
 pub(crate) struct FuncImplTemplate<'a> {
     pub namespace: Option<String>,
-    pub methods: Vec<String>,
+    pub methods: Vec<MethodInfo<'a>>,
     pub c_header: C2Header,
     pub fmt: &'a Cpp2Formatter<'a>,
 }
@@ -375,31 +375,6 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
         }
         .render_into(self.impl_header)
         .unwrap();
-    }
-
-    /// Generate a free function and output it's (impl, decl) as a pair of strings
-    /// Returns None if the function is marked as disabled
-    pub fn gen_function(
-        &mut self,
-        func_id: hir::FunctionId,
-        func: &'tcx hir::Method,
-    ) -> Option<String> {
-        let info = self.gen_method_info(func_id.into(), func)?;
-        let fmt = &self.formatter;
-
-        #[derive(Template)]
-        #[template(
-            path = "cpp/function_defs/func_block_function.h.jinja",
-            escape = "none"
-        )]
-        struct FunctionImpl<'a> {
-            m: &'a MethodInfo<'a>,
-            fmt: &'a Cpp2Formatter<'a>,
-        }
-
-        let impl_bl = FunctionImpl { m: &info, fmt };
-
-        Some(impl_bl.to_string())
     }
 
     pub fn gen_method_info(

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -178,7 +178,7 @@ pub(crate) fn run<'tcx>(
 
             let methods = funcs
                 .into_iter()
-                .filter_map(|(id, func)| ty_context.gen_function(id, func))
+                .filter_map(|(id, func)| ty_context.gen_method_info(id.into(), func))
                 .collect();
 
             crate::cpp::gen::FuncImplTemplate {

--- a/tool/src/nanobind/formatter.rs
+++ b/tool/src/nanobind/formatter.rs
@@ -28,20 +28,10 @@ impl<'tcx> PyFormatter<'tcx> {
         }
     }
 
-    pub fn fmt_binding_fn(&self, id: TypeId, namespaced: bool) -> String {
-        let resolved = self.cxx.c.tcx().resolve_type(id);
-        let type_name = resolved
-            .attrs()
-            .rename
-            .apply(resolved.name().as_str().into());
-        match &resolved.attrs().namespace {
-            Some(ns) if namespaced => {
-                format!("{ns}::add_{type_name}_binding")
-            }
-            _ => {
-                format!("add_{type_name}_binding")
-            }
-        }
+    pub fn fmt_binding_fn(&self, id: TypeId) -> String {
+        let def = self.cxx.c.tcx().resolve_type(id);
+        let type_name = def.attrs().rename.apply(def.name().as_str().into());
+        format!("add_{type_name}_binding")
     }
 
     pub fn fmt_binding_impl_path(&self, id: TypeId) -> String {

--- a/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__opaque_gen.snap
+++ b/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__opaque_gen.snap
@@ -50,23 +50,20 @@ void diplomat_tp_dealloc(PyObject *self)
 
 struct _Dummy {};
 
-NB_MODULE(pymod, pymod_mod)
+NB_MODULE(pymod, mod)
 {
     {
-        nb::class_<_Dummy> dummy(pymod_mod, "__dummy__");
+        nb::class_<_Dummy> dummy(mod, "__dummy__");
         nb_tp_dealloc = (void (*)(void *))nb::type_get_slot(dummy, Py_tp_dealloc);
     }
 
-    nb::class_<std::monostate>(pymod_mod, "monostate")
+    nb::class_<std::monostate>(mod, "monostate")
         .def("__repr__", [](const std::monostate &)
              { return ""; })
         .def("__str__", [](const std::monostate &)
-             { return ""; });
-             
-
-    // Module declarations
+             { return ""; });// Module declarations
     // Add bindings
-    mylib::add_OpaqueStruct_binding(pymod_mylib_mod);
+    mylib::add_OpaqueStruct_binding(mylib_mod);
     
     
 }

--- a/tool/templates/cpp/free_functions.h.jinja
+++ b/tool/templates/cpp/free_functions.h.jinja
@@ -7,7 +7,7 @@ namespace {{lib_name}} {
 {% endif -%}
 
 {% for m in methods %}
-{{m}}
+{% include "cpp/function_defs/func_block_function.h.jinja" -%}
 {%- endfor ~%}
 
 {% if namespace.is_some() || fmt.lib_name.is_some() -%}

--- a/tool/templates/nanobind/root_module.cpp.jinja
+++ b/tool/templates/nanobind/root_module.cpp.jinja
@@ -52,33 +52,33 @@ void diplomat_tp_dealloc(PyObject *self)
 
 struct _Dummy {};
 
-NB_MODULE({{module_name}}, {{module_name}}_mod)
+NB_MODULE({{module_name}}, mod)
 {
     {
-        nb::class_<_Dummy> dummy({{module_name}}_mod, "__dummy__");
+        nb::class_<_Dummy> dummy(mod, "__dummy__");
         nb_tp_dealloc = (void (*)(void *))nb::type_get_slot(dummy, Py_tp_dealloc);
     }
 
-    nb::class_<std::monostate>({{module_name}}_mod, "monostate")
+    nb::class_<std::monostate>(mod, "monostate")
         .def("__repr__", [](const std::monostate &)
              { return ""; })
         .def("__str__", [](const std::monostate &)
              { return ""; });
              
 
+    {%- let mod_str = ["mod".to_string()] -%}
     // Module declarations
     {% for module_path in sub_modules %}
-    {%- let module_name = module_path.join("_") -%}
-    {%- let parent_name = module_path[..module_path.len()-1].join("_") -%}
-        nb::module_ {{module_name}}_mod = {{parent_name}}_mod.def_submodule("{{module_path.last().unwrap()}}");
+        {%- let module_name = [module_path.as_slice(), mod_str.as_slice()].concat().join("_") -%}
+        {%- let parent_name = [module_path[..module_path.len()-1], mod_str.as_slice()].concat().join("_") -%}
+        nb::module_ {{module_name}} = {{parent_name}}.def_submodule("{{module_path.last().unwrap()}}");
     {% endfor -%}
 
     // Add bindings
-    {%- for (module_path, fns) in module_fns -%}
-        {%- let module_name = module_path.join("_") -%}
-
+    {%- for (namespaces, fns) in module_fns -%}
+        {%- let module_name = [namespaces.as_slice(), mod_str.as_slice()].concat().join("_") -%}
         {% for func in fns %}
-    {{ func -}}({{module_name}}_mod);
+    {{ func -}}({{module_name}});
         {%- endfor %}
     {% endfor %}
     


### PR DESCRIPTION
Last part of https://github.com/rust-diplomat/diplomat/issues/955

This cleans up the way gen_function is called (by deleting it) and more directly concatenating sub-function generation rather than passing an array of pre-generated strings into the larger template

This does intentionally make some changes to the nanobind codegen, but none that are really functional.