### PR TITLE
Extract attributes from free function parameters

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -557,6 +557,14 @@ fn gen_bridge(mut input: ItemMod) -> ItemMod {
                 }
             }
         }
+        Item::Fn(f) => {
+            for i in f.sig.inputs.iter_mut() {
+                let _attrs = match i {
+                    syn::FnArg::Receiver(s) => AttributeInfo::extract(&mut s.attrs),
+                    syn::FnArg::Typed(t) => AttributeInfo::extract(&mut t.attrs),
+                };
+            }
+        }
         _ => (),
     });
 


### PR DESCRIPTION
We support attributes on parameters in methods, just not free functions.

Fixes the CI issues found in https://github.com/rust-diplomat/diplomat/pull/1025