### PR TITLE
Replace `DiplomatWriteable` references in the book

### DIFF
--- a/book/src/types.md
+++ b/book/src/types.md
@@ -18,7 +18,7 @@ Diplomat only supports a small set of types that can be passed over FFI.
          - `&str`: A validated, UTF-8 string. Will be converted/validated by the target language bindings if necessary.
          - `&DiplomatStr`: An unvalidated string expected to be UTF-8.
          - `&DiplomatStr16`: An unvalidated string expected to be UTF-16.
-     - [`DiplomatWriteable`](./writeable.md) for returning strings. This needs to be the last parameter of the method.
+     - [`DiplomatWrite`](./write.md) for returning strings. This needs to be the last parameter of the method.
      - [`Option<&T>` ,`Option<Box<T>>`](./option.md) of opaque types, `Option<T>` of structs, enums, primitives, or the above slice types
      - [Callbacks](./callbacks.md) in parameters. Support is limited.
      - `Result<T, E>` in return values

--- a/book/src/write.md
+++ b/book/src/write.md
@@ -1,13 +1,13 @@
-# Returning strings: Writeables
+# Returning strings: Write
 
-Most languages have their own type to handle strings. To avoid unnecessary allocations, Diplomat supports [`DiplomatWriteable`](https://docs.rs/diplomat-runtime/0.2.0/diplomat_runtime/struct.DiplomatWriteable.html), a type with a `Write` implementation which can be used to write to appropriate string types on the other side.
+Most languages have their own type to handle strings. To avoid unnecessary allocations, Diplomat supports [`DiplomatWrite`](https://docs.rs/diplomat-runtime/latest/diplomat_runtime/struct.DiplomatWrite.html), a type with a `Write` implementation which can be used to write to appropriate string types on the other side.
 
 For example, if we want to have methods that philosophically return a `String` or a `Result<String>`, we can do the following:
 
 ```rust
 #[diplomat::bridge]
 mod ffi {
-    use diplomat_runtime::DiplomatWriteable;
+    use diplomat_runtime::DiplomatWrite;
     use std::fmt::Write;
 
     #[diplomat::opaque]
@@ -15,12 +15,12 @@ mod ffi {
     pub struct Thingy(u8);
 
     impl Thingy {
-        pub fn debug_output(&self, writeable: &mut DiplomatWriteable) {
-            write!(writeable, "{:?}", self);
+        pub fn debug_output(&self, write: &mut DiplomatWrite) {
+            write!(write, "{:?}", self);
         }
 
-        pub fn maybe_get_string(&self, writeable: &mut DiplomatWriteable) -> Result<(), ()> {
-            write!(writeable, "integer is {}", self.0).map_err(|_| ())
+        pub fn maybe_get_string(&self, write: &mut DiplomatWrite) -> Result<(), ()> {
+            write!(write, "integer is {}", self.0).map_err(|_| ())
         }
     }
 }


### PR DESCRIPTION
`DiplomatWriteable` was renamed to `DiplomatWrite` in #483. This replaces all references to `DiplomatWriteable` in the book.