### PR TITLE
Nanobind Double New on this type causes crash

### DIFF
--- a/feature_tests/nanobind/test/test_attrs.py
+++ b/feature_tests/nanobind/test/test_attrs.py
@@ -5,6 +5,8 @@ def test_attrs():
     assert r.method == 77, "property should call"
     assert r.abirenamed == 123, "method should call"
 
+    other_r = somelib.ns.AttrOpaque1Renamed()
+
     e = somelib.ns.RenamedAttrEnum.A
 
     un = somelib.Unnamespaced.make(e)


### PR DESCRIPTION
This seems to work okay with some of the other types I test in Python, but for whatever reason calling `AttrOpaque1Renamed`'s constructor twice (as in this failing test) causes a crash (at least on Windows). With the error:

```
Critical nanobind error: nanobind::detail::nb_type_put_unique(type='somelib::ns::AttrOpaque1Renamed', cpp_delete=1): unexpected status flags! (state=2, destruct=1, cpp_delete=1)
```

Currently troubleshooting. Failing test included in this PR.