### PR TITLE
Nanobind Add Type Generation for Callbacks

### DIFF
--- a/feature_tests/nanobind/src/sub_modules/somelib/CallbackWrapper_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/CallbackWrapper_binding.cpp
@@ -1,8 +1,12 @@
 #include "diplomat_nanobind_common.hpp"
 
 
+#include "CallbackTestingStruct.hpp"
 #include "CallbackWrapper.hpp"
 #include "MyString.hpp"
+#include "MyStructContainingAnOption.hpp"
+#include "Opaque.hpp"
+#include "PrimitiveStruct.hpp"
 
 namespace somelib {
 void add_CallbackWrapper_binding(nb::module_ mod) {

--- a/tool/src/cpp/gen.rs
+++ b/tool/src/cpp/gen.rs
@@ -886,7 +886,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
         ret
     }
 
-    fn gen_fn_sig(&mut self, cb: &dyn CallbackInstantiationFunctionality) -> String {
+    pub(crate) fn gen_fn_sig(&mut self, cb: &dyn CallbackInstantiationFunctionality) -> String {
         let t = cb.get_output_type().unwrap();
 
         let return_type = self.gen_cpp_return_type_name(t, false);

--- a/tool/src/nanobind/gen.rs
+++ b/tool/src/nanobind/gen.rs
@@ -509,7 +509,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx> {
             Type::DiplomatOption(ref inner) => {
                 format!("std::optional<{}>", self.gen_type_name(inner)).into()
             }
-            Type::Callback(..) => "".into(),
+            Type::Callback(ref cb) => format!("std::function<{}>", self.cpp.gen_fn_sig(cb)).into(),
             _ => unreachable!("unknown AST/HIR variant"),
         }
     }

--- a/tool/src/nanobind/mod.rs
+++ b/tool/src/nanobind/mod.rs
@@ -423,6 +423,12 @@ mod test {
                     pub fn do_thing() -> bool {
                         return true;
                     }
+
+                    pub fn takes_callback(f : impl Fn()) {
+                        todo!()
+                    }
+                    #[diplomat::attr(*, rename="takes_callback")]
+                    pub fn takes_other_callback(f : impl Fn(bool)) {}
                 }
             }
             }

--- a/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__opaque_gen.snap
+++ b/tool/src/nanobind/snapshots/diplomat_tool__nanobind__test__opaque_gen.snap
@@ -1,6 +1,6 @@
 ---
 source: tool/src/nanobind/mod.rs
-expression: generated
+expression: out
 ---
 PyType_Slot mylib_OpaqueStruct_slots[] = {
     {Py_tp_free, (void *)mylib::OpaqueStruct::operator delete },
@@ -10,4 +10,6 @@ PyType_Slot mylib_OpaqueStruct_slots[] = {
 nb::class_<mylib::OpaqueStruct> opaque(mod, "OpaqueStruct", nb::type_slots(mylib_OpaqueStruct_slots));
 opaque
     .def_static("do_thing", &mylib::OpaqueStruct::do_thing)
-    .def_static("new", std::move(maybe_op_unwrap(&mylib::OpaqueStruct::new_)));
+    .def_static("new", std::move(maybe_op_unwrap(&mylib::OpaqueStruct::new_)))
+    .def_static("takes_callback", nb::overload_cast<std::function<void()>>(&mylib::OpaqueStruct::takes_callback), "f"_a)
+    .def_static("takes_callback", nb::overload_cast<std::function<void(bool)>>(&mylib::OpaqueStruct::takes_callback), "f"_a);


### PR DESCRIPTION
Nanobind doesn't have type name generation information for callbacks, which is important for overloading.

This is a quick fix to generate that typing information.