### PR TITLE
Seal most HIR traits

### DIFF
--- a/core/src/hir/elision.rs
+++ b/core/src/hir/elision.rs
@@ -99,6 +99,7 @@
 use super::lifetimes::{BoundedLifetime, Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
 use super::LoweringContext;
 use crate::ast;
+use crate::hir::ty_position::Sealed;
 use smallvec::SmallVec;
 
 /// Lower [`ast::Lifetime`]s to [`Lifetime`]s.
@@ -107,7 +108,7 @@ use smallvec::SmallVec;
 /// to abstractly lower lifetimes without concern for what sort of tracking
 /// goes on. In particular, elision inference requires updating internal state
 /// when visiting lifetimes in the input.
-pub trait LifetimeLowerer {
+pub trait LifetimeLowerer: Sealed {
     /// Lowers an [`ast::Lifetime`].
     fn lower_lifetime(&mut self, lifetime: &ast::Lifetime) -> MaybeStatic<Lifetime>;
 
@@ -227,6 +228,12 @@ pub(super) struct ReturnLifetimeLowerer<'ast> {
     elision_source: ElisionSource,
     base: BaseLifetimeLowerer<'ast>,
 }
+
+impl<'ast> Sealed for BaseLifetimeLowerer<'ast> {}
+impl<'ast> Sealed for SelfParamLifetimeLowerer<'ast> {}
+impl<'ast> Sealed for ParamLifetimeLowerer<'ast> {}
+impl<'ast> Sealed for ReturnLifetimeLowerer<'ast> {}
+impl<'ast> Sealed for &'ast ast::LifetimeEnv {}
 
 impl<'ast> BaseLifetimeLowerer<'ast> {
     /// Returns a [`Lifetime`] representing a new anonymous lifetime, and

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -9,6 +9,7 @@ use super::{
 };
 
 use super::lifetimes::{Lifetime, LifetimeEnv, Lifetimes, MaybeStatic};
+use super::ty_position::Sealed;
 
 use borrowing_field::BorrowingFieldVisitor;
 use borrowing_param::BorrowingParamVisitor;
@@ -41,7 +42,7 @@ pub struct Method {
     pub attrs: Attrs,
 }
 
-pub trait CallbackInstantiationFunctionality {
+pub trait CallbackInstantiationFunctionality: Sealed {
     #[allow(clippy::result_unit_err)]
     fn get_inputs(&self) -> Result<&[CallbackParam], ()>; // the types of the parameters
     #[allow(clippy::result_unit_err)]
@@ -64,6 +65,9 @@ pub struct Callback {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum NoCallback {}
+
+impl Sealed for Callback {}
+impl Sealed for NoCallback {}
 
 impl CallbackInstantiationFunctionality for Callback {
     fn get_inputs(&self) -> Result<&[CallbackParam], ()> {


### PR DESCRIPTION
These should never have been unsealed.

`diplomat-core` does not have direct users and these traits are not implemented by other Diplomat crates; I feel comfortable making a non-breaking release with this change.