### PR TITLE
C++: Fix function pointer assignment mismatch on embedded toolchains

### DIFF
--- a/example/cpp/include/diplomat_runtime.hpp
+++ b/example/cpp/include/diplomat_runtime.hpp
@@ -102,12 +102,16 @@ extern "C" inline void _flush(capi::DiplomatWrite* w) {
   string->resize(w->len);
 }
 
-extern "C" inline bool _grow(capi::DiplomatWrite* w, uintptr_t requested) {
+extern "C" inline bool _grow_impl(capi::DiplomatWrite* w, uintptr_t requested) {
   std::string* string = reinterpret_cast<std::string*>(w->context);
   string->resize(requested);
   w->cap = string->length();
   w->buf = &(*string)[0];
   return true;
+}
+
+extern "C" inline bool _grow(capi::DiplomatWrite* w, size_t requested) {
+  return _grow_impl(w, static_cast<uintptr_t>(requested));
 }
 
 inline capi::DiplomatWrite WriteFromString(std::string& string) {

--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -102,12 +102,16 @@ extern "C" inline void _flush(capi::DiplomatWrite* w) {
   string->resize(w->len);
 }
 
-extern "C" inline bool _grow(capi::DiplomatWrite* w, uintptr_t requested) {
+extern "C" inline bool _grow_impl(capi::DiplomatWrite* w, uintptr_t requested) {
   std::string* string = reinterpret_cast<std::string*>(w->context);
   string->resize(requested);
   w->cap = string->length();
   w->buf = &(*string)[0];
   return true;
+}
+
+extern "C" inline bool _grow(capi::DiplomatWrite* w, size_t requested) {
+  return _grow_impl(w, static_cast<uintptr_t>(requested));
 }
 
 inline capi::DiplomatWrite WriteFromString(std::string& string) {

--- a/feature_tests/nanobind/src/include/diplomat_runtime.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_runtime.hpp
@@ -102,12 +102,16 @@ extern "C" inline void _flush(capi::DiplomatWrite* w) {
   string->resize(w->len);
 }
 
-extern "C" inline bool _grow(capi::DiplomatWrite* w, uintptr_t requested) {
+extern "C" inline bool _grow_impl(capi::DiplomatWrite* w, uintptr_t requested) {
   std::string* string = reinterpret_cast<std::string*>(w->context);
   string->resize(requested);
   w->cap = string->length();
   w->buf = &(*string)[0];
   return true;
+}
+
+extern "C" inline bool _grow(capi::DiplomatWrite* w, size_t requested) {
+  return _grow_impl(w, static_cast<uintptr_t>(requested));
 }
 
 inline capi::DiplomatWrite WriteFromString(std::string& string) {

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -48,12 +48,16 @@ extern "C" inline void _flush(capi::DiplomatWrite* w) {
   string->resize(w->len);
 }
 
-extern "C" inline bool _grow(capi::DiplomatWrite* w, uintptr_t requested) {
+extern "C" inline bool _grow_impl(capi::DiplomatWrite* w, uintptr_t requested) {
   std::string* string = reinterpret_cast<std::string*>(w->context);
   string->resize(requested);
   w->cap = string->length();
   w->buf = &(*string)[0];
   return true;
+}
+
+extern "C" inline bool _grow(capi::DiplomatWrite* w, size_t requested) {
+  return _grow_impl(w, static_cast<uintptr_t>(requested));
 }
 
 inline capi::DiplomatWrite WriteFromString(std::string& string) {


### PR DESCRIPTION
On embedded toolchains (e.g., Zephyr GCC), size_t and uintptr_t can resolve to distinct primitive types (unsigned int vs long unsigned int). This causes strict type mismatch errors during function pointer assignment (w.grow = _grow).

This adds an underlying _grow_impl and provides a _grow wrapper accepting size_t to ensure cross-platform C++ assignment compatibility.