### PR TITLE
Nanobind: Use `string_view_for_slice` instead of `string_view`

### DIFF
--- a/tool/src/nanobind/gen.rs
+++ b/tool/src/nanobind/gen.rs
@@ -495,7 +495,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx> {
             }
             Type::Slice(hir::Slice::Strs(encoding)) => format!(
                 "diplomat::span<const {}>",
-                self.formatter.cxx.fmt_borrowed_str(encoding)
+                self.formatter.cxx.fmt_borrowed_str_in_slice(encoding)
             )
             .into(),
             Type::Slice(hir::Slice::Struct(b, ref st)) => {

--- a/tool/src/nanobind/mod.rs
+++ b/tool/src/nanobind/mod.rs
@@ -427,8 +427,14 @@ mod test {
                     pub fn takes_callback(f : impl Fn()) {
                         todo!()
                     }
+
                     #[diplomat::attr(*, rename="takes_callback")]
                     pub fn takes_other_callback(f : impl Fn(bool)) {}
+
+                    #[diplomat::attr(*, rename="new")]
+                    pub fn str_slice_override(sl : &[DiplomatStrSlice]) {
+                        todo!()
+                    }
                 }
             }
             }

--- a/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__opaque_gen.snap
+++ b/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__opaque_gen.snap
@@ -10,6 +10,7 @@ PyType_Slot mylib_OpaqueStruct_slots[] = {
 nb::class_<mylib::OpaqueStruct> opaque(mod, "OpaqueStruct", nb::type_slots(mylib_OpaqueStruct_slots));
 opaque
     .def_static("do_thing", &mylib::OpaqueStruct::do_thing)
-    .def_static("new", std::move(maybe_op_unwrap(&mylib::OpaqueStruct::new_)))
+    .def_static("new", std::move(maybe_op_unwrap(nb::overload_cast<>(&mylib::OpaqueStruct::new_))))
+    .def_static("new", std::move(maybe_op_unwrap(nb::overload_cast<diplomat::span<const diplomat::string_view_for_slice>>(&mylib::OpaqueStruct::new_))), "sl"_a)
     .def_static("takes_callback", nb::overload_cast<std::function<void()>>(&mylib::OpaqueStruct::takes_callback), "f"_a)
     .def_static("takes_callback", nb::overload_cast<std::function<void(bool)>>(&mylib::OpaqueStruct::takes_callback), "f"_a);


### PR DESCRIPTION
Fixes a small issue in the generation code (that only shows up in overloads), `string_view_for_slice` uses the wrong formatter in Nanobind's type name generation, and is genned as `string_view` instead.

This is just a quick fix for that.