### PR TITLE
Add Lowering Error on `Result<Option<..>, ..>` for non-opaque types

### DIFF
--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1932,6 +1932,41 @@ impl<'ast> LoweringContext<'ast> {
         params
     }
 
+    fn maybe_error_on_option_result(&mut self, result_type: &ast::TypeName) -> Result<(), ()> {
+        match result_type {
+            ast::TypeName::Result(ok_ty, err_ty, _) => {
+                match ok_ty.as_ref() {
+                    ast::TypeName::Option(inner, ast::StdlibOrDiplomat::Stdlib)
+                        if !matches!(
+                            inner.as_ref(),
+                            ast::TypeName::Box(..) | ast::TypeName::Reference(..)
+                        ) =>
+                    {
+                        self.errors.push(LoweringError::Other(format!("{result_type} wraps Option<{inner}>; {inner} is not an opaque. Please use DiplomatOption<{inner}> instead.")));
+                        return Err(());
+                    }
+                    _ => {}
+                }
+
+                match err_ty.as_ref() {
+                    ast::TypeName::Option(inner, ast::StdlibOrDiplomat::Stdlib)
+                        if !matches!(
+                            inner.as_ref(),
+                            ast::TypeName::Box(..) | ast::TypeName::Reference(..)
+                        ) =>
+                    {
+                        self.errors.push(LoweringError::Other(format!("{result_type} wraps Option<{inner}>; {inner} is not an opaque. Please use DiplomatOption<{inner}> instead.")));
+                        return Err(());
+                    }
+                    _ => {}
+                }
+
+                Ok(())
+            }
+            _ => unreachable!("Expected Result type, not {result_type}"),
+        }
+    }
+
     /// Lowers the return type of an [`ast::Method`] into a [`hir::ReturnFallability`].
     ///
     /// If there are any errors, they're pushed to `errors` and `None` is returned.
