### PR TITLE
Partial comparison support

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -269,8 +269,10 @@ pub enum SpecialMethod {
     Setter(Option<String>),
     /// A stringifier. Must have no parameters and return a string (DiplomatWrite)
     Stringifier,
-    /// A comparison operator. Currently not universally supported
-    Comparison,
+    /// A comparison operator. Currently not universally supported.
+    ///
+    /// bool is true if the comparison is partial (i.e., [`Option<std::cmp::Ordering>`]).
+    Comparison(bool),
     /// An iterator (a type that is mutated to produce new values)
     Iterator,
     /// An iterable (a type that can produce an iterator)
@@ -307,7 +309,7 @@ impl SpecialMethod {
             "getter" => Ok(Some(Self::Getter(parse_meta(meta)?))),
             "setter" => Ok(Some(Self::Setter(parse_meta(meta)?))),
             "stringifier" => Ok(Some(Self::Stringifier)),
-            "comparison" => Ok(Some(Self::Comparison)),
+            "comparison" => Ok(Some(Self::Comparison(false))),
             "iterator" => Ok(Some(Self::Iterator)),
             "iterable" => Ok(Some(Self::Iterable)),
             "indexer" => Ok(Some(Self::Indexer)),
@@ -838,7 +840,7 @@ impl Attrs {
                             ));
                         }
                     }
