### PR TITLE
Document analyze_types

### DIFF
--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -116,6 +116,10 @@ struct ModuleBuilder {
     functions_by_name: BTreeMap<Ident, Function>,
     sub_modules: Vec<Module>,
     imports: Vec<(Path, Ident)>,
+    /// As we traverse through the module, are we inside of #[diplomat::bridge]?
+    /// If so, then `analyze_types` is set to true, and types, functions, and traits are all updated according to information parsed.
+    /// 
+    /// Otherwise, we traverse through modules until we find a module marked by #[diplomat::bridge]
     analyze_types: bool,
     type_parent_attrs: Attrs,
     impl_parent_attrs: Attrs,
@@ -369,6 +373,7 @@ impl Module {
         out.insert(path_to_self, mod_symbols);
     }
 
+    /// Convert an [`ItemMod`] to a [`Module`]
     pub fn from_syn(input: &ItemMod, force_analyze: bool) -> Module {
         let mod_attrs: Attrs = (&*input.attrs).into();
 


### PR DESCRIPTION
Not sure how exactly to document `force_analyze`, since it seems to be one-use and not that useful?

From my notes on Slack:

> I'm not entirely sure what `force_analyze` is used for, since it's only used in the macro under `gen_bridge`.
> If I had to take a guess, it's for the macro tests, since those don't include the attributes that would set analyze_types to true.
> Seems like Shadaj added it a few years ago: [https://github.com/ambiguousname/diplomat/commit/0513b67584a0700a9744658d446ae15e327ca185#diff-d1b4b3981da5616fdbffd7[…]e75b479e9d5cf649df34a7515R62](https://github.com/ambiguousname/diplomat/commit/0513b67584a0700a9744658d446ae15e327ca185#diff-d1b4b3981da5616fdbffd723ee5f2225a445943e75b479e9d5cf649df34a7515R62)
> My thought is I could just re-write the tests to include the `#[diplomat::bridge]` attribute, and then I could take out `force_analyze`.