@@ -1949,6 +1984,7 @@ impl<'ast> LoweringContext<'ast> {
         };
         match return_type.unwrap_or(&ast::TypeName::Unit) {
             ast::TypeName::Result(ok_ty, err_ty, _) => {
+                self.maybe_error_on_option_result(return_type.unwrap_or(&ast::TypeName::Unit))?;
                 let ok_ty = match ok_ty.as_ref() {
                     ast::TypeName::Unit => Ok(write_or_unit),
                     ty => self
@@ -2024,6 +2060,7 @@ impl<'ast> LoweringContext<'ast> {
     ) -> Result<ReturnType<InputOnly>, ()> {
         match return_type.unwrap_or(&ast::TypeName::Unit) {
             ast::TypeName::Result(ok_ty, err_ty, _) => {
+                self.maybe_error_on_option_result(return_type.unwrap_or(&ast::TypeName::Unit))?;
                 let ok_ty = match ok_ty.as_ref() {
                     ast::TypeName::Unit => Ok(SuccessType::Unit),
                     ty => self

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
@@ -15,3 +15,4 @@ Lowering error in Opaque::return_self: Method `Opaque_return_self` takes an opaq
 Lowering error in Opaque::use_opaque_owned: Opaque passed by value: OtherOpaque
 Lowering error in Opaque::return_opaque_owned: Opaque passed by value in input: OtherOpaque
 Lowering error in Opaque::use_out_as_in: found struct in input that is marked with #[diplomat::out]: OutStruct in OutStruct
+Lowering error in Opaque::wraps_result_option: Result<Option<OutStruct>, Option<OutStruct>> wraps Option<OutStruct>; OutStruct is not an opaque. Please use DiplomatOption<OutStruct> instead.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_result_option_wrap_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_result_option_wrap_fails.snap
@@ -1,0 +1,6 @@
+---
+source: core/src/hir/type_context.rs
+expression: output
+---
+Lowering error in MyStruct::takes_callback: Result<Option<MyStruct>, Option<MyStruct>> wraps Option<MyStruct>; MyStruct is not an opaque. Please use DiplomatOption<MyStruct> instead.
+Lowering error in SomeTrait::xyz: Result<Option<MyStruct>, Option<MyStruct>> wraps Option<MyStruct>; MyStruct is not an opaque. Please use DiplomatOption<MyStruct> instead.

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -341,11 +341,11 @@ impl TypeContext {
         let structs = ctx.lower_all_structs(ast_structs.into_iter());
         let opaques = ctx.lower_all_opaques(ast_opaques.into_iter());
         let enums = ctx.lower_all_enums(ast_enums.into_iter());
-        let traits = ctx.lower_all_traits(ast_traits.into_iter()).unwrap();
+        let traits = ctx.lower_all_traits(ast_traits.into_iter());
         let functions = ctx.lower_all_functions(ast_functions.into_iter());
 
-        match (out_structs, structs, opaques, enums, functions) {
-            (Ok(out_structs), Ok(structs), Ok(opaques), Ok(enums), Ok(functions)) => {
+        match (out_structs, structs, opaques, enums, functions, traits) {
+            (Ok(out_structs), Ok(structs), Ok(opaques), Ok(enums), Ok(functions), Ok(traits)) => {
                 let res = Self {
                     out_structs,
                     structs,
@@ -954,6 +954,7 @@ mod tests {
                     pub fn use_opaque_owned(&self, opaque: OtherOpaque) {}
                     pub fn return_opaque_owned(&self) -> OtherOpaque {}
                     pub fn use_out_as_in(&self, out: OutStruct) {}
+                    pub fn wraps_result_option(&self) -> Result<Option<OutStruct>, Option<OutStruct>> {}
                 }
 
                 pub fn free_function(foo : &Opaque) {}
@@ -1440,6 +1441,45 @@ mod tests {
         let mut attr_validator = hir::BasicAttributeValidator::new("tests");
         attr_validator.support.abi_compatibles = true;
         attr_validator.support.struct_refs = true;
+        attr_validator.support.callbacks = true;
+        let config = super::LoweringConfig {
+            unsafe_references_in_callbacks: true,
+        };
+        match hir::TypeContext::from_syn(&parsed, config, attr_validator, None) {
+            Ok(_context) => (),
+            Err(e) => {
+                for (ctx, err) in e {
+                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                }
+            }
+        };
+        insta::with_settings!({}, { insta::assert_snapshot!(output) });
+    }
+
+    #[test]
+    fn test_callback_result_option_wrap_fails() {
+        // We may end up supporting this in the future, but
+        // we want to test that it is currently forbidden
+        let parsed: syn::File = syn::parse_quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                pub struct MyStruct {
+                    a : i32
+                }
+
+                pub trait SomeTrait {
+                    fn xyz() -> Result<Option<MyStruct>, Option<MyStruct>>;
+                }
+
+                impl MyStruct {
+                    pub fn takes_callback(c : impl Fn() -> Result<Option<MyStruct>, Option<MyStruct>>) {}
+                }
+            }
+        };
+
+        let mut output = String::new();
+
+        let mut attr_validator = hir::BasicAttributeValidator::new("tests");
         attr_validator.support.callbacks = true;
         let config = super::LoweringConfig {
             unsafe_references_in_callbacks: true,

--- a/feature_tests/c/include/CallbackWrapper.h
+++ b/feature_tests/c/include/CallbackWrapper.h
@@ -9,6 +9,7 @@
 
 #include "CallbackTestingStruct.d.h"
 #include "MyString.d.h"
+#include "MyStruct.d.h"
 #include "MyStructContainingAnOption.d.h"
 #include "Opaque.d.h"
 #include "PrimitiveStruct.d.h"
@@ -132,6 +133,13 @@ typedef struct DiplomatCallback_CallbackWrapper_test_slice_conversion_t {
     DiplomatCallback_CallbackWrapper_test_slice_conversion_t_result (*run_callback)(const void*);
     void (*destructor)(const void*);
 } DiplomatCallback_CallbackWrapper_test_slice_conversion_t;
+typedef struct DiplomatCallback_CallbackWrapper_test_result_option_struct_conversion_t_result {union {MyStruct_option ok; }; bool is_ok;} DiplomatCallback_CallbackWrapper_test_result_option_struct_conversion_t_result;
+
+typedef struct DiplomatCallback_CallbackWrapper_test_result_option_struct_conversion_t {
+    const void* data;
+    DiplomatCallback_CallbackWrapper_test_result_option_struct_conversion_t_result (*run_callback)(const void*);
+    void (*destructor)(const void*);
+} DiplomatCallback_CallbackWrapper_test_result_option_struct_conversion_t;
 typedef struct DiplomatCallback_CallbackWrapper_test_struct_slice_conversion_t_result {union {DiplomatPrimitiveStructView ok; }; bool is_ok;} DiplomatCallback_CallbackWrapper_test_struct_slice_conversion_t_result;
 
 typedef struct DiplomatCallback_CallbackWrapper_test_struct_slice_conversion_t {
@@ -182,6 +190,8 @@ void CallbackWrapper_test_inner_conversion(DiplomatCallback_CallbackWrapper_test
 void CallbackWrapper_test_str_conversion(DiplomatCallback_CallbackWrapper_test_str_conversion_t t_cb_wrap);
 
 void CallbackWrapper_test_slice_conversion(DiplomatCallback_CallbackWrapper_test_slice_conversion_t t_cb_wrap);
+
+void CallbackWrapper_test_result_option_struct_conversion(DiplomatCallback_CallbackWrapper_test_result_option_struct_conversion_t t_cb_wrap);
 
 void CallbackWrapper_test_struct_slice_conversion(DiplomatCallback_CallbackWrapper_test_struct_slice_conversion_t t_cb_wrap);
 

--- a/feature_tests/c/include/ErrorStruct.h
+++ b/feature_tests/c/include/ErrorStruct.h
@@ -13,7 +13,10 @@
 
 
 
-// No Content
+
+
+typedef struct ErrorStruct_returns_result_option_result {union {ErrorStruct_option ok; }; bool is_ok;} ErrorStruct_returns_result_option_result;
+ErrorStruct_returns_result_option_result ErrorStruct_returns_result_option(bool is_some);
 
 
 

--- a/feature_tests/cpp/include/ErrorStruct.d.hpp
+++ b/feature_tests/cpp/include/ErrorStruct.d.hpp
@@ -10,6 +10,10 @@
 #include <optional>
 #include <cstdlib>
 #include "diplomat_runtime.hpp"
+namespace somelib {
+struct ErrorStruct;
+} // namespace somelib
+
 
 
 namespace somelib {
@@ -28,6 +32,8 @@ namespace somelib {
 struct ErrorStruct {
     int32_t i;
     int32_t j;
+
+  inline static somelib::diplomat::result<std::optional<somelib::ErrorStruct>, std::monostate> returns_result_option(bool is_some);
 
     inline somelib::capi::ErrorStruct AsFFI() const;
     inline static somelib::ErrorStruct FromFFI(somelib::capi::ErrorStruct c_struct);

--- a/feature_tests/cpp/include/ErrorStruct.hpp
+++ b/feature_tests/cpp/include/ErrorStruct.hpp
@@ -16,9 +16,19 @@
 
 namespace somelib {
 namespace capi {
+    extern "C" {
 
+    typedef struct ErrorStruct_returns_result_option_result {union {somelib::capi::ErrorStruct_option ok; }; bool is_ok;} ErrorStruct_returns_result_option_result;
+    ErrorStruct_returns_result_option_result ErrorStruct_returns_result_option(bool is_some);
+
+    } // extern "C"
 } // namespace capi
 } // namespace
+
+inline somelib::diplomat::result<std::optional<somelib::ErrorStruct>, std::monostate> somelib::ErrorStruct::returns_result_option(bool is_some) {
+    auto result = somelib::capi::ErrorStruct_returns_result_option(is_some);
+    return result.is_ok ? somelib::diplomat::result<std::optional<somelib::ErrorStruct>, std::monostate>(somelib::diplomat::Ok<std::optional<somelib::ErrorStruct>>(result.ok.is_ok ? std::optional(somelib::ErrorStruct::FromFFI(result.ok.ok)) : std::nullopt)) : somelib::diplomat::result<std::optional<somelib::ErrorStruct>, std::monostate>(somelib::diplomat::Err<std::monostate>());
+}
 
 
 inline somelib::capi::ErrorStruct somelib::ErrorStruct::AsFFI() const {

--- a/feature_tests/cpp/tests/callback.cpp
+++ b/feature_tests/cpp/tests/callback.cpp
@@ -184,4 +184,19 @@ int main(int argc, char *argv[])
         });
     }
 
+    // FIXME: https://github.com/rust-diplomat/diplomat/issues/1154
+    // {
+    //     o.test_result_option_struct_conversion([]() {
+    //         return diplomat::Ok<std::optional<somelib::MyStruct>>(std::optional(somelib::MyStruct {
+    //             5,
+    //             false,
+    //             1,
+    //             2,
+    //             3,
+    //             'A',
+    //             somelib::MyEnum::A
+    //         }));
+    //     });
+    // }
+
 }

--- a/feature_tests/cpp/tests/result.cpp
+++ b/feature_tests/cpp/tests/result.cpp
@@ -50,4 +50,11 @@ int main(int argc, char *argv[])
     auto complex_v = NonTrivial(2);
     // non-trivial type, copying not allowed
     //auto complex_rvalue = diplomat::Ok(complex_v); // This is expected to fail compilation
+
+    auto result_option_some = somelib::ErrorStruct::returns_result_option(true);
+    auto result_option_out = std::move(result_option_some).ok().value();
+    simple_assert_eq("Result of Option of Struct", result_option_out.value().j, 125);
+
+    auto result_option_none = somelib::ErrorStruct::returns_result_option(false);
+    simple_assert("Result of Option of Struct", !std::move(result_option_none).ok().value().has_value());
 }

--- a/feature_tests/dart/lib/src/ErrorStruct.g.dart
+++ b/feature_tests/dart/lib/src/ErrorStruct.g.dart
@@ -37,6 +37,14 @@ final class ErrorStruct {
     return struct;
   }
 
+  static ErrorStruct? returnsResultOption(bool isSome) {
+    final result = _ErrorStruct_returns_result_option(isSome);
+    if (!result.isOk) {
+      return null;
+    }
+    return result.union.ok.isOk ? ErrorStruct._fromFfi(result.union.ok.union.ok) : null;
+  }
+
 
   @override
   bool operator ==(Object other) =>
@@ -50,5 +58,10 @@ final class ErrorStruct {
         j,
       ]);
 }
+
+@_DiplomatFfiUse('ErrorStruct_returns_result_option')
+@ffi.Native<_ResultResultErrorStructFfiVoidVoid Function(ffi.Bool)>(isLeaf: true, symbol: 'ErrorStruct_returns_result_option')
+// ignore: non_constant_identifier_names
+external _ResultResultErrorStructFfiVoidVoid _ErrorStruct_returns_result_option(bool isSome);
 
 // dart format on

--- a/feature_tests/dart/lib/src/lib.g.dart
+++ b/feature_tests/dart/lib/src/lib.g.dart
@@ -221,6 +221,32 @@ final class _ResultDoubleVoid extends ffi.Struct {
   }
 }
 
+final class _ResultErrorStructFfiVoidUnion extends ffi.Union {
+  external _ErrorStructFfi ok;
+
+}
+
+final class _ResultErrorStructFfiVoid extends ffi.Struct {
+  external _ResultErrorStructFfiVoidUnion union;
+
+  @ffi.Bool()
+  external bool isOk;
+
+  // ignore: unused_element
+  factory _ResultErrorStructFfiVoid.ok(_ErrorStructFfi val) {
+    final struct = ffi.Struct.create<_ResultErrorStructFfiVoid>();
+    struct.isOk = true;
+    struct.union.ok = val;
+    return struct;
+  }
+  // ignore: unused_element
+  factory _ResultErrorStructFfiVoid.err() {
+    final struct = ffi.Struct.create<_ResultErrorStructFfiVoid>();
+    struct.isOk = false;
+    return struct;
+  }
+}
+
 final class _ResultInt32OpaqueUnion extends ffi.Union {
   @ffi.Int32()
   external int ok;
@@ -460,6 +486,32 @@ final class _ResultOptionStructFfiVoid extends ffi.Struct {
   // ignore: unused_element
   factory _ResultOptionStructFfiVoid.err() {
     final struct = ffi.Struct.create<_ResultOptionStructFfiVoid>();
+    struct.isOk = false;
+    return struct;
+  }
+}
+
+final class _ResultResultErrorStructFfiVoidVoidUnion extends ffi.Union {
+  external _ResultErrorStructFfiVoid ok;
+
+}
+
+final class _ResultResultErrorStructFfiVoidVoid extends ffi.Struct {
+  external _ResultResultErrorStructFfiVoidVoidUnion union;
+
+  @ffi.Bool()
+  external bool isOk;
+
+  // ignore: unused_element
+  factory _ResultResultErrorStructFfiVoidVoid.ok(_ResultErrorStructFfiVoid val) {
+    final struct = ffi.Struct.create<_ResultResultErrorStructFfiVoidVoid>();
+    struct.isOk = true;
+    struct.union.ok = val;
+    return struct;
+  }
+  // ignore: unused_element
+  factory _ResultResultErrorStructFfiVoidVoid.err() {
+    final struct = ffi.Struct.create<_ResultResultErrorStructFfiVoidVoid>();
     struct.isOk = false;
     return struct;
   }

--- a/feature_tests/js/api/ErrorStruct.d.ts
+++ b/feature_tests/js/api/ErrorStruct.d.ts
@@ -22,4 +22,6 @@ export class ErrorStruct {
     */
     constructor(structObj: ErrorStruct_obj);
 
+
+    static returnsResultOption(isSome: boolean): ErrorStruct | null | null;
 }

--- a/feature_tests/js/api/ErrorStruct.mjs
+++ b/feature_tests/js/api/ErrorStruct.mjs
@@ -107,6 +107,25 @@ export class ErrorStruct {
     }
 
 
+    static returnsResultOption(isSome) {
+        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 13, 4, true);
+
+
+        const result = wasm.ErrorStruct_returns_result_option(diplomatReceive.buffer, isSome);
+
+        try {
+            if (!diplomatReceive.resultFlag) {
+                return null;
+            }
+            return diplomatRuntime.readOption(wasm, diplomatReceive.buffer, 8, (wasm, offset) => { const deref = offset; return ErrorStruct._fromFFI(diplomatRuntime.internalConstructor, deref) });
+        }
+
+        finally {
+            diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
+            diplomatReceive.free();
+        }
+    }
+
     constructor(structObj) {
         return this.#internalConstructor(...arguments)
     }

--- a/feature_tests/nanobind/src/include/ErrorStruct.d.hpp
+++ b/feature_tests/nanobind/src/include/ErrorStruct.d.hpp
@@ -10,6 +10,10 @@
 #include <optional>
 #include <cstdlib>
 #include "diplomat_runtime.hpp"
+namespace somelib {
+struct ErrorStruct;
+} // namespace somelib
+
 
 
 namespace somelib {
@@ -28,6 +32,8 @@ namespace somelib {
 struct ErrorStruct {
     int32_t i;
     int32_t j;
+
+  inline static somelib::diplomat::result<std::optional<somelib::ErrorStruct>, std::monostate> returns_result_option(bool is_some);
 
     inline somelib::capi::ErrorStruct AsFFI() const;
     inline static somelib::ErrorStruct FromFFI(somelib::capi::ErrorStruct c_struct);

--- a/feature_tests/nanobind/src/include/ErrorStruct.hpp
+++ b/feature_tests/nanobind/src/include/ErrorStruct.hpp
@@ -16,9 +16,19 @@
 
 namespace somelib {
 namespace capi {
+    extern "C" {
 
+    typedef struct ErrorStruct_returns_result_option_result {union {somelib::capi::ErrorStruct_option ok; }; bool is_ok;} ErrorStruct_returns_result_option_result;
+    ErrorStruct_returns_result_option_result ErrorStruct_returns_result_option(bool is_some);
+
+    } // extern "C"
 } // namespace capi
 } // namespace
+
+inline somelib::diplomat::result<std::optional<somelib::ErrorStruct>, std::monostate> somelib::ErrorStruct::returns_result_option(bool is_some) {
+    auto result = somelib::capi::ErrorStruct_returns_result_option(is_some);
+    return result.is_ok ? somelib::diplomat::result<std::optional<somelib::ErrorStruct>, std::monostate>(somelib::diplomat::Ok<std::optional<somelib::ErrorStruct>>(result.ok.is_ok ? std::optional(somelib::ErrorStruct::FromFFI(result.ok.ok)) : std::nullopt)) : somelib::diplomat::result<std::optional<somelib::ErrorStruct>, std::monostate>(somelib::diplomat::Err<std::monostate>());
+}
 
 
 inline somelib::capi::ErrorStruct somelib::ErrorStruct::AsFFI() const {

--- a/feature_tests/nanobind/src/sub_modules/somelib/ErrorStruct_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/ErrorStruct_binding.cpp
@@ -10,7 +10,8 @@ void add_ErrorStruct_binding(nb::module_ mod) {
         .def(nb::init<>())
         .def(nb::init<int32_t, int32_t>(), "i"_a.none(),  "j"_a.none())
         .def_rw("i", &somelib::ErrorStruct::i)
-        .def_rw("j", &somelib::ErrorStruct::j);
+        .def_rw("j", &somelib::ErrorStruct::j)
+        .def_static("returns_result_option", &somelib::ErrorStruct::returns_result_option, "is_some"_a);
 }
 
 } 

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -1,6 +1,6 @@
 #[diplomat::bridge]
 mod ffi {
-    use crate::slices::ffi::MyString;
+    use crate::{slices::ffi::MyString, structs::ffi::MyStruct};
 
     #[diplomat::cfg(supports = "callbacks")]
     pub struct CallbackWrapper {
@@ -118,6 +118,19 @@ mod ffi {
         pub fn test_slice_conversion<'a>(t: impl Fn() -> Result<&'a [f64], ()>) {
             let sl = t().expect("Could not get f64 slice.");
             assert_eq!(sl[1], 2.0);
+        }
+
+        // FIXME: https://github.com/rust-diplomat/diplomat/issues/1154
+        #[diplomat::attr(any(cpp, nanobind, kotlin), disable)]
+        pub fn test_result_option_struct_conversion(
+            t: impl Fn() -> Result<DiplomatOption<MyStruct>, ()>,
+        ) {
+            let st = t();
+            assert!(st.is_ok());
+            let st_opt = st.unwrap().into_option();
+            assert!(st_opt.is_some());
+            let st = st_opt.unwrap();
+            assert_eq!(st.into_a(), 5);
         }
 
         #[diplomat::attr(kotlin, disable)]

--- a/feature_tests/src/result.rs
+++ b/feature_tests/src/result.rs
@@ -22,6 +22,17 @@ pub mod ffi {
         i: i32,
         j: i32,
     }
+    impl ErrorStruct {
+        #[diplomat::attr(kotlin, disable)]
+        pub fn returns_result_option(is_some: bool) -> Result<DiplomatOption<ErrorStruct>, ()> {
+            if is_some {
+                Ok(Some(ErrorStruct { i: 0, j: 125 }).into())
+            } else {
+                Ok(None.into())
+            }
+        }
+    }
+
     impl ResultOpaque {
         #[diplomat::attr(all(*, supports = fallible_constructors), constructor)]
         pub fn new(i: i32) -> Result<Box<ResultOpaque>, ErrorEnum> {


### PR DESCRIPTION
Closes #1153.

Forces `DiplomatOption` to be used instead, since we don't want to deal with the hassle of converting the inner struct with the runtime macro.

This does not handle https://github.com/rust-diplomat/diplomat/issues/1154, that will be a separate PR.