### PR TITLE
Fix macro_rules use in non-bridge modules making diplomat-tool panic

### DIFF
--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -267,22 +267,25 @@ impl ModuleBuilder {
                 }
             }
             Item::Macro(mac) => {
-                if let Some(i) = &mac.ident {
-                    let macro_rules_attr = mac.attrs.iter().find(|a| {
-                        a.path() == &syn::parse_str::<syn::Path>("diplomat::macro_rules").unwrap()
-                    });
+                if self.analyze_types {
+                    if let Some(i) = &mac.ident {
+                        let macro_rules_attr = mac.attrs.iter().find(|a| {
+                            a.path()
+                                == &syn::parse_str::<syn::Path>("diplomat::macro_rules").unwrap()
+                        });
 
-                    if macro_rules_attr.is_some() {
-                        self.mod_macros.add_item_macro(mac);
+                        if macro_rules_attr.is_some() {
+                            self.mod_macros.add_item_macro(mac);
+                        } else {
+                            println!(
+                                r#"WARNING: Found macro_rules definition "macro_rules! {i}" with no #[diplomat::macro_rules] attribute. This will not be evaluated in Diplomat bindings."#
+                            );
+                        }
                     } else {
-                        println!(
-                            r#"WARNING: Found macro_rules definition "macro_rules! {i}" with no #[diplomat::macro_rules] attribute. This will not be evaluated in Diplomat bindings."#
-                        );
-                    }
-                } else {
-                    let items = self.mod_macros.evaluate_item_macro(mac);
-                    for i in items {
-                        self.add(&i);
+                        let items = self.mod_macros.evaluate_item_macro(mac);
+                        for i in items {
+                            self.add(&i);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Using a `macro_rules!` macro - not annotated as a `diplomat::macro_rules`- in a module leads to a panic in diplomat-tool, even when that module is not a bridge module.

The panic:

```
thread 'main' (6160) panicked at [...]\cargo\registry\src\index.crates.io-1949cf8c6b5b557f\diplomat_core-0.13.0\src\ast\macros.rs:50:17:
Could not find definition for thread_local. Have you tried creating a #[diplomat::macro_rules] macro_rules! thread_local definition?
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

See the following lib.rs:

```rust
// lib.rs

// This panics
mod internal {
    std::thread_local! {}
}

// This is ok
std::thread_local! {}
```

The proposed fix applies the same gating of analysis to macros as applied to types, traits, etc. in the `ModuleBuilder`.