### PR TITLE
Add specific classes for Kotlin memory management instead of using Pair

### DIFF
--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -66,6 +66,25 @@ interface DiplomatAllocateLib: Library {
 
 
 
+internal class GCSlice(val memory: Memory?, val slice: Slice) {
+    fun close() {
+        memory?.close()
+    }
+}
+
+internal class GCSlices(val memory: Memory?, val subMemory: List<Memory?>, val slice: Slice) {
+    fun close() {
+        memory?.close()
+        subMemory.forEach { it?.close() }
+    }
+}
+
+
+internal class OwnedSlice(val pointer: Pointer?, val slice: Slice) {
+
+}
+
+
 internal object PrimitiveArrayTools {
 
     val libClass: Class<DiplomatAllocateLib> = DiplomatAllocateLib::class.java
@@ -114,58 +133,58 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(boolArray: BooleanArray): Pair<Memory?, Slice> {
+    fun borrow(boolArray: BooleanArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(boolArray.size.toLong())
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(boolArray: BooleanArray): Pair<Pointer?, Slice> {
+    fun move(boolArray: BooleanArray): OwnedSlice {
         val mem = allocateOwnedMemory(boolArray.size.toLong() * boolAlign, boolAlign)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(byteArray: ByteArray): Pair<Memory?, Slice> {
+    fun borrow(byteArray: ByteArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(byteArray.size.toLong())
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(byteArray: ByteArray): Pair<Pointer?, Slice> {
+    fun move(byteArray: ByteArray): OwnedSlice {
         val mem = allocateOwnedMemory(byteArray.size.toLong() * Byte.SIZE_BYTES.toLong(), uByteAlign, )
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
-    fun borrow(uByteArray: UByteArray): Pair<Memory?, Slice> {
+    fun borrow(uByteArray: UByteArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(uByteArray.size.toLong())
         val byteArray = uByteArray.asByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uByteArray: UByteArray): Pair<Pointer?, Slice> {
+    fun move(uByteArray: UByteArray): OwnedSlice {
         val mem = allocateOwnedMemory(uByteArray.size.toLong() * Byte.SIZE_BYTES.toLong(), uByteAlign, )
         val byteArray = uByteArray.asByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
-    fun borrow(shortArray: ShortArray): Pair<Memory?, Slice> {
+    fun borrow(shortArray: ShortArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(shortArray: ShortArray): Pair<Pointer?, Slice> {
+    fun move(shortArray: ShortArray): OwnedSlice {
         val mem = allocateOwnedMemory(Short.SIZE_BYTES * shortArray.size.toLong(), Short.SIZE_BYTES.toLong())
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: ShortArray, ptr: Pointer?) : Slice {
@@ -180,18 +199,18 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(uShortArray: UShortArray): Pair<Memory?, Slice> {
+    fun borrow(uShortArray: UShortArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Short.SIZE_BYTES * uShortArray.size.toLong())
         val shortArray = uShortArray.asShortArray()
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uShortArray: UShortArray): Pair<Pointer?, Slice> {
+    fun move(uShortArray: UShortArray): OwnedSlice {
         val mem = allocateOwnedMemory(Short.SIZE_BYTES * uShortArray.size.toLong(), Short.SIZE_BYTES.toLong())
         val shortArray = uShortArray.asShortArray()
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: IntArray, ptr: Pointer?) : Slice {
@@ -206,42 +225,42 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(intArray: IntArray): Pair<Memory?, Slice> {
+    fun borrow(intArray: IntArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(intArray: IntArray): Pair<Pointer?, Slice> {
+    fun move(intArray: IntArray): OwnedSlice {
         val mem = allocateOwnedMemory(Int.SIZE_BYTES * intArray.size.toLong(), Int.SIZE_BYTES.toLong())
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(uIntArray: UIntArray): Pair<Memory?, Slice> {
+    fun borrow(uIntArray: UIntArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Int.SIZE_BYTES * uIntArray.size.toLong())
         val intArray = uIntArray.asIntArray()
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uIntArray: UIntArray): Pair<Pointer?, Slice> {
+    fun move(uIntArray: UIntArray): OwnedSlice {
         val mem = allocateOwnedMemory(Int.SIZE_BYTES * uIntArray.size.toLong(), Int.SIZE_BYTES.toLong())
         val intArray = uIntArray.asIntArray()
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(longArray: LongArray): Pair<Memory?, Slice> {
+    fun borrow(longArray: LongArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Long.SIZE_BYTES * longArray.size.toLong())
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(longArray: LongArray): Pair<Pointer?, Slice> {
+    fun move(longArray: LongArray): OwnedSlice {
         val mem = allocateOwnedMemory(Long.SIZE_BYTES * longArray.size.toLong(), Long.SIZE_BYTES.toLong())
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: LongArray, ptr: Pointer?) : Slice {
@@ -256,18 +275,18 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(uLongArray: ULongArray): Pair<Memory?, Slice> {
+    fun borrow(uLongArray: ULongArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Long.SIZE_BYTES * uLongArray.size.toLong())
         val longArray = uLongArray.asLongArray()
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uLongArray: ULongArray): Pair<Pointer?, Slice> {
+    fun move(uLongArray: ULongArray): OwnedSlice {
         val mem = allocateOwnedMemory(Long.SIZE_BYTES * uLongArray.size.toLong(), Long.SIZE_BYTES.toLong())
         val longArray = uLongArray.asLongArray()
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: FloatArray, ptr: Pointer?) : Slice {
@@ -282,16 +301,16 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(floatArray: FloatArray): Pair<Memory?, Slice> {
+    fun borrow(floatArray: FloatArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Float.SIZE_BYTES * floatArray.size.toLong())
         val slice = copy(floatArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(floatArray: FloatArray): Pair<Pointer?, Slice> {
+    fun move(floatArray: FloatArray): OwnedSlice {
         val mem = allocateOwnedMemory(Float.SIZE_BYTES * floatArray.size.toLong(), Float.SIZE_BYTES.toLong())
         val slice = copy(floatArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: DoubleArray, ptr: Pointer?) : Slice {
@@ -306,16 +325,16 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(doubleArray: DoubleArray): Pair<Memory?, Slice> {
+    fun borrow(doubleArray: DoubleArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
         val slice = copy(doubleArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(doubleArray: DoubleArray): Pair<Pointer?, Slice> {
+    fun move(doubleArray: DoubleArray): OwnedSlice {
         val mem = allocateOwnedMemory(Double.SIZE_BYTES * doubleArray.size.toLong(), Double.SIZE_BYTES.toLong())
         val slice = copy(doubleArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
@@ -363,19 +382,19 @@ internal object PrimitiveArrayTools {
         return slice.data.getDoubleArray(0, slice.len.toInt())
     }
 
-    fun borrowUtf8(str: String): Pair<Memory?, Slice> {
+    fun borrowUtf8(str: String): GCSlice {
         return borrow(str.toByteArray())
     }
 
-    fun moveUtf8(str: String): Pair<Pointer?, Slice> {
+    fun moveUtf8(str: String): OwnedSlice {
         return move(str.toByteArray())
     }
 
-    fun borrowUtf16(str: String): Pair<Memory?, Slice> {
+    fun borrowUtf16(str: String): GCSlice {
         return borrow(str.map {it.code.toShort()}.toShortArray())
     }
 
-    fun moveUtf16(str: String): Pair<Pointer?, Slice> {
+    fun moveUtf16(str: String): OwnedSlice {
         return move(str.map {it.code.toShort()}.toShortArray())
     }
 
@@ -392,7 +411,7 @@ internal object PrimitiveArrayTools {
         return charArray
     }
 
-    fun borrowUtf8s(array: Array<String>): Pair<List<Memory?>, Slice> {
+    fun borrowUtf8s(array: Array<String>): GCSlices {
         val sliceSize = Slice.SIZE
         val mem = allocateGarbageCollectedMemory(sliceSize * array.size.toLong())
         val ptr = if (mem != null) {
@@ -401,18 +420,18 @@ internal object PrimitiveArrayTools {
             Pointer(0)
         }
         val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
-            val (mem, slice) = borrowUtf8(str)
-            ptr.setPointer(idx * sliceSize, slice.data)
-            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
-            mem
+            val mem = borrowUtf8(str)
+            ptr.setPointer(idx * sliceSize, mem.slice.data)
+            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, mem.slice.len.toLong())
+            mem.memory
         }
         val slice = Slice()
         slice.data = ptr
         slice.len = FFISizet(array.size.toLong().toULong())
-        return Pair(mems + mem, slice)
+        return GCSlices(mem, mems, slice)
     }
 
-    fun borrowUtf16s(array: Array<String>): Pair<List<Memory?>, Slice> {
+    fun borrowUtf16s(array: Array<String>): GCSlices {
         val sliceSize = Slice.SIZE
         val mem = allocateGarbageCollectedMemory(sliceSize * array.size.toLong())
         val ptr = if (mem != null) {
@@ -421,15 +440,15 @@ internal object PrimitiveArrayTools {
             Pointer(0)
         }
         val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
-            val (mem, slice) = borrowUtf16(str)
-            ptr.setPointer(idx * sliceSize, slice.data)
-            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
-            mem
+            val mem = borrowUtf16(str)
+            ptr.setPointer(idx * sliceSize, mem.slice.data)
+            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, mem.slice.len.toLong())
+            mem.memory
         }
         val slice = Slice()
         slice.data = ptr
         slice.len = FFISizet(array.size.toLong().toULong())
-        return Pair(mems + mem, slice)
+        return GCSlices(mem, mems, slice)
     }
 
     fun getUtf16s(slice: Slice): List<String> {

--- a/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Locale.kt
+++ b/example/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Locale.kt
@@ -34,14 +34,14 @@ class Locale internal constructor (
         /** Construct an [Locale] from a locale identifier represented as a string.
         */
         fun new_(name: String): Locale {
-            val (nameMem, nameSlice) = PrimitiveArrayTools.borrowUtf8(name)
+            val nameSliceMemory = PrimitiveArrayTools.borrowUtf8(name)
             
-            val returnVal = lib.icu4x_Locale_new_mv1(nameSlice);
+            val returnVal = lib.icu4x_Locale_new_mv1(nameSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Locale(handle, selfEdges)
             CLEANER.register(returnOpaque, Locale.LocaleCleaner(handle, Locale.lib));
-            if (nameMem != null) nameMem.close()
+            nameSliceMemory?.close()
             return returnOpaque
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFields.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFields.kt
@@ -82,9 +82,9 @@ class BorrowedFields (var a: String, var b: String, var c: String) {
     }
     internal fun toNative(): BorrowedFieldsNative {
         var native = BorrowedFieldsNative()
-        native.a = PrimitiveArrayTools.borrowUtf16(this.a).second
-        native.b = PrimitiveArrayTools.borrowUtf8(this.b).second
-        native.c = PrimitiveArrayTools.borrowUtf8(this.c).second
+        native.a = PrimitiveArrayTools.borrowUtf16(this.a).slice
+        native.b = PrimitiveArrayTools.borrowUtf8(this.b).slice
+        native.c = PrimitiveArrayTools.borrowUtf8(this.c).slice
         return native
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsReturning.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsReturning.kt
@@ -76,7 +76,7 @@ class BorrowedFieldsReturning (var bytes: String) {
     }
     internal fun toNative(): BorrowedFieldsReturningNative {
         var native = BorrowedFieldsReturningNative()
-        native.bytes = PrimitiveArrayTools.borrowUtf8(this.bytes).second
+        native.bytes = PrimitiveArrayTools.borrowUtf8(this.bytes).slice
         return native
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsWithBounds.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowedFieldsWithBounds.kt
@@ -82,9 +82,9 @@ class BorrowedFieldsWithBounds (var fieldA: String, var fieldB: String, var fiel
     }
     internal fun toNative(): BorrowedFieldsWithBoundsNative {
         var native = BorrowedFieldsWithBoundsNative()
-        native.fieldA = PrimitiveArrayTools.borrowUtf16(this.fieldA).second
-        native.fieldB = PrimitiveArrayTools.borrowUtf8(this.fieldB).second
-        native.fieldC = PrimitiveArrayTools.borrowUtf8(this.fieldC).second
+        native.fieldA = PrimitiveArrayTools.borrowUtf16(this.fieldA).slice
+        native.fieldB = PrimitiveArrayTools.borrowUtf8(this.fieldB).slice
+        native.fieldC = PrimitiveArrayTools.borrowUtf8(this.fieldC).slice
         return native
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowingOptionStruct.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/BorrowingOptionStruct.kt
@@ -76,7 +76,7 @@ class BorrowingOptionStruct (var a: String?) {
     }
     internal fun toNative(): BorrowingOptionStructNative {
         var native = BorrowingOptionStructNative()
-        native.a = this.a?.let { OptionSlice.some(PrimitiveArrayTools.borrowUtf8(it).second) } ?: OptionSlice.none()
+        native.a = this.a?.let { OptionSlice.some(PrimitiveArrayTools.borrowUtf8(it).slice) } ?: OptionSlice.none()
         return native
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/CallbackWrapper.kt
@@ -404,9 +404,9 @@ class CallbackWrapper (var cantBeEmpty: Boolean) {
         @JvmStatic
         
         fun testSliceCbArg(arg: UByteArray, f: (UByteArray)->Unit): Unit {
-            val (argMem, argSlice) = PrimitiveArrayTools.borrow(arg)
+            val argSliceMemory = PrimitiveArrayTools.borrow(arg)
             
-            val returnVal = lib.CallbackWrapper_test_slice_cb_arg(argSlice, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f.fromCallback(f).nativeStruct);
+            val returnVal = lib.CallbackWrapper_test_slice_cb_arg(argSliceMemory.slice, DiplomatCallback_CallbackWrapper_test_slice_cb_arg_diplomatCallback_f.fromCallback(f).nativeStruct);
             
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Float64Vec.kt
@@ -41,87 +41,87 @@ class Float64Vec internal constructor (
         @JvmStatic
         
         fun newBool(v: BooleanArray): Float64Vec {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrow(v)
+            val vSliceMemory = PrimitiveArrayTools.borrow(v)
             
-            val returnVal = lib.Float64Vec_new_bool(vSlice);
+            val returnVal = lib.Float64Vec_new_bool(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            if (vMem != null) vMem.close()
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun newI16(v: ShortArray): Float64Vec {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrow(v)
+            val vSliceMemory = PrimitiveArrayTools.borrow(v)
             
-            val returnVal = lib.Float64Vec_new_i16(vSlice);
+            val returnVal = lib.Float64Vec_new_i16(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            if (vMem != null) vMem.close()
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun newU16(v: UShortArray): Float64Vec {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrow(v)
+            val vSliceMemory = PrimitiveArrayTools.borrow(v)
             
-            val returnVal = lib.Float64Vec_new_u16(vSlice);
+            val returnVal = lib.Float64Vec_new_u16(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            if (vMem != null) vMem.close()
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun newIsize(v: LongArray): Float64Vec {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrow(v)
+            val vSliceMemory = PrimitiveArrayTools.borrow(v)
             
-            val returnVal = lib.Float64Vec_new_isize(vSlice);
+            val returnVal = lib.Float64Vec_new_isize(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            if (vMem != null) vMem.close()
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun newUsize(v: ULongArray): Float64Vec {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrow(v)
+            val vSliceMemory = PrimitiveArrayTools.borrow(v)
             
-            val returnVal = lib.Float64Vec_new_usize(vSlice);
+            val returnVal = lib.Float64Vec_new_usize(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            if (vMem != null) vMem.close()
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun newF64BeBytes(v: ByteArray): Float64Vec {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrow(v)
+            val vSliceMemory = PrimitiveArrayTools.borrow(v)
             
-            val returnVal = lib.Float64Vec_new_f64_be_bytes(vSlice);
+            val returnVal = lib.Float64Vec_new_f64_be_bytes(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
             CLEANER.register(returnOpaque, Float64Vec.Float64VecCleaner(handle, Float64Vec.lib));
-            if (vMem != null) vMem.close()
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun newFromOwned(v: DoubleArray): Float64Vec {
-            val (vMem, vSlice) = PrimitiveArrayTools.move(v)
+            val vSliceMemory = PrimitiveArrayTools.move(v)
             
-            val returnVal = lib.Float64Vec_new_from_owned(vSlice);
+            val returnVal = lib.Float64Vec_new_from_owned(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Float64Vec(handle, selfEdges)
@@ -137,16 +137,16 @@ class Float64Vec internal constructor (
     }
     
     fun fillSlice(v: DoubleArray): Unit {
-        val (vMem, vSlice) = PrimitiveArrayTools.borrow(v)
+        val vSliceMemory = PrimitiveArrayTools.borrow(v)
         
-        val returnVal = lib.Float64Vec_fill_slice(handle, vSlice);
+        val returnVal = lib.Float64Vec_fill_slice(handle, vSliceMemory.slice);
         
     }
     
     fun setValue(newSlice: DoubleArray): Unit {
-        val (newSliceMem, newSliceSlice) = PrimitiveArrayTools.borrow(newSlice)
+        val newSliceSliceMemory = PrimitiveArrayTools.borrow(newSlice)
         
-        val returnVal = lib.Float64Vec_set_value(handle, newSliceSlice);
+        val returnVal = lib.Float64Vec_set_value(handle, newSliceSliceMemory.slice);
         
     }
     

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Foo.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Foo.kt
@@ -33,15 +33,15 @@ class Foo internal constructor (
         @JvmStatic
         
         fun newStatic(x: String): Foo {
-            val (xMem, xSlice) = PrimitiveArrayTools.borrowUtf8(x)
+            val xSliceMemory = PrimitiveArrayTools.borrowUtf8(x)
             
-            val returnVal = lib.Foo_new_static(xSlice);
+            val returnVal = lib.Foo_new_static(xSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val aEdges: List<Any?> = listOf()
             val handle = returnVal 
             val returnOpaque = Foo(handle, selfEdges, aEdges)
             CLEANER.register(returnOpaque, Foo.FooCleaner(handle, Foo.lib));
-            if (xMem != null) xMem.close()
+            xSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Lib.kt
@@ -66,6 +66,25 @@ interface DiplomatAllocateLib: Library {
 
 
 
+internal class GCSlice(val memory: Memory?, val slice: Slice) {
+    fun close() {
+        memory?.close()
+    }
+}
+
+internal class GCSlices(val memory: Memory?, val subMemory: List<Memory?>, val slice: Slice) {
+    fun close() {
+        memory?.close()
+        subMemory.forEach { it?.close() }
+    }
+}
+
+
+internal class OwnedSlice(val pointer: Pointer?, val slice: Slice) {
+
+}
+
+
 internal object PrimitiveArrayTools {
 
     val libClass: Class<DiplomatAllocateLib> = DiplomatAllocateLib::class.java
@@ -114,58 +133,58 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(boolArray: BooleanArray): Pair<Memory?, Slice> {
+    fun borrow(boolArray: BooleanArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(boolArray.size.toLong())
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(boolArray: BooleanArray): Pair<Pointer?, Slice> {
+    fun move(boolArray: BooleanArray): OwnedSlice {
         val mem = allocateOwnedMemory(boolArray.size.toLong() * boolAlign, boolAlign)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(byteArray: ByteArray): Pair<Memory?, Slice> {
+    fun borrow(byteArray: ByteArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(byteArray.size.toLong())
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(byteArray: ByteArray): Pair<Pointer?, Slice> {
+    fun move(byteArray: ByteArray): OwnedSlice {
         val mem = allocateOwnedMemory(byteArray.size.toLong() * Byte.SIZE_BYTES.toLong(), uByteAlign, )
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
-    fun borrow(uByteArray: UByteArray): Pair<Memory?, Slice> {
+    fun borrow(uByteArray: UByteArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(uByteArray.size.toLong())
         val byteArray = uByteArray.asByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uByteArray: UByteArray): Pair<Pointer?, Slice> {
+    fun move(uByteArray: UByteArray): OwnedSlice {
         val mem = allocateOwnedMemory(uByteArray.size.toLong() * Byte.SIZE_BYTES.toLong(), uByteAlign, )
         val byteArray = uByteArray.asByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
-    fun borrow(shortArray: ShortArray): Pair<Memory?, Slice> {
+    fun borrow(shortArray: ShortArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(shortArray: ShortArray): Pair<Pointer?, Slice> {
+    fun move(shortArray: ShortArray): OwnedSlice {
         val mem = allocateOwnedMemory(Short.SIZE_BYTES * shortArray.size.toLong(), Short.SIZE_BYTES.toLong())
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: ShortArray, ptr: Pointer?) : Slice {
@@ -180,18 +199,18 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(uShortArray: UShortArray): Pair<Memory?, Slice> {
+    fun borrow(uShortArray: UShortArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Short.SIZE_BYTES * uShortArray.size.toLong())
         val shortArray = uShortArray.asShortArray()
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uShortArray: UShortArray): Pair<Pointer?, Slice> {
+    fun move(uShortArray: UShortArray): OwnedSlice {
         val mem = allocateOwnedMemory(Short.SIZE_BYTES * uShortArray.size.toLong(), Short.SIZE_BYTES.toLong())
         val shortArray = uShortArray.asShortArray()
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: IntArray, ptr: Pointer?) : Slice {
@@ -206,42 +225,42 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(intArray: IntArray): Pair<Memory?, Slice> {
+    fun borrow(intArray: IntArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(intArray: IntArray): Pair<Pointer?, Slice> {
+    fun move(intArray: IntArray): OwnedSlice {
         val mem = allocateOwnedMemory(Int.SIZE_BYTES * intArray.size.toLong(), Int.SIZE_BYTES.toLong())
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(uIntArray: UIntArray): Pair<Memory?, Slice> {
+    fun borrow(uIntArray: UIntArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Int.SIZE_BYTES * uIntArray.size.toLong())
         val intArray = uIntArray.asIntArray()
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uIntArray: UIntArray): Pair<Pointer?, Slice> {
+    fun move(uIntArray: UIntArray): OwnedSlice {
         val mem = allocateOwnedMemory(Int.SIZE_BYTES * uIntArray.size.toLong(), Int.SIZE_BYTES.toLong())
         val intArray = uIntArray.asIntArray()
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(longArray: LongArray): Pair<Memory?, Slice> {
+    fun borrow(longArray: LongArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Long.SIZE_BYTES * longArray.size.toLong())
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(longArray: LongArray): Pair<Pointer?, Slice> {
+    fun move(longArray: LongArray): OwnedSlice {
         val mem = allocateOwnedMemory(Long.SIZE_BYTES * longArray.size.toLong(), Long.SIZE_BYTES.toLong())
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: LongArray, ptr: Pointer?) : Slice {
@@ -256,18 +275,18 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(uLongArray: ULongArray): Pair<Memory?, Slice> {
+    fun borrow(uLongArray: ULongArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Long.SIZE_BYTES * uLongArray.size.toLong())
         val longArray = uLongArray.asLongArray()
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uLongArray: ULongArray): Pair<Pointer?, Slice> {
+    fun move(uLongArray: ULongArray): OwnedSlice {
         val mem = allocateOwnedMemory(Long.SIZE_BYTES * uLongArray.size.toLong(), Long.SIZE_BYTES.toLong())
         val longArray = uLongArray.asLongArray()
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: FloatArray, ptr: Pointer?) : Slice {
@@ -282,16 +301,16 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(floatArray: FloatArray): Pair<Memory?, Slice> {
+    fun borrow(floatArray: FloatArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Float.SIZE_BYTES * floatArray.size.toLong())
         val slice = copy(floatArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(floatArray: FloatArray): Pair<Pointer?, Slice> {
+    fun move(floatArray: FloatArray): OwnedSlice {
         val mem = allocateOwnedMemory(Float.SIZE_BYTES * floatArray.size.toLong(), Float.SIZE_BYTES.toLong())
         val slice = copy(floatArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: DoubleArray, ptr: Pointer?) : Slice {
@@ -306,16 +325,16 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(doubleArray: DoubleArray): Pair<Memory?, Slice> {
+    fun borrow(doubleArray: DoubleArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
         val slice = copy(doubleArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(doubleArray: DoubleArray): Pair<Pointer?, Slice> {
+    fun move(doubleArray: DoubleArray): OwnedSlice {
         val mem = allocateOwnedMemory(Double.SIZE_BYTES * doubleArray.size.toLong(), Double.SIZE_BYTES.toLong())
         val slice = copy(doubleArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
@@ -363,19 +382,19 @@ internal object PrimitiveArrayTools {
         return slice.data.getDoubleArray(0, slice.len.toInt())
     }
 
-    fun borrowUtf8(str: String): Pair<Memory?, Slice> {
+    fun borrowUtf8(str: String): GCSlice {
         return borrow(str.toByteArray())
     }
 
-    fun moveUtf8(str: String): Pair<Pointer?, Slice> {
+    fun moveUtf8(str: String): OwnedSlice {
         return move(str.toByteArray())
     }
 
-    fun borrowUtf16(str: String): Pair<Memory?, Slice> {
+    fun borrowUtf16(str: String): GCSlice {
         return borrow(str.map {it.code.toShort()}.toShortArray())
     }
 
-    fun moveUtf16(str: String): Pair<Pointer?, Slice> {
+    fun moveUtf16(str: String): OwnedSlice {
         return move(str.map {it.code.toShort()}.toShortArray())
     }
 
@@ -392,7 +411,7 @@ internal object PrimitiveArrayTools {
         return charArray
     }
 
-    fun borrowUtf8s(array: Array<String>): Pair<List<Memory?>, Slice> {
+    fun borrowUtf8s(array: Array<String>): GCSlices {
         val sliceSize = Slice.SIZE
         val mem = allocateGarbageCollectedMemory(sliceSize * array.size.toLong())
         val ptr = if (mem != null) {
@@ -401,18 +420,18 @@ internal object PrimitiveArrayTools {
             Pointer(0)
         }
         val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
-            val (mem, slice) = borrowUtf8(str)
-            ptr.setPointer(idx * sliceSize, slice.data)
-            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
-            mem
+            val mem = borrowUtf8(str)
+            ptr.setPointer(idx * sliceSize, mem.slice.data)
+            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, mem.slice.len.toLong())
+            mem.memory
         }
         val slice = Slice()
         slice.data = ptr
         slice.len = FFISizet(array.size.toLong().toULong())
-        return Pair(mems + mem, slice)
+        return GCSlices(mem, mems, slice)
     }
 
-    fun borrowUtf16s(array: Array<String>): Pair<List<Memory?>, Slice> {
+    fun borrowUtf16s(array: Array<String>): GCSlices {
         val sliceSize = Slice.SIZE
         val mem = allocateGarbageCollectedMemory(sliceSize * array.size.toLong())
         val ptr = if (mem != null) {
@@ -421,15 +440,15 @@ internal object PrimitiveArrayTools {
             Pointer(0)
         }
         val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
-            val (mem, slice) = borrowUtf16(str)
-            ptr.setPointer(idx * sliceSize, slice.data)
-            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
-            mem
+            val mem = borrowUtf16(str)
+            ptr.setPointer(idx * sliceSize, mem.slice.data)
+            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, mem.slice.len.toLong())
+            mem.memory
         }
         val slice = Slice()
         slice.data = ptr
         slice.len = FFISizet(array.size.toLong().toULong())
-        return Pair(mems + mem, slice)
+        return GCSlices(mem, mems, slice)
     }
 
     fun getUtf16s(slice: Slice): List<String> {

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterable.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyIterable.kt
@@ -30,14 +30,14 @@ class MyIterable internal constructor (
         @JvmStatic
         
         fun new_(x: UByteArray): MyIterable {
-            val (xMem, xSlice) = PrimitiveArrayTools.borrow(x)
+            val xSliceMemory = PrimitiveArrayTools.borrow(x)
             
-            val returnVal = lib.namespace_MyIterable_new(xSlice);
+            val returnVal = lib.namespace_MyIterable_new(xSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = MyIterable(handle, selfEdges)
             CLEANER.register(returnOpaque, MyIterable.MyIterableCleaner(handle, MyIterable.lib));
-            if (xMem != null) xMem.close()
+            xSliceMemory?.close()
             return returnOpaque
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
@@ -37,35 +37,35 @@ class MyString internal constructor (
         @JvmStatic
         
         fun new_(v: String): MyString {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrowUtf8(v)
+            val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
-            val returnVal = lib.MyString_new(vSlice);
+            val returnVal = lib.MyString_new(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = MyString(handle, selfEdges)
             CLEANER.register(returnOpaque, MyString.MyStringCleaner(handle, MyString.lib));
-            if (vMem != null) vMem.close()
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun newUnsafe(v: String): MyString {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrowUtf8(v)
+            val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
-            val returnVal = lib.MyString_new_unsafe(vSlice);
+            val returnVal = lib.MyString_new_unsafe(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = MyString(handle, selfEdges)
             CLEANER.register(returnOpaque, MyString.MyStringCleaner(handle, MyString.lib));
-            if (vMem != null) vMem.close()
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun newOwned(v: String): MyString {
-            val (vMem, vSlice) = PrimitiveArrayTools.moveUtf8(v)
+            val vSliceMemory = PrimitiveArrayTools.moveUtf8(v)
             
-            val returnVal = lib.MyString_new_owned(vSlice);
+            val returnVal = lib.MyString_new_owned(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = MyString(handle, selfEdges)
@@ -75,14 +75,14 @@ class MyString internal constructor (
         @JvmStatic
         
         fun newFromFirst(v: Array<String>): MyString {
-            val (vMem, vSlice) = PrimitiveArrayTools.borrowUtf8s(v)
+            val vSliceMemory = PrimitiveArrayTools.borrowUtf8s(v)
             
-            val returnVal = lib.MyString_new_from_first(vSlice);
+            val returnVal = lib.MyString_new_from_first(vSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = MyString(handle, selfEdges)
             CLEANER.register(returnOpaque, MyString.MyStringCleaner(handle, MyString.lib));
-            vMem.forEach {if (it != null) it.close()}
+            vSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
@@ -95,9 +95,9 @@ class MyString internal constructor (
         @JvmStatic
         
         fun stringTransform(foo: String): String {
-            val (fooMem, fooSlice) = PrimitiveArrayTools.borrowUtf8(foo)
+            val fooSliceMemory = PrimitiveArrayTools.borrowUtf8(foo)
             val write = DW.lib.diplomat_buffer_write_create(0)
-            val returnVal = lib.MyString_string_transform(fooSlice, write);
+            val returnVal = lib.MyString_string_transform(fooSliceMemory.slice, write);
             
             val returnString = DW.writeToString(write)
             return returnString
@@ -105,9 +105,9 @@ class MyString internal constructor (
     }
     
     fun setStr(newStr: String): Unit {
-        val (newStrMem, newStrSlice) = PrimitiveArrayTools.borrowUtf8(newStr)
+        val newStrSliceMemory = PrimitiveArrayTools.borrowUtf8(newStr)
         
-        val returnVal = lib.MyString_set_str(handle, newStrSlice);
+        val returnVal = lib.MyString_set_str(handle, newStrSliceMemory.slice);
         
     }
     

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Opaque.kt
@@ -47,27 +47,27 @@ class Opaque internal constructor (
         @JvmStatic
         
         fun tryFromUtf8(input: String): Opaque? {
-            val (inputMem, inputSlice) = PrimitiveArrayTools.borrowUtf8(input)
+            val inputSliceMemory = PrimitiveArrayTools.borrowUtf8(input)
             
-            val returnVal = lib.Opaque_try_from_utf8(inputSlice);
+            val returnVal = lib.Opaque_try_from_utf8(inputSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal ?: return null
             val returnOpaque = Opaque(handle, selfEdges)
             CLEANER.register(returnOpaque, Opaque.OpaqueCleaner(handle, Opaque.lib));
-            if (inputMem != null) inputMem.close()
+            inputSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic
         
         fun fromStr(input: String): Opaque {
-            val (inputMem, inputSlice) = PrimitiveArrayTools.borrowUtf8(input)
+            val inputSliceMemory = PrimitiveArrayTools.borrowUtf8(input)
             
-            val returnVal = lib.Opaque_from_str(inputSlice);
+            val returnVal = lib.Opaque_from_str(inputSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Opaque(handle, selfEdges)
             CLEANER.register(returnOpaque, Opaque.OpaqueCleaner(handle, Opaque.lib));
-            if (inputMem != null) inputMem.close()
+            inputSliceMemory?.close()
             return returnOpaque
         }
         @JvmStatic

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueThinVec.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OpaqueThinVec.kt
@@ -33,18 +33,18 @@ class OpaqueThinVec internal constructor (
         @JvmStatic
         
         fun create(a: IntArray, b: FloatArray, c: String): OpaqueThinVec {
-            val (aMem, aSlice) = PrimitiveArrayTools.borrow(a)
-            val (bMem, bSlice) = PrimitiveArrayTools.borrow(b)
-            val (cMem, cSlice) = PrimitiveArrayTools.borrowUtf8(c)
+            val aSliceMemory = PrimitiveArrayTools.borrow(a)
+            val bSliceMemory = PrimitiveArrayTools.borrow(b)
+            val cSliceMemory = PrimitiveArrayTools.borrowUtf8(c)
             
-            val returnVal = lib.OpaqueThinVec_create(aSlice, bSlice, cSlice);
+            val returnVal = lib.OpaqueThinVec_create(aSliceMemory.slice, bSliceMemory.slice, cSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = OpaqueThinVec(handle, selfEdges)
             CLEANER.register(returnOpaque, OpaqueThinVec.OpaqueThinVecCleaner(handle, OpaqueThinVec.lib));
-            if (aMem != null) aMem.close()
-            if (bMem != null) bMem.close()
-            if (cMem != null) cMem.close()
+            aSliceMemory?.close()
+            bSliceMemory?.close()
+            cSliceMemory?.close()
             return returnOpaque
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/OptionString.kt
@@ -31,14 +31,14 @@ class OptionString internal constructor (
         @JvmStatic
         
         fun new_(diplomatStr: String): OptionString? {
-            val (diplomatStrMem, diplomatStrSlice) = PrimitiveArrayTools.borrowUtf8(diplomatStr)
+            val diplomatStrSliceMemory = PrimitiveArrayTools.borrowUtf8(diplomatStr)
             
-            val returnVal = lib.OptionString_new(diplomatStrSlice);
+            val returnVal = lib.OptionString_new(diplomatStrSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal ?: return null
             val returnOpaque = OptionString(handle, selfEdges)
             CLEANER.register(returnOpaque, OptionString.OptionStringCleaner(handle, OptionString.lib));
-            if (diplomatStrMem != null) diplomatStrMem.close()
+            diplomatStrSliceMemory?.close()
             return returnOpaque
         }
     }

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/ResultOpaque.kt
@@ -171,13 +171,13 @@ class ResultOpaque internal constructor (
     *Test that this interacts gracefully with returning a reference type
     */
     fun takesStr(v: String): ResultOpaque {
-        val (vMem, vSlice) = PrimitiveArrayTools.borrowUtf8(v)
+        val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
         
-        val returnVal = lib.ResultOpaque_takes_str(handle, vSlice);
+        val returnVal = lib.ResultOpaque_takes_str(handle, vSliceMemory.slice);
         val selfEdges: List<Any> = listOf(this)
         val handle = returnVal 
         val returnOpaque = ResultOpaque(handle, selfEdges)
-        if (vMem != null) vMem.close()
+        vSliceMemory?.close()
         return returnOpaque
     }
     

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/StructWithSlices.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/StructWithSlices.kt
@@ -80,8 +80,8 @@ class StructWithSlices (var first: String, var second: UShortArray) {
     }
     internal fun toNative(): StructWithSlicesNative {
         var native = StructWithSlicesNative()
-        native.first = PrimitiveArrayTools.borrowUtf8(this.first).second
-        native.second = PrimitiveArrayTools.borrow(this.second).second
+        native.first = PrimitiveArrayTools.borrowUtf8(this.first).slice
+        native.second = PrimitiveArrayTools.borrow(this.second).slice
         return native
     }
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Utf16Wrap.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/Utf16Wrap.kt
@@ -31,14 +31,14 @@ class Utf16Wrap internal constructor (
         @JvmStatic
         
         fun fromUtf16(input: String): Utf16Wrap {
-            val (inputMem, inputSlice) = PrimitiveArrayTools.borrowUtf16(input)
+            val inputSliceMemory = PrimitiveArrayTools.borrowUtf16(input)
             
-            val returnVal = lib.Utf16Wrap_from_utf16(inputSlice);
+            val returnVal = lib.Utf16Wrap_from_utf16(inputSliceMemory.slice);
             val selfEdges: List<Any> = listOf()
             val handle = returnVal 
             val returnOpaque = Utf16Wrap(handle, selfEdges)
             CLEANER.register(returnOpaque, Utf16Wrap.Utf16WrapCleaner(handle, Utf16Wrap.lib));
-            if (inputMem != null) inputMem.close()
+            inputSliceMemory?.close()
             return returnOpaque
         }
     }

--- a/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/NativeTest.kt
+++ b/feature_tests/kotlin/somelib/src/test/kotlin/dev/diplomattest/somelib/NativeTest.kt
@@ -11,18 +11,18 @@ class NativeTest {
         val random =  Random(2984751)
         for (run in 0 .. 100) {
             val array = random.nextBytes(1000)
-            val (mem, slice) = PrimitiveArrayTools.borrow(array)
-            val got = slice.data.getByteArray(0, array.size)
-            if (mem != null) mem.close()
+            val mem = PrimitiveArrayTools.borrow(array)
+            val got = mem.slice.data.getByteArray(0, array.size)
+            mem.close()
             assertEquals(got.toList(), array.toList())
         }
 
         for (run in 0 .. 100) {
             val array = random.nextBytes(1000)
             val uByteArray = array.map { it.toUByte()}.toUByteArray()
-            val (mem, slice) = PrimitiveArrayTools.borrow(array)
-            val got = slice.data.getByteArray(0, array.size).asUByteArray()
-            if (mem != null) mem.close()
+            val mem = PrimitiveArrayTools.borrow(array)
+            val got = mem.slice.data.getByteArray(0, array.size).asUByteArray()
+            mem.close()
             assertEquals(got.map { it.toUByte()}, uByteArray.toList())
         }
 
@@ -30,18 +30,18 @@ class NativeTest {
         for (run in 0 .. 100) {
             val size = 1000
             val intArray = (0..size).map { random.nextInt() }.toIntArray()
-            val (mem, slice) = PrimitiveArrayTools.borrow(intArray)
-            val got = slice.data.getIntArray(0, intArray.size)
-            if (mem != null) mem.close()
+            val mem = PrimitiveArrayTools.borrow(intArray)
+            val got = mem.slice.data.getIntArray(0, intArray.size)
+            mem.close()
             assertEquals(got.toList(), intArray.toList())
         }
 
         for (run in 0 .. 100) {
             val size = 1000
             val intArray = (0..size).map { random.nextInt().toUInt() }.toUIntArray()
-            val (mem, slice) = PrimitiveArrayTools.borrow(intArray)
-            val got = slice.data.getIntArray(0, intArray.size).asUIntArray()
-            if (mem != null) mem.close()
+            val mem = PrimitiveArrayTools.borrow(intArray)
+            val got = mem.slice.data.getIntArray(0, intArray.size).asUIntArray()
+            mem.close()
             assertEquals(got.toList(), intArray.toList())
         }
 

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -214,7 +214,7 @@ impl<'tcx> KotlinFormatter<'tcx> {
         };
         match ty {
             LifetimeEdgeKind::OpaqueParam => format!("listOf({param_name})").into(),
-            LifetimeEdgeKind::SliceParam => format!("listOf({param_name}Mem)").into(),
+            LifetimeEdgeKind::SliceParam => format!("listOf({param_name}SliceMemory.mem)").into(),
             LifetimeEdgeKind::StructLifetime(lt_env, lt, is_option) => {
                 assert!(
                     !is_option,

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_multiple_ref_args.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__opaque_gen_multiple_ref_args.snap
@@ -33,16 +33,16 @@ class AnotherOpaque internal constructor (
     }
     
     fun getRustOwnedBytes(a: UByteArray, b: UByteArray): RustOwnedBytes {
-        val (aMem, aSlice) = PrimitiveArrayTools.borrow(a)
-        val (bMem, bSlice) = PrimitiveArrayTools.borrow(b)
+        val aSliceMemory = PrimitiveArrayTools.borrow(a)
+        val bSliceMemory = PrimitiveArrayTools.borrow(b)
         
-        val returnVal = lib.AnotherOpaque_get_rust_owned_bytes(handle, aSlice, bSlice);
+        val returnVal = lib.AnotherOpaque_get_rust_owned_bytes(handle, aSliceMemory.slice, bSliceMemory.slice);
         val selfEdges: List<Any> = listOf()
         val handle = returnVal 
         val returnOpaque = RustOwnedBytes(handle, selfEdges)
         CLEANER.register(returnOpaque, RustOwnedBytes.RustOwnedBytesCleaner(handle, RustOwnedBytes.lib));
-        if (aMem != null) aMem.close()
-        if (bMem != null) bMem.close()
+        aSliceMemory?.close()
+        bSliceMemory?.close()
         return returnOpaque
     }
 

--- a/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
+++ b/tool/src/kotlin/snapshots/diplomat_tool__kotlin__test__struct.snap
@@ -236,7 +236,7 @@ class MyNativeStruct (var a: Boolean, var b: Byte, var c: UByte, var d: Short, v
         native.j = this.j
         native.k = this.k
         native.l = this.l
-        native.m = PrimitiveArrayTools.borrow(this.m).second
+        native.m = PrimitiveArrayTools.borrow(this.m).slice
         native.n = this.n.handle
         return native
     }

--- a/tool/templates/kotlin/SliceConversion.kt.jinja
+++ b/tool/templates/kotlin/SliceConversion.kt.jinja
@@ -1,2 +1,2 @@
 
-val {% if closeable %}({{kt_param_name}}Mem, {{kt_param_name}}Slice){% else %}{{kt_param_name}}Slice{% endif %} = PrimitiveArrayTools.{{slice_method}}({{kt_param_name}})
+val {{kt_param_name}}SliceMemory = PrimitiveArrayTools.{{slice_method}}({{kt_param_name}})

--- a/tool/templates/kotlin/init.kt.jinja
+++ b/tool/templates/kotlin/init.kt.jinja
@@ -68,6 +68,25 @@ interface DiplomatAllocateLib: Library {
 
 
 
+internal class GCSlice(val memory: Memory?, val slice: Slice) {
+    fun close() {
+        memory?.close()
+    }
+}
+
+internal class GCSlices(val memory: Memory?, val subMemory: List<Memory?>, val slice: Slice) {
+    fun close() {
+        memory?.close()
+        subMemory.forEach { it?.close() }
+    }
+}
+
+
+internal class OwnedSlice(val pointer: Pointer?, val slice: Slice) {
+
+}
+
+
 internal object PrimitiveArrayTools {
 
     val libClass: Class<DiplomatAllocateLib> = DiplomatAllocateLib::class.java
@@ -116,58 +135,58 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(boolArray: BooleanArray): Pair<Memory?, Slice> {
+    fun borrow(boolArray: BooleanArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(boolArray.size.toLong())
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(boolArray: BooleanArray): Pair<Pointer?, Slice> {
+    fun move(boolArray: BooleanArray): OwnedSlice {
         val mem = allocateOwnedMemory(boolArray.size.toLong() * boolAlign, boolAlign)
         val byteArray = boolArray.map {if (it) 1.toByte() else 0.toByte() }.toByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(byteArray: ByteArray): Pair<Memory?, Slice> {
+    fun borrow(byteArray: ByteArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(byteArray.size.toLong())
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(byteArray: ByteArray): Pair<Pointer?, Slice> {
+    fun move(byteArray: ByteArray): OwnedSlice {
         val mem = allocateOwnedMemory(byteArray.size.toLong() * Byte.SIZE_BYTES.toLong(), uByteAlign, )
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
-    fun borrow(uByteArray: UByteArray): Pair<Memory?, Slice> {
+    fun borrow(uByteArray: UByteArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(uByteArray.size.toLong())
         val byteArray = uByteArray.asByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uByteArray: UByteArray): Pair<Pointer?, Slice> {
+    fun move(uByteArray: UByteArray): OwnedSlice {
         val mem = allocateOwnedMemory(uByteArray.size.toLong() * Byte.SIZE_BYTES.toLong(), uByteAlign, )
         val byteArray = uByteArray.asByteArray()
         val slice = copy(byteArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
-    fun borrow(shortArray: ShortArray): Pair<Memory?, Slice> {
+    fun borrow(shortArray: ShortArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Short.SIZE_BYTES * shortArray.size.toLong())
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(shortArray: ShortArray): Pair<Pointer?, Slice> {
+    fun move(shortArray: ShortArray): OwnedSlice {
         val mem = allocateOwnedMemory(Short.SIZE_BYTES * shortArray.size.toLong(), Short.SIZE_BYTES.toLong())
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: ShortArray, ptr: Pointer?) : Slice {
@@ -182,18 +201,18 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(uShortArray: UShortArray): Pair<Memory?, Slice> {
+    fun borrow(uShortArray: UShortArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Short.SIZE_BYTES * uShortArray.size.toLong())
         val shortArray = uShortArray.asShortArray()
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uShortArray: UShortArray): Pair<Pointer?, Slice> {
+    fun move(uShortArray: UShortArray): OwnedSlice {
         val mem = allocateOwnedMemory(Short.SIZE_BYTES * uShortArray.size.toLong(), Short.SIZE_BYTES.toLong())
         val shortArray = uShortArray.asShortArray()
         val slice = copy(shortArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: IntArray, ptr: Pointer?) : Slice {
@@ -208,42 +227,42 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(intArray: IntArray): Pair<Memory?, Slice> {
+    fun borrow(intArray: IntArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Int.SIZE_BYTES * intArray.size.toLong())
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(intArray: IntArray): Pair<Pointer?, Slice> {
+    fun move(intArray: IntArray): OwnedSlice {
         val mem = allocateOwnedMemory(Int.SIZE_BYTES * intArray.size.toLong(), Int.SIZE_BYTES.toLong())
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(uIntArray: UIntArray): Pair<Memory?, Slice> {
+    fun borrow(uIntArray: UIntArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Int.SIZE_BYTES * uIntArray.size.toLong())
         val intArray = uIntArray.asIntArray()
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uIntArray: UIntArray): Pair<Pointer?, Slice> {
+    fun move(uIntArray: UIntArray): OwnedSlice {
         val mem = allocateOwnedMemory(Int.SIZE_BYTES * uIntArray.size.toLong(), Int.SIZE_BYTES.toLong())
         val intArray = uIntArray.asIntArray()
         val slice = copy(intArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
-    fun borrow(longArray: LongArray): Pair<Memory?, Slice> {
+    fun borrow(longArray: LongArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Long.SIZE_BYTES * longArray.size.toLong())
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(longArray: LongArray): Pair<Pointer?, Slice> {
+    fun move(longArray: LongArray): OwnedSlice {
         val mem = allocateOwnedMemory(Long.SIZE_BYTES * longArray.size.toLong(), Long.SIZE_BYTES.toLong())
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: LongArray, ptr: Pointer?) : Slice {
@@ -258,18 +277,18 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(uLongArray: ULongArray): Pair<Memory?, Slice> {
+    fun borrow(uLongArray: ULongArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Long.SIZE_BYTES * uLongArray.size.toLong())
         val longArray = uLongArray.asLongArray()
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(uLongArray: ULongArray): Pair<Pointer?, Slice> {
+    fun move(uLongArray: ULongArray): OwnedSlice {
         val mem = allocateOwnedMemory(Long.SIZE_BYTES * uLongArray.size.toLong(), Long.SIZE_BYTES.toLong())
         val longArray = uLongArray.asLongArray()
         val slice = copy(longArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: FloatArray, ptr: Pointer?) : Slice {
@@ -284,16 +303,16 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(floatArray: FloatArray): Pair<Memory?, Slice> {
+    fun borrow(floatArray: FloatArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Float.SIZE_BYTES * floatArray.size.toLong())
         val slice = copy(floatArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(floatArray: FloatArray): Pair<Pointer?, Slice> {
+    fun move(floatArray: FloatArray): OwnedSlice {
         val mem = allocateOwnedMemory(Float.SIZE_BYTES * floatArray.size.toLong(), Float.SIZE_BYTES.toLong())
         val slice = copy(floatArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
     fun copy(arr: DoubleArray, ptr: Pointer?) : Slice {
@@ -308,16 +327,16 @@ internal object PrimitiveArrayTools {
         return slice
     }
 
-    fun borrow(doubleArray: DoubleArray): Pair<Memory?, Slice> {
+    fun borrow(doubleArray: DoubleArray): GCSlice {
         val mem = allocateGarbageCollectedMemory(Double.SIZE_BYTES * doubleArray.size.toLong())
         val slice = copy(doubleArray, mem)
-        return Pair(mem, slice)
+        return GCSlice(mem, slice)
     }
 
-    fun move(doubleArray: DoubleArray): Pair<Pointer?, Slice> {
+    fun move(doubleArray: DoubleArray): OwnedSlice {
         val mem = allocateOwnedMemory(Double.SIZE_BYTES * doubleArray.size.toLong(), Double.SIZE_BYTES.toLong())
         val slice = copy(doubleArray, mem)
-        return Pair(mem, slice)
+        return OwnedSlice(mem, slice)
     }
 
 
@@ -365,19 +384,19 @@ internal object PrimitiveArrayTools {
         return slice.data.getDoubleArray(0, slice.len.toInt())
     }
 
-    fun borrowUtf8(str: String): Pair<Memory?, Slice> {
+    fun borrowUtf8(str: String): GCSlice {
         return borrow(str.toByteArray())
     }
 
-    fun moveUtf8(str: String): Pair<Pointer?, Slice> {
+    fun moveUtf8(str: String): OwnedSlice {
         return move(str.toByteArray())
     }
 
-    fun borrowUtf16(str: String): Pair<Memory?, Slice> {
+    fun borrowUtf16(str: String): GCSlice {
         return borrow(str.map {it.code.toShort()}.toShortArray())
     }
 
-    fun moveUtf16(str: String): Pair<Pointer?, Slice> {
+    fun moveUtf16(str: String): OwnedSlice {
         return move(str.map {it.code.toShort()}.toShortArray())
     }
 
@@ -394,7 +413,7 @@ internal object PrimitiveArrayTools {
         return charArray
     }
 
-    fun borrowUtf8s(array: Array<String>): Pair<List<Memory?>, Slice> {
+    fun borrowUtf8s(array: Array<String>): GCSlices {
         val sliceSize = Slice.SIZE
         val mem = allocateGarbageCollectedMemory(sliceSize * array.size.toLong())
         val ptr = if (mem != null) {
@@ -403,18 +422,18 @@ internal object PrimitiveArrayTools {
             Pointer(0)
         }
         val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
-            val (mem, slice) = borrowUtf8(str)
-            ptr.setPointer(idx * sliceSize, slice.data)
-            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
-            mem
+            val mem = borrowUtf8(str)
+            ptr.setPointer(idx * sliceSize, mem.slice.data)
+            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, mem.slice.len.toLong())
+            mem.memory
         }
         val slice = Slice()
         slice.data = ptr
         slice.len = FFISizet(array.size.toLong().toULong())
-        return Pair(mems + mem, slice)
+        return GCSlices(mem, mems, slice)
     }
 
-    fun borrowUtf16s(array: Array<String>): Pair<List<Memory?>, Slice> {
+    fun borrowUtf16s(array: Array<String>): GCSlices {
         val sliceSize = Slice.SIZE
         val mem = allocateGarbageCollectedMemory(sliceSize * array.size.toLong())
         val ptr = if (mem != null) {
@@ -423,15 +442,15 @@ internal object PrimitiveArrayTools {
             Pointer(0)
         }
         val mems: List<Memory?> = array.zip(0..array.size.toLong()).map { (str, idx) ->
-            val (mem, slice) = borrowUtf16(str)
-            ptr.setPointer(idx * sliceSize, slice.data)
-            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, slice.len.toLong())
-            mem
+            val mem = borrowUtf16(str)
+            ptr.setPointer(idx * sliceSize, mem.slice.data)
+            ptr.setLong(idx * sliceSize + Long.SIZE_BYTES, mem.slice.len.toLong())
+            mem.memory
         }
         val slice = Slice()
         slice.data = ptr
         slice.len = FFISizet(array.size.toLong().toULong())
-        return Pair(mems + mem, slice)
+        return GCSlices(mem, mems, slice)
     }
 
     fun getUtf16s(slice: Slice): List<String> {


### PR DESCRIPTION
Progress in https://github.com/rust-diplomat/diplomat/issues/1003

It'll be easier to debug these things, and more importantly easier to stick these in borrow arrays when we need to.