### PR TITLE
Update Diplomat to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "diplomat"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "diplomat_core",
  "insta",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-example"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "diplomat",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-feature-tests"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "jni",
  "log",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-tool"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "askama",
  "clap",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat_core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "displaydoc",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["core", "macro", "runtime", "tool", "example", "feature_tests"]
 [workspace.package]
 
 # Individual subcrates may choose to temporarily switch to a different version
-version = "0.13.0"
+version = "0.14.0"
 # Applies to diplomat-core, diplomat, and diplomat-runtime
 # Diplomat-tool has no MSRV for now
 rust-version = "1.81"
@@ -21,7 +21,7 @@ categories = ["development-tools", "compilers"]
 keywords = ["ffi", "codegen"]
 
 [workspace.dependencies]
-diplomat = { version = "0.13.0", path = "macro", default-features = false }
-diplomat_core = { version = "0.13.0", path = "core", default-features = false }
-diplomat-runtime = { version = "0.13.0", path = "runtime", default-features = false }
-diplomat-tool = { version = "0.13.0", path = "tool", default-features = false }
+diplomat = { version = "0.14.0", path = "macro", default-features = false }
+diplomat_core = { version = "0.14.0", path = "core", default-features = false }
+diplomat-runtime = { version = "0.14.0", path = "runtime", default-features = false }
+diplomat-tool = { version = "0.14.0", path = "tool", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diplomat-runtime"
 description = "Common runtime utilities used by diplomat codegen"
-version = "0.13.1"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
diplomat-tool's public API changed a little, and also core did https://github.com/rust-diplomat/diplomat/pull/983.


Note that this does release a new diplomat-runtime even though it had no breaking changes. We plan to keep these versions in sync until diplomat-runtime has a 1.0, which should be soon (https://github.com/rust-diplomat/diplomat/issues/958)

I'm hoping to slow down the rate of breaking releases; we should be more careful about changing HIR and tool API.