### PR TITLE
Add Maven feature tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,10 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
       with:
         gradle-version: "8.10"
-    - name: Test Kotlin
+    - name: Test Kotlin (Gradle)
       run: cargo make test-kotlin
+    - name: Test Kotlin (Maven)
+      run: cargo make test-kotlin-mvn
   test-nanobind:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -55,6 +55,10 @@ dependencies = ["test-dart-example", "test-dart-feature"]
 category = "Tests"
 dependencies = ["test-kotlin-example", "test-kotlin-feature"]
 
+[tasks.test-kotlin-mvn]
+category = "Tests"
+dependencies = ["test-kotlin-feature-mvn"]
+
 [tasks.test-nanobind]
 category = "Tests"
 dependencies = ["test-nanobind-feature"]
@@ -171,38 +175,64 @@ exec --fail-on-error dart analyze
 exec --fail-on-error dart test
 '''
 
-[tasks.test-kotlin-example.mac]
+[tasks.copy-kotlin-example.mac]
 env = { "OUT_FILE" = "dylib" }
 
-[tasks.test-kotlin-example.linux]
+[tasks.copy-kotlin-example.linux]
 env = { "OUT_FILE" = "so", "LD_LIBRARY_PATH" = "./" }
 
-[tasks.test-kotlin-example]
+[tasks.copy-kotlin-example]
 category = "Tests"
 script_runner = "@duckscript"
 dependencies = ["build-example-jvm"]
 script = '''
 exit_on_error true
 cp target/debug/libdiplomat_example.${OUT_FILE} example/kotlin/somelib/libsomelib.${OUT_FILE}
+'''
+
+[tasks.test-kotlin-example]
+category = "Tests"
+script_runner = "@duckscript"
+dependencies = ["copy-kotlin-example"]
+script = '''
+exit_on_error true
 cd example/kotlin/somelib
 exec --fail-on-error gradle test --warning-mode all
 '''
 
-[tasks.test-kotlin-feature.mac]
+[tasks.copy-kotlin-feature.mac]
 env = { "OUT_FILE" = "dylib" }
 
-[tasks.test-kotlin-feature.linux]
+[tasks.copy-kotlin-feature.linux]
 env = { "OUT_FILE" = "so", "LD_LIBRARY_PATH" = "./" }
 
-[tasks.test-kotlin-feature]
+[tasks.copy-kotlin-feature]
 category = "Tests"
 script_runner = "@duckscript"
 dependencies = ["build-feature-jvm"]
 script = '''
 exit_on_error true
 cp target/debug/libdiplomat_feature_tests.${OUT_FILE} feature_tests/kotlin/somelib/libsomelib.${OUT_FILE}
+'''
+
+[tasks.test-kotlin-feature]
+category = "Tests"
+script_runner = "@duckscript"
+dependencies = ["copy-kotlin-feature"]
+script = '''
+exit_on_error true
 cd feature_tests/kotlin/somelib
 exec --fail-on-error gradle test  --warning-mode all 
+'''
+
+[tasks.test-kotlin-feature-mvn]
+category = "Tests"
+script_runner = "@duckscript"
+dependencies = ["copy-kotlin-feature"]
+script = '''
+exit_on_error true
+cd feature_tests/kotlin/somelib
+exec --fail-on-error mvn test
 '''
 
 [tasks.test-nanobind-feature]

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["Manish Goregaokar"]
 language = "en"
-multilingual = false
 src = "src"
 title = "The Diplomat Book"

--- a/feature_tests/kotlin/somelib/pom.xml
+++ b/feature_tests/kotlin/somelib/pom.xml
@@ -9,13 +9,21 @@
   <url>http://maven.apache.org</url>
 
     <properties>
-        <kotlin.version>1.9.0</kotlin.version>
+        <kotlin.version>2.1.0</kotlin.version>
+        <junit.jupiter.version>5.9.2</junit.jupiter.version>
+        <junit.platform.version>1.14.0</junit.platform.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+            <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -28,58 +36,124 @@
             <artifactId>jna</artifactId>
             <version>5.14.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <version>${junit.platform.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit.platform.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <version>1.13.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik-kotlin</artifactId>
+            <version>1.9.3</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-            <plugins>
-                <plugin>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-maven-plugin</artifactId>
-                    <version>${kotlin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>compile</id>
-                            <phase>process-sources</phase>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>test-compile</id>
-                            <phase>process-test-sources</phase>
-                            <goals>
-                                <goal>test-compile</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <!-- Configure maven-compiler-plugin to work with Kotlin -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                    <executions>
-                        <execution>
-                            <id>default-compile</id>
-                            <phase>none</phase>
-                        </execution>
-                        <execution>
-                            <id>default-testCompile</id>
-                            <phase>none</phase>
-                        </execution>
-                        <execution>
-                            <id>java-compile</id>
-                            <phase>compile</phase>
-                            <goals> <goal>compile</goal> </goals>
-                        </execution>
-                        <execution>
-                            <id>java-test-compile</id>
-                            <phase>test-compile</phase>
-                            <goals> <goal>testCompile</goal> </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
+        <resources>
+          <resource>
+            <!-- Perhaps this should pick up from src/resources or src/main/native or something. Ideally
+                 this can be taught to run cargo build. Use basedir for now so that it does the same thing
+                 as the gradle build. -->
+            <filtering>false</filtering>
+            <directory>${basedir}</directory>
+            <includes>
+              <include>libsomelib.so</include>
+              <include>libsomelib.dylib</include>
+              <include>libsomelib.dll</include>
+            </includes>
+          </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                 <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Configure maven-compiler-plugin to work with Kotlin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals> <goal>compile</goal> </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals> <goal>testCompile</goal> </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.19.1</version>
+              <dependencies>
+                <dependency>
+                  <groupId>org.junit.jupiter</groupId>
+                  <artifactId>junit-jupiter-engine</artifactId>
+                  <version>${junit.jupiter.version}</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+        </plugins>
         </build>
 </project>


### PR DESCRIPTION
Useful for people trying to get stuff working with Maven


(Also, I am still unable to get the Gradle build working locally)

Would be cool to try and get https://github.com/questdb/rust-maven-plugin working.

Note that this only adds it for feature_tests, not for example. I think that's fine for now, I didn't want to add more sets of CI tasks.