### PR TITLE
Add Clang lifetime annotations to C++ backend

### DIFF
--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -18,6 +18,20 @@
 #include <array>
 #endif
 
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(msvc::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[clang::lifetimebound]]
+#endif
+#endif
+#endif
+
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#define DIPLOMAT_LIFETIME_BOUND
+#endif
+
 namespace icu4x {
 namespace diplomat {
 

--- a/feature_tests/cpp/include/Bar.d.hpp
+++ b/feature_tests/cpp/include/Bar.d.hpp
@@ -33,7 +33,7 @@ namespace somelib {
 class Bar {
 public:
 
-  inline const somelib::Foo& foo() const;
+  inline const somelib::Foo& foo() const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::Bar* AsFFI() const;
     inline somelib::capi::Bar* AsFFI();

--- a/feature_tests/cpp/include/Bar.hpp
+++ b/feature_tests/cpp/include/Bar.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline const somelib::Foo& somelib::Bar::foo() const {
+inline const somelib::Foo& somelib::Bar::foo() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Bar_foo(this->AsFFI());
     return *somelib::Foo::FromFFI(result);
 }

--- a/feature_tests/cpp/include/BorrowedFields.d.hpp
+++ b/feature_tests/cpp/include/BorrowedFields.d.hpp
@@ -37,7 +37,7 @@ struct BorrowedFields {
     std::string_view b;
     std::string_view c;
 
-  inline static somelib::diplomat::result<somelib::BorrowedFields, somelib::diplomat::Utf8Error> from_bar_and_strings(const somelib::Bar& bar, std::u16string_view dstr16, std::string_view utf8_str);
+  inline static somelib::diplomat::result<somelib::BorrowedFields, somelib::diplomat::Utf8Error> from_bar_and_strings(const somelib::Bar& bar DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16 DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str DIPLOMAT_LIFETIME_BOUND);
 
     inline somelib::capi::BorrowedFields AsFFI() const;
     inline static somelib::BorrowedFields FromFFI(somelib::capi::BorrowedFields c_struct);

--- a/feature_tests/cpp/include/BorrowedFields.hpp
+++ b/feature_tests/cpp/include/BorrowedFields.hpp
@@ -25,7 +25,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline somelib::diplomat::result<somelib::BorrowedFields, somelib::diplomat::Utf8Error> somelib::BorrowedFields::from_bar_and_strings(const somelib::Bar& bar, std::u16string_view dstr16, std::string_view utf8_str) {
+inline somelib::diplomat::result<somelib::BorrowedFields, somelib::diplomat::Utf8Error> somelib::BorrowedFields::from_bar_and_strings(const somelib::Bar& bar DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16 DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str DIPLOMAT_LIFETIME_BOUND) {
     if (!somelib::diplomat::capi::diplomat_is_str(utf8_str.data(), utf8_str.size())) {
     return somelib::diplomat::Err<somelib::diplomat::Utf8Error>();
   }

--- a/feature_tests/cpp/include/BorrowedFieldsWithBounds.d.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsWithBounds.d.hpp
@@ -37,7 +37,7 @@ struct BorrowedFieldsWithBounds {
     std::string_view field_b;
     std::string_view field_c;
 
-  inline static somelib::diplomat::result<somelib::BorrowedFieldsWithBounds, somelib::diplomat::Utf8Error> from_foo_and_strings(const somelib::Foo& foo, std::u16string_view dstr16_x, std::string_view utf8_str_z);
+  inline static somelib::diplomat::result<somelib::BorrowedFieldsWithBounds, somelib::diplomat::Utf8Error> from_foo_and_strings(const somelib::Foo& foo DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_x DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_z DIPLOMAT_LIFETIME_BOUND);
 
     inline somelib::capi::BorrowedFieldsWithBounds AsFFI() const;
     inline static somelib::BorrowedFieldsWithBounds FromFFI(somelib::capi::BorrowedFieldsWithBounds c_struct);

--- a/feature_tests/cpp/include/BorrowedFieldsWithBounds.hpp
+++ b/feature_tests/cpp/include/BorrowedFieldsWithBounds.hpp
@@ -25,7 +25,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline somelib::diplomat::result<somelib::BorrowedFieldsWithBounds, somelib::diplomat::Utf8Error> somelib::BorrowedFieldsWithBounds::from_foo_and_strings(const somelib::Foo& foo, std::u16string_view dstr16_x, std::string_view utf8_str_z) {
+inline somelib::diplomat::result<somelib::BorrowedFieldsWithBounds, somelib::diplomat::Utf8Error> somelib::BorrowedFieldsWithBounds::from_foo_and_strings(const somelib::Foo& foo DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_x DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_z DIPLOMAT_LIFETIME_BOUND) {
     if (!somelib::diplomat::capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size())) {
     return somelib::diplomat::Err<somelib::diplomat::Utf8Error>();
   }

--- a/feature_tests/cpp/include/Float64Vec.d.hpp
+++ b/feature_tests/cpp/include/Float64Vec.d.hpp
@@ -47,7 +47,7 @@ public:
 
   inline static std::unique_ptr<somelib::Float64Vec> new_f64_be_bytes(somelib::diplomat::span<const uint8_t> v);
 
-  inline somelib::diplomat::span<const double> as_slice() const;
+  inline somelib::diplomat::span<const double> as_slice() const DIPLOMAT_LIFETIME_BOUND;
 
   inline void fill_slice(somelib::diplomat::span<double> v) const;
 
@@ -57,7 +57,7 @@ public:
   template<typename W>
   inline void to_string_write(W& writeable_output) const;
 
-  inline somelib::diplomat::span<const double> borrow() const;
+  inline somelib::diplomat::span<const double> borrow() const DIPLOMAT_LIFETIME_BOUND;
 
   inline std::optional<double> operator[](size_t i) const;
 

--- a/feature_tests/cpp/include/Float64Vec.hpp
+++ b/feature_tests/cpp/include/Float64Vec.hpp
@@ -86,7 +86,7 @@ inline std::unique_ptr<somelib::Float64Vec> somelib::Float64Vec::new_f64_be_byte
     return std::unique_ptr<somelib::Float64Vec>(somelib::Float64Vec::FromFFI(result));
 }
 
-inline somelib::diplomat::span<const double> somelib::Float64Vec::as_slice() const {
+inline somelib::diplomat::span<const double> somelib::Float64Vec::as_slice() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Float64Vec_as_slice(this->AsFFI());
     return somelib::diplomat::span<const double>(result.data, result.len);
 }
@@ -115,7 +115,7 @@ inline void somelib::Float64Vec::to_string_write(W& writeable) const {
         &write);
 }
 
-inline somelib::diplomat::span<const double> somelib::Float64Vec::borrow() const {
+inline somelib::diplomat::span<const double> somelib::Float64Vec::borrow() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Float64Vec_borrow(this->AsFFI());
     return somelib::diplomat::span<const double>(result.data, result.len);
 }

--- a/feature_tests/cpp/include/Foo.d.hpp
+++ b/feature_tests/cpp/include/Foo.d.hpp
@@ -38,20 +38,20 @@ namespace somelib {
 class Foo {
 public:
 
-  inline static std::unique_ptr<somelib::Foo> new_(std::string_view x);
+  inline static std::unique_ptr<somelib::Foo> new_(std::string_view x DIPLOMAT_LIFETIME_BOUND);
 
-  inline std::unique_ptr<somelib::Bar> get_bar() const;
+  inline std::unique_ptr<somelib::Bar> get_bar() const DIPLOMAT_LIFETIME_BOUND;
 
   inline static std::unique_ptr<somelib::Foo> new_static(std::string_view x);
 
-  inline somelib::BorrowedFieldsReturning as_returning() const;
+  inline somelib::BorrowedFieldsReturning as_returning() const DIPLOMAT_LIFETIME_BOUND;
 
-  inline static std::unique_ptr<somelib::Foo> extract_from_fields(somelib::BorrowedFields fields);
+  inline static std::unique_ptr<somelib::Foo> extract_from_fields(somelib::BorrowedFields fields DIPLOMAT_LIFETIME_BOUND);
 
   /**
    * Test that the extraction logic correctly pins the right fields
    */
-  inline static std::unique_ptr<somelib::Foo> extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds, std::string_view another_string);
+  inline static std::unique_ptr<somelib::Foo> extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds DIPLOMAT_LIFETIME_BOUND, std::string_view another_string DIPLOMAT_LIFETIME_BOUND);
 
     inline const somelib::capi::Foo* AsFFI() const;
     inline somelib::capi::Foo* AsFFI();

--- a/feature_tests/cpp/include/Foo.hpp
+++ b/feature_tests/cpp/include/Foo.hpp
@@ -40,12 +40,12 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<somelib::Foo> somelib::Foo::new_(std::string_view x) {
+inline std::unique_ptr<somelib::Foo> somelib::Foo::new_(std::string_view x DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::Foo_new({x.data(), x.size()});
     return std::unique_ptr<somelib::Foo>(somelib::Foo::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::Bar> somelib::Foo::get_bar() const {
+inline std::unique_ptr<somelib::Bar> somelib::Foo::get_bar() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Foo_get_bar(this->AsFFI());
     return std::unique_ptr<somelib::Bar>(somelib::Bar::FromFFI(result));
 }
@@ -55,17 +55,17 @@ inline std::unique_ptr<somelib::Foo> somelib::Foo::new_static(std::string_view x
     return std::unique_ptr<somelib::Foo>(somelib::Foo::FromFFI(result));
 }
 
-inline somelib::BorrowedFieldsReturning somelib::Foo::as_returning() const {
+inline somelib::BorrowedFieldsReturning somelib::Foo::as_returning() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Foo_as_returning(this->AsFFI());
     return somelib::BorrowedFieldsReturning::FromFFI(result);
 }
 
-inline std::unique_ptr<somelib::Foo> somelib::Foo::extract_from_fields(somelib::BorrowedFields fields) {
+inline std::unique_ptr<somelib::Foo> somelib::Foo::extract_from_fields(somelib::BorrowedFields fields DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::Foo_extract_from_fields(fields.AsFFI());
     return std::unique_ptr<somelib::Foo>(somelib::Foo::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::Foo> somelib::Foo::extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds, std::string_view another_string) {
+inline std::unique_ptr<somelib::Foo> somelib::Foo::extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds DIPLOMAT_LIFETIME_BOUND, std::string_view another_string DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::Foo_extract_from_bounds(bounds.AsFFI(),
         {another_string.data(), another_string.size()});
     return std::unique_ptr<somelib::Foo>(somelib::Foo::FromFFI(result));

--- a/feature_tests/cpp/include/MyString.d.hpp
+++ b/feature_tests/cpp/include/MyString.d.hpp
@@ -55,7 +55,7 @@ public:
   template<typename W>
   inline static somelib::diplomat::result<std::monostate, somelib::diplomat::Utf8Error> string_transform_write(std::string_view foo, W& writeable_output);
 
-  inline std::string_view borrow() const;
+  inline std::string_view borrow() const DIPLOMAT_LIFETIME_BOUND;
 
   inline static std::string slice_of_opaques(somelib::diplomat::span<const somelib::MyString*> sl);
   template<typename W>

--- a/feature_tests/cpp/include/MyString.hpp
+++ b/feature_tests/cpp/include/MyString.hpp
@@ -117,7 +117,7 @@ inline somelib::diplomat::result<std::monostate, somelib::diplomat::Utf8Error> s
     return somelib::diplomat::Ok<std::monostate>();
 }
 
-inline std::string_view somelib::MyString::borrow() const {
+inline std::string_view somelib::MyString::borrow() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::MyString_borrow(this->AsFFI());
     return std::string_view(result.data, result.len);
 }

--- a/feature_tests/cpp/include/NestedBorrowedFields.d.hpp
+++ b/feature_tests/cpp/include/NestedBorrowedFields.d.hpp
@@ -43,7 +43,7 @@ struct NestedBorrowedFields {
     somelib::BorrowedFieldsWithBounds bounds;
     somelib::BorrowedFieldsWithBounds bounds2;
 
-  inline static somelib::diplomat::result<somelib::NestedBorrowedFields, somelib::diplomat::Utf8Error> from_bar_and_foo_and_strings(const somelib::Bar& bar, const somelib::Foo& foo, std::u16string_view dstr16_x, std::u16string_view dstr16_z, std::string_view utf8_str_y, std::string_view utf8_str_z);
+  inline static somelib::diplomat::result<somelib::NestedBorrowedFields, somelib::diplomat::Utf8Error> from_bar_and_foo_and_strings(const somelib::Bar& bar DIPLOMAT_LIFETIME_BOUND, const somelib::Foo& foo DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_x DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_z DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_y DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_z DIPLOMAT_LIFETIME_BOUND);
 
     inline somelib::capi::NestedBorrowedFields AsFFI() const;
     inline static somelib::NestedBorrowedFields FromFFI(somelib::capi::NestedBorrowedFields c_struct);

--- a/feature_tests/cpp/include/NestedBorrowedFields.hpp
+++ b/feature_tests/cpp/include/NestedBorrowedFields.hpp
@@ -28,7 +28,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline somelib::diplomat::result<somelib::NestedBorrowedFields, somelib::diplomat::Utf8Error> somelib::NestedBorrowedFields::from_bar_and_foo_and_strings(const somelib::Bar& bar, const somelib::Foo& foo, std::u16string_view dstr16_x, std::u16string_view dstr16_z, std::string_view utf8_str_y, std::string_view utf8_str_z) {
+inline somelib::diplomat::result<somelib::NestedBorrowedFields, somelib::diplomat::Utf8Error> somelib::NestedBorrowedFields::from_bar_and_foo_and_strings(const somelib::Bar& bar DIPLOMAT_LIFETIME_BOUND, const somelib::Foo& foo DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_x DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_z DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_y DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_z DIPLOMAT_LIFETIME_BOUND) {
     if (!somelib::diplomat::capi::diplomat_is_str(utf8_str_y.data(), utf8_str_y.size())) {
     return somelib::diplomat::Err<somelib::diplomat::Utf8Error>();
   }

--- a/feature_tests/cpp/include/One.d.hpp
+++ b/feature_tests/cpp/include/One.d.hpp
@@ -35,27 +35,27 @@ namespace somelib {
 class One {
 public:
 
-  inline static std::unique_ptr<somelib::One> transitivity(const somelib::One& hold, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> transitivity(const somelib::One& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> cycle(const somelib::Two& hold, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> cycle(const somelib::Two& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> many_dependents(const somelib::One& a, const somelib::One& b, const somelib::Two& c, const somelib::Two& d, const somelib::Two& nohold);
+  inline static std::unique_ptr<somelib::One> many_dependents(const somelib::One& a DIPLOMAT_LIFETIME_BOUND, const somelib::One& b DIPLOMAT_LIFETIME_BOUND, const somelib::Two& c DIPLOMAT_LIFETIME_BOUND, const somelib::Two& d DIPLOMAT_LIFETIME_BOUND, const somelib::Two& nohold);
 
-  inline static std::unique_ptr<somelib::One> return_outlives_param(const somelib::Two& hold, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> return_outlives_param(const somelib::Two& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> diamond_top(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom);
+  inline static std::unique_ptr<somelib::One> diamond_top(const somelib::One& top DIPLOMAT_LIFETIME_BOUND, const somelib::One& left DIPLOMAT_LIFETIME_BOUND, const somelib::One& right DIPLOMAT_LIFETIME_BOUND, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND);
 
-  inline static std::unique_ptr<somelib::One> diamond_left(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom);
+  inline static std::unique_ptr<somelib::One> diamond_left(const somelib::One& top, const somelib::One& left DIPLOMAT_LIFETIME_BOUND, const somelib::One& right, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND);
 
-  inline static std::unique_ptr<somelib::One> diamond_right(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom);
+  inline static std::unique_ptr<somelib::One> diamond_right(const somelib::One& top, const somelib::One& left, const somelib::One& right DIPLOMAT_LIFETIME_BOUND, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND);
 
-  inline static std::unique_ptr<somelib::One> diamond_bottom(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom);
+  inline static std::unique_ptr<somelib::One> diamond_bottom(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND);
 
-  inline static std::unique_ptr<somelib::One> diamond_and_nested_types(const somelib::One& a, const somelib::One& b, const somelib::One& c, const somelib::One& d, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> diamond_and_nested_types(const somelib::One& a DIPLOMAT_LIFETIME_BOUND, const somelib::One& b DIPLOMAT_LIFETIME_BOUND, const somelib::One& c DIPLOMAT_LIFETIME_BOUND, const somelib::One& d DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> implicit_bounds(const somelib::One& explicit_hold, const somelib::One& implicit_hold, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> implicit_bounds(const somelib::One& explicit_hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> implicit_bounds_deep(const somelib::One& explicit_, const somelib::One& implicit_1, const somelib::One& implicit_2, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> implicit_bounds_deep(const somelib::One& explicit_ DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_1 DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_2 DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
     inline const somelib::capi::One* AsFFI() const;
     inline somelib::capi::One* AsFFI();

--- a/feature_tests/cpp/include/One.hpp
+++ b/feature_tests/cpp/include/One.hpp
@@ -47,19 +47,19 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<somelib::One> somelib::One::transitivity(const somelib::One& hold, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::transitivity(const somelib::One& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_transitivity(hold.AsFFI(),
         nohold.AsFFI());
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::cycle(const somelib::Two& hold, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::cycle(const somelib::Two& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_cycle(hold.AsFFI(),
         nohold.AsFFI());
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::many_dependents(const somelib::One& a, const somelib::One& b, const somelib::Two& c, const somelib::Two& d, const somelib::Two& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::many_dependents(const somelib::One& a DIPLOMAT_LIFETIME_BOUND, const somelib::One& b DIPLOMAT_LIFETIME_BOUND, const somelib::Two& c DIPLOMAT_LIFETIME_BOUND, const somelib::Two& d DIPLOMAT_LIFETIME_BOUND, const somelib::Two& nohold) {
     auto result = somelib::capi::One_many_dependents(a.AsFFI(),
         b.AsFFI(),
         c.AsFFI(),
@@ -68,13 +68,13 @@ inline std::unique_ptr<somelib::One> somelib::One::many_dependents(const somelib
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::return_outlives_param(const somelib::Two& hold, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::return_outlives_param(const somelib::Two& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_return_outlives_param(hold.AsFFI(),
         nohold.AsFFI());
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_top(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_top(const somelib::One& top DIPLOMAT_LIFETIME_BOUND, const somelib::One& left DIPLOMAT_LIFETIME_BOUND, const somelib::One& right DIPLOMAT_LIFETIME_BOUND, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::One_diamond_top(top.AsFFI(),
         left.AsFFI(),
         right.AsFFI(),
@@ -82,7 +82,7 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_top(const somelib::On
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_left(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_left(const somelib::One& top, const somelib::One& left DIPLOMAT_LIFETIME_BOUND, const somelib::One& right, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::One_diamond_left(top.AsFFI(),
         left.AsFFI(),
         right.AsFFI(),
@@ -90,7 +90,7 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_left(const somelib::O
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_right(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_right(const somelib::One& top, const somelib::One& left, const somelib::One& right DIPLOMAT_LIFETIME_BOUND, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::One_diamond_right(top.AsFFI(),
         left.AsFFI(),
         right.AsFFI(),
@@ -98,7 +98,7 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_right(const somelib::
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_bottom(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_bottom(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::One_diamond_bottom(top.AsFFI(),
         left.AsFFI(),
         right.AsFFI(),
@@ -106,7 +106,7 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_bottom(const somelib:
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_and_nested_types(const somelib::One& a, const somelib::One& b, const somelib::One& c, const somelib::One& d, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_and_nested_types(const somelib::One& a DIPLOMAT_LIFETIME_BOUND, const somelib::One& b DIPLOMAT_LIFETIME_BOUND, const somelib::One& c DIPLOMAT_LIFETIME_BOUND, const somelib::One& d DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_diamond_and_nested_types(a.AsFFI(),
         b.AsFFI(),
         c.AsFFI(),
@@ -115,14 +115,14 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_and_nested_types(cons
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::implicit_bounds(const somelib::One& explicit_hold, const somelib::One& implicit_hold, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::implicit_bounds(const somelib::One& explicit_hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_implicit_bounds(explicit_hold.AsFFI(),
         implicit_hold.AsFFI(),
         nohold.AsFFI());
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::implicit_bounds_deep(const somelib::One& explicit_, const somelib::One& implicit_1, const somelib::One& implicit_2, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::implicit_bounds_deep(const somelib::One& explicit_ DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_1 DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_2 DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_implicit_bounds_deep(explicit_.AsFFI(),
         implicit_1.AsFFI(),
         implicit_2.AsFFI(),

--- a/feature_tests/cpp/include/OpaqueMutexedString.d.hpp
+++ b/feature_tests/cpp/include/OpaqueMutexedString.d.hpp
@@ -39,15 +39,15 @@ public:
 
   inline void change(size_t number) const;
 
-  inline const somelib::OpaqueMutexedString& borrow() const;
+  inline const somelib::OpaqueMutexedString& borrow() const DIPLOMAT_LIFETIME_BOUND;
 
-  inline static const somelib::OpaqueMutexedString& borrow_other(const somelib::OpaqueMutexedString& other);
+  inline static const somelib::OpaqueMutexedString& borrow_other(const somelib::OpaqueMutexedString& other DIPLOMAT_LIFETIME_BOUND);
 
-  inline const somelib::OpaqueMutexedString& borrow_self_or_other(const somelib::OpaqueMutexedString& other) const;
+  inline const somelib::OpaqueMutexedString& borrow_self_or_other(const somelib::OpaqueMutexedString& other DIPLOMAT_LIFETIME_BOUND) const DIPLOMAT_LIFETIME_BOUND;
 
   inline size_t get_len_and_add(size_t other) const;
 
-  inline std::string_view dummy_str() const;
+  inline std::string_view dummy_str() const DIPLOMAT_LIFETIME_BOUND;
 
   inline std::unique_ptr<somelib::Utf16Wrap> wrapper() const;
 

--- a/feature_tests/cpp/include/OpaqueMutexedString.hpp
+++ b/feature_tests/cpp/include/OpaqueMutexedString.hpp
@@ -53,17 +53,17 @@ inline void somelib::OpaqueMutexedString::change(size_t number) const {
         number);
 }
 
-inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow() const {
+inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueMutexedString_borrow(this->AsFFI());
     return *somelib::OpaqueMutexedString::FromFFI(result);
 }
 
-inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow_other(const somelib::OpaqueMutexedString& other) {
+inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow_other(const somelib::OpaqueMutexedString& other DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::OpaqueMutexedString_borrow_other(other.AsFFI());
     return *somelib::OpaqueMutexedString::FromFFI(result);
 }
 
-inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow_self_or_other(const somelib::OpaqueMutexedString& other) const {
+inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow_self_or_other(const somelib::OpaqueMutexedString& other DIPLOMAT_LIFETIME_BOUND) const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueMutexedString_borrow_self_or_other(this->AsFFI(),
         other.AsFFI());
     return *somelib::OpaqueMutexedString::FromFFI(result);
@@ -75,7 +75,7 @@ inline size_t somelib::OpaqueMutexedString::get_len_and_add(size_t other) const 
     return result;
 }
 
-inline std::string_view somelib::OpaqueMutexedString::dummy_str() const {
+inline std::string_view somelib::OpaqueMutexedString::dummy_str() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueMutexedString_dummy_str(this->AsFFI());
     return std::string_view(result.data, result.len);
 }

--- a/feature_tests/cpp/include/OpaqueThinIter.d.hpp
+++ b/feature_tests/cpp/include/OpaqueThinIter.d.hpp
@@ -33,7 +33,7 @@ namespace somelib {
 class OpaqueThinIter {
 public:
 
-  inline const somelib::OpaqueThin* next();
+  inline const somelib::OpaqueThin* next() DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::OpaqueThinIter* AsFFI() const;
     inline somelib::capi::OpaqueThinIter* AsFFI();

--- a/feature_tests/cpp/include/OpaqueThinIter.hpp
+++ b/feature_tests/cpp/include/OpaqueThinIter.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline const somelib::OpaqueThin* somelib::OpaqueThinIter::next() {
+inline const somelib::OpaqueThin* somelib::OpaqueThinIter::next() DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueThinIter_next(this->AsFFI());
     return somelib::OpaqueThin::FromFFI(result);
 }

--- a/feature_tests/cpp/include/OpaqueThinVec.d.hpp
+++ b/feature_tests/cpp/include/OpaqueThinVec.d.hpp
@@ -39,15 +39,15 @@ public:
 
   inline static std::unique_ptr<somelib::OpaqueThinVec> create(somelib::diplomat::span<const int32_t> a, somelib::diplomat::span<const float> b, std::string_view c);
 
-  inline std::unique_ptr<somelib::OpaqueThinIter> iter() const;
+  inline std::unique_ptr<somelib::OpaqueThinIter> iter() const DIPLOMAT_LIFETIME_BOUND;
   inline somelib::diplomat::next_to_iter_helper<somelib::OpaqueThinIter> begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
 
   inline size_t len() const;
 
-  inline const somelib::OpaqueThin* operator[](size_t idx) const;
+  inline const somelib::OpaqueThin* operator[](size_t idx) const DIPLOMAT_LIFETIME_BOUND;
 
-  inline const somelib::OpaqueThin* first() const;
+  inline const somelib::OpaqueThin* first() const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::OpaqueThinVec* AsFFI() const;
     inline somelib::capi::OpaqueThinVec* AsFFI();

--- a/feature_tests/cpp/include/OpaqueThinVec.hpp
+++ b/feature_tests/cpp/include/OpaqueThinVec.hpp
@@ -43,7 +43,7 @@ inline std::unique_ptr<somelib::OpaqueThinVec> somelib::OpaqueThinVec::create(so
     return std::unique_ptr<somelib::OpaqueThinVec>(somelib::OpaqueThinVec::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::OpaqueThinIter> somelib::OpaqueThinVec::iter() const {
+inline std::unique_ptr<somelib::OpaqueThinIter> somelib::OpaqueThinVec::iter() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueThinVec_iter(this->AsFFI());
     return std::unique_ptr<somelib::OpaqueThinIter>(somelib::OpaqueThinIter::FromFFI(result));
 }
@@ -57,13 +57,13 @@ inline size_t somelib::OpaqueThinVec::len() const {
     return result;
 }
 
-inline const somelib::OpaqueThin* somelib::OpaqueThinVec::operator[](size_t idx) const {
+inline const somelib::OpaqueThin* somelib::OpaqueThinVec::operator[](size_t idx) const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueThinVec_get(this->AsFFI(),
         idx);
     return somelib::OpaqueThin::FromFFI(result);
 }
 
-inline const somelib::OpaqueThin* somelib::OpaqueThinVec::first() const {
+inline const somelib::OpaqueThin* somelib::OpaqueThinVec::first() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueThinVec_first(this->AsFFI());
     return somelib::OpaqueThin::FromFFI(result);
 }

--- a/feature_tests/cpp/include/OptionOpaque.d.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.d.hpp
@@ -55,9 +55,9 @@ public:
 
   inline static somelib::OptionStruct new_struct_nones();
 
-  inline const somelib::OptionOpaque* returns_none_self() const;
+  inline const somelib::OptionOpaque* returns_none_self() const DIPLOMAT_LIFETIME_BOUND;
 
-  inline const somelib::OptionOpaque* returns_some_self() const;
+  inline const somelib::OptionOpaque* returns_some_self() const DIPLOMAT_LIFETIME_BOUND;
 
   inline void assert_integer(int32_t i) const;
 

--- a/feature_tests/cpp/include/OptionOpaque.hpp
+++ b/feature_tests/cpp/include/OptionOpaque.hpp
@@ -126,12 +126,12 @@ inline somelib::OptionStruct somelib::OptionOpaque::new_struct_nones() {
     return somelib::OptionStruct::FromFFI(result);
 }
 
-inline const somelib::OptionOpaque* somelib::OptionOpaque::returns_none_self() const {
+inline const somelib::OptionOpaque* somelib::OptionOpaque::returns_none_self() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OptionOpaque_returns_none_self(this->AsFFI());
     return somelib::OptionOpaque::FromFFI(result);
 }
 
-inline const somelib::OptionOpaque* somelib::OptionOpaque::returns_some_self() const {
+inline const somelib::OptionOpaque* somelib::OptionOpaque::returns_some_self() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OptionOpaque_returns_some_self(this->AsFFI());
     return somelib::OptionOpaque::FromFFI(result);
 }

--- a/feature_tests/cpp/include/OptionString.d.hpp
+++ b/feature_tests/cpp/include/OptionString.d.hpp
@@ -39,7 +39,7 @@ public:
   template<typename W>
   inline somelib::diplomat::result<std::monostate, std::monostate> write_write(W& writeable_output) const;
 
-  inline std::optional<std::string_view> borrow() const;
+  inline std::optional<std::string_view> borrow() const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::OptionString* AsFFI() const;
     inline somelib::capi::OptionString* AsFFI();

--- a/feature_tests/cpp/include/OptionString.hpp
+++ b/feature_tests/cpp/include/OptionString.hpp
@@ -52,7 +52,7 @@ inline somelib::diplomat::result<std::monostate, std::monostate> somelib::Option
     return result.is_ok ? somelib::diplomat::result<std::monostate, std::monostate>(somelib::diplomat::Ok<std::monostate>()) : somelib::diplomat::result<std::monostate, std::monostate>(somelib::diplomat::Err<std::monostate>());
 }
 
-inline std::optional<std::string_view> somelib::OptionString::borrow() const {
+inline std::optional<std::string_view> somelib::OptionString::borrow() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OptionString_borrow(this->AsFFI());
     return result.is_ok ? std::optional<std::string_view>(std::string_view(result.ok.data, result.ok.len)) : std::nullopt;
 }

--- a/feature_tests/cpp/include/PrimitiveStructVec.d.hpp
+++ b/feature_tests/cpp/include/PrimitiveStructVec.d.hpp
@@ -45,9 +45,9 @@ public:
 
   inline size_t len() const;
 
-  inline somelib::diplomat::span<const somelib::PrimitiveStruct> as_slice() const;
+  inline somelib::diplomat::span<const somelib::PrimitiveStruct> as_slice() const DIPLOMAT_LIFETIME_BOUND;
 
-  inline somelib::diplomat::span<somelib::PrimitiveStruct> as_slice_mut();
+  inline somelib::diplomat::span<somelib::PrimitiveStruct> as_slice_mut() DIPLOMAT_LIFETIME_BOUND;
 
   inline std::optional<somelib::PrimitiveStruct> get(size_t idx) const;
 

--- a/feature_tests/cpp/include/PrimitiveStructVec.hpp
+++ b/feature_tests/cpp/include/PrimitiveStructVec.hpp
@@ -58,12 +58,12 @@ inline size_t somelib::PrimitiveStructVec::len() const {
     return result;
 }
 
-inline somelib::diplomat::span<const somelib::PrimitiveStruct> somelib::PrimitiveStructVec::as_slice() const {
+inline somelib::diplomat::span<const somelib::PrimitiveStruct> somelib::PrimitiveStructVec::as_slice() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::PrimitiveStructVec_as_slice(this->AsFFI());
     return somelib::diplomat::span<const somelib::PrimitiveStruct>(reinterpret_cast<const somelib::PrimitiveStruct*>(result.data), result.len);
 }
 
-inline somelib::diplomat::span<somelib::PrimitiveStruct> somelib::PrimitiveStructVec::as_slice_mut() {
+inline somelib::diplomat::span<somelib::PrimitiveStruct> somelib::PrimitiveStructVec::as_slice_mut() DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::PrimitiveStructVec_as_slice_mut(this->AsFFI());
     return somelib::diplomat::span<somelib::PrimitiveStruct>(reinterpret_cast<somelib::PrimitiveStruct*>(result.data), result.len);
 }

--- a/feature_tests/cpp/include/RefList.d.hpp
+++ b/feature_tests/cpp/include/RefList.d.hpp
@@ -35,7 +35,7 @@ namespace somelib {
 class RefList {
 public:
 
-  inline static std::unique_ptr<somelib::RefList> node(const somelib::RefListParameter& data);
+  inline static std::unique_ptr<somelib::RefList> node(const somelib::RefListParameter& data DIPLOMAT_LIFETIME_BOUND);
 
     inline const somelib::capi::RefList* AsFFI() const;
     inline somelib::capi::RefList* AsFFI();

--- a/feature_tests/cpp/include/RefList.hpp
+++ b/feature_tests/cpp/include/RefList.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<somelib::RefList> somelib::RefList::node(const somelib::RefListParameter& data) {
+inline std::unique_ptr<somelib::RefList> somelib::RefList::node(const somelib::RefListParameter& data DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::RefList_node(data.AsFFI());
     return std::unique_ptr<somelib::RefList>(somelib::RefList::FromFFI(result));
 }

--- a/feature_tests/cpp/include/ResultOpaque.d.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.d.hpp
@@ -51,17 +51,17 @@ public:
 
   inline static somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::ResultOpaque>> new_in_enum_err(int32_t i);
 
-  inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> give_self() const;
+  inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> give_self() const DIPLOMAT_LIFETIME_BOUND;
 
   /**
    * When we take &str, the return type becomes a Result
    * Test that this interacts gracefully with returning a reference type
    */
-  inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> takes_str(std::string_view _v);
+  inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> takes_str(std::string_view _v) DIPLOMAT_LIFETIME_BOUND;
 
-  inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> stringify_error() const;
+  inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> stringify_error() const DIPLOMAT_LIFETIME_BOUND;
   template<typename W>
-  inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> stringify_error_write(W& writeable_output) const;
+  inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> stringify_error_write(W& writeable_output) const DIPLOMAT_LIFETIME_BOUND;
 
   inline void assert_integer(int32_t i) const;
 

--- a/feature_tests/cpp/include/ResultOpaque.hpp
+++ b/feature_tests/cpp/include/ResultOpaque.hpp
@@ -100,12 +100,12 @@ inline somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::Re
     return result.is_ok ? somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::ResultOpaque>>(somelib::diplomat::Ok<somelib::ErrorEnum>(somelib::ErrorEnum::FromFFI(result.ok))) : somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::ResultOpaque>>(somelib::diplomat::Err<std::unique_ptr<somelib::ResultOpaque>>(std::unique_ptr<somelib::ResultOpaque>(somelib::ResultOpaque::FromFFI(result.err))));
 }
 
-inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> somelib::ResultOpaque::give_self() const {
+inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> somelib::ResultOpaque::give_self() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::ResultOpaque_give_self(this->AsFFI());
     return result.is_ok ? somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&>(somelib::diplomat::Ok<std::monostate>()) : somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&>(somelib::diplomat::Err<const somelib::ResultOpaque&>(*somelib::ResultOpaque::FromFFI(result.err)));
 }
 
-inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> somelib::ResultOpaque::takes_str(std::string_view _v) {
+inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> somelib::ResultOpaque::takes_str(std::string_view _v) DIPLOMAT_LIFETIME_BOUND {
     if (!somelib::diplomat::capi::diplomat_is_str(_v.data(), _v.size())) {
     return somelib::diplomat::Err<somelib::diplomat::Utf8Error>();
   }
@@ -114,7 +114,7 @@ inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8
     return somelib::diplomat::Ok<somelib::ResultOpaque&>(*somelib::ResultOpaque::FromFFI(result));
 }
 
-inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> somelib::ResultOpaque::stringify_error() const {
+inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> somelib::ResultOpaque::stringify_error() const DIPLOMAT_LIFETIME_BOUND {
     std::string output;
     somelib::diplomat::capi::DiplomatWrite write = somelib::diplomat::WriteFromString(output);
     auto result = somelib::capi::ResultOpaque_stringify_error(this->AsFFI(),
@@ -122,7 +122,7 @@ inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> some
     return result.is_ok ? somelib::diplomat::result<std::string, const somelib::ResultOpaque&>(somelib::diplomat::Ok<std::string>(std::move(output))) : somelib::diplomat::result<std::string, const somelib::ResultOpaque&>(somelib::diplomat::Err<const somelib::ResultOpaque&>(*somelib::ResultOpaque::FromFFI(result.err)));
 }
 template<typename W>
-inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> somelib::ResultOpaque::stringify_error_write(W& writeable) const {
+inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> somelib::ResultOpaque::stringify_error_write(W& writeable) const DIPLOMAT_LIFETIME_BOUND {
     somelib::diplomat::capi::DiplomatWrite write = somelib::diplomat::WriteTrait<W>::Construct(writeable);
     auto result = somelib::capi::ResultOpaque_stringify_error(this->AsFFI(),
         &write);

--- a/feature_tests/cpp/include/Utf16Wrap.d.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.d.hpp
@@ -39,7 +39,7 @@ public:
   template<typename W>
   inline void get_debug_str_write(W& writeable_output) const;
 
-  inline std::u16string_view borrow_cont() const;
+  inline std::u16string_view borrow_cont() const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::Utf16Wrap* AsFFI() const;
     inline somelib::capi::Utf16Wrap* AsFFI();

--- a/feature_tests/cpp/include/Utf16Wrap.hpp
+++ b/feature_tests/cpp/include/Utf16Wrap.hpp
@@ -49,7 +49,7 @@ inline void somelib::Utf16Wrap::get_debug_str_write(W& writeable) const {
         &write);
 }
 
-inline std::u16string_view somelib::Utf16Wrap::borrow_cont() const {
+inline std::u16string_view somelib::Utf16Wrap::borrow_cont() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Utf16Wrap_borrow_cont(this->AsFFI());
     return std::u16string_view(result.data, result.len);
 }

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -18,6 +18,20 @@
 #include <array>
 #endif
 
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(msvc::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[clang::lifetimebound]]
+#endif
+#endif
+#endif
+
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#define DIPLOMAT_LIFETIME_BOUND
+#endif
+
 namespace somelib {
 namespace diplomat {
 

--- a/feature_tests/cpp/include/ns/RenamedMyIndexer.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIndexer.d.hpp
@@ -37,9 +37,9 @@ public:
 
   inline static std::unique_ptr<somelib::ns::RenamedMyIndexer> new_(somelib::diplomat::span<const diplomat::string_view_for_slice> v);
 
-  inline std::optional<std::string_view> operator[](size_t i) const;
+  inline std::optional<std::string_view> operator[](size_t i) const DIPLOMAT_LIFETIME_BOUND;
 
-  inline std::optional<std::string_view> operator[](std::string_view s) const;
+  inline std::optional<std::string_view> operator[](std::string_view s) const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::ns::capi::RenamedMyIndexer* AsFFI() const;
     inline somelib::ns::capi::RenamedMyIndexer* AsFFI();

--- a/feature_tests/cpp/include/ns/RenamedMyIndexer.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIndexer.hpp
@@ -37,13 +37,13 @@ inline std::unique_ptr<somelib::ns::RenamedMyIndexer> somelib::ns::RenamedMyInde
     return std::unique_ptr<somelib::ns::RenamedMyIndexer>(somelib::ns::RenamedMyIndexer::FromFFI(result));
 }
 
-inline std::optional<std::string_view> somelib::ns::RenamedMyIndexer::operator[](size_t i) const {
+inline std::optional<std::string_view> somelib::ns::RenamedMyIndexer::operator[](size_t i) const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_MyIndexer_get(this->AsFFI(),
         i);
     return result.is_ok ? std::optional<std::string_view>(std::string_view(result.ok.data, result.ok.len)) : std::nullopt;
 }
 
-inline std::optional<std::string_view> somelib::ns::RenamedMyIndexer::operator[](std::string_view s) const {
+inline std::optional<std::string_view> somelib::ns::RenamedMyIndexer::operator[](std::string_view s) const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_MyIndexer_get_str(this->AsFFI(),
         {s.data(), s.size()});
     return result.is_ok ? std::optional<std::string_view>(std::string_view(result.ok.data, result.ok.len)) : std::nullopt;

--- a/feature_tests/cpp/include/ns/RenamedMyIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterable.d.hpp
@@ -39,7 +39,7 @@ public:
 
   inline static std::unique_ptr<somelib::ns::RenamedMyIterable> new_(somelib::diplomat::span<const uint8_t> x);
 
-  inline std::unique_ptr<somelib::ns::RenamedMyIterator> iter() const;
+  inline std::unique_ptr<somelib::ns::RenamedMyIterator> iter() const DIPLOMAT_LIFETIME_BOUND;
   inline somelib::diplomat::next_to_iter_helper<somelib::ns::RenamedMyIterator> begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
 

--- a/feature_tests/cpp/include/ns/RenamedMyIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedMyIterable.hpp
@@ -34,7 +34,7 @@ inline std::unique_ptr<somelib::ns::RenamedMyIterable> somelib::ns::RenamedMyIte
     return std::unique_ptr<somelib::ns::RenamedMyIterable>(somelib::ns::RenamedMyIterable::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::ns::RenamedMyIterator> somelib::ns::RenamedMyIterable::iter() const {
+inline std::unique_ptr<somelib::ns::RenamedMyIterator> somelib::ns::RenamedMyIterable::iter() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_MyIterable_iter(this->AsFFI());
     return std::unique_ptr<somelib::ns::RenamedMyIterator>(somelib::ns::RenamedMyIterator::FromFFI(result));
 }

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterable.d.hpp
@@ -39,7 +39,7 @@ public:
 
   inline static std::unique_ptr<somelib::ns::RenamedOpaqueIterable> new_(size_t size);
 
-  inline std::unique_ptr<somelib::ns::RenamedOpaqueIterator> iter() const;
+  inline std::unique_ptr<somelib::ns::RenamedOpaqueIterator> iter() const DIPLOMAT_LIFETIME_BOUND;
   inline somelib::diplomat::next_to_iter_helper<somelib::ns::RenamedOpaqueIterator> begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
 

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterable.hpp
@@ -34,7 +34,7 @@ inline std::unique_ptr<somelib::ns::RenamedOpaqueIterable> somelib::ns::RenamedO
     return std::unique_ptr<somelib::ns::RenamedOpaqueIterable>(somelib::ns::RenamedOpaqueIterable::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::ns::RenamedOpaqueIterator> somelib::ns::RenamedOpaqueIterable::iter() const {
+inline std::unique_ptr<somelib::ns::RenamedOpaqueIterator> somelib::ns::RenamedOpaqueIterable::iter() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_OpaqueIterable_iter(this->AsFFI());
     return std::unique_ptr<somelib::ns::RenamedOpaqueIterator>(somelib::ns::RenamedOpaqueIterator::FromFFI(result));
 }

--- a/feature_tests/cpp/include/ns/RenamedOpaqueRefIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueRefIterable.d.hpp
@@ -39,7 +39,7 @@ public:
 
   inline static std::unique_ptr<somelib::ns::RenamedOpaqueRefIterable> new_(size_t size);
 
-  inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator> iter() const;
+  inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator> iter() const DIPLOMAT_LIFETIME_BOUND;
   inline somelib::diplomat::next_to_iter_helper<somelib::ns::RenamedOpaqueRefIterator> begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
 

--- a/feature_tests/cpp/include/ns/RenamedOpaqueRefIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueRefIterable.hpp
@@ -34,7 +34,7 @@ inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterable> somelib::ns::Renam
     return std::unique_ptr<somelib::ns::RenamedOpaqueRefIterable>(somelib::ns::RenamedOpaqueRefIterable::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator> somelib::ns::RenamedOpaqueRefIterable::iter() const {
+inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator> somelib::ns::RenamedOpaqueRefIterable::iter() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_OpaqueRefIterable_iter(this->AsFFI());
     return std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator>(somelib::ns::RenamedOpaqueRefIterator::FromFFI(result));
 }

--- a/feature_tests/cpp/include/ns/RenamedOpaqueRefIterator.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueRefIterator.d.hpp
@@ -35,7 +35,7 @@ namespace somelib::ns {
 class RenamedOpaqueRefIterator {
 public:
 
-  inline const somelib::ns::AttrOpaque1Renamed* next();
+  inline const somelib::ns::AttrOpaque1Renamed* next() DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::ns::capi::RenamedOpaqueRefIterator* AsFFI() const;
     inline somelib::ns::capi::RenamedOpaqueRefIterator* AsFFI();

--- a/feature_tests/cpp/include/ns/RenamedOpaqueRefIterator.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueRefIterator.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline const somelib::ns::AttrOpaque1Renamed* somelib::ns::RenamedOpaqueRefIterator::next() {
+inline const somelib::ns::AttrOpaque1Renamed* somelib::ns::RenamedOpaqueRefIterator::next() DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_OpaqueRefIterator_next(this->AsFFI());
     return somelib::ns::AttrOpaque1Renamed::FromFFI(result);
 }

--- a/feature_tests/nanobind/src/include/Bar.d.hpp
+++ b/feature_tests/nanobind/src/include/Bar.d.hpp
@@ -33,7 +33,7 @@ namespace somelib {
 class Bar {
 public:
 
-  inline const somelib::Foo& foo() const;
+  inline const somelib::Foo& foo() const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::Bar* AsFFI() const;
     inline somelib::capi::Bar* AsFFI();

--- a/feature_tests/nanobind/src/include/Bar.hpp
+++ b/feature_tests/nanobind/src/include/Bar.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline const somelib::Foo& somelib::Bar::foo() const {
+inline const somelib::Foo& somelib::Bar::foo() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Bar_foo(this->AsFFI());
     return *somelib::Foo::FromFFI(result);
 }

--- a/feature_tests/nanobind/src/include/BorrowedFields.d.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFields.d.hpp
@@ -37,7 +37,7 @@ struct BorrowedFields {
     std::string_view b;
     std::string_view c;
 
-  inline static somelib::diplomat::result<somelib::BorrowedFields, somelib::diplomat::Utf8Error> from_bar_and_strings(const somelib::Bar& bar, std::u16string_view dstr16, std::string_view utf8_str);
+  inline static somelib::diplomat::result<somelib::BorrowedFields, somelib::diplomat::Utf8Error> from_bar_and_strings(const somelib::Bar& bar DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16 DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str DIPLOMAT_LIFETIME_BOUND);
 
     inline somelib::capi::BorrowedFields AsFFI() const;
     inline static somelib::BorrowedFields FromFFI(somelib::capi::BorrowedFields c_struct);

--- a/feature_tests/nanobind/src/include/BorrowedFields.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFields.hpp
@@ -25,7 +25,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline somelib::diplomat::result<somelib::BorrowedFields, somelib::diplomat::Utf8Error> somelib::BorrowedFields::from_bar_and_strings(const somelib::Bar& bar, std::u16string_view dstr16, std::string_view utf8_str) {
+inline somelib::diplomat::result<somelib::BorrowedFields, somelib::diplomat::Utf8Error> somelib::BorrowedFields::from_bar_and_strings(const somelib::Bar& bar DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16 DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str DIPLOMAT_LIFETIME_BOUND) {
     if (!somelib::diplomat::capi::diplomat_is_str(utf8_str.data(), utf8_str.size())) {
     return somelib::diplomat::Err<somelib::diplomat::Utf8Error>();
   }

--- a/feature_tests/nanobind/src/include/BorrowedFieldsWithBounds.d.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFieldsWithBounds.d.hpp
@@ -37,7 +37,7 @@ struct BorrowedFieldsWithBounds {
     std::string_view field_b;
     std::string_view field_c;
 
-  inline static somelib::diplomat::result<somelib::BorrowedFieldsWithBounds, somelib::diplomat::Utf8Error> from_foo_and_strings(const somelib::Foo& foo, std::u16string_view dstr16_x, std::string_view utf8_str_z);
+  inline static somelib::diplomat::result<somelib::BorrowedFieldsWithBounds, somelib::diplomat::Utf8Error> from_foo_and_strings(const somelib::Foo& foo DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_x DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_z DIPLOMAT_LIFETIME_BOUND);
 
     inline somelib::capi::BorrowedFieldsWithBounds AsFFI() const;
     inline static somelib::BorrowedFieldsWithBounds FromFFI(somelib::capi::BorrowedFieldsWithBounds c_struct);

--- a/feature_tests/nanobind/src/include/BorrowedFieldsWithBounds.hpp
+++ b/feature_tests/nanobind/src/include/BorrowedFieldsWithBounds.hpp
@@ -25,7 +25,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline somelib::diplomat::result<somelib::BorrowedFieldsWithBounds, somelib::diplomat::Utf8Error> somelib::BorrowedFieldsWithBounds::from_foo_and_strings(const somelib::Foo& foo, std::u16string_view dstr16_x, std::string_view utf8_str_z) {
+inline somelib::diplomat::result<somelib::BorrowedFieldsWithBounds, somelib::diplomat::Utf8Error> somelib::BorrowedFieldsWithBounds::from_foo_and_strings(const somelib::Foo& foo DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_x DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_z DIPLOMAT_LIFETIME_BOUND) {
     if (!somelib::diplomat::capi::diplomat_is_str(utf8_str_z.data(), utf8_str_z.size())) {
     return somelib::diplomat::Err<somelib::diplomat::Utf8Error>();
   }

--- a/feature_tests/nanobind/src/include/Float64Vec.d.hpp
+++ b/feature_tests/nanobind/src/include/Float64Vec.d.hpp
@@ -47,7 +47,7 @@ public:
 
   inline static std::unique_ptr<somelib::Float64Vec> new_f64_be_bytes(somelib::diplomat::span<const uint8_t> v);
 
-  inline somelib::diplomat::span<const double> as_slice() const;
+  inline somelib::diplomat::span<const double> as_slice() const DIPLOMAT_LIFETIME_BOUND;
 
   inline void set_value(somelib::diplomat::span<const double> new_slice);
 
@@ -55,7 +55,7 @@ public:
   template<typename W>
   inline void to_string_write(W& writeable_output) const;
 
-  inline somelib::diplomat::span<const double> borrow() const;
+  inline somelib::diplomat::span<const double> borrow() const DIPLOMAT_LIFETIME_BOUND;
 
   inline std::optional<double> operator[](size_t i) const;
 

--- a/feature_tests/nanobind/src/include/Float64Vec.hpp
+++ b/feature_tests/nanobind/src/include/Float64Vec.hpp
@@ -84,7 +84,7 @@ inline std::unique_ptr<somelib::Float64Vec> somelib::Float64Vec::new_f64_be_byte
     return std::unique_ptr<somelib::Float64Vec>(somelib::Float64Vec::FromFFI(result));
 }
 
-inline somelib::diplomat::span<const double> somelib::Float64Vec::as_slice() const {
+inline somelib::diplomat::span<const double> somelib::Float64Vec::as_slice() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Float64Vec_as_slice(this->AsFFI());
     return somelib::diplomat::span<const double>(result.data, result.len);
 }
@@ -108,7 +108,7 @@ inline void somelib::Float64Vec::to_string_write(W& writeable) const {
         &write);
 }
 
-inline somelib::diplomat::span<const double> somelib::Float64Vec::borrow() const {
+inline somelib::diplomat::span<const double> somelib::Float64Vec::borrow() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Float64Vec_borrow(this->AsFFI());
     return somelib::diplomat::span<const double>(result.data, result.len);
 }

--- a/feature_tests/nanobind/src/include/Foo.d.hpp
+++ b/feature_tests/nanobind/src/include/Foo.d.hpp
@@ -38,20 +38,20 @@ namespace somelib {
 class Foo {
 public:
 
-  inline static std::unique_ptr<somelib::Foo> new_(std::string_view x);
+  inline static std::unique_ptr<somelib::Foo> new_(std::string_view x DIPLOMAT_LIFETIME_BOUND);
 
-  inline std::unique_ptr<somelib::Bar> get_bar() const;
+  inline std::unique_ptr<somelib::Bar> get_bar() const DIPLOMAT_LIFETIME_BOUND;
 
   inline static std::unique_ptr<somelib::Foo> new_static(std::string_view x);
 
-  inline somelib::BorrowedFieldsReturning as_returning() const;
+  inline somelib::BorrowedFieldsReturning as_returning() const DIPLOMAT_LIFETIME_BOUND;
 
-  inline static std::unique_ptr<somelib::Foo> extract_from_fields(somelib::BorrowedFields fields);
+  inline static std::unique_ptr<somelib::Foo> extract_from_fields(somelib::BorrowedFields fields DIPLOMAT_LIFETIME_BOUND);
 
   /**
    * Test that the extraction logic correctly pins the right fields
    */
-  inline static std::unique_ptr<somelib::Foo> extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds, std::string_view another_string);
+  inline static std::unique_ptr<somelib::Foo> extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds DIPLOMAT_LIFETIME_BOUND, std::string_view another_string DIPLOMAT_LIFETIME_BOUND);
 
     inline const somelib::capi::Foo* AsFFI() const;
     inline somelib::capi::Foo* AsFFI();

--- a/feature_tests/nanobind/src/include/Foo.hpp
+++ b/feature_tests/nanobind/src/include/Foo.hpp
@@ -40,12 +40,12 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<somelib::Foo> somelib::Foo::new_(std::string_view x) {
+inline std::unique_ptr<somelib::Foo> somelib::Foo::new_(std::string_view x DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::Foo_new({x.data(), x.size()});
     return std::unique_ptr<somelib::Foo>(somelib::Foo::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::Bar> somelib::Foo::get_bar() const {
+inline std::unique_ptr<somelib::Bar> somelib::Foo::get_bar() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Foo_get_bar(this->AsFFI());
     return std::unique_ptr<somelib::Bar>(somelib::Bar::FromFFI(result));
 }
@@ -55,17 +55,17 @@ inline std::unique_ptr<somelib::Foo> somelib::Foo::new_static(std::string_view x
     return std::unique_ptr<somelib::Foo>(somelib::Foo::FromFFI(result));
 }
 
-inline somelib::BorrowedFieldsReturning somelib::Foo::as_returning() const {
+inline somelib::BorrowedFieldsReturning somelib::Foo::as_returning() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Foo_as_returning(this->AsFFI());
     return somelib::BorrowedFieldsReturning::FromFFI(result);
 }
 
-inline std::unique_ptr<somelib::Foo> somelib::Foo::extract_from_fields(somelib::BorrowedFields fields) {
+inline std::unique_ptr<somelib::Foo> somelib::Foo::extract_from_fields(somelib::BorrowedFields fields DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::Foo_extract_from_fields(fields.AsFFI());
     return std::unique_ptr<somelib::Foo>(somelib::Foo::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::Foo> somelib::Foo::extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds, std::string_view another_string) {
+inline std::unique_ptr<somelib::Foo> somelib::Foo::extract_from_bounds(somelib::BorrowedFieldsWithBounds bounds DIPLOMAT_LIFETIME_BOUND, std::string_view another_string DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::Foo_extract_from_bounds(bounds.AsFFI(),
         {another_string.data(), another_string.size()});
     return std::unique_ptr<somelib::Foo>(somelib::Foo::FromFFI(result));

--- a/feature_tests/nanobind/src/include/MyString.d.hpp
+++ b/feature_tests/nanobind/src/include/MyString.d.hpp
@@ -55,7 +55,7 @@ public:
   template<typename W>
   inline static somelib::diplomat::result<std::monostate, somelib::diplomat::Utf8Error> string_transform_write(std::string_view foo, W& writeable_output);
 
-  inline std::string_view borrow() const;
+  inline std::string_view borrow() const DIPLOMAT_LIFETIME_BOUND;
 
   inline static std::string slice_of_opaques(somelib::diplomat::span<const somelib::MyString*> sl);
   template<typename W>

--- a/feature_tests/nanobind/src/include/MyString.hpp
+++ b/feature_tests/nanobind/src/include/MyString.hpp
@@ -117,7 +117,7 @@ inline somelib::diplomat::result<std::monostate, somelib::diplomat::Utf8Error> s
     return somelib::diplomat::Ok<std::monostate>();
 }
 
-inline std::string_view somelib::MyString::borrow() const {
+inline std::string_view somelib::MyString::borrow() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::MyString_borrow(this->AsFFI());
     return std::string_view(result.data, result.len);
 }

--- a/feature_tests/nanobind/src/include/NestedBorrowedFields.d.hpp
+++ b/feature_tests/nanobind/src/include/NestedBorrowedFields.d.hpp
@@ -43,7 +43,7 @@ struct NestedBorrowedFields {
     somelib::BorrowedFieldsWithBounds bounds;
     somelib::BorrowedFieldsWithBounds bounds2;
 
-  inline static somelib::diplomat::result<somelib::NestedBorrowedFields, somelib::diplomat::Utf8Error> from_bar_and_foo_and_strings(const somelib::Bar& bar, const somelib::Foo& foo, std::u16string_view dstr16_x, std::u16string_view dstr16_z, std::string_view utf8_str_y, std::string_view utf8_str_z);
+  inline static somelib::diplomat::result<somelib::NestedBorrowedFields, somelib::diplomat::Utf8Error> from_bar_and_foo_and_strings(const somelib::Bar& bar DIPLOMAT_LIFETIME_BOUND, const somelib::Foo& foo DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_x DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_z DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_y DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_z DIPLOMAT_LIFETIME_BOUND);
 
     inline somelib::capi::NestedBorrowedFields AsFFI() const;
     inline static somelib::NestedBorrowedFields FromFFI(somelib::capi::NestedBorrowedFields c_struct);

--- a/feature_tests/nanobind/src/include/NestedBorrowedFields.hpp
+++ b/feature_tests/nanobind/src/include/NestedBorrowedFields.hpp
@@ -28,7 +28,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline somelib::diplomat::result<somelib::NestedBorrowedFields, somelib::diplomat::Utf8Error> somelib::NestedBorrowedFields::from_bar_and_foo_and_strings(const somelib::Bar& bar, const somelib::Foo& foo, std::u16string_view dstr16_x, std::u16string_view dstr16_z, std::string_view utf8_str_y, std::string_view utf8_str_z) {
+inline somelib::diplomat::result<somelib::NestedBorrowedFields, somelib::diplomat::Utf8Error> somelib::NestedBorrowedFields::from_bar_and_foo_and_strings(const somelib::Bar& bar DIPLOMAT_LIFETIME_BOUND, const somelib::Foo& foo DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_x DIPLOMAT_LIFETIME_BOUND, std::u16string_view dstr16_z DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_y DIPLOMAT_LIFETIME_BOUND, std::string_view utf8_str_z DIPLOMAT_LIFETIME_BOUND) {
     if (!somelib::diplomat::capi::diplomat_is_str(utf8_str_y.data(), utf8_str_y.size())) {
     return somelib::diplomat::Err<somelib::diplomat::Utf8Error>();
   }

--- a/feature_tests/nanobind/src/include/One.d.hpp
+++ b/feature_tests/nanobind/src/include/One.d.hpp
@@ -35,27 +35,27 @@ namespace somelib {
 class One {
 public:
 
-  inline static std::unique_ptr<somelib::One> transitivity(const somelib::One& hold, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> transitivity(const somelib::One& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> cycle(const somelib::Two& hold, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> cycle(const somelib::Two& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> many_dependents(const somelib::One& a, const somelib::One& b, const somelib::Two& c, const somelib::Two& d, const somelib::Two& nohold);
+  inline static std::unique_ptr<somelib::One> many_dependents(const somelib::One& a DIPLOMAT_LIFETIME_BOUND, const somelib::One& b DIPLOMAT_LIFETIME_BOUND, const somelib::Two& c DIPLOMAT_LIFETIME_BOUND, const somelib::Two& d DIPLOMAT_LIFETIME_BOUND, const somelib::Two& nohold);
 
-  inline static std::unique_ptr<somelib::One> return_outlives_param(const somelib::Two& hold, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> return_outlives_param(const somelib::Two& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> diamond_top(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom);
+  inline static std::unique_ptr<somelib::One> diamond_top(const somelib::One& top DIPLOMAT_LIFETIME_BOUND, const somelib::One& left DIPLOMAT_LIFETIME_BOUND, const somelib::One& right DIPLOMAT_LIFETIME_BOUND, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND);
 
-  inline static std::unique_ptr<somelib::One> diamond_left(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom);
+  inline static std::unique_ptr<somelib::One> diamond_left(const somelib::One& top, const somelib::One& left DIPLOMAT_LIFETIME_BOUND, const somelib::One& right, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND);
 
-  inline static std::unique_ptr<somelib::One> diamond_right(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom);
+  inline static std::unique_ptr<somelib::One> diamond_right(const somelib::One& top, const somelib::One& left, const somelib::One& right DIPLOMAT_LIFETIME_BOUND, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND);
 
-  inline static std::unique_ptr<somelib::One> diamond_bottom(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom);
+  inline static std::unique_ptr<somelib::One> diamond_bottom(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND);
 
-  inline static std::unique_ptr<somelib::One> diamond_and_nested_types(const somelib::One& a, const somelib::One& b, const somelib::One& c, const somelib::One& d, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> diamond_and_nested_types(const somelib::One& a DIPLOMAT_LIFETIME_BOUND, const somelib::One& b DIPLOMAT_LIFETIME_BOUND, const somelib::One& c DIPLOMAT_LIFETIME_BOUND, const somelib::One& d DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> implicit_bounds(const somelib::One& explicit_hold, const somelib::One& implicit_hold, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> implicit_bounds(const somelib::One& explicit_hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
-  inline static std::unique_ptr<somelib::One> implicit_bounds_deep(const somelib::One& explicit_, const somelib::One& implicit_1, const somelib::One& implicit_2, const somelib::One& nohold);
+  inline static std::unique_ptr<somelib::One> implicit_bounds_deep(const somelib::One& explicit_ DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_1 DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_2 DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold);
 
     inline const somelib::capi::One* AsFFI() const;
     inline somelib::capi::One* AsFFI();

--- a/feature_tests/nanobind/src/include/One.hpp
+++ b/feature_tests/nanobind/src/include/One.hpp
@@ -47,19 +47,19 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<somelib::One> somelib::One::transitivity(const somelib::One& hold, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::transitivity(const somelib::One& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_transitivity(hold.AsFFI(),
         nohold.AsFFI());
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::cycle(const somelib::Two& hold, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::cycle(const somelib::Two& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_cycle(hold.AsFFI(),
         nohold.AsFFI());
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::many_dependents(const somelib::One& a, const somelib::One& b, const somelib::Two& c, const somelib::Two& d, const somelib::Two& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::many_dependents(const somelib::One& a DIPLOMAT_LIFETIME_BOUND, const somelib::One& b DIPLOMAT_LIFETIME_BOUND, const somelib::Two& c DIPLOMAT_LIFETIME_BOUND, const somelib::Two& d DIPLOMAT_LIFETIME_BOUND, const somelib::Two& nohold) {
     auto result = somelib::capi::One_many_dependents(a.AsFFI(),
         b.AsFFI(),
         c.AsFFI(),
@@ -68,13 +68,13 @@ inline std::unique_ptr<somelib::One> somelib::One::many_dependents(const somelib
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::return_outlives_param(const somelib::Two& hold, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::return_outlives_param(const somelib::Two& hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_return_outlives_param(hold.AsFFI(),
         nohold.AsFFI());
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_top(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_top(const somelib::One& top DIPLOMAT_LIFETIME_BOUND, const somelib::One& left DIPLOMAT_LIFETIME_BOUND, const somelib::One& right DIPLOMAT_LIFETIME_BOUND, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::One_diamond_top(top.AsFFI(),
         left.AsFFI(),
         right.AsFFI(),
@@ -82,7 +82,7 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_top(const somelib::On
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_left(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_left(const somelib::One& top, const somelib::One& left DIPLOMAT_LIFETIME_BOUND, const somelib::One& right, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::One_diamond_left(top.AsFFI(),
         left.AsFFI(),
         right.AsFFI(),
@@ -90,7 +90,7 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_left(const somelib::O
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_right(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_right(const somelib::One& top, const somelib::One& left, const somelib::One& right DIPLOMAT_LIFETIME_BOUND, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::One_diamond_right(top.AsFFI(),
         left.AsFFI(),
         right.AsFFI(),
@@ -98,7 +98,7 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_right(const somelib::
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_bottom(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_bottom(const somelib::One& top, const somelib::One& left, const somelib::One& right, const somelib::One& bottom DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::One_diamond_bottom(top.AsFFI(),
         left.AsFFI(),
         right.AsFFI(),
@@ -106,7 +106,7 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_bottom(const somelib:
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::diamond_and_nested_types(const somelib::One& a, const somelib::One& b, const somelib::One& c, const somelib::One& d, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::diamond_and_nested_types(const somelib::One& a DIPLOMAT_LIFETIME_BOUND, const somelib::One& b DIPLOMAT_LIFETIME_BOUND, const somelib::One& c DIPLOMAT_LIFETIME_BOUND, const somelib::One& d DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_diamond_and_nested_types(a.AsFFI(),
         b.AsFFI(),
         c.AsFFI(),
@@ -115,14 +115,14 @@ inline std::unique_ptr<somelib::One> somelib::One::diamond_and_nested_types(cons
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::implicit_bounds(const somelib::One& explicit_hold, const somelib::One& implicit_hold, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::implicit_bounds(const somelib::One& explicit_hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_hold DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_implicit_bounds(explicit_hold.AsFFI(),
         implicit_hold.AsFFI(),
         nohold.AsFFI());
     return std::unique_ptr<somelib::One>(somelib::One::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::One> somelib::One::implicit_bounds_deep(const somelib::One& explicit_, const somelib::One& implicit_1, const somelib::One& implicit_2, const somelib::One& nohold) {
+inline std::unique_ptr<somelib::One> somelib::One::implicit_bounds_deep(const somelib::One& explicit_ DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_1 DIPLOMAT_LIFETIME_BOUND, const somelib::One& implicit_2 DIPLOMAT_LIFETIME_BOUND, const somelib::One& nohold) {
     auto result = somelib::capi::One_implicit_bounds_deep(explicit_.AsFFI(),
         implicit_1.AsFFI(),
         implicit_2.AsFFI(),

--- a/feature_tests/nanobind/src/include/OpaqueMutexedString.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueMutexedString.d.hpp
@@ -39,15 +39,15 @@ public:
 
   inline void change(size_t number) const;
 
-  inline const somelib::OpaqueMutexedString& borrow() const;
+  inline const somelib::OpaqueMutexedString& borrow() const DIPLOMAT_LIFETIME_BOUND;
 
-  inline static const somelib::OpaqueMutexedString& borrow_other(const somelib::OpaqueMutexedString& other);
+  inline static const somelib::OpaqueMutexedString& borrow_other(const somelib::OpaqueMutexedString& other DIPLOMAT_LIFETIME_BOUND);
 
-  inline const somelib::OpaqueMutexedString& borrow_self_or_other(const somelib::OpaqueMutexedString& other) const;
+  inline const somelib::OpaqueMutexedString& borrow_self_or_other(const somelib::OpaqueMutexedString& other DIPLOMAT_LIFETIME_BOUND) const DIPLOMAT_LIFETIME_BOUND;
 
   inline size_t get_len_and_add(size_t other) const;
 
-  inline std::string_view dummy_str() const;
+  inline std::string_view dummy_str() const DIPLOMAT_LIFETIME_BOUND;
 
   inline std::unique_ptr<somelib::Utf16Wrap> wrapper() const;
 

--- a/feature_tests/nanobind/src/include/OpaqueMutexedString.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueMutexedString.hpp
@@ -53,17 +53,17 @@ inline void somelib::OpaqueMutexedString::change(size_t number) const {
         number);
 }
 
-inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow() const {
+inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueMutexedString_borrow(this->AsFFI());
     return *somelib::OpaqueMutexedString::FromFFI(result);
 }
 
-inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow_other(const somelib::OpaqueMutexedString& other) {
+inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow_other(const somelib::OpaqueMutexedString& other DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::OpaqueMutexedString_borrow_other(other.AsFFI());
     return *somelib::OpaqueMutexedString::FromFFI(result);
 }
 
-inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow_self_or_other(const somelib::OpaqueMutexedString& other) const {
+inline const somelib::OpaqueMutexedString& somelib::OpaqueMutexedString::borrow_self_or_other(const somelib::OpaqueMutexedString& other DIPLOMAT_LIFETIME_BOUND) const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueMutexedString_borrow_self_or_other(this->AsFFI(),
         other.AsFFI());
     return *somelib::OpaqueMutexedString::FromFFI(result);
@@ -75,7 +75,7 @@ inline size_t somelib::OpaqueMutexedString::get_len_and_add(size_t other) const 
     return result;
 }
 
-inline std::string_view somelib::OpaqueMutexedString::dummy_str() const {
+inline std::string_view somelib::OpaqueMutexedString::dummy_str() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueMutexedString_dummy_str(this->AsFFI());
     return std::string_view(result.data, result.len);
 }

--- a/feature_tests/nanobind/src/include/OpaqueThinIter.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinIter.d.hpp
@@ -33,7 +33,7 @@ namespace somelib {
 class OpaqueThinIter {
 public:
 
-  inline const somelib::OpaqueThin* next();
+  inline const somelib::OpaqueThin* next() DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::OpaqueThinIter* AsFFI() const;
     inline somelib::capi::OpaqueThinIter* AsFFI();

--- a/feature_tests/nanobind/src/include/OpaqueThinIter.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinIter.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline const somelib::OpaqueThin* somelib::OpaqueThinIter::next() {
+inline const somelib::OpaqueThin* somelib::OpaqueThinIter::next() DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueThinIter_next(this->AsFFI());
     return somelib::OpaqueThin::FromFFI(result);
 }

--- a/feature_tests/nanobind/src/include/OpaqueThinVec.d.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinVec.d.hpp
@@ -39,15 +39,15 @@ public:
 
   inline static std::unique_ptr<somelib::OpaqueThinVec> create(somelib::diplomat::span<const int32_t> a, somelib::diplomat::span<const float> b, std::string_view c);
 
-  inline std::unique_ptr<somelib::OpaqueThinIter> iter() const;
+  inline std::unique_ptr<somelib::OpaqueThinIter> iter() const DIPLOMAT_LIFETIME_BOUND;
   inline somelib::diplomat::next_to_iter_helper<somelib::OpaqueThinIter> begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
 
   inline size_t __len__() const;
 
-  inline const somelib::OpaqueThin* operator[](size_t idx) const;
+  inline const somelib::OpaqueThin* operator[](size_t idx) const DIPLOMAT_LIFETIME_BOUND;
 
-  inline const somelib::OpaqueThin* first() const;
+  inline const somelib::OpaqueThin* first() const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::OpaqueThinVec* AsFFI() const;
     inline somelib::capi::OpaqueThinVec* AsFFI();

--- a/feature_tests/nanobind/src/include/OpaqueThinVec.hpp
+++ b/feature_tests/nanobind/src/include/OpaqueThinVec.hpp
@@ -43,7 +43,7 @@ inline std::unique_ptr<somelib::OpaqueThinVec> somelib::OpaqueThinVec::create(so
     return std::unique_ptr<somelib::OpaqueThinVec>(somelib::OpaqueThinVec::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::OpaqueThinIter> somelib::OpaqueThinVec::iter() const {
+inline std::unique_ptr<somelib::OpaqueThinIter> somelib::OpaqueThinVec::iter() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueThinVec_iter(this->AsFFI());
     return std::unique_ptr<somelib::OpaqueThinIter>(somelib::OpaqueThinIter::FromFFI(result));
 }
@@ -57,13 +57,13 @@ inline size_t somelib::OpaqueThinVec::__len__() const {
     return result;
 }
 
-inline const somelib::OpaqueThin* somelib::OpaqueThinVec::operator[](size_t idx) const {
+inline const somelib::OpaqueThin* somelib::OpaqueThinVec::operator[](size_t idx) const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueThinVec_get(this->AsFFI(),
         idx);
     return somelib::OpaqueThin::FromFFI(result);
 }
 
-inline const somelib::OpaqueThin* somelib::OpaqueThinVec::first() const {
+inline const somelib::OpaqueThin* somelib::OpaqueThinVec::first() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OpaqueThinVec_first(this->AsFFI());
     return somelib::OpaqueThin::FromFFI(result);
 }

--- a/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.d.hpp
@@ -55,9 +55,9 @@ public:
 
   inline static somelib::OptionStruct new_struct_nones();
 
-  inline const somelib::OptionOpaque* returns_none_self() const;
+  inline const somelib::OptionOpaque* returns_none_self() const DIPLOMAT_LIFETIME_BOUND;
 
-  inline const somelib::OptionOpaque* returns_some_self() const;
+  inline const somelib::OptionOpaque* returns_some_self() const DIPLOMAT_LIFETIME_BOUND;
 
   inline void assert_integer(int32_t i) const;
 

--- a/feature_tests/nanobind/src/include/OptionOpaque.hpp
+++ b/feature_tests/nanobind/src/include/OptionOpaque.hpp
@@ -126,12 +126,12 @@ inline somelib::OptionStruct somelib::OptionOpaque::new_struct_nones() {
     return somelib::OptionStruct::FromFFI(result);
 }
 
-inline const somelib::OptionOpaque* somelib::OptionOpaque::returns_none_self() const {
+inline const somelib::OptionOpaque* somelib::OptionOpaque::returns_none_self() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OptionOpaque_returns_none_self(this->AsFFI());
     return somelib::OptionOpaque::FromFFI(result);
 }
 
-inline const somelib::OptionOpaque* somelib::OptionOpaque::returns_some_self() const {
+inline const somelib::OptionOpaque* somelib::OptionOpaque::returns_some_self() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OptionOpaque_returns_some_self(this->AsFFI());
     return somelib::OptionOpaque::FromFFI(result);
 }

--- a/feature_tests/nanobind/src/include/OptionString.d.hpp
+++ b/feature_tests/nanobind/src/include/OptionString.d.hpp
@@ -39,7 +39,7 @@ public:
   template<typename W>
   inline somelib::diplomat::result<std::monostate, std::monostate> write_write(W& writeable_output) const;
 
-  inline std::optional<std::string_view> borrow() const;
+  inline std::optional<std::string_view> borrow() const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::OptionString* AsFFI() const;
     inline somelib::capi::OptionString* AsFFI();

--- a/feature_tests/nanobind/src/include/OptionString.hpp
+++ b/feature_tests/nanobind/src/include/OptionString.hpp
@@ -52,7 +52,7 @@ inline somelib::diplomat::result<std::monostate, std::monostate> somelib::Option
     return result.is_ok ? somelib::diplomat::result<std::monostate, std::monostate>(somelib::diplomat::Ok<std::monostate>()) : somelib::diplomat::result<std::monostate, std::monostate>(somelib::diplomat::Err<std::monostate>());
 }
 
-inline std::optional<std::string_view> somelib::OptionString::borrow() const {
+inline std::optional<std::string_view> somelib::OptionString::borrow() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::OptionString_borrow(this->AsFFI());
     return result.is_ok ? std::optional<std::string_view>(std::string_view(result.ok.data, result.ok.len)) : std::nullopt;
 }

--- a/feature_tests/nanobind/src/include/PrimitiveStructVec.d.hpp
+++ b/feature_tests/nanobind/src/include/PrimitiveStructVec.d.hpp
@@ -45,7 +45,7 @@ public:
 
   inline size_t __len__() const;
 
-  inline somelib::diplomat::span<const somelib::PrimitiveStruct> as_slice() const;
+  inline somelib::diplomat::span<const somelib::PrimitiveStruct> as_slice() const DIPLOMAT_LIFETIME_BOUND;
 
   inline std::optional<somelib::PrimitiveStruct> operator[](size_t idx) const;
 

--- a/feature_tests/nanobind/src/include/PrimitiveStructVec.hpp
+++ b/feature_tests/nanobind/src/include/PrimitiveStructVec.hpp
@@ -56,7 +56,7 @@ inline size_t somelib::PrimitiveStructVec::__len__() const {
     return result;
 }
 
-inline somelib::diplomat::span<const somelib::PrimitiveStruct> somelib::PrimitiveStructVec::as_slice() const {
+inline somelib::diplomat::span<const somelib::PrimitiveStruct> somelib::PrimitiveStructVec::as_slice() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::PrimitiveStructVec_as_slice(this->AsFFI());
     return somelib::diplomat::span<const somelib::PrimitiveStruct>(reinterpret_cast<const somelib::PrimitiveStruct*>(result.data), result.len);
 }

--- a/feature_tests/nanobind/src/include/RefList.d.hpp
+++ b/feature_tests/nanobind/src/include/RefList.d.hpp
@@ -35,7 +35,7 @@ namespace somelib {
 class RefList {
 public:
 
-  inline static std::unique_ptr<somelib::RefList> node(const somelib::RefListParameter& data);
+  inline static std::unique_ptr<somelib::RefList> node(const somelib::RefListParameter& data DIPLOMAT_LIFETIME_BOUND);
 
     inline const somelib::capi::RefList* AsFFI() const;
     inline somelib::capi::RefList* AsFFI();

--- a/feature_tests/nanobind/src/include/RefList.hpp
+++ b/feature_tests/nanobind/src/include/RefList.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<somelib::RefList> somelib::RefList::node(const somelib::RefListParameter& data) {
+inline std::unique_ptr<somelib::RefList> somelib::RefList::node(const somelib::RefListParameter& data DIPLOMAT_LIFETIME_BOUND) {
     auto result = somelib::capi::RefList_node(data.AsFFI());
     return std::unique_ptr<somelib::RefList>(somelib::RefList::FromFFI(result));
 }

--- a/feature_tests/nanobind/src/include/ResultOpaque.d.hpp
+++ b/feature_tests/nanobind/src/include/ResultOpaque.d.hpp
@@ -51,17 +51,17 @@ public:
 
   inline static somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::ResultOpaque>> new_in_enum_err(int32_t i);
 
-  inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> give_self() const;
+  inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> give_self() const DIPLOMAT_LIFETIME_BOUND;
 
   /**
    * When we take &str, the return type becomes a Result
    * Test that this interacts gracefully with returning a reference type
    */
-  inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> takes_str(std::string_view _v);
+  inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> takes_str(std::string_view _v) DIPLOMAT_LIFETIME_BOUND;
 
-  inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> stringify_error() const;
+  inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> stringify_error() const DIPLOMAT_LIFETIME_BOUND;
   template<typename W>
-  inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> stringify_error_write(W& writeable_output) const;
+  inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> stringify_error_write(W& writeable_output) const DIPLOMAT_LIFETIME_BOUND;
 
   inline void assert_integer(int32_t i) const;
 

--- a/feature_tests/nanobind/src/include/ResultOpaque.hpp
+++ b/feature_tests/nanobind/src/include/ResultOpaque.hpp
@@ -100,12 +100,12 @@ inline somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::Re
     return result.is_ok ? somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::ResultOpaque>>(somelib::diplomat::Ok<somelib::ErrorEnum>(somelib::ErrorEnum::FromFFI(result.ok))) : somelib::diplomat::result<somelib::ErrorEnum, std::unique_ptr<somelib::ResultOpaque>>(somelib::diplomat::Err<std::unique_ptr<somelib::ResultOpaque>>(std::unique_ptr<somelib::ResultOpaque>(somelib::ResultOpaque::FromFFI(result.err))));
 }
 
-inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> somelib::ResultOpaque::give_self() const {
+inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> somelib::ResultOpaque::give_self() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::ResultOpaque_give_self(this->AsFFI());
     return result.is_ok ? somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&>(somelib::diplomat::Ok<std::monostate>()) : somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&>(somelib::diplomat::Err<const somelib::ResultOpaque&>(*somelib::ResultOpaque::FromFFI(result.err)));
 }
 
-inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> somelib::ResultOpaque::takes_str(std::string_view _v) {
+inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8Error> somelib::ResultOpaque::takes_str(std::string_view _v) DIPLOMAT_LIFETIME_BOUND {
     if (!somelib::diplomat::capi::diplomat_is_str(_v.data(), _v.size())) {
     return somelib::diplomat::Err<somelib::diplomat::Utf8Error>();
   }
@@ -114,7 +114,7 @@ inline somelib::diplomat::result<somelib::ResultOpaque&, somelib::diplomat::Utf8
     return somelib::diplomat::Ok<somelib::ResultOpaque&>(*somelib::ResultOpaque::FromFFI(result));
 }
 
-inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> somelib::ResultOpaque::stringify_error() const {
+inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> somelib::ResultOpaque::stringify_error() const DIPLOMAT_LIFETIME_BOUND {
     std::string output;
     somelib::diplomat::capi::DiplomatWrite write = somelib::diplomat::WriteFromString(output);
     auto result = somelib::capi::ResultOpaque_stringify_error(this->AsFFI(),
@@ -122,7 +122,7 @@ inline somelib::diplomat::result<std::string, const somelib::ResultOpaque&> some
     return result.is_ok ? somelib::diplomat::result<std::string, const somelib::ResultOpaque&>(somelib::diplomat::Ok<std::string>(std::move(output))) : somelib::diplomat::result<std::string, const somelib::ResultOpaque&>(somelib::diplomat::Err<const somelib::ResultOpaque&>(*somelib::ResultOpaque::FromFFI(result.err)));
 }
 template<typename W>
-inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> somelib::ResultOpaque::stringify_error_write(W& writeable) const {
+inline somelib::diplomat::result<std::monostate, const somelib::ResultOpaque&> somelib::ResultOpaque::stringify_error_write(W& writeable) const DIPLOMAT_LIFETIME_BOUND {
     somelib::diplomat::capi::DiplomatWrite write = somelib::diplomat::WriteTrait<W>::Construct(writeable);
     auto result = somelib::capi::ResultOpaque_stringify_error(this->AsFFI(),
         &write);

--- a/feature_tests/nanobind/src/include/Utf16Wrap.d.hpp
+++ b/feature_tests/nanobind/src/include/Utf16Wrap.d.hpp
@@ -39,7 +39,7 @@ public:
   template<typename W>
   inline void get_debug_str_write(W& writeable_output) const;
 
-  inline std::u16string_view borrow_cont() const;
+  inline std::u16string_view borrow_cont() const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::capi::Utf16Wrap* AsFFI() const;
     inline somelib::capi::Utf16Wrap* AsFFI();

--- a/feature_tests/nanobind/src/include/Utf16Wrap.hpp
+++ b/feature_tests/nanobind/src/include/Utf16Wrap.hpp
@@ -49,7 +49,7 @@ inline void somelib::Utf16Wrap::get_debug_str_write(W& writeable) const {
         &write);
 }
 
-inline std::u16string_view somelib::Utf16Wrap::borrow_cont() const {
+inline std::u16string_view somelib::Utf16Wrap::borrow_cont() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::capi::Utf16Wrap_borrow_cont(this->AsFFI());
     return std::u16string_view(result.data, result.len);
 }

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -18,6 +18,20 @@
 #include <array>
 #endif
 
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(msvc::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[clang::lifetimebound]]
+#endif
+#endif
+#endif
+
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#define DIPLOMAT_LIFETIME_BOUND
+#endif
+
 namespace somelib {
 namespace diplomat {
 

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIndexer.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIndexer.d.hpp
@@ -37,9 +37,9 @@ public:
 
   inline static std::unique_ptr<somelib::ns::RenamedMyIndexer> new_(somelib::diplomat::span<const diplomat::string_view_for_slice> v);
 
-  inline std::optional<std::string_view> operator[](size_t i) const;
+  inline std::optional<std::string_view> operator[](size_t i) const DIPLOMAT_LIFETIME_BOUND;
 
-  inline std::optional<std::string_view> operator[](std::string_view s) const;
+  inline std::optional<std::string_view> operator[](std::string_view s) const DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::ns::capi::RenamedMyIndexer* AsFFI() const;
     inline somelib::ns::capi::RenamedMyIndexer* AsFFI();

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIndexer.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIndexer.hpp
@@ -37,13 +37,13 @@ inline std::unique_ptr<somelib::ns::RenamedMyIndexer> somelib::ns::RenamedMyInde
     return std::unique_ptr<somelib::ns::RenamedMyIndexer>(somelib::ns::RenamedMyIndexer::FromFFI(result));
 }
 
-inline std::optional<std::string_view> somelib::ns::RenamedMyIndexer::operator[](size_t i) const {
+inline std::optional<std::string_view> somelib::ns::RenamedMyIndexer::operator[](size_t i) const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_MyIndexer_get(this->AsFFI(),
         i);
     return result.is_ok ? std::optional<std::string_view>(std::string_view(result.ok.data, result.ok.len)) : std::nullopt;
 }
 
-inline std::optional<std::string_view> somelib::ns::RenamedMyIndexer::operator[](std::string_view s) const {
+inline std::optional<std::string_view> somelib::ns::RenamedMyIndexer::operator[](std::string_view s) const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_MyIndexer_get_str(this->AsFFI(),
         {s.data(), s.size()});
     return result.is_ok ? std::optional<std::string_view>(std::string_view(result.ok.data, result.ok.len)) : std::nullopt;

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIterable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIterable.d.hpp
@@ -39,7 +39,7 @@ public:
 
   inline static std::unique_ptr<somelib::ns::RenamedMyIterable> new_(somelib::diplomat::span<const uint8_t> x);
 
-  inline std::unique_ptr<somelib::ns::RenamedMyIterator> iter() const;
+  inline std::unique_ptr<somelib::ns::RenamedMyIterator> iter() const DIPLOMAT_LIFETIME_BOUND;
   inline somelib::diplomat::next_to_iter_helper<somelib::ns::RenamedMyIterator> begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
 

--- a/feature_tests/nanobind/src/include/ns/RenamedMyIterable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedMyIterable.hpp
@@ -36,7 +36,7 @@ inline std::unique_ptr<somelib::ns::RenamedMyIterable> somelib::ns::RenamedMyIte
     return std::unique_ptr<somelib::ns::RenamedMyIterable>(somelib::ns::RenamedMyIterable::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::ns::RenamedMyIterator> somelib::ns::RenamedMyIterable::iter() const {
+inline std::unique_ptr<somelib::ns::RenamedMyIterator> somelib::ns::RenamedMyIterable::iter() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_MyIterable_iter(this->AsFFI());
     return std::unique_ptr<somelib::ns::RenamedMyIterator>(somelib::ns::RenamedMyIterator::FromFFI(result));
 }

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterable.d.hpp
@@ -39,7 +39,7 @@ public:
 
   inline static std::unique_ptr<somelib::ns::RenamedOpaqueIterable> new_(size_t size);
 
-  inline std::unique_ptr<somelib::ns::RenamedOpaqueIterator> iter() const;
+  inline std::unique_ptr<somelib::ns::RenamedOpaqueIterator> iter() const DIPLOMAT_LIFETIME_BOUND;
   inline somelib::diplomat::next_to_iter_helper<somelib::ns::RenamedOpaqueIterator> begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
 

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueIterable.hpp
@@ -34,7 +34,7 @@ inline std::unique_ptr<somelib::ns::RenamedOpaqueIterable> somelib::ns::RenamedO
     return std::unique_ptr<somelib::ns::RenamedOpaqueIterable>(somelib::ns::RenamedOpaqueIterable::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::ns::RenamedOpaqueIterator> somelib::ns::RenamedOpaqueIterable::iter() const {
+inline std::unique_ptr<somelib::ns::RenamedOpaqueIterator> somelib::ns::RenamedOpaqueIterable::iter() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_OpaqueIterable_iter(this->AsFFI());
     return std::unique_ptr<somelib::ns::RenamedOpaqueIterator>(somelib::ns::RenamedOpaqueIterator::FromFFI(result));
 }

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueRefIterable.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueRefIterable.d.hpp
@@ -39,7 +39,7 @@ public:
 
   inline static std::unique_ptr<somelib::ns::RenamedOpaqueRefIterable> new_(size_t size);
 
-  inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator> iter() const;
+  inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator> iter() const DIPLOMAT_LIFETIME_BOUND;
   inline somelib::diplomat::next_to_iter_helper<somelib::ns::RenamedOpaqueRefIterator> begin() const;
   inline std::nullopt_t end() const { return std::nullopt; }
 

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueRefIterable.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueRefIterable.hpp
@@ -34,7 +34,7 @@ inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterable> somelib::ns::Renam
     return std::unique_ptr<somelib::ns::RenamedOpaqueRefIterable>(somelib::ns::RenamedOpaqueRefIterable::FromFFI(result));
 }
 
-inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator> somelib::ns::RenamedOpaqueRefIterable::iter() const {
+inline std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator> somelib::ns::RenamedOpaqueRefIterable::iter() const DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_OpaqueRefIterable_iter(this->AsFFI());
     return std::unique_ptr<somelib::ns::RenamedOpaqueRefIterator>(somelib::ns::RenamedOpaqueRefIterator::FromFFI(result));
 }

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueRefIterator.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueRefIterator.d.hpp
@@ -35,7 +35,7 @@ namespace somelib::ns {
 class RenamedOpaqueRefIterator {
 public:
 
-  inline const somelib::ns::AttrOpaque1Renamed* next();
+  inline const somelib::ns::AttrOpaque1Renamed* next() DIPLOMAT_LIFETIME_BOUND;
 
     inline const somelib::ns::capi::RenamedOpaqueRefIterator* AsFFI() const;
     inline somelib::ns::capi::RenamedOpaqueRefIterator* AsFFI();

--- a/feature_tests/nanobind/src/include/ns/RenamedOpaqueRefIterator.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedOpaqueRefIterator.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline const somelib::ns::AttrOpaque1Renamed* somelib::ns::RenamedOpaqueRefIterator::next() {
+inline const somelib::ns::AttrOpaque1Renamed* somelib::ns::RenamedOpaqueRefIterator::next() DIPLOMAT_LIFETIME_BOUND {
     auto result = somelib::ns::capi::namespace_OpaqueRefIterator_next(this->AsFFI());
     return somelib::ns::AttrOpaque1Renamed::FromFFI(result);
 }

--- a/tool/src/cpp/gen.rs
+++ b/tool/src/cpp/gen.rs
@@ -6,6 +6,7 @@ use crate::config;
 use crate::read_custom_binding;
 use crate::ErrorStore;
 use askama::Template;
+use diplomat_core::hir::borrowing_param::ParamBorrowInfo;
 use diplomat_core::hir::CallbackInstantiationFunctionality;
 use diplomat_core::hir::IncludeLocation;
 use diplomat_core::hir::IncludeSource;
@@ -28,6 +29,7 @@ pub struct NamedType<'a> {
     pub(crate) type_name: Cow<'a, str>,
     /// Default value (for method params, but could eventually be for structs).
     pub(crate) default_value: Option<Cow<'a, str>>,
+    pub(crate) lifetimebound: bool,
 }
 
 impl<'a> NamedType<'a> {
@@ -507,6 +509,20 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
         let abi_name = self
             .formatter
             .namespace_c_name(id, method.abi_name.as_str());
+
+        let mut this_borrowed = false;
+        let mut visitor = method.borrowing_param_visitor(self.c.tcx, false);
+
+        if let Some(param_self) = method.param_self.as_ref() {
+            let info = visitor.visit_param(&param_self.ty.clone().into(), "this");
+            if !matches!(
+                info,
+                ParamBorrowInfo::NotBorrowed | ParamBorrowInfo::TemporarySlice
+            ) {
+                this_borrowed = true;
+            }
+        }
+
         let mut param_decls = Vec::new();
         let mut cpp_to_c_params = Vec::new();
 
@@ -559,6 +575,13 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
 
         for param in method.params.iter() {
             let mut decls = self.gen_ty_decl(&param.ty, param.name.as_str());
+            let info = visitor.visit_param(&param.ty, decls.var_name.as_ref());
+            if !matches!(
+                info,
+                ParamBorrowInfo::NotBorrowed | ParamBorrowInfo::TemporarySlice
+            ) {
+                decls.lifetimebound = true;
+            }
             if let Some(d) = &param.attrs.default_value {
                 let s = match d {
                     hir::DefaultArgValue::Bool(b) => b.to_string(),
@@ -702,7 +725,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
                 vec![]
             };
 
-        let post_qualifiers = match &method.param_self {
+        let mut post_qualifiers = match &method.param_self {
             Some(param_self)
                 if param_self.ty.is_immutably_borrowed() || param_self.ty.is_consuming() =>
             {
@@ -711,6 +734,10 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
             Some(_) => vec![],
             None => vec![],
         };
+
+        if this_borrowed {
+            post_qualifiers.push("DIPLOMAT_LIFETIME_BOUND".into());
+        }
 
         Some(MethodInfo::<'ccx> {
             method,
@@ -773,6 +800,7 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx, '_> {
             var_name,
             type_name,
             default_value: None,
+            lifetimebound: false,
         }
     }
 

--- a/tool/templates/cpp/function_defs/param_decls_list.h.jinja
+++ b/tool/templates/cpp/function_defs/param_decls_list.h.jinja
@@ -1,4 +1,4 @@
     {%- for param in m.param_decls %}
         {%- if !loop.first %}, {% endif -%}
-        {{ param.type_name }} {{ param.var_name }} {%- if param.default_value.is_some() && declaration %} = {{param.default_value.as_ref().unwrap()-}} {% endif -%}
+        {{ param.type_name }} {{ param.var_name }} {%- if param.lifetimebound %} DIPLOMAT_LIFETIME_BOUND{% endif -%} {%- if param.default_value.is_some() && declaration %} = {{param.default_value.as_ref().unwrap()-}} {% endif -%}
     {%- endfor -%}

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -18,6 +18,20 @@
 #include <array>
 #endif
 
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(msvc::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+#define DIPLOMAT_LIFETIME_BOUND [[clang::lifetimebound]]
+#endif
+#endif
+#endif
+
+#ifndef DIPLOMAT_LIFETIME_BOUND
+#define DIPLOMAT_LIFETIME_BOUND
+#endif
+
 {% if let Some(lib_name) = lib_name -%} namespace {{lib_name}} { {%- endif ~%}
 namespace diplomat {
 


### PR DESCRIPTION
Fixes https://github.com/rust-diplomat/diplomat/issues/390

Pretty straightforward, we have Fancy Lifetime Infra, and clang needs Basic Lifetime Infra, so it's very simple to get the few bits of information we actually need out of it.