### PR TITLE
Use `void* data` instead of destructor pointer in C bindings

### DIFF
--- a/feature_tests/c/include/TesterTrait.d.h
+++ b/feature_tests/c/include/TesterTrait.d.h
@@ -24,7 +24,7 @@ typedef struct TesterTrait_VTable {
 } TesterTrait_VTable;
 
 typedef struct DiplomatTraitStruct_TesterTrait {
-    void (*destructor)(const void*);
+    void* data;
     TesterTrait_VTable vtable;
 } DiplomatTraitStruct_TesterTrait;
 

--- a/tool/templates/c/trait.h.jinja
+++ b/tool/templates/c/trait.h.jinja
@@ -13,7 +13,7 @@ struct {{trt_name}}_VTable {
 
 {% if !is_for_cpp -%} typedef {% endif -%}
 struct DiplomatTraitStruct_{{trt_name}} {
-    void (*destructor)(const void*);
+    void* data;
     {{trt_name}}_VTable vtable;
 } {%- if !is_for_cpp %} DiplomatTraitStruct_{{trt_name}} {%- endif %};
 


### PR DESCRIPTION
Currently working on documenting how Diplomat uses the C ABI in the book, and found a seeming mismatch. In the C bindings, we call the first field in  `DiplomatTraitStruct` `destructor`, when in the macro this is `data` (and is used as a `self` pointer).