-                    SpecialMethod::Comparison => {
+                    SpecialMethod::Comparison(_) => {
                         check_param_count("Comparator", 1, errors);
                         if special_method_presence.comparator {
                             errors.push(LoweringError::Other(
@@ -1277,6 +1279,8 @@ pub struct BackendAttrSupport {
     pub stringifiers: bool,
     /// Marking a method as the `compare_to` method, which is special in this language.
     pub comparators: bool,
+    /// Supports comparators that return `Option`
+    pub partial_comparators: bool,
     /// Marking a method as the `next` method, which is special in this language.
     pub iterators: bool,
     /// Marking a method as the `iterator` method, which is special in this language.
@@ -1340,6 +1344,7 @@ impl BackendAttrSupport {
             accessors: true,
             stringifiers: true,
             comparators: true,
+            partial_comparators: true,
             iterators: true,
             iterables: true,
             indexing: true,
@@ -1378,6 +1383,7 @@ impl BackendAttrSupport {
             "accessors" => Some(self.accessors),
             "stringifiers" => Some(self.stringifiers),
             "comparators" => Some(self.comparators),
+            "partial_comparators" => Some(self.partial_comparators),
             "iterators" => Some(self.iterators),
             "iterables" => Some(self.iterables),
             "indexing" => Some(self.indexing),
@@ -1526,6 +1532,7 @@ impl AttributeValidator for BasicAttributeValidator {
                 static_accessors,
                 stringifiers,
                 comparators,
+                partial_comparators,
                 iterators,
                 iterables,
                 indexing,
@@ -1563,6 +1570,7 @@ impl AttributeValidator for BasicAttributeValidator {
                 "static_accessors" => static_accessors,
                 "stringifiers" => stringifiers,
                 "comparators" => comparators,
+                "partial_comparators" => partial_comparators,
                 "iterators" => iterators,
                 "iterables" => iterables,
                 "indexing" => indexing,

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -713,7 +713,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let abi_name = self.lower_ident(&method.abi_name, "method abi name")?;
 
-        let hir_method = Method {
+        let mut hir_method = Method {
             docs: Docs::from_ast(&method.docs, self.attr_validator.as_ref(), &mut self.errors),
             name: name?,
             abi_name,
@@ -734,13 +734,30 @@ impl<'ast> LoweringContext<'ast> {
 
         let is_comparison = matches!(
             hir_method.attrs.special_method,
-            Some(SpecialMethod::Comparison)
+            Some(SpecialMethod::Comparison(_))
         );
-        if is_comparison && method.return_type != Some(ast::TypeName::Ordering) {
-            self.errors.push(LoweringError::Other(
-                "Found comparison method that does not return cmp::Ordering".into(),
-            ));
-            return Err(());
+
+        if is_comparison {
+            let is_optional_ord = if let Some(ast::TypeName::Option(t, _)) = &method.return_type {
+                if matches!(**t, ast::TypeName::Ordering) {
+                    if !self.attr_validator.attrs_supported().partial_comparators {
+                        self.errors.push(LoweringError::Other("Comparators that return `Option` are not supported by this backend (Filter with #[diplomat::cfg(supports=partial_comparators)]).".into()));
+                    }
+                    hir_method.attrs.special_method = Some(SpecialMethod::Comparison(true));
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
+            if !(method.return_type == Some(ast::TypeName::Ordering) || is_optional_ord) {
+                self.errors.push(LoweringError::Other(
+                    "Found comparison method that does not return cmp::Ordering or Optional<cmp::Ordering>".into(),
+                ));
+                return Err(());
+            }
         }
 
         Ok(hir_method)

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__comparator.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__comparator.snap
@@ -13,7 +13,7 @@ Lowering error in Opaque::comparator_none: Cannot define two comparators on the 
 Lowering error in Opaque::comparator_othertype: Cannot define two comparators on the same type
 Lowering error in Opaque::comparator_othertype: Comparators must accept a self parameter
 Lowering error in Opaque::comparator_badreturn: Cannot define two comparators on the same type
-Lowering error in Opaque::comparator_badreturn: Found comparison method that does not return cmp::Ordering
+Lowering error in Opaque::comparator_badreturn: Found comparison method that does not return cmp::Ordering or Optional<cmp::Ordering>
 Lowering error in Opaque::comparison_correct: Cannot define two comparators on the same type
 Lowering error in Opaque::ordering_wrong: Found cmp::Ordering in parameter or struct field, it is only allowed in return types
 Lowering error in Opaque::comparison_mut: Cannot define two comparators on the same type

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__partial_comparison_unsupported.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__partial_comparison_unsupported.snap
@@ -1,0 +1,5 @@
+---
+source: core/src/hir/type_context.rs
+expression: output
+---
+Lowering error in PartialComparable::cmp: Comparators that return `Option` are not supported by this backend (Filter with #[diplomat::cfg(supports=partial_comparators)]).

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1435,4 +1435,22 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_partial_comparison_unsupported() {
+        uitest_lowering! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct PartialComparable;
+
+                impl PartialComparable {
+                    #[diplomat::attr(auto, comparison)]
+                    pub fn cmp(&self, other : &PartialComparable) -> Option<core::cmp::Ordering> {
+                        todo!()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/feature_tests/cpp/include/ns/RenamedComparable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedComparable.d.hpp
@@ -32,6 +32,7 @@ public:
   inline static std::unique_ptr<somelib::ns::RenamedComparable> new_(uint8_t int_);
 
   inline int8_t cmp(const somelib::ns::RenamedComparable& other) const;
+
   inline bool operator==(const somelib::ns::RenamedComparable& other) const;
   inline bool operator!=(const somelib::ns::RenamedComparable& other) const;
   inline bool operator<=(const somelib::ns::RenamedComparable& other) const;

--- a/feature_tests/cpp/include/ns/RenamedComparable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedComparable.hpp
@@ -39,27 +39,33 @@ inline int8_t somelib::ns::RenamedComparable::cmp(const somelib::ns::RenamedComp
     return result;
 }
 inline bool somelib::ns::RenamedComparable::operator==(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) == 0;
+    auto val = this->cmp(other);
+    return val == 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator!=(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) != 0;
+    auto val = this->cmp(other);
+    return val != 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator<=(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) <= 0;
+    auto val = this->cmp(other);
+    return val <= 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator>=(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) >= 0;
+    auto val = this->cmp(other);
+    return val >= 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator<(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) < 0;
+    auto val = this->cmp(other);
+    return val < 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator>(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) > 0;
+    auto val = this->cmp(other);
+    return val > 0;
 }
 
 inline const somelib::ns::capi::RenamedComparable* somelib::ns::RenamedComparable::AsFFI() const {

--- a/feature_tests/cpp/include/ns/RenamedPartialComparable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedPartialComparable.d.hpp
@@ -1,0 +1,60 @@
+#ifndef SOMELIB_ns_RenamedPartialComparable_D_HPP
+#define SOMELIB_ns_RenamedPartialComparable_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+namespace somelib {
+namespace ns {
+namespace capi { struct RenamedPartialComparable; }
+class RenamedPartialComparable;
+} // namespace ns
+} // namespace somelib
+
+
+
+namespace somelib::ns {
+namespace capi {
+    struct RenamedPartialComparable;
+} // namespace capi
+} // namespace
+
+namespace somelib::ns {
+class RenamedPartialComparable {
+public:
+
+  inline static std::unique_ptr<somelib::ns::RenamedPartialComparable> new_(float float_);
+
+  inline std::optional<int8_t> partial_cmp(const somelib::ns::RenamedPartialComparable& other) const;
+
+  inline std::optional<bool> operator==(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator!=(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator<=(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator>=(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator<(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator>(const somelib::ns::RenamedPartialComparable& other) const;
+
+  inline std::optional<int8_t> test_nonstd(const somelib::ns::RenamedPartialComparable& other) const;
+
+    inline const somelib::ns::capi::RenamedPartialComparable* AsFFI() const;
+    inline somelib::ns::capi::RenamedPartialComparable* AsFFI();
+    inline static const somelib::ns::RenamedPartialComparable* FromFFI(const somelib::ns::capi::RenamedPartialComparable* ptr);
+    inline static somelib::ns::RenamedPartialComparable* FromFFI(somelib::ns::capi::RenamedPartialComparable* ptr);
+    inline static void operator delete(void* ptr);
+private:
+    RenamedPartialComparable() = delete;
+    RenamedPartialComparable(const somelib::ns::RenamedPartialComparable&) = delete;
+    RenamedPartialComparable(somelib::ns::RenamedPartialComparable&&) noexcept = delete;
+    RenamedPartialComparable operator=(const somelib::ns::RenamedPartialComparable&) = delete;
+    RenamedPartialComparable operator=(somelib::ns::RenamedPartialComparable&&) noexcept = delete;
+    static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // SOMELIB_ns_RenamedPartialComparable_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedPartialComparable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedPartialComparable.hpp
@@ -1,0 +1,102 @@
+#ifndef SOMELIB_ns_RenamedPartialComparable_HPP
+#define SOMELIB_ns_RenamedPartialComparable_HPP
+
+#include "RenamedPartialComparable.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace somelib::ns {
+namespace capi {
+    extern "C" {
+
+    somelib::ns::capi::RenamedPartialComparable* namespace_PartialComparable_new(float float_);
+
+    typedef struct namespace_PartialComparable_partial_cmp_result {union {int8_t ok; }; bool is_ok;} namespace_PartialComparable_partial_cmp_result;
+    namespace_PartialComparable_partial_cmp_result namespace_PartialComparable_partial_cmp(const somelib::ns::capi::RenamedPartialComparable* self, const somelib::ns::capi::RenamedPartialComparable* other);
+
+    typedef struct namespace_PartialComparable_test_nonstd_result {union {int8_t ok; }; bool is_ok;} namespace_PartialComparable_test_nonstd_result;
+    namespace_PartialComparable_test_nonstd_result namespace_PartialComparable_test_nonstd(const somelib::ns::capi::RenamedPartialComparable* self, const somelib::ns::capi::RenamedPartialComparable* other);
+
+    void namespace_PartialComparable_destroy(RenamedPartialComparable* self);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<somelib::ns::RenamedPartialComparable> somelib::ns::RenamedPartialComparable::new_(float float_) {
+    auto result = somelib::ns::capi::namespace_PartialComparable_new(float_);
+    return std::unique_ptr<somelib::ns::RenamedPartialComparable>(somelib::ns::RenamedPartialComparable::FromFFI(result));
+}
+
+inline std::optional<int8_t> somelib::ns::RenamedPartialComparable::partial_cmp(const somelib::ns::RenamedPartialComparable& other) const {
+    auto result = somelib::ns::capi::namespace_PartialComparable_partial_cmp(this->AsFFI(),
+        other.AsFFI());
+    return result.is_ok ? std::optional<int8_t>(result.ok) : std::nullopt;
+}
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator==(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() == 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator!=(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() != 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator<=(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() <= 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator>=(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() >= 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator<(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() < 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator>(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() > 0;
+}
+
+inline std::optional<int8_t> somelib::ns::RenamedPartialComparable::test_nonstd(const somelib::ns::RenamedPartialComparable& other) const {
+    auto result = somelib::ns::capi::namespace_PartialComparable_test_nonstd(this->AsFFI(),
+        other.AsFFI());
+    return result.is_ok ? std::optional<int8_t>(result.ok) : std::nullopt;
+}
+
+inline const somelib::ns::capi::RenamedPartialComparable* somelib::ns::RenamedPartialComparable::AsFFI() const {
+    return reinterpret_cast<const somelib::ns::capi::RenamedPartialComparable*>(this);
+}
+
+inline somelib::ns::capi::RenamedPartialComparable* somelib::ns::RenamedPartialComparable::AsFFI() {
+    return reinterpret_cast<somelib::ns::capi::RenamedPartialComparable*>(this);
+}
+
+inline const somelib::ns::RenamedPartialComparable* somelib::ns::RenamedPartialComparable::FromFFI(const somelib::ns::capi::RenamedPartialComparable* ptr) {
+    return reinterpret_cast<const somelib::ns::RenamedPartialComparable*>(ptr);
+}
+
+inline somelib::ns::RenamedPartialComparable* somelib::ns::RenamedPartialComparable::FromFFI(somelib::ns::capi::RenamedPartialComparable* ptr) {
+    return reinterpret_cast<somelib::ns::RenamedPartialComparable*>(ptr);
+}
+
+inline void somelib::ns::RenamedPartialComparable::operator delete(void* ptr) {
+    somelib::ns::capi::namespace_PartialComparable_destroy(reinterpret_cast<somelib::ns::capi::RenamedPartialComparable*>(ptr));
+}
+
+
+#endif // SOMELIB_ns_RenamedPartialComparable_HPP

--- a/feature_tests/cpp/tests/attrs.cpp
+++ b/feature_tests/cpp/tests/attrs.cpp
@@ -136,7 +136,7 @@ int main(int argc, char* argv[]) {
     auto partial_cmp_b = ns::RenamedPartialComparable::new_(100.0f);
     auto partial_cmp_c = ns::RenamedPartialComparable::new_(std::numeric_limits<float>::quiet_NaN());
 
-    
+
     simple_assert("Partial Comparison GT", (*partial_cmp_b > *partial_cmp_a).value());
     simple_assert("Partial Comparison LT", (*partial_cmp_a < *partial_cmp_b).value());
     simple_assert("Partial Comparison NE", (*partial_cmp_a != *partial_cmp_b).value());

--- a/feature_tests/cpp/tests/attrs.cpp
+++ b/feature_tests/cpp/tests/attrs.cpp
@@ -15,6 +15,7 @@
 #include "../include/ns/RenamedStringList.hpp"
 #include "../include/ns/RenamedBlockOverride.hpp"
 #include "../include/ns/RenamedMixinTest.hpp"
+#include "../include/ns/RenamedPartialComparable.hpp"
 
 using namespace somelib;
 
@@ -130,4 +131,16 @@ int main(int argc, char* argv[]) {
     simple_assert_eq("Default values bool", nested::ns::Renamednested_ns_fn(), false);
 
     simple_assert_eq("Mixin generation", ns::RenamedMixinTest::hello(), "Hello!");
+
+    auto partial_cmp_a = ns::RenamedPartialComparable::new_(10.0f);
+    auto partial_cmp_b = ns::RenamedPartialComparable::new_(100.0f);
+    auto partial_cmp_c = ns::RenamedPartialComparable::new_(std::numeric_limits<float>::quiet_NaN());
+
+    
+    simple_assert("Partial Comparison GT", (*partial_cmp_b > *partial_cmp_a).value());
+    simple_assert("Partial Comparison LT", (*partial_cmp_a < *partial_cmp_b).value());
+    simple_assert("Partial Comparison NE", (*partial_cmp_a != *partial_cmp_b).value());
+    simple_assert("Partial Comparison EQ None", !(*partial_cmp_a == *partial_cmp_c).has_value());
+    simple_assert("Partial Comparison GT None", !(*partial_cmp_c > *partial_cmp_a).has_value());
+    simple_assert("Partial Comparison LT None", !(*partial_cmp_c < *partial_cmp_a).has_value());
 }

--- a/feature_tests/nanobind/src/include/ns/RenamedComparable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedComparable.d.hpp
@@ -32,6 +32,7 @@ public:
   inline static std::unique_ptr<somelib::ns::RenamedComparable> new_(uint8_t int_);
 
   inline int8_t cmp(const somelib::ns::RenamedComparable& other) const;
+
   inline bool operator==(const somelib::ns::RenamedComparable& other) const;
   inline bool operator!=(const somelib::ns::RenamedComparable& other) const;
   inline bool operator<=(const somelib::ns::RenamedComparable& other) const;

--- a/feature_tests/nanobind/src/include/ns/RenamedComparable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedComparable.hpp
@@ -39,27 +39,33 @@ inline int8_t somelib::ns::RenamedComparable::cmp(const somelib::ns::RenamedComp
     return result;
 }
 inline bool somelib::ns::RenamedComparable::operator==(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) == 0;
+    auto val = this->cmp(other);
+    return val == 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator!=(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) != 0;
+    auto val = this->cmp(other);
+    return val != 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator<=(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) <= 0;
+    auto val = this->cmp(other);
+    return val <= 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator>=(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) >= 0;
+    auto val = this->cmp(other);
+    return val >= 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator<(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) < 0;
+    auto val = this->cmp(other);
+    return val < 0;
 }
 
 inline bool somelib::ns::RenamedComparable::operator>(const somelib::ns::RenamedComparable& other) const {
-    return this->cmp(other) > 0;
+    auto val = this->cmp(other);
+    return val > 0;
 }
 
 inline const somelib::ns::capi::RenamedComparable* somelib::ns::RenamedComparable::AsFFI() const {

--- a/feature_tests/nanobind/src/include/ns/RenamedPartialComparable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedPartialComparable.d.hpp
@@ -1,0 +1,60 @@
+#ifndef SOMELIB_ns_RenamedPartialComparable_D_HPP
+#define SOMELIB_ns_RenamedPartialComparable_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+namespace somelib {
+namespace ns {
+namespace capi { struct RenamedPartialComparable; }
+class RenamedPartialComparable;
+} // namespace ns
+} // namespace somelib
+
+
+
+namespace somelib::ns {
+namespace capi {
+    struct RenamedPartialComparable;
+} // namespace capi
+} // namespace
+
+namespace somelib::ns {
+class RenamedPartialComparable {
+public:
+
+  inline static std::unique_ptr<somelib::ns::RenamedPartialComparable> new_(float float_);
+
+  inline std::optional<int8_t> partial_cmp(const somelib::ns::RenamedPartialComparable& other) const;
+
+  inline std::optional<bool> operator==(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator!=(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator<=(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator>=(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator<(const somelib::ns::RenamedPartialComparable& other) const;
+  inline std::optional<bool> operator>(const somelib::ns::RenamedPartialComparable& other) const;
+
+  inline std::optional<int8_t> test_nonstd(const somelib::ns::RenamedPartialComparable& other) const;
+
+    inline const somelib::ns::capi::RenamedPartialComparable* AsFFI() const;
+    inline somelib::ns::capi::RenamedPartialComparable* AsFFI();
+    inline static const somelib::ns::RenamedPartialComparable* FromFFI(const somelib::ns::capi::RenamedPartialComparable* ptr);
+    inline static somelib::ns::RenamedPartialComparable* FromFFI(somelib::ns::capi::RenamedPartialComparable* ptr);
+    inline static void operator delete(void* ptr);
+private:
+    RenamedPartialComparable() = delete;
+    RenamedPartialComparable(const somelib::ns::RenamedPartialComparable&) = delete;
+    RenamedPartialComparable(somelib::ns::RenamedPartialComparable&&) noexcept = delete;
+    RenamedPartialComparable operator=(const somelib::ns::RenamedPartialComparable&) = delete;
+    RenamedPartialComparable operator=(somelib::ns::RenamedPartialComparable&&) noexcept = delete;
+    static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // SOMELIB_ns_RenamedPartialComparable_D_HPP

--- a/feature_tests/nanobind/src/include/ns/RenamedPartialComparable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedPartialComparable.hpp
@@ -1,0 +1,102 @@
+#ifndef SOMELIB_ns_RenamedPartialComparable_HPP
+#define SOMELIB_ns_RenamedPartialComparable_HPP
+
+#include "RenamedPartialComparable.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace somelib::ns {
+namespace capi {
+    extern "C" {
+
+    somelib::ns::capi::RenamedPartialComparable* namespace_PartialComparable_new(float float_);
+
+    typedef struct namespace_PartialComparable_partial_cmp_result {union {int8_t ok; }; bool is_ok;} namespace_PartialComparable_partial_cmp_result;
+    namespace_PartialComparable_partial_cmp_result namespace_PartialComparable_partial_cmp(const somelib::ns::capi::RenamedPartialComparable* self, const somelib::ns::capi::RenamedPartialComparable* other);
+
+    typedef struct namespace_PartialComparable_test_nonstd_result {union {int8_t ok; }; bool is_ok;} namespace_PartialComparable_test_nonstd_result;
+    namespace_PartialComparable_test_nonstd_result namespace_PartialComparable_test_nonstd(const somelib::ns::capi::RenamedPartialComparable* self, const somelib::ns::capi::RenamedPartialComparable* other);
+
+    void namespace_PartialComparable_destroy(RenamedPartialComparable* self);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<somelib::ns::RenamedPartialComparable> somelib::ns::RenamedPartialComparable::new_(float float_) {
+    auto result = somelib::ns::capi::namespace_PartialComparable_new(float_);
+    return std::unique_ptr<somelib::ns::RenamedPartialComparable>(somelib::ns::RenamedPartialComparable::FromFFI(result));
+}
+
+inline std::optional<int8_t> somelib::ns::RenamedPartialComparable::partial_cmp(const somelib::ns::RenamedPartialComparable& other) const {
+    auto result = somelib::ns::capi::namespace_PartialComparable_partial_cmp(this->AsFFI(),
+        other.AsFFI());
+    return result.is_ok ? std::optional<int8_t>(result.ok) : std::nullopt;
+}
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator==(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() == 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator!=(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() != 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator<=(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() <= 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator>=(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() >= 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator<(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() < 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparable::operator>(const somelib::ns::RenamedPartialComparable& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() > 0;
+}
+
+inline std::optional<int8_t> somelib::ns::RenamedPartialComparable::test_nonstd(const somelib::ns::RenamedPartialComparable& other) const {
+    auto result = somelib::ns::capi::namespace_PartialComparable_test_nonstd(this->AsFFI(),
+        other.AsFFI());
+    return result.is_ok ? std::optional<int8_t>(result.ok) : std::nullopt;
+}
+
+inline const somelib::ns::capi::RenamedPartialComparable* somelib::ns::RenamedPartialComparable::AsFFI() const {
+    return reinterpret_cast<const somelib::ns::capi::RenamedPartialComparable*>(this);
+}
+
+inline somelib::ns::capi::RenamedPartialComparable* somelib::ns::RenamedPartialComparable::AsFFI() {
+    return reinterpret_cast<somelib::ns::capi::RenamedPartialComparable*>(this);
+}
+
+inline const somelib::ns::RenamedPartialComparable* somelib::ns::RenamedPartialComparable::FromFFI(const somelib::ns::capi::RenamedPartialComparable* ptr) {
+    return reinterpret_cast<const somelib::ns::RenamedPartialComparable*>(ptr);
+}
+
+inline somelib::ns::RenamedPartialComparable* somelib::ns::RenamedPartialComparable::FromFFI(somelib::ns::capi::RenamedPartialComparable* ptr) {
+    return reinterpret_cast<somelib::ns::RenamedPartialComparable*>(ptr);
+}
+
+inline void somelib::ns::RenamedPartialComparable::operator delete(void* ptr) {
+    somelib::ns::capi::namespace_PartialComparable_destroy(reinterpret_cast<somelib::ns::capi::RenamedPartialComparable*>(ptr));
+}
+
+
+#endif // SOMELIB_ns_RenamedPartialComparable_HPP

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -95,6 +95,7 @@ void add_RenamedOpaqueRefIterator_binding(nb::module_);
 void add_RenamedOpaqueZST_binding(nb::module_);
 void add_RenamedOpaqueZSTIndexer_binding(nb::module_);
 void add_RenamedOpaqueZSTIterator_binding(nb::module_);
+void add_RenamedPartialComparable_binding(nb::module_);
 void add_RenamedStringList_binding(nb::module_);
 void add_RenamedTestOpaque_binding(nb::module_);
 void add_RenamedVectorTest_binding(nb::module_);
@@ -248,6 +249,7 @@ NB_MODULE(somelib, mod)
     ns::add_RenamedOpaqueZST_binding(ns_mod);
     ns::add_RenamedOpaqueZSTIndexer_binding(ns_mod);
     ns::add_RenamedOpaqueZSTIterator_binding(ns_mod);
+    ns::add_RenamedPartialComparable_binding(ns_mod);
     ns::add_RenamedStringList_binding(ns_mod);
     ns::add_RenamedTestOpaque_binding(ns_mod);
     ns::add_RenamedVectorTest_binding(ns_mod);

--- a/feature_tests/nanobind/src/sub_modules/somelib/ns/RenamedPartialComparable_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/ns/RenamedPartialComparable_binding.cpp
@@ -1,0 +1,25 @@
+#include "diplomat_nanobind_common.hpp"
+
+
+#include "ns/RenamedPartialComparable.hpp"
+
+namespace somelib::ns {
+void add_RenamedPartialComparable_binding(nb::module_ mod) {
+    PyType_Slot somelib_ns_RenamedPartialComparable_slots[] = {
+        {Py_tp_free, (void *)somelib::ns::RenamedPartialComparable::operator delete },
+        {Py_tp_dealloc, (void *)diplomat_tp_dealloc},
+        {0, nullptr}};
+    
+    nb::class_<somelib::ns::RenamedPartialComparable> opaque(mod, "RenamedPartialComparable", nb::type_slots(somelib_ns_RenamedPartialComparable_slots));
+    opaque
+        .def(nb::new_(std::move(maybe_op_unwrap(&somelib::ns::RenamedPartialComparable::new_))), "float_"_a)
+        .def(nb::self == nb::self)
+            .def(nb::self != nb::self)
+            .def(nb::self <= nb::self)
+            .def(nb::self >= nb::self)
+            .def(nb::self < nb::self)
+            .def(nb::self > nb::self)
+        .def("test_nonstd", &somelib::ns::RenamedPartialComparable::test_nonstd, "other"_a);
+}
+
+} 

--- a/feature_tests/nanobind/test/test_attrs.py
+++ b/feature_tests/nanobind/test/test_attrs.py
@@ -71,3 +71,15 @@ def test_sequencing():
     for a in ind:
         i = i + 1
     assert i == 3
+
+def test_partial_comparison():
+    import math
+    a = somelib.ns.RenamedPartialComparable(10)
+    b = somelib.ns.RenamedPartialComparable(20)
+    c = somelib.ns.RenamedPartialComparable(math.nan)
+    assert b > a
+    assert a < b
+    assert a != b
+    assert not(c > a)
+    assert not(c == a)
+    assert not(c != a)

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -168,6 +168,28 @@ pub mod ffi {
     }
 
     #[diplomat::opaque]
+    #[diplomat::cfg(supports = partial_comparators)]
+    pub struct PartialComparable(f32);
+    impl PartialComparable {
+        #[diplomat::attr(auto, constructor)]
+        pub fn new(float: f32) -> Box<Self> {
+            Box::new(Self(float))
+        }
+
+        #[diplomat::attr(auto, comparison)]
+        pub fn partial_cmp(&self, other: &PartialComparable) -> Option<core::cmp::Ordering> {
+            self.0.partial_cmp(&other.0)
+        }
+
+        pub fn test_nonstd(
+            &self,
+            other: &PartialComparable,
+        ) -> DiplomatOption<core::cmp::Ordering> {
+            self.0.partial_cmp(&other.0).into()
+        }
+    }
+
+    #[diplomat::opaque]
     #[diplomat::cfg(supports = indexing)]
     pub struct MyIndexer(Vec<String>);
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -358,14 +358,20 @@ fn gen_custom_function(func_info: FuncGen) -> Item {
                 }
                 // anything else goes through DiplomatResult
                 _ => {
-                    let ty = ty.to_syn();
+                    let ty_s = ty.to_syn();
                     let conversion = if *is_std_option == StdlibOrDiplomat::Stdlib {
                         quote! { .ok_or(()).into() }
                     } else {
                         quote! {}
                     };
+
+                    let conversion = if **ty == ast::TypeName::Ordering {
+                        quote! { .map(|i| i as i8) #conversion }
+                    } else {
+                        conversion
+                    };
                     (
-                        quote! { -> diplomat_runtime::DiplomatResult<#ty, ()> },
+                        quote! { -> diplomat_runtime::DiplomatResult<#ty_s, ()> },
                         conversion,
                     )
                 }

--- a/runtime/src/result.rs
+++ b/runtime/src/result.rs
@@ -47,6 +47,32 @@ impl<T> DiplomatOption<T> {
     pub fn into_converted_option<U: From<T>>(self) -> Option<U> {
         self.into_option().map(Into::into)
     }
+
+    pub fn map<U, F>(mut self, f: F) -> DiplomatOption<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        if self.is_ok {
+            unsafe {
+                let res = f(ManuallyDrop::take(&mut self.value.ok));
+                DiplomatResult {
+                    value: DiplomatResultValue {
+                        ok: ManuallyDrop::new(res),
+                    },
+                    is_ok: true,
+                }
+            }
+        } else {
+            unsafe {
+                DiplomatResult {
+                    value: DiplomatResultValue {
+                        err: self.value.err,
+                    },
+                    is_ok: false,
+                }
+            }
+        }
+    }
 }
 
 impl<T: Clone, E: Clone> Clone for DiplomatResult<T, E> {

--- a/tool/src/cpp/mod.rs
+++ b/tool/src/cpp/mod.rs
@@ -51,6 +51,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.accessors = false;
     a.static_accessors = false;
     a.comparators = true;
+    a.partial_comparators = true;
     a.stringifiers = false; // TODO
     a.iterators = true;
     a.iterables = true;

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -609,7 +609,7 @@ impl<'cx> ItemGenContext<'_, 'cx> {
                 self.formatter.fmt_accessor_name(name, method)
             ),
             Some(SpecialMethod::Stringifier) => "@override\n  String toString()".into(),
-            Some(SpecialMethod::Comparison) => {
+            Some(SpecialMethod::Comparison(false)) => {
                 format!("@override\n  int compareTo({type_name} other)")
             }
             Some(SpecialMethod::Iterator) => format!("{return_ty} _iteratorNext({params})"),

--- a/tool/src/nanobind/mod.rs
+++ b/tool/src/nanobind/mod.rs
@@ -39,6 +39,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.accessors = true;
     a.static_accessors = true;
     a.comparators = true;
+    a.partial_comparators = true;
     a.stringifiers = true;
     a.iterators = true;
     a.iterables = true;

--- a/tool/templates/cpp/function_defs/method_decl.h.jinja
+++ b/tool/templates/cpp/function_defs/method_decl.h.jinja
@@ -1,4 +1,14 @@
 {%- extends "method_decl_base.h.jinja" -%}
+
+{%- macro comparison_decl(return_ty) %}
+  inline {{return_ty}} operator==(const {{type_name}}& other) const;
+  inline {{return_ty}} operator!=(const {{type_name}}& other) const;
+  inline {{return_ty}} operator<=(const {{type_name}}& other) const;
+  inline {{return_ty}} operator>=(const {{type_name}}& other) const;
+  inline {{return_ty}} operator<(const {{type_name}}& other) const;
+  inline {{return_ty}} operator>(const {{type_name}}& other) const;
+{%- endmacro -%}
+
 {% block post_func %}
 {%- let is_self_opaque = matches!(m.method.param_self, Some(hir::ParamSelf{ ty : SelfType::Opaque(_), ..})) -%}
 
@@ -14,13 +24,10 @@
 {%- let helper_type = m.return_ty.replace("std::unique_ptr", &fmt.lib_prefixed_path("diplomat::next_to_iter_helper") ) %}
   inline {{helper_type}} begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
-{%- when Some(hir::SpecialMethod::Comparison) %}
-  inline bool operator==(const {{type_name}}& other) const;
-  inline bool operator!=(const {{type_name}}& other) const;
-  inline bool operator<=(const {{type_name}}& other) const;
-  inline bool operator>=(const {{type_name}}& other) const;
-  inline bool operator<(const {{type_name}}& other) const;
-  inline bool operator>(const {{type_name}}& other) const;
+{%- when Some(hir::SpecialMethod::Comparison(false)) %}
+{{comparison_decl("bool")}}
+{%- when Some(hir::SpecialMethod::Comparison(true)) %}
+{{comparison_decl("std::optional<bool>")}}
 {%- when _ -%}
 {%- endmatch -%}
 {% endblock %}

--- a/tool/templates/cpp/function_defs/method_impl.h.jinja
+++ b/tool/templates/cpp/function_defs/method_impl.h.jinja
@@ -3,6 +3,38 @@
 {{- type_name -}}::
 {%- endblock -%}
 
+{%- macro comparison_impl(unwrap_expr, return_ty) -%}
+inline {{return_ty}} {{type_name}}::operator==(const {{type_name}}& other) const {
+    auto val = this->{{m.method_name}}(other);
+    {{unwrap_expr}} == 0;
+}
+
+inline {{return_ty}} {{type_name}}::operator!=(const {{type_name}}& other) const {
+    auto val = this->{{m.method_name}}(other);
+    {{unwrap_expr}} != 0;
+}
+
+inline {{return_ty}} {{type_name}}::operator<=(const {{type_name}}& other) const {
+    auto val = this->{{m.method_name}}(other);
+    {{unwrap_expr}} <= 0;
+}
+
+inline {{return_ty}} {{type_name}}::operator>=(const {{type_name}}& other) const {
+    auto val = this->{{m.method_name}}(other);
+    {{unwrap_expr}} >= 0;
+}
+
+inline {{return_ty}} {{type_name}}::operator<(const {{type_name}}& other) const {
+    auto val = this->{{m.method_name}}(other);
+    {{unwrap_expr}} < 0;
+}
+
+inline {{return_ty}} {{type_name}}::operator>(const {{type_name}}& other) const {
+    auto val = this->{{m.method_name}}(other);
+    {{unwrap_expr}} > 0;
+}
+{%- endmacro -%}
+
 {%- block special_methods -%}
 {%- let is_self_opaque = matches!(m.method.param_self, Some(hir::ParamSelf{ ty : SelfType::Opaque(_), ..})) -%}
 {%- match m.method.attrs.special_method -%}
@@ -22,30 +54,10 @@ inline {{helper_type}} {{- type_name }}::begin() const {
     return iter();
 }
 
-{%- when Some(hir::SpecialMethod::Comparison) %}
-inline bool {{type_name}}::operator==(const {{type_name}}& other) const {
-    return this->{{m.method_name}}(other) == 0;
-}
-
-inline bool {{type_name}}::operator!=(const {{type_name}}& other) const {
-    return this->{{m.method_name}}(other) != 0;
-}
-
-inline bool {{type_name}}::operator<=(const {{type_name}}& other) const {
-    return this->{{m.method_name}}(other) <= 0;
-}
-
-inline bool {{type_name}}::operator>=(const {{type_name}}& other) const {
-    return this->{{m.method_name}}(other) >= 0;
-}
-
-inline bool {{type_name}}::operator<(const {{type_name}}& other) const {
-    return this->{{m.method_name}}(other) < 0;
-}
-
-inline bool {{type_name}}::operator>(const {{type_name}}& other) const {
-    return this->{{m.method_name}}(other) > 0;
-}
+{%- when Some(hir::SpecialMethod::Comparison(false)) %}
+{{comparison_impl("return val", "bool")}}
+{%- when Some(hir::SpecialMethod::Comparison(true))%}
+{{comparison_impl("if (!val.has_value()) { return std::nullopt; } return val.value()", "std::optional<bool>")}}
 {%- when _ -%}
 {%- endmatch -%}
 {%- endblock -%}

--- a/tool/templates/nanobind/method_impl.cpp.jinja
+++ b/tool/templates/nanobind/method_impl.cpp.jinja
@@ -24,7 +24,7 @@
     {%- when crate::hir::SpecialMethod::AddAssign | crate::hir::SpecialMethod::SubAssign |
             crate::hir::SpecialMethod::MulAssign | crate::hir::SpecialMethod::DivAssign -%}
         (nb::self {{special_method.operator_str().unwrap()}} nb::self, nb::rv_policy::none)
-    {%- when crate::hir::SpecialMethod::Comparison -%}
+    {%- when crate::hir::SpecialMethod::Comparison(_) -%}
         (nb::self == nb::self)
         .def(nb::self != nb::self)
         .def(nb::self <= nb::self)


### PR DESCRIPTION
Closes https://github.com/rust-diplomat/diplomat/issues/1103.

Just to note, this currently includes partial comparisons as information inside of `SpecialMethod::Comparison`. They can theoretically be made as part of their own flag. This would ensure `#[diplomat::attr(auto, ...)]` works and removes the mutation in lowering code, at the cost of not being as concise when writing bindings.

TODOs:

- [ ] Docs