### PR TITLE
Draft of using `syn::Span` for AST erroring

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 [dependencies]
 syn = { version = "2", features = [ "full", "extra-traits" ] }
 quote = "1.0"
-proc-macro2 = "1.0.27"
+proc-macro2 = { version = "1.0.27", features = ["span-locations"] }
 serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 displaydoc = { version = "0.2", optional = true }
 smallvec = "1.9.0"

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -210,7 +210,11 @@ impl PathType {
                     None => panic!(
                         "Could not resolve symbol {} in {}",
                         o,
-                        cur_path.elements.join("::")
+                        if let Some(sp) = elem.span() {
+                            format!("{}.rs:{}:{}", cur_path.elements[0], sp.start_line, sp.column_line)
+                        } else {
+                            cur_path.elements.join("::")
+                        }
                     ),
                 },
             }

--- a/feature_tests/src/option.rs
+++ b/feature_tests/src/option.rs
@@ -41,7 +41,7 @@ pub mod ffi {
     #[diplomat::attr(not(supports = option), disable)]
     #[derive(Debug)]
     pub struct OptionInputStruct {
-        a: DiplomatOption<u8>,
+        a: ABC,
         b: DiplomatOption<DiplomatChar>,
         c: DiplomatOption<OptionEnum>,
     }


### PR DESCRIPTION
This isn't meant to be a PR to be merged, but merely a showcase that the AST is able to handle printing errors with line numbers with minimal changes.

If you pull and run, you'll notice a new error in `option.rs:44` that the AST has been re-written to catch and name the line number for.

This is accomplished just by adding a new `Span` struct to the AST `Ident`; `syn` with the `span-locations` feature makes this possible. I was surprised that `syn_inline_module` manages to know the line numbers accurately, I have yet to find a scenario where it's unable to note the exact line number in a file.