### PR TITLE
Fix nanobind stub type for diplomat::result to show success type instead of 'result'

### DIFF
--- a/feature_tests/nanobind/src/include/diplomat_nanobind_common.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_nanobind_common.hpp
@@ -133,7 +133,7 @@ namespace nanobind::detail
         bool is_ok;
         Py_ssize_t size;
         using Caster = make_caster<U>;
-        static constexpr auto Name = const_name("result");
+        static constexpr auto Name = Caster::Name;
 
         static handle from_cpp(somelib::diplomat::result<T, E> value, rv_policy p, cleanup_list *cl) noexcept
         {

--- a/feature_tests/nanobind/test/test_result.py
+++ b/feature_tests/nanobind/test/test_result.py
@@ -61,3 +61,24 @@ class TestResult(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             somelib.FallibleOpaqueConstructor()
         cm.exception.args[0].assert_integer(10)
+
+    def test_result_type_signatures(self):
+        """The diplomat::result<T, E> type_caster unwraps to T on success and raises on error,
+        so the Python-visible return type should be T, not the bare word 'result'.
+
+        nanobind's __doc__ contains the signature (e.g. "new_int(i: int) -> int").
+        The .pyi stub should show:
+            def new_int(i: int) -> int: ...
+            def new_failing_foo() -> ResultOpaque: ...
+        NOT:
+            def new_int(i: int) -> result: ...
+        """
+        def get_return_type(method):
+            """Extract the return type string from a nanobind method's __doc__ signature."""
+            for line in method.__doc__.splitlines():
+                if "->" in line:
+                    return line.split("->")[-1].strip()
+            return None
+
+        assert get_return_type(somelib.ResultOpaque.new_int) == "int"
+        assert get_return_type(somelib.ResultOpaque.new_failing_foo).endswith("ResultOpaque")

--- a/tool/templates/nanobind/common.h.jinja
+++ b/tool/templates/nanobind/common.h.jinja
@@ -133,7 +133,7 @@ namespace nanobind::detail
         bool is_ok;
         Py_ssize_t size;
         using Caster = make_caster<U>;
-        static constexpr auto Name = const_name("result");
+        static constexpr auto Name = Caster::Name;
 
         static handle from_cpp({{lib_name}}::diplomat::result<T, E> value, rv_policy p, cleanup_list *cl) noexcept
         {


### PR DESCRIPTION
The `type_caster` for `diplomat::result<T, E>` used `const_name("result")` as its `Name`, causing nanobind's stubgen to emit `-> result` in .pyi stubs. Since the caster unwraps on success (returning `T`) and raises on error, the Python-visible return type is `T`. Use `Caster::Name` to forward the inner type's name so stubs correctly show e.g. `-> int` or `-> MyType`.

Concretely, this fixes a stubgen issue in icu4x from

```python
class ZonedDateTime:

    @staticmethod
    def full_from_string(v: str, calendar: Calendar, iana_parser: IanaParser, _offset_calculator: VariantOffsetsCalculator) -> result: ... # result is just an undefined token
```
to

```python
class ZonedDateTime:

    @staticmethod
    def full_from_string(v: str, calendar: Calendar, iana_parser: IanaParser, _offset_calculator: VariantOffsetsCalculator) -> ZonedDateTime: ...
```

There is not currently any testing infrastructure for the types nanobind introspects and creates from our bindings, so i instead opted for a test which shows that the intermediate step of `__doc__` which I believe is what nanobind uses to create these stubs