### PR TITLE
Fix C++ codegen using wrong view type for Slice::Strs with UTF-16 encoding

### DIFF
--- a/feature_tests/c/include/MyString.h
+++ b/feature_tests/c/include/MyString.h
@@ -21,6 +21,8 @@ MyString* MyString_new_unsafe(DiplomatStringView v);
 
 MyString* MyString_new_from_first(DiplomatStringsView v);
 
+MyString* MyString_new_from_utf16(DiplomatStrings16View v);
+
 void MyString_set_str(MyString* self, DiplomatStringView new_str);
 
 void MyString_get_str(const MyString* self, DiplomatWrite* write);

--- a/feature_tests/cpp/include/MyString.d.hpp
+++ b/feature_tests/cpp/include/MyString.d.hpp
@@ -33,6 +33,8 @@ public:
 
   inline static std::unique_ptr<somelib::MyString> new_from_first(somelib::diplomat::span<const diplomat::string_view_for_slice> v);
 
+  inline static std::unique_ptr<somelib::MyString> new_from_utf16(somelib::diplomat::span<const diplomat::u16string_view_for_slice> v);
+
   inline void set_str(std::string_view new_str);
 
   inline std::string get_str() const;

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -24,6 +24,8 @@ namespace capi {
 
     somelib::capi::MyString* MyString_new_from_first(somelib::diplomat::capi::DiplomatStringsView v);
 
+    somelib::capi::MyString* MyString_new_from_utf16(somelib::diplomat::capi::DiplomatStrings16View v);
+
     void MyString_set_str(somelib::capi::MyString* self, somelib::diplomat::capi::DiplomatStringView new_str);
 
     void MyString_get_str(const somelib::capi::MyString* self, somelib::diplomat::capi::DiplomatWrite* write);
@@ -55,6 +57,11 @@ inline somelib::diplomat::result<std::unique_ptr<somelib::MyString>, somelib::di
 
 inline std::unique_ptr<somelib::MyString> somelib::MyString::new_from_first(somelib::diplomat::span<const diplomat::string_view_for_slice> v) {
     auto result = somelib::capi::MyString_new_from_first({reinterpret_cast<const somelib::diplomat::capi::DiplomatStringView*>(v.data()), v.size()});
+    return std::unique_ptr<somelib::MyString>(somelib::MyString::FromFFI(result));
+}
+
+inline std::unique_ptr<somelib::MyString> somelib::MyString::new_from_utf16(somelib::diplomat::span<const diplomat::u16string_view_for_slice> v) {
+    auto result = somelib::capi::MyString_new_from_utf16({reinterpret_cast<const somelib::diplomat::capi::DiplomatString16View*>(v.data()), v.size()});
     return std::unique_ptr<somelib::MyString>(somelib::MyString::FromFFI(result));
 }
 

--- a/feature_tests/dart/lib/src/MyString.g.dart
+++ b/feature_tests/dart/lib/src/MyString.g.dart
@@ -46,6 +46,12 @@ final class MyString implements ffi.Finalizable {
     return MyString._fromFfi(result, []);
   }
 
+  static MyString newFromUtf16(core.List<core.String> v) {
+    final temp = _FinalizedArena();
+    final result = _MyString_new_from_utf16(v._utf16SliceAllocIn(temp.arena));
+    return MyString._fromFfi(result, []);
+  }
+
   set str(String newStr) {
     final temp = _FinalizedArena();
     _MyString_set_str(_ffi, newStr._utf8AllocIn(temp.arena));
@@ -102,6 +108,11 @@ external ffi.Pointer<ffi.Opaque> _MyString_new_owned(_SliceUtf8 v);
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceSliceUtf8)>(isLeaf: true, symbol: 'MyString_new_from_first')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _MyString_new_from_first(_SliceSliceUtf8 v);
+
+@_DiplomatFfiUse('MyString_new_from_utf16')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceSliceUtf16)>(isLeaf: true, symbol: 'MyString_new_from_utf16')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _MyString_new_from_utf16(_SliceSliceUtf16 v);
 
 @_DiplomatFfiUse('MyString_set_str')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'MyString_set_str')

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -904,6 +904,56 @@ extension on core.List<int> {
   }
 }
 
+final class _SliceSliceUtf16 extends ffi.Struct {
+  external ffi.Pointer<_SliceUtf16> _data;
+
+  @ffi.Size()
+  external int _length;
+
+  // This is expensive
+  @override
+  bool operator ==(Object other) {
+    if (other is! _SliceSliceUtf16 || other._length != _length) {
+      return false;
+    }
+
+    for (var i = 0; i < _length; i++) {
+      if (other._data[i] != _data[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // This is cheap
+  @override
+  int get hashCode => _length.hashCode;
+
+  // ignore: unused_element
+  core.List<core.String> _toDart(core.List<Object> lifetimeEdges, {bool isStatic = false}) {
+    final r = core.Iterable.generate(_length, (i) => _data[i]._toDart(lifetimeEdges)).toList(growable: false);
+    if (lifetimeEdges.isEmpty && !isStatic) {
+      // unsupported
+    } else {
+      // Lifetime edges will be cleaned up
+    }
+    return r;
+  }
+}
+
+extension on core.List<core.String> {
+  // ignore: unused_element
+  _SliceSliceUtf16 _utf16SliceAllocIn(ffi.Allocator alloc) {
+    final slice = ffi.Struct.create<_SliceSliceUtf16>();
+    slice._data = alloc(length);
+    for (var i = 0; i < length; i++) {
+      slice._data[i] = this[i]._utf16AllocIn(alloc);
+    }
+    slice._length = length;
+    return slice;
+  }
+}
+
 final class _SliceSliceUtf8 extends ffi.Struct {
   external ffi.Pointer<_SliceUtf8> _data;
 

--- a/feature_tests/js/api/MyString.d.ts
+++ b/feature_tests/js/api/MyString.d.ts
@@ -14,6 +14,8 @@ export class MyString {
 
     static newFromFirst(v: Array<string>): MyString;
 
+    static newFromUtf16(v: Array<string>): MyString;
+
     set str(newStr: string);
 
     get str(): string;

--- a/feature_tests/js/api/MyString.mjs
+++ b/feature_tests/js/api/MyString.mjs
@@ -107,6 +107,24 @@ export class MyString {
         }
     }
 
+    static newFromUtf16(v) {
+        let functionCleanupArena = new diplomatRuntime.CleanupArena();
+
+        const vSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.strs(wasm, v, "string16")));
+
+        const result = wasm.MyString_new_from_utf16(vSlice.ptr);
+
+        try {
+            return new MyString(diplomatRuntime.internalConstructor, result, []);
+        }
+
+        finally {
+            diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
+            functionCleanupArena.free();
+
+        }
+    }
+
     set str(newStr) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 

--- a/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
+++ b/feature_tests/kotlin/somelib/src/main/kotlin/dev/diplomattest/somelib/MyString.kt
@@ -11,6 +11,7 @@ internal interface MyStringLib: Library {
     fun MyString_new_unsafe(v: Slice): Pointer
     fun MyString_new_owned(v: Slice): Pointer
     fun MyString_new_from_first(v: Slice): Pointer
+    fun MyString_new_from_utf16(v: Slice): Pointer
     fun MyString_set_str(handle: Pointer, newStr: Slice): Unit
     fun MyString_get_str(handle: Pointer, write: Pointer): Unit
     fun MyString_get_static_str(): Slice
@@ -91,6 +92,21 @@ class MyString internal constructor (
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8s(v)
             
             val returnVal = lib.MyString_new_from_first(vSliceMemory.slice);
+            try {
+                val selfEdges: List<Any> = listOf()
+                val handle = returnVal 
+                val returnOpaque = MyString(handle, selfEdges, true)
+                return returnOpaque
+            } finally {
+                vSliceMemory.close()
+            }
+        }
+        @JvmStatic
+        
+        fun newFromUtf16(v: Array<String>): MyString {
+            val vSliceMemory = PrimitiveArrayTools.borrowUtf16s(v)
+            
+            val returnVal = lib.MyString_new_from_utf16(vSliceMemory.slice);
             try {
                 val selfEdges: List<Any> = listOf()
                 val handle = returnVal 

--- a/feature_tests/nanobind/src/include/MyString.d.hpp
+++ b/feature_tests/nanobind/src/include/MyString.d.hpp
@@ -33,6 +33,8 @@ public:
 
   inline static std::unique_ptr<somelib::MyString> new_from_first(somelib::diplomat::span<const diplomat::string_view_for_slice> v);
 
+  inline static std::unique_ptr<somelib::MyString> new_from_utf16(somelib::diplomat::span<const diplomat::u16string_view_for_slice> v);
+
   inline void set_str(std::string_view new_str);
 
   inline std::string get_str() const;

--- a/feature_tests/nanobind/src/include/MyString.hpp
+++ b/feature_tests/nanobind/src/include/MyString.hpp
@@ -24,6 +24,8 @@ namespace capi {
 
     somelib::capi::MyString* MyString_new_from_first(somelib::diplomat::capi::DiplomatStringsView v);
 
+    somelib::capi::MyString* MyString_new_from_utf16(somelib::diplomat::capi::DiplomatStrings16View v);
+
     void MyString_set_str(somelib::capi::MyString* self, somelib::diplomat::capi::DiplomatStringView new_str);
 
     void MyString_get_str(const somelib::capi::MyString* self, somelib::diplomat::capi::DiplomatWrite* write);
@@ -55,6 +57,11 @@ inline somelib::diplomat::result<std::unique_ptr<somelib::MyString>, somelib::di
 
 inline std::unique_ptr<somelib::MyString> somelib::MyString::new_from_first(somelib::diplomat::span<const diplomat::string_view_for_slice> v) {
     auto result = somelib::capi::MyString_new_from_first({reinterpret_cast<const somelib::diplomat::capi::DiplomatStringView*>(v.data()), v.size()});
+    return std::unique_ptr<somelib::MyString>(somelib::MyString::FromFFI(result));
+}
+
+inline std::unique_ptr<somelib::MyString> somelib::MyString::new_from_utf16(somelib::diplomat::span<const diplomat::u16string_view_for_slice> v) {
+    auto result = somelib::capi::MyString_new_from_utf16({reinterpret_cast<const somelib::diplomat::capi::DiplomatString16View*>(v.data()), v.size()});
     return std::unique_ptr<somelib::MyString>(somelib::MyString::FromFFI(result));
 }
 

--- a/feature_tests/nanobind/src/sub_modules/somelib/MyString_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/MyString_binding.cpp
@@ -16,6 +16,7 @@ void add_MyString_binding(nb::module_ mod) {
         .def("borrow", &somelib::MyString::borrow)
         .def_static("get_static_str", &somelib::MyString::get_static_str)
         .def_static("new_from_first", std::move(maybe_op_unwrap(&somelib::MyString::new_from_first)), "v"_a)
+        .def_static("new_from_utf16", std::move(maybe_op_unwrap(&somelib::MyString::new_from_utf16)), "v"_a)
         .def_static("new_unsafe", std::move(maybe_op_unwrap(&somelib::MyString::new_unsafe)), "v"_a)
         .def_prop_rw("str", &somelib::MyString::get_str, &somelib::MyString::set_str)
         .def_static("string_transform", &somelib::MyString::string_transform, "foo"_a);

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -1,6 +1,6 @@
 #[diplomat::bridge]
 pub mod ffi {
-    use diplomat_runtime::{DiplomatStr, DiplomatStrSlice, DiplomatWrite};
+    use diplomat_runtime::{DiplomatStr, DiplomatStr16Slice, DiplomatStrSlice, DiplomatWrite};
     use std::fmt::Write as _;
 
     #[diplomat::opaque_mut]
@@ -24,6 +24,11 @@ pub mod ffi {
 
         pub fn new_from_first(v: &[DiplomatStrSlice]) -> Box<MyString> {
             Box::new(Self(core::str::from_utf8(v[0].into()).unwrap().into()))
+        }
+
+        pub fn new_from_utf16(v: &[DiplomatStr16Slice]) -> Box<MyString> {
+            let first: &[u16] = v[0].into();
+            Box::new(Self(String::from_utf16(first).unwrap()))
         }
 
         #[diplomat::attr(auto, setter = "str")]

--- a/tool/src/cpp/gen.rs
+++ b/tool/src/cpp/gen.rs
@@ -1021,19 +1021,22 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
                 )
                 .into()
             }
-            Type::Slice(Slice::Struct(b, ref st)) => format!(
-                "{{reinterpret_cast<{}{}*>({cpp_name}.data()), {cpp_name}.size()}}",
-                if b.mutability().is_mutable() {
+            Type::Slice(Slice::Struct(b, ref st)) => {
+                let mutability = if b.mutability().is_mutable() {
                     ""
                 } else {
                     "const "
-                },
-                self.formatter.namespace_c_name(
+                };
+                let c_name = self.formatter.namespace_c_name(
                     st.id().into(),
-                    &self.formatter.fmt_type_name_unnamespaced(st.id())
+                    &self.formatter.fmt_type_name_unnamespaced(st.id()),
+                );
+                format!(
+                    "{{reinterpret_cast<{mutability}{c_name}*>({cpp_name}.data()), {cpp_name}.size()}}",
+
                 )
-            )
-            .into(),
+                .into()
+            }
             Type::Slice(..) => format!("{{{cpp_name}.data(), {cpp_name}.size()}}").into(),
             Type::DiplomatOption(ref inner) => {
                 let conversion = self.gen_cpp_to_c_for_type(

--- a/tool/src/cpp/gen.rs
+++ b/tool/src/cpp/gen.rs
@@ -990,37 +990,58 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
                 let attrs = match self.c.tcx.resolve_type(s.id()) {
                     TypeDef::OutStruct(s) => &s.attrs,
                     TypeDef::Struct(s) => &s.attrs,
-                    _ => unreachable!()
+                    _ => unreachable!(),
                 };
 
                 if attrs.abi_compatible {
                     if let MaybeOwn::Borrow(borrow) = s.owner() {
-                        let c_name = self.formatter.namespace_c_name(s.id().into(), &self.formatter.fmt_type_name_unnamespaced(s.id()));
+                        let c_name = self.formatter.namespace_c_name(
+                            s.id().into(),
+                            &self.formatter.fmt_type_name_unnamespaced(s.id()),
+                        );
                         return match borrow.mutability {
                             Mutability::Immutable => {
                                 format!("reinterpret_cast<const {c_name}*>(&{cpp_name})")
-                            },
+                            }
                             Mutability::Mutable => {
                                 format!("reinterpret_cast<{c_name}*>(&{cpp_name})")
                             }
-                        }.into();
+                        }
+                        .into();
                     }
                 }
                 format!("{cpp_name}.AsFFI()").into()
-            },
+            }
             Type::Enum(..) => format!("{cpp_name}.AsFFI()").into(),
-            Type::Slice(Slice::Strs(..)) => format!(
+            Type::Slice(Slice::Strs(encoding)) => {
                 // This cast is valid as diplomat::string_view_for_slice is used to ensure correct layout
-                "{{reinterpret_cast<const {lib_name_ns_prefix}diplomat::capi::DiplomatStringView*>({cpp_name}.data()), {cpp_name}.size()}}"
-            ).into(),
-            Type::Slice(Slice::Struct(b, ref st)) => format!("{{reinterpret_cast<{}{}*>({cpp_name}.data()), {cpp_name}.size()}}",
-                if b.mutability().is_mutable() { "" } else { "const " },
-                self.formatter.namespace_c_name(st.id().into(), &self.formatter.fmt_type_name_unnamespaced(st.id()))
-            ).into(),
+                let str_view = self.c.formatter.fmt_str_view_name(encoding);
+                format!(
+                    "{{reinterpret_cast<const {str_view}*>({cpp_name}.data()), {cpp_name}.size()}}"
+                )
+                .into()
+            }
+            Type::Slice(Slice::Struct(b, ref st)) => format!(
+                "{{reinterpret_cast<{}{}*>({cpp_name}.data()), {cpp_name}.size()}}",
+                if b.mutability().is_mutable() {
+                    ""
+                } else {
+                    "const "
+                },
+                self.formatter.namespace_c_name(
+                    st.id().into(),
+                    &self.formatter.fmt_type_name_unnamespaced(st.id())
+                )
+            )
+            .into(),
             Type::Slice(..) => format!("{{{cpp_name}.data(), {cpp_name}.size()}}").into(),
             Type::DiplomatOption(ref inner) => {
-                let conversion =
-                    self.gen_cpp_to_c_for_type(inner, format!("{cpp_name}.value()").into(), method_abi_name, namespace);
+                let conversion = self.gen_cpp_to_c_for_type(
+                    inner,
+                    format!("{cpp_name}.value()").into(),
+                    method_abi_name,
+                    namespace,
+                );
                 let copt = self.c.gen_ty_name(ty, &mut Default::default());
                 format!("{cpp_name}.has_value() ? ({copt}{{ {{ {conversion} }}, true }}) : ({copt}{{ {{}}, false }})").into()
             }
@@ -1038,10 +1059,18 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
                             None => "std::monostate".into(),
                         };
 
-                        let return_type = self.formatter.fmt_c_api_callback_ret(namespace, method_abi_name.unwrap(), &cpp_name);
+                        let return_type = self.formatter.fmt_c_api_callback_ret(
+                            namespace,
+                            method_abi_name.unwrap(),
+                            &cpp_name,
+                        );
 
-                        self.formatter.fmt_run_callback_converter(&cpp_name, "c_run_callback_result", vec![&ok_type_name, &err_type_name, &return_type])
-                    },
+                        self.formatter.fmt_run_callback_converter(
+                            &cpp_name,
+                            "c_run_callback_result",
+                            vec![&ok_type_name, &err_type_name, &return_type],
+                        )
+                    }
                     ReturnType::Nullable(ref success) => {
                         let type_name = match success {
                             hir::SuccessType::Unit => "std::monostate".into(),
@@ -1049,15 +1078,32 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
                             _ => unreachable!("unknown AST/HIR variant"),
                         };
 
-                        let return_type = self.formatter.fmt_c_api_callback_ret(namespace, method_abi_name.unwrap(), &cpp_name);
-                        self.formatter.fmt_run_callback_converter(&cpp_name, "c_run_callback_diplomat_option", vec![&type_name, &return_type])
+                        let return_type = self.formatter.fmt_c_api_callback_ret(
+                            namespace,
+                            method_abi_name.unwrap(),
+                            &cpp_name,
+                        );
+                        self.formatter.fmt_run_callback_converter(
+                            &cpp_name,
+                            "c_run_callback_diplomat_option",
+                            vec![&type_name, &return_type],
+                        )
                     }
                     ReturnType::Infallible(SuccessType::OutType(Type::Opaque(o))) => {
-                        let opaque_type = self.c.formatter.fmt_type_name_maybe_namespaced(o.tcx_id.into());
+                        let opaque_type = self
+                            .c
+                            .formatter
+                            .fmt_type_name_maybe_namespaced(o.tcx_id.into());
                         let ptr_ty = self.c.formatter.fmt_ptr(&opaque_type, o.owner.mutability);
-                        self.formatter.fmt_run_callback_converter(&cpp_name, "c_run_callback_diplomat_opaque", vec![&ptr_ty])
-                    },
-                    _ => format!("{lib_name_ns_prefix}diplomat::fn_traits({cpp_name}).c_run_callback")
+                        self.formatter.fmt_run_callback_converter(
+                            &cpp_name,
+                            "c_run_callback_diplomat_opaque",
+                            vec![&ptr_ty],
+                        )
+                    }
+                    _ => format!(
+                        "{lib_name_ns_prefix}diplomat::fn_traits({cpp_name}).c_run_callback"
+                    ),
                 };
                 format!("{{new decltype({cpp_name})(std::move({cpp_name})), {run_callback}, {lib_name_ns_prefix}diplomat::fn_traits({cpp_name}).c_delete}}",).into()
             }


### PR DESCRIPTION
The C++ code generator hardcodes `DiplomatStringView` for all `Slice::Strs` types regardless of encoding. For UTF-16 string slices (`&[DiplomatStr16Slice]`), this produced incorrect `reinterpret_cast` to `DiplomatStringView*` instead of `DiplomatString16View*`.

Fix by destructuring the encoding from `Slice::Strs(encoding)` and using `fmt_str_view_name(encoding)` to select the correct view type.

Adds a `new_from_utf16` test method to the `MyString` feature test to exercise this code path.

---

Found when generating codegen for icu4x

https://github.com/unicode-org/icu4x/blob/3b55a3ee7e2b879a83065ceb7d1540e44688b548/ffi/capi/src/list.rs#L173

```rust
        #[diplomat::rust_link(icu::list::ListFormatter::format, FnInStruct)]
        #[diplomat::rust_link(icu::list::ListFormatter::format_to_string, FnInStruct, hidden)]
        #[diplomat::rust_link(icu::list::FormattedList, Struct, hidden)]
        #[diplomat::attr(not(supports = utf8_strings), rename = "format")]
        #[diplomat::attr(supports = utf8_strings, rename = "format16")]
        pub fn format_utf16(&self, list: &[DiplomatStr16Slice], write: &mut DiplomatWrite) {
            let _infallible = self
                .0
                .format(
                    list.iter()
                        .map(|a| potential_utf::PotentialUtf16::from_slice(a))
                        .map(writeable::adapters::LossyWrap),
                )
                .write_to(write);
        }
```