### PR TITLE
Clippy 0.1.95 Update

### DIFF
--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -161,13 +161,12 @@ struct ModuleBuilder<'a> {
 impl<'a> ModuleBuilder<'a> {
     fn add(&mut self, a: &Item) {
         match a {
-            Item::Use(u) => {
-                if self.analyze_types {
+            Item::Use(u)
+                if self.analyze_types => {
                     extract_imports(&Path::empty(), &u.tree, &mut self.imports);
                 }
-            }
-            Item::Struct(strct) => {
-                if self.analyze_types {
+            Item::Struct(strct)
+                if self.analyze_types => {
                     if self.skip_private_items && !matches!(strct.vis, syn::Visibility::Public(..))
                     {
                         self.private_types_by_name.insert((&strct.ident).into());
@@ -202,10 +201,9 @@ impl<'a> ModuleBuilder<'a> {
                     self.custom_types_by_name
                         .insert(Ident::from(&strct.ident), custom_type);
                 }
-            }
 
-            Item::Enum(enm) => {
-                if self.analyze_types {
+            Item::Enum(enm)
+                if self.analyze_types => {
                     let ident = (&enm.ident).into();
 
                     if self.skip_private_items && !matches!(enm.vis, syn::Visibility::Public(..)) {
@@ -231,10 +229,9 @@ impl<'a> ModuleBuilder<'a> {
                     };
                     self.custom_types_by_name.insert(ident, custom_enum);
                 }
-            }
 
-            Item::Impl(imp) => {
-                if self.analyze_types && imp.trait_.is_none() {
+            Item::Impl(imp)
+                if self.analyze_types && imp.trait_.is_none() => {
                     let self_path = match imp.self_ty.as_ref() {
                         syn::Type::Path(s) => PathType::from(s),
                         _ => panic!("Self type not found"),
@@ -306,20 +303,18 @@ impl<'a> ModuleBuilder<'a> {
                         }
                     }
                 }
-            }
             Item::Mod(item_mod) => {
                 self.sub_modules
                     .push(Module::from_syn(item_mod, false, self.include_info.clone()));
             }
-            Item::Trait(trt) => {
-                if self.analyze_types {
+            Item::Trait(trt)
+                if self.analyze_types => {
                     let ident = (&trt.ident).into();
                     let trt = Trait::new(trt, &self.type_parent_attrs);
                     self.custom_traits_by_name.insert(ident, trt);
                 }
-            }
-            Item::Macro(mac) => {
-                if self.analyze_types {
+            Item::Macro(mac)
+                if self.analyze_types => {
                     if let Some(i) = &mac.ident {
                         let macro_rules_attr = mac.attrs.iter().find(|a| {
                             a.path()
@@ -340,9 +335,8 @@ impl<'a> ModuleBuilder<'a> {
                         }
                     }
                 }
-            }
-            Item::Fn(f) => {
-                if self.analyze_types {
+            Item::Fn(f)
+                if self.analyze_types => {
                     let is_public = matches!(f.vis, Visibility::Public(_));
                     let has_diplomat_attrs = f
                         .attrs
@@ -361,7 +355,6 @@ impl<'a> ModuleBuilder<'a> {
                         self.functions_by_name.insert(out.name.clone(), out);
                     }
                 }
-            }
             _ => {}
         }
     }

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -161,136 +161,128 @@ struct ModuleBuilder<'a> {
 impl<'a> ModuleBuilder<'a> {
     fn add(&mut self, a: &Item) {
         match a {
-            Item::Use(u)
-                if self.analyze_types => {
-                    extract_imports(&Path::empty(), &u.tree, &mut self.imports);
+            Item::Use(u) if self.analyze_types => {
+                extract_imports(&Path::empty(), &u.tree, &mut self.imports);
+            }
+            Item::Struct(strct) if self.analyze_types => {
+                if self.skip_private_items && !matches!(strct.vis, syn::Visibility::Public(..)) {
+                    self.private_types_by_name.insert((&strct.ident).into());
+                    return;
                 }
-            Item::Struct(strct)
-                if self.analyze_types => {
-                    if self.skip_private_items && !matches!(strct.vis, syn::Visibility::Public(..))
-                    {
-                        self.private_types_by_name.insert((&strct.ident).into());
-                        return;
+                let custom_type = match DiplomatStructAttribute::parse(&strct.attrs[..]) {
+                    Ok(None) => {
+                        CustomType::Struct(Struct::new(strct, false, &self.type_parent_attrs))
                     }
-                    let custom_type = match DiplomatStructAttribute::parse(&strct.attrs[..]) {
-                        Ok(None) => {
-                            CustomType::Struct(Struct::new(strct, false, &self.type_parent_attrs))
-                        }
-                        Ok(Some(DiplomatStructAttribute::Out)) => {
-                            CustomType::Struct(Struct::new(strct, true, &self.type_parent_attrs))
-                        }
-                        Ok(Some(DiplomatStructAttribute::TypeAttr(
-                            DiplomatTypeAttribute::Opaque,
-                        ))) => CustomType::Opaque(OpaqueType::new_struct(
+                    Ok(Some(DiplomatStructAttribute::Out)) => {
+                        CustomType::Struct(Struct::new(strct, true, &self.type_parent_attrs))
+                    }
+                    Ok(Some(DiplomatStructAttribute::TypeAttr(DiplomatTypeAttribute::Opaque))) => {
+                        CustomType::Opaque(OpaqueType::new_struct(
                             strct,
                             Mutability::Immutable,
                             &self.type_parent_attrs,
-                        )),
-                        Ok(Some(DiplomatStructAttribute::TypeAttr(
-                            DiplomatTypeAttribute::OpaqueMut,
-                        ))) => CustomType::Opaque(OpaqueType::new_struct(
-                            strct,
-                            Mutability::Mutable,
-                            &self.type_parent_attrs,
-                        )),
-                        Err(errors) => {
-                            panic!("Multiple conflicting Diplomat struct attributes, there can be at most one: {errors:?}");
-                        }
-                    };
+                        ))
+                    }
+                    Ok(Some(DiplomatStructAttribute::TypeAttr(
+                        DiplomatTypeAttribute::OpaqueMut,
+                    ))) => CustomType::Opaque(OpaqueType::new_struct(
+                        strct,
+                        Mutability::Mutable,
+                        &self.type_parent_attrs,
+                    )),
+                    Err(errors) => {
+                        panic!("Multiple conflicting Diplomat struct attributes, there can be at most one: {errors:?}");
+                    }
+                };
 
-                    self.custom_types_by_name
-                        .insert(Ident::from(&strct.ident), custom_type);
+                self.custom_types_by_name
+                    .insert(Ident::from(&strct.ident), custom_type);
+            }
+
+            Item::Enum(enm) if self.analyze_types => {
+                let ident = (&enm.ident).into();
+
+                if self.skip_private_items && !matches!(enm.vis, syn::Visibility::Public(..)) {
+                    self.private_types_by_name.insert(ident);
+                    return;
                 }
 
-            Item::Enum(enm)
-                if self.analyze_types => {
-                    let ident = (&enm.ident).into();
-
-                    if self.skip_private_items && !matches!(enm.vis, syn::Visibility::Public(..)) {
-                        self.private_types_by_name.insert(ident);
-                        return;
+                let custom_enum = match DiplomatTypeAttribute::parse(&enm.attrs[..]) {
+                    Ok(None) => CustomType::Enum(Enum::new(enm, &self.type_parent_attrs)),
+                    Ok(Some(DiplomatTypeAttribute::Opaque)) => CustomType::Opaque(
+                        OpaqueType::new_enum(enm, Mutability::Immutable, &self.type_parent_attrs),
+                    ),
+                    Ok(Some(DiplomatTypeAttribute::OpaqueMut)) => CustomType::Opaque(
+                        OpaqueType::new_enum(enm, Mutability::Mutable, &self.type_parent_attrs),
+                    ),
+                    Err(errors) => {
+                        panic!("Multiple conflicting Diplomat enum attributes, there can be at most one: {errors:?}");
                     }
+                };
+                self.custom_types_by_name.insert(ident, custom_enum);
+            }
 
-                    let custom_enum = match DiplomatTypeAttribute::parse(&enm.attrs[..]) {
-                        Ok(None) => CustomType::Enum(Enum::new(enm, &self.type_parent_attrs)),
-                        Ok(Some(DiplomatTypeAttribute::Opaque)) => {
-                            CustomType::Opaque(OpaqueType::new_enum(
-                                enm,
-                                Mutability::Immutable,
-                                &self.type_parent_attrs,
-                            ))
+            Item::Impl(imp) if self.analyze_types && imp.trait_.is_none() => {
+                let self_path = match imp.self_ty.as_ref() {
+                    syn::Type::Path(s) => PathType::from(s),
+                    _ => panic!("Self type not found"),
+                };
+                let mut impl_attrs = self.impl_parent_attrs.clone();
+                impl_attrs.add_attrs(&imp.attrs);
+                let method_parent_attrs =
+                    impl_attrs.attrs_for_inheritance(AttrInheritContext::MethodFromImpl);
+                let self_ident = self_path.path.elements.last().unwrap();
+
+                // Do a prepass to evaluate macros:
+                let mut impl_item_vec = Vec::new();
+                for i in &imp.items {
+                    match i {
+                        ImplItem::Fn(f) => {
+                            impl_item_vec.push(ImplItem::Fn(f.clone()));
                         }
-                        Ok(Some(DiplomatTypeAttribute::OpaqueMut)) => CustomType::Opaque(
-                            OpaqueType::new_enum(enm, Mutability::Mutable, &self.type_parent_attrs),
-                        ),
-                        Err(errors) => {
-                            panic!("Multiple conflicting Diplomat enum attributes, there can be at most one: {errors:?}");
+                        ImplItem::Macro(mac) => {
+                            let mut items = self.mod_macros.evaluate_impl_item_macro(mac);
+                            impl_item_vec.append(&mut items);
                         }
-                    };
-                    self.custom_types_by_name.insert(ident, custom_enum);
+                        _ => {}
+                    }
                 }
 
-            Item::Impl(imp)
-                if self.analyze_types && imp.trait_.is_none() => {
-                    let self_path = match imp.self_ty.as_ref() {
-                        syn::Type::Path(s) => PathType::from(s),
-                        _ => panic!("Self type not found"),
-                    };
-                    let mut impl_attrs = self.impl_parent_attrs.clone();
-                    impl_attrs.add_attrs(&imp.attrs);
-                    let method_parent_attrs =
-                        impl_attrs.attrs_for_inheritance(AttrInheritContext::MethodFromImpl);
-                    let self_ident = self_path.path.elements.last().unwrap();
+                // Then only add functions to the block:
+                let mut new_methods = impl_item_vec
+                    .iter()
+                    .filter_map(|i| match i {
+                        ImplItem::Fn(m) => Some(m),
+                        _ => None,
+                    })
+                    .filter(|m| {
+                        let is_public = matches!(m.vis, Visibility::Public(_));
+                        let has_diplomat_attrs = m
+                            .attrs
+                            .iter()
+                            .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
+                        assert!(
+                            is_public || !has_diplomat_attrs,
+                            "Non-public method with diplomat attrs found: {self_ident}::{}",
+                            m.sig.ident
+                        );
+                        is_public
+                    })
+                    .map(|m| {
+                        Method::from_syn(
+                            m,
+                            self_path.clone(),
+                            Some(&imp.generics),
+                            &method_parent_attrs,
+                        )
+                    })
+                    .collect();
 
-                    // Do a prepass to evaluate macros:
-                    let mut impl_item_vec = Vec::new();
-                    for i in &imp.items {
-                        match i {
-                            ImplItem::Fn(f) => {
-                                impl_item_vec.push(ImplItem::Fn(f.clone()));
-                            }
-                            ImplItem::Macro(mac) => {
-                                let mut items = self.mod_macros.evaluate_impl_item_macro(mac);
-                                impl_item_vec.append(&mut items);
-                            }
-                            _ => {}
-                        }
-                    }
+                if self.skip_private_items && self.private_types_by_name.contains(self_ident) {
+                    return;
+                }
 
-                    // Then only add functions to the block:
-                    let mut new_methods = impl_item_vec
-                        .iter()
-                        .filter_map(|i| match i {
-                            ImplItem::Fn(m) => Some(m),
-                            _ => None,
-                        })
-                        .filter(|m| {
-                            let is_public = matches!(m.vis, Visibility::Public(_));
-                            let has_diplomat_attrs = m.attrs.iter().any(|a| {
-                                a.path().segments.iter().next().unwrap().ident == "diplomat"
-                            });
-                            assert!(
-                                is_public || !has_diplomat_attrs,
-                                "Non-public method with diplomat attrs found: {self_ident}::{}",
-                                m.sig.ident
-                            );
-                            is_public
-                        })
-                        .map(|m| {
-                            Method::from_syn(
-                                m,
-                                self_path.clone(),
-                                Some(&imp.generics),
-                                &method_parent_attrs,
-                            )
-                        })
-                        .collect();
-
-                    if self.skip_private_items && self.private_types_by_name.contains(self_ident) {
-                        return;
-                    }
-
-                    match self.custom_types_by_name.get_mut(self_ident)
+                match self.custom_types_by_name.get_mut(self_ident)
                                                 .unwrap_or_else(|| panic!("Diplomat currently requires impls to be in the same module as their self type ({self_ident})")) {
                         CustomType::Struct(strct) => {
                             strct.methods.append(&mut new_methods);
@@ -302,59 +294,55 @@ impl<'a> ModuleBuilder<'a> {
                             enm.methods.append(&mut new_methods);
                         }
                     }
-                }
+            }
             Item::Mod(item_mod) => {
                 self.sub_modules
                     .push(Module::from_syn(item_mod, false, self.include_info.clone()));
             }
-            Item::Trait(trt)
-                if self.analyze_types => {
-                    let ident = (&trt.ident).into();
-                    let trt = Trait::new(trt, &self.type_parent_attrs);
-                    self.custom_traits_by_name.insert(ident, trt);
-                }
-            Item::Macro(mac)
-                if self.analyze_types => {
-                    if let Some(i) = &mac.ident {
-                        let macro_rules_attr = mac.attrs.iter().find(|a| {
-                            a.path()
-                                == &syn::parse_str::<syn::Path>("diplomat::macro_rules").unwrap()
-                        });
+            Item::Trait(trt) if self.analyze_types => {
+                let ident = (&trt.ident).into();
+                let trt = Trait::new(trt, &self.type_parent_attrs);
+                self.custom_traits_by_name.insert(ident, trt);
+            }
+            Item::Macro(mac) if self.analyze_types => {
+                if let Some(i) = &mac.ident {
+                    let macro_rules_attr = mac.attrs.iter().find(|a| {
+                        a.path() == &syn::parse_str::<syn::Path>("diplomat::macro_rules").unwrap()
+                    });
 
-                        if macro_rules_attr.is_some() {
-                            self.mod_macros.add_item_macro(mac);
-                        } else {
-                            println!(
-                                r#"WARNING: Found macro_rules definition "macro_rules! {i}" with no #[diplomat::macro_rules] attribute. This will not be evaluated in Diplomat bindings."#
-                            );
-                        }
+                    if macro_rules_attr.is_some() {
+                        self.mod_macros.add_item_macro(mac);
                     } else {
-                        let items = self.mod_macros.evaluate_item_macro(mac);
-                        for i in items {
-                            self.add(&i);
-                        }
+                        println!(
+                            r#"WARNING: Found macro_rules definition "macro_rules! {i}" with no #[diplomat::macro_rules] attribute. This will not be evaluated in Diplomat bindings."#
+                        );
+                    }
+                } else {
+                    let items = self.mod_macros.evaluate_item_macro(mac);
+                    for i in items {
+                        self.add(&i);
                     }
                 }
-            Item::Fn(f)
-                if self.analyze_types => {
-                    let is_public = matches!(f.vis, Visibility::Public(_));
-                    let has_diplomat_attrs = f
-                        .attrs
-                        .iter()
-                        .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
-                    assert!(
-                        is_public || !has_diplomat_attrs,
-                        "Non-public function with diplomat attrs found: {}",
-                        f.sig.ident
-                    );
-                    if is_public {
-                        let parent_attrs = self
-                            .impl_parent_attrs
-                            .attrs_for_inheritance(AttrInheritContext::MethodFromImpl);
-                        let out = Function::from_syn(f, &parent_attrs);
-                        self.functions_by_name.insert(out.name.clone(), out);
-                    }
+            }
+            Item::Fn(f) if self.analyze_types => {
+                let is_public = matches!(f.vis, Visibility::Public(_));
+                let has_diplomat_attrs = f
+                    .attrs
+                    .iter()
+                    .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
+                assert!(
+                    is_public || !has_diplomat_attrs,
+                    "Non-public function with diplomat attrs found: {}",
+                    f.sig.ident
+                );
+                if is_public {
+                    let parent_attrs = self
+                        .impl_parent_attrs
+                        .attrs_for_inheritance(AttrInheritContext::MethodFromImpl);
+                    let out = Function::from_syn(f, &parent_attrs);
+                    self.functions_by_name.insert(out.name.clone(), out);
                 }
+            }
             _ => {}
         }
     }

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -68,10 +68,9 @@ pub struct KotlinConfig {
 impl KotlinConfig {
     pub fn set(&mut self, key: &str, value: toml::Value) {
         match key {
-            "domain"
-                if value.is_str() => {
-                    self.domain = value.as_str().map(|s| s.to_string());
-                }
+            "domain" if value.is_str() => {
+                self.domain = value.as_str().map(|s| s.to_string());
+            }
             "use_finalizers_not_cleaners" => {
                 self.use_finalizers_not_cleaners = value.as_str().map(|val| val == "true");
             }

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -68,11 +68,10 @@ pub struct KotlinConfig {
 impl KotlinConfig {
     pub fn set(&mut self, key: &str, value: toml::Value) {
         match key {
-            "domain" => {
-                if value.is_str() {
+            "domain"
+                if value.is_str() => {
                     self.domain = value.as_str().map(|s| s.to_string());
                 }
-            }
             "use_finalizers_not_cleaners" => {
                 self.use_finalizers_not_cleaners = value.as_str().map(|val| val == "true");
             }


### PR DESCRIPTION
Updates the new lints to match Clippy 0.1.95 (and fix CI). This just updates the `match` guards.