### PR TITLE
AST Location errors second pass

### DIFF
--- a/core/src/ast/enums.rs
+++ b/core/src/ast/enums.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 use crate::ast::idents::IntoWithSpan;
-use crate::ast::logging::create_report;
+use crate::ast::logging::create_simple_report;
 use crate::ast::SpanLocation;
 
 use super::docs::Docs;
@@ -29,7 +29,7 @@ impl Enum {
             // Assuming all enums cannot have lifetimes? We don't even have a
             // `lifetimes` field. If we change our minds we can adjust this later
             // and update the `CustomType::lifetimes` API accordingly.
-            create_report(
+            create_simple_report(
                 (&enm.ident).spanned_into(module_location),
                 "Enums cannot have generic parameters.".into(),
                 "Suggestion: remove generics".into(),
@@ -48,7 +48,7 @@ impl Enum {
                 .iter()
                 .map(|v| {
                     if !matches!(v.fields, syn::Fields::Unit) {
-                        create_report(
+                        create_simple_report(
                             (&v.ident).spanned_into(module_location),
                             "Enums cannot have fields, we only support C-like enums".into(),
                             "Remove field variant".into(),
@@ -64,7 +64,7 @@ impl Enum {
                             if let Ok(syn::Lit::Int(ref lit_int)) = lit {
                                 lit_int.base10_parse::<isize>().unwrap()
                             } else {
-                                create_report(
+                                create_simple_report(
                                     (&v.ident).spanned_into(module_location),
                                     "Enum discriminants must be constant integers".into(),
                                     "Expected discriminant to be a constant integer".into(),

--- a/core/src/ast/functions.rs
+++ b/core/src/ast/functions.rs
@@ -2,7 +2,9 @@ use serde::Serialize;
 use syn::ItemFn;
 
 use crate::ast::{
-    Attrs, Docs, Ident, LifetimeEnv, Param, PathType, SpanLocation, TypeName, idents::{FromWithSpan, IntoWithSpan}, logging::{AstReport, ContextLocation, create_report}
+    idents::{FromWithSpan, IntoWithSpan},
+    logging::{create_report, AstReport, ContextLocation},
+    Attrs, Docs, Ident, LifetimeEnv, Param, PathType, SpanLocation, TypeName,
 };
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Debug)]
@@ -28,16 +30,15 @@ impl Function {
     ) -> Function {
         let ident: Ident = (&f.sig.ident).spanned_into(module_location);
         if let Some(recv) = f.sig.receiver() {
-            create_report(
-                AstReport::new(
-                    "Cannot use self parameter in free function.".into(),
-                    f.sig.ident.span().spanned_into(module_location),
-                    "".into(),
-                    vec![
-                        ContextLocation::new(recv.self_token.span.spanned_into(module_location), "Suggestion: remove self param.".into())
-                    ]
-                )
-            );
+            create_report(AstReport::new(
+                "Cannot use self parameter in free function.".into(),
+                f.sig.ident.span().spanned_into(module_location),
+                "".into(),
+                vec![ContextLocation::new(
+                    recv.self_token.span.spanned_into(module_location),
+                    "Suggestion: remove self param.".into(),
+                )],
+            ));
         }
 
         let mut attrs = parent_attrs.clone();

--- a/core/src/ast/functions.rs
+++ b/core/src/ast/functions.rs
@@ -27,14 +27,14 @@ impl Function {
         module_location: &SpanLocation,
     ) -> Function {
         let ident: Ident = (&f.sig.ident).spanned_into(module_location);
-        if f.sig.receiver().is_some() {
+        if let Some(recv) = f.sig.receiver() {
             create_report(
                 AstReport::new(
                     "Cannot use self parameter in free function.".into(),
-                    (&f.sig.ident).spanned_into(module_location),
+                    f.sig.ident.span().spanned_into(module_location),
                     "".into(),
                     vec![
-                        ContextLocation::new(f.sig.receiver().unwrap().self_token.span.spanned_into(module_location), "Suggestion: remove self param.".into())
+                        ContextLocation::new(recv.self_token.span.spanned_into(module_location), "Suggestion: remove self param.".into())
                     ]
                 )
             );

--- a/core/src/ast/functions.rs
+++ b/core/src/ast/functions.rs
@@ -2,8 +2,7 @@ use serde::Serialize;
 use syn::ItemFn;
 
 use crate::ast::{
-    idents::{FromWithSpan, IntoWithSpan},
-    Attrs, Docs, Ident, LifetimeEnv, Param, PathType, SpanLocation, TypeName,
+    Attrs, Docs, Ident, LifetimeEnv, Param, PathType, SpanLocation, TypeName, idents::{FromWithSpan, IntoWithSpan}, logging::{AstReport, ContextLocation, create_report}
 };
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Debug)]
@@ -29,7 +28,16 @@ impl Function {
     ) -> Function {
         let ident: Ident = (&f.sig.ident).spanned_into(module_location);
         if f.sig.receiver().is_some() {
-            panic!("Cannot use self parameter in free function {ident:?}")
+            create_report(
+                AstReport::new(
+                    "Cannot use self parameter in free function.".into(),
+                    (&f.sig.ident).spanned_into(module_location),
+                    "".into(),
+                    vec![
+                        ContextLocation::new(f.sig.receiver().unwrap().self_token.span.spanned_into(module_location), "Suggestion: remove self param.".into())
+                    ]
+                )
+            );
         }
 
         let mut attrs = parent_attrs.clone();

--- a/core/src/ast/idents.rs
+++ b/core/src/ast/idents.rs
@@ -147,24 +147,29 @@ impl fmt::Display for Ident {
 
 impl FromWithSpan<&syn::Ident> for Ident {
     fn spanned_from(ident: &syn::Ident, span_location: &SpanLocation) -> Self {
-        let span = ident.span();
-        let start = span.start();
-        let end = span.end();
         Self(
             Cow::from(ident.to_string()),
-            Some(Span {
-                start: LineColumn {
-                    line: start.line,
-                    col: start.column,
-                },
-                end: LineColumn {
-                    line: end.line,
-                    col: end.column,
-                },
-                range: span.byte_range(),
-                span_location: span_location.clone(),
-            }),
+            Some(ident.span().spanned_into(span_location)),
         )
+    }
+}
+
+impl FromWithSpan<proc_macro2::Span> for Span {
+    fn spanned_from(span: proc_macro2::Span, span_location: &SpanLocation) -> Self {
+        let start = span.start();
+        let end = span.end();
+        Span {
+            start: LineColumn {
+                line: start.line,
+                col: start.column,
+            },
+            end: LineColumn {
+                line: end.line,
+                col: end.column,
+            },
+            range: span.byte_range(),
+            span_location: span_location.clone(),
+        }
     }
 }
 

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -289,9 +289,18 @@ impl LifetimeEnv {
 
         if let Some(ref where_clause) = generics.where_clause {
             self.extend_bounds(where_clause.predicates.iter().map(|pred| match pred {
-                syn::WherePredicate::Type(_) => panic!("trait bounds are unsupported"),
+                syn::WherePredicate::Type(_) => {
+                    create_report(AstReport::new(
+                        "Trait bounds are unsupported.".into(),
+                        pred.span().spanned_into(module_location),
+                        "Suggestion: Remove type predicate.".into(),
+                        vec![]
+                    ))
+                },
                 syn::WherePredicate::Lifetime(pred) => (&pred.lifetime, &pred.bounds),
-                _ => panic!("Found unknown kind of where predicate"),
+                _ => {
+                    create_report(AstReport::new("Unrecognized where predicate.".into(), pred.span().spanned_into(module_location), "".into(), vec![]))
+                },
             }));
         }
     }

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -263,9 +263,23 @@ impl LifetimeEnv {
     /// Add the lifetimes from generic parameters and where bounds.
     fn extend_generics(&mut self, generics: &syn::Generics, module_location: &SpanLocation) {
         let generic_bounds = generics.params.iter().map(|generic| match generic {
-            syn::GenericParam::Type(_) => panic!("generic types are unsupported"),
+            syn::GenericParam::Type(_) => {
+                create_report(AstReport::new(
+                    "Generic types are unsupported.".into(),
+                    generic.span().spanned_into(module_location),
+                    "Suggestion: Remove generic type.".into(),
+                    vec![]
+                ));
+            },
             syn::GenericParam::Lifetime(def) => (&def.lifetime, &def.bounds),
-            syn::GenericParam::Const(_) => panic!("const generics are unsupported"),
+            syn::GenericParam::Const(_) => {
+                create_report(AstReport::new(
+                    "Const generics are unsupported.".into(),
+                    generic.span().spanned_into(module_location),
+                    "Suggestion: Remove const generic.".into(),
+                    vec![]
+                ));
+            },
         });
 
         let generic_defs = generic_bounds.clone().map(|(lifetime, _)| lifetime);

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -1,11 +1,11 @@
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use serde::{Deserialize, Serialize};
+use syn::spanned::Spanned;
 use std::fmt;
 
 use crate::ast::{
-    idents::{FromWithSpan, IntoWithSpan},
-    SpanLocation,
+    SpanLocation, idents::{FromWithSpan, IntoWithSpan}, logging::{AstReport, ContextLocation, create_report}
 };
 
 use super::{Attrs, Docs, Ident, Param, SelfParam, TraitSelfParam, TypeName};
@@ -156,9 +156,13 @@ impl LifetimeEnv {
         this
     }
 
-    pub fn from_trait(trt: &syn::ItemTrait) -> Self {
-        if trt.generics.lifetimes().next().is_some() {
-            panic!("Diplomat traits are not allowed to have any lifetime parameters")
+    pub fn from_trait(trt: &syn::ItemTrait, module_location: &SpanLocation) -> Self {
+        if let Some(lt) = trt.generics.lifetimes().next() {
+            create_report(AstReport::new(
+                "Diplomat traits are not allowed to have any lifetime parameters.".into(),
+                trt.ident.span().spanned_into(module_location),
+                "".into(),
+                vec![ContextLocation::new(lt.span().spanned_into(module_location), "Remove lifetime annotations".into())]));
         }
         LifetimeEnv::new()
     }

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -348,11 +348,19 @@ impl LifetimeEnv {
         I: IntoIterator<Item = &'a L>,
     {
         for lifetime in iter {
-            if self.id(lifetime).is_some() {
-                panic!(
-                    "lifetime name `{}` declared twice in the same scope",
-                    NamedLifetime::spanned_from(lifetime, module_location)
-                );
+            if let Some(idx) = self.id(lifetime) {
+                let context_locations = if let Some(sp) = self.nodes[idx].lifetime.0.span() {
+                    vec![ContextLocation::new(sp, "Defined first here.".into())]
+                } else {
+                    vec![]
+                };
+                let lt = NamedLifetime::spanned_from(lifetime, module_location);
+                create_report(AstReport::new(
+                    "Lifetime declared twice in the same scope".into(),
+                    lt.0.span().unwrap(),
+                    format!("Lifetime {lt} already exists."),
+                    context_locations
+                ));
             }
 
             self.nodes.push(LifetimeNode {

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -1,11 +1,13 @@
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use serde::{Deserialize, Serialize};
-use syn::spanned::Spanned;
 use std::fmt;
+use syn::spanned::Spanned;
 
 use crate::ast::{
-    SpanLocation, idents::{FromWithSpan, IntoWithSpan}, logging::{AstReport, ContextLocation, create_report}
+    idents::{FromWithSpan, IntoWithSpan},
+    logging::{create_report, AstReport, ContextLocation},
+    SpanLocation,
 };
 
 use super::{Attrs, Docs, Ident, Param, SelfParam, TraitSelfParam, TypeName};
@@ -162,7 +164,11 @@ impl LifetimeEnv {
                 "Diplomat traits are not allowed to have any lifetime parameters.".into(),
                 trt.ident.span().spanned_into(module_location),
                 "".into(),
-                vec![ContextLocation::new(lt.span().spanned_into(module_location), "Remove lifetime annotations".into())]));
+                vec![ContextLocation::new(
+                    lt.span().spanned_into(module_location),
+                    "Remove lifetime annotations".into(),
+                )],
+            ));
         }
         LifetimeEnv::new()
     }
@@ -268,18 +274,18 @@ impl LifetimeEnv {
                     "Generic types are unsupported.".into(),
                     generic.span().spanned_into(module_location),
                     "Suggestion: Remove generic type.".into(),
-                    vec![]
+                    vec![],
                 ));
-            },
+            }
             syn::GenericParam::Lifetime(def) => (&def.lifetime, &def.bounds),
             syn::GenericParam::Const(_) => {
                 create_report(AstReport::new(
                     "Const generics are unsupported.".into(),
                     generic.span().spanned_into(module_location),
                     "Suggestion: Remove const generic.".into(),
-                    vec![]
+                    vec![],
                 ));
-            },
+            }
         });
 
         let generic_defs = generic_bounds.clone().map(|(lifetime, _)| lifetime);
@@ -289,18 +295,19 @@ impl LifetimeEnv {
 
         if let Some(ref where_clause) = generics.where_clause {
             self.extend_bounds(where_clause.predicates.iter().map(|pred| match pred {
-                syn::WherePredicate::Type(_) => {
-                    create_report(AstReport::new(
-                        "Trait bounds are unsupported.".into(),
-                        pred.span().spanned_into(module_location),
-                        "Suggestion: Remove type predicate.".into(),
-                        vec![]
-                    ))
-                },
+                syn::WherePredicate::Type(_) => create_report(AstReport::new(
+                    "Trait bounds are unsupported.".into(),
+                    pred.span().spanned_into(module_location),
+                    "Suggestion: Remove type predicate.".into(),
+                    vec![],
+                )),
                 syn::WherePredicate::Lifetime(pred) => (&pred.lifetime, &pred.bounds),
-                _ => {
-                    create_report(AstReport::new("Unrecognized where predicate.".into(), pred.span().spanned_into(module_location), "".into(), vec![]))
-                },
+                _ => create_report(AstReport::new(
+                    "Unrecognized where predicate.".into(),
+                    pred.span().spanned_into(module_location),
+                    "".into(),
+                    vec![],
+                )),
             }));
         }
     }
@@ -359,7 +366,7 @@ impl LifetimeEnv {
                     "Lifetime declared twice in the same scope".into(),
                     lt.0.span().unwrap(),
                     format!("Lifetime {lt} already exists."),
-                    context_locations
+                    context_locations,
                 ));
             }
 

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -209,7 +209,7 @@ mod tests {
         );
     }
 
-    const FILES_TO_TEST: &[&str] = &["duplicate_attrs.rs", "enum_field_variant.rs", "attr_on_non_pub.rs"];
+    const FILES_TO_TEST: &[&str] = &["duplicate_attrs.rs", "enum_field_variant.rs", "attr_on_non_pub.rs", "nonstd_result.rs"];
 
     fn test_file_list(suffix: &'static str) {
         {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -269,7 +269,8 @@ mod tests {
         "lifetime_on_trait.rs",
         "generic_types.rs",
         "where_pred.rs",
-        "lifetime_redefine.rs"
+        "lifetime_redefine.rs",
+        "undefined_macro.rs"
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -270,7 +270,9 @@ mod tests {
         "generic_types.rs",
         "where_pred.rs",
         "lifetime_redefine.rs",
-        "undefined_macro.rs"
+        "undefined_macro.rs",
+        "macro_parse_error.rs",
+        "macro_expansion_error.rs"
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -1,6 +1,6 @@
 use std::sync::RwLock;
 
-use crate::ast::{Ident, SpanLocation};
+use crate::ast::{Ident, SpanLocation, idents::Span};
 
 /// For overwriting by tests.
 static WRITER: RwLock<&(dyn Fn() -> Box<dyn std::io::Write> + Send + Sync)> =
@@ -10,14 +10,14 @@ static WRITER: RwLock<&(dyn Fn() -> Box<dyn std::io::Write> + Send + Sync)> =
 pub(crate) struct ContextLocation {
     // Allow for pretty-print:
     #[allow(unused)]
-    location : super::idents::Span,
+    location : Span,
     // Allow for pretty-print:
     #[allow(unused)]
     label : String
 }
 
 impl ContextLocation {
-    pub fn new(location : super::idents::Span, label : String) -> Self {
+    pub fn new(location : Span, label : String) -> Self {
         Self {
             location,
             label
@@ -27,7 +27,7 @@ impl ContextLocation {
 
 pub(crate) struct AstReport {
     title : String,
-    primary_loc : Ident,
+    primary_loc : Option<Span>,
     primary_label : String,
     // Used for pretty-printing, not ugly printing:
     #[allow(unused)]
@@ -35,10 +35,10 @@ pub(crate) struct AstReport {
 }
 
 impl AstReport {
-    pub fn new(title : String, primary_loc : Ident, primary_label : String, context_locations : Vec<ContextLocation>) -> Self {
+    pub fn new(title : String, primary_loc : Span, primary_label : String, context_locations : Vec<ContextLocation>) -> Self {
         Self {
             title,
-            primary_loc,
+            primary_loc: Some(primary_loc),
             primary_label,
             context_locations,
         }
@@ -46,7 +46,7 @@ impl AstReport {
 }
 
 pub(crate) fn create_simple_report(id: Ident, title: String, label: String) -> ! {
-    create_report(AstReport { title, primary_loc: id, primary_label: label, context_locations: vec![] })
+    create_report(AstReport { title, primary_loc: id.span(), primary_label: label, context_locations: vec![] })
 }
 
 
@@ -86,7 +86,7 @@ pub(crate) fn create_report(report : AstReport) -> ! {
     use std::io::Write;
     let mut out = WRITER.read().unwrap()();
 
-    let span = report.primary_loc.span();
+    let span = report.primary_loc;
     let src = if let Some(sp) = &span {
         match &sp.span_location {
             SpanLocation::FilePath(f) => {
@@ -260,7 +260,14 @@ mod tests {
         );
     }
 
-    const FILES_TO_TEST: &[&str] = &["duplicate_attrs.rs", "enum_field_variant.rs", "attr_on_non_pub.rs", "nonstd_result.rs", "self_in_free_func.rs"];
+    const FILES_TO_TEST: &[&str] = &[
+        "duplicate_attrs.rs",
+        "enum_field_variant.rs",
+        "attr_on_non_pub.rs",
+        "nonstd_result.rs",
+        "self_in_free_func.rs",
+        "lifetime_on_trait.rs"
+    ];
 
     fn test_file_list(suffix: &'static str) {
         {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -266,7 +266,8 @@ mod tests {
         "attr_on_non_pub.rs",
         "nonstd_result.rs",
         "self_in_free_func.rs",
-        "lifetime_on_trait.rs"
+        "lifetime_on_trait.rs",
+        "generic_types.rs"
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -209,7 +209,7 @@ mod tests {
         );
     }
 
-    const FILES_TO_TEST: &[&str] = &["duplicate_attrs.rs", "enum_field_variant.rs"];
+    const FILES_TO_TEST: &[&str] = &["duplicate_attrs.rs", "enum_field_variant.rs", "attr_on_non_pub.rs"];
 
     fn test_file_list(suffix: &'static str) {
         {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -1,41 +1,42 @@
 use std::sync::RwLock;
 
-use crate::ast::{Ident, SpanLocation, idents::Span};
+use crate::ast::{idents::Span, Ident, SpanLocation};
 
 /// For overwriting by tests.
 static WRITER: RwLock<&(dyn Fn() -> Box<dyn std::io::Write> + Send + Sync)> =
     RwLock::new(&(|| Box::new(std::io::stderr())));
 
-
 pub(crate) struct ContextLocation {
     // Allow for pretty-print:
     #[allow(unused)]
-    location : Span,
+    location: Span,
     // Allow for pretty-print:
     #[allow(unused)]
-    label : String
+    label: String,
 }
 
 impl ContextLocation {
-    pub fn new(location : Span, label : String) -> Self {
-        Self {
-            location,
-            label
-        }
+    pub fn new(location: Span, label: String) -> Self {
+        Self { location, label }
     }
 }
 
 pub(crate) struct AstReport {
-    title : String,
-    primary_loc : Option<Span>,
-    primary_label : String,
+    title: String,
+    primary_loc: Option<Span>,
+    primary_label: String,
     // Used for pretty-printing, not ugly printing:
     #[allow(unused)]
-    context_locations : Vec<ContextLocation>,
+    context_locations: Vec<ContextLocation>,
 }
 
 impl AstReport {
-    pub fn new(title : String, primary_loc : Span, primary_label : String, context_locations : Vec<ContextLocation>) -> Self {
+    pub fn new(
+        title: String,
+        primary_loc: Span,
+        primary_label: String,
+        context_locations: Vec<ContextLocation>,
+    ) -> Self {
         Self {
             title,
             primary_loc: Some(primary_loc),
@@ -46,14 +47,18 @@ impl AstReport {
 }
 
 pub(crate) fn create_simple_report(id: Ident, title: String, label: String) -> ! {
-    create_report(AstReport { title, primary_loc: id.span(), primary_label: label, context_locations: vec![] })
+    create_report(AstReport {
+        title,
+        primary_loc: id.span(),
+        primary_label: label,
+        context_locations: vec![],
+    })
 }
-
 
 /// Bytes range has not been stabilized in Rust macro.
 /// We can't tell if we're in a proc macro context,
 /// so we just check if the range doesn't make sense:
-fn evaluate_bytes(sp : &super::idents::Span, src : &String) -> std::ops::Range<usize> {
+fn evaluate_bytes(sp: &super::idents::Span, src: &str) -> std::ops::Range<usize> {
     if sp.range.is_empty() && (sp.start.line != sp.end.line || sp.end.col - sp.start.col > 0) {
         match sp.span_location {
             SpanLocation::None => 0..0,
@@ -82,7 +87,7 @@ fn evaluate_bytes(sp : &super::idents::Span, src : &String) -> std::ops::Range<u
     }
 }
 
-pub(crate) fn create_report(report : AstReport) -> ! {
+pub(crate) fn create_report(report: AstReport) -> ! {
     use std::io::Write;
     let mut out = WRITER.read().unwrap()();
 
@@ -113,7 +118,13 @@ pub(crate) fn create_report(report : AstReport) -> ! {
             Some(SpanLocation::FilePath(..)) | Some(SpanLocation::LocalSource(..))
         ) && b.end > src.len()
         {
-            panic!("Span source improperly calculated. Got range {} > {}. Original error: {}: {}", b.end, src.len(), report.title, report.primary_label);
+            panic!(
+                "Span source improperly calculated. Got range {} > {}. Original error: {}: {}",
+                b.end,
+                src.len(),
+                report.title,
+                report.primary_label
+            );
         }
     }
     #[cfg(feature = "pretty-print")]
@@ -137,7 +148,8 @@ pub(crate) fn create_report(report : AstReport) -> ! {
                         AnnotationKind::Primary
                             .span(bytes_range.unwrap())
                             .label(report.primary_label),
-                    ).annotations(annotations),
+                    )
+                    .annotations(annotations),
             )]
         } else {
             &[Level::ERROR
@@ -272,7 +284,7 @@ mod tests {
         "lifetime_redefine.rs",
         "undefined_macro.rs",
         "macro_parse_error.rs",
-        "macro_expansion_error.rs"
+        "macro_expansion_error.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -6,11 +6,87 @@ use crate::ast::{Ident, SpanLocation};
 static WRITER: RwLock<&(dyn Fn() -> Box<dyn std::io::Write> + Send + Sync)> =
     RwLock::new(&(|| Box::new(std::io::stderr())));
 
-pub(crate) fn create_report(id: Ident, title: String, label: String) -> ! {
+
+pub(crate) struct ContextLocation {
+    // Allow for pretty-print:
+    #[allow(unused)]
+    location : super::idents::Span,
+    // Allow for pretty-print:
+    #[allow(unused)]
+    label : String
+}
+
+impl ContextLocation {
+    pub fn new(location : super::idents::Span, label : String) -> Self {
+        Self {
+            location,
+            label
+        }
+    }
+}
+
+pub(crate) struct AstReport {
+    title : String,
+    primary_loc : Ident,
+    primary_label : String,
+    // Used for pretty-printing, not ugly printing:
+    #[allow(unused)]
+    context_locations : Vec<ContextLocation>,
+}
+
+impl AstReport {
+    pub fn new(title : String, primary_loc : Ident, primary_label : String, context_locations : Vec<ContextLocation>) -> Self {
+        Self {
+            title,
+            primary_loc,
+            primary_label,
+            context_locations,
+        }
+    }
+}
+
+pub(crate) fn create_simple_report(id: Ident, title: String, label: String) -> ! {
+    create_report(AstReport { title, primary_loc: id, primary_label: label, context_locations: vec![] })
+}
+
+
+/// Bytes range has not been stabilized in Rust macro.
+/// We can't tell if we're in a proc macro context,
+/// so we just check if the range doesn't make sense:
+fn evaluate_bytes(sp : &super::idents::Span, src : &String) -> std::ops::Range<usize> {
+    if sp.range.is_empty() && (sp.start.line != sp.end.line || sp.end.col - sp.start.col > 0) {
+        match sp.span_location {
+            SpanLocation::None => 0..0,
+            _ => {
+                // Need an accurate byte count that accounts for both:
+                // CRLF and LF endings, so we just make sure to split on the end at `\n` (LF):
+                let split = src.split_inclusive('\n');
+                let mut start_byte = 0usize;
+                let mut end_byte = src.len();
+                let mut running_byte_total = 0usize;
+                for (idx, st) in split.enumerate() {
+                    if (idx + 1) == sp.start.line {
+                        start_byte = running_byte_total + sp.start.col;
+                    }
+                    if (idx + 1) == sp.end.line {
+                        end_byte = running_byte_total + sp.end.col;
+                        break;
+                    }
+                    running_byte_total += st.len();
+                }
+                start_byte..end_byte
+            }
+        }
+    } else {
+        sp.range.clone()
+    }
+}
+
+pub(crate) fn create_report(report : AstReport) -> ! {
     use std::io::Write;
     let mut out = WRITER.read().unwrap()();
 
-    let span = id.span();
+    let span = report.primary_loc.span();
     let src = if let Some(sp) = &span {
         match &sp.span_location {
             SpanLocation::FilePath(f) => {
@@ -28,37 +104,7 @@ pub(crate) fn create_report(id: Ident, title: String, label: String) -> ! {
         "<No associated span>".into()
     };
 
-    let bytes_range = span.as_ref().map(|sp| {
-        // Bytes range has not been stabilized in Rust macro.
-        // We can't tell if we're in a proc macro context,
-        // so we just check if the range doesn't make sense:
-        if sp.range.is_empty() && (sp.start.line != sp.end.line || sp.end.col - sp.start.col > 0) {
-            match sp.span_location {
-                SpanLocation::None => 0..0,
-                _ => {
-                    // Need an accurate byte count that accounts for both:
-                    // CRLF and LF endings, so we just make sure to split on the end at `\n` (LF):
-                    let split = src.split_inclusive('\n');
-                    let mut start_byte = 0usize;
-                    let mut end_byte = src.len();
-                    let mut running_byte_total = 0usize;
-                    for (idx, st) in split.enumerate() {
-                        if (idx + 1) == sp.start.line {
-                            start_byte = running_byte_total + sp.start.col;
-                        }
-                        if (idx + 1) == sp.end.line {
-                            end_byte = running_byte_total + sp.end.col;
-                            break;
-                        }
-                        running_byte_total += st.len();
-                    }
-                    start_byte..end_byte
-                }
-            }
-        } else {
-            sp.range.clone()
-        }
-    });
+    let bytes_range = span.as_ref().map(|sp| evaluate_bytes(sp, &src));
 
     if let Some(b) = &bytes_range {
         // If we go past the length, then we've somehow got the wrong SpanLocation.
@@ -67,7 +113,7 @@ pub(crate) fn create_report(id: Ident, title: String, label: String) -> ! {
             Some(SpanLocation::FilePath(..)) | Some(SpanLocation::LocalSource(..))
         ) && b.end > src.len()
         {
-            panic!("Span source improperly calculated. Got range {0} > {1}. Original error: {title}: {label}", b.end, src.len());
+            panic!("Span source improperly calculated. Got range {} > {}. Original error: {}: {}", b.end, src.len(), report.title, report.primary_label);
         }
     }
     #[cfg(feature = "pretty-print")]
@@ -76,22 +122,27 @@ pub(crate) fn create_report(id: Ident, title: String, label: String) -> ! {
         let report = if let Some(sp) = span {
             use annotate_snippets::{Annotation, AnnotationKind};
 
-            &[Level::ERROR.primary_title(&title).element(
-                Snippet::<Annotation>::source(src)
+            let annotations = report.context_locations.iter().map(|l| {
+                let bytes = evaluate_bytes(&l.location, &src);
+                AnnotationKind::Context.span(bytes).label(&l.label)
+            });
+
+            &[Level::ERROR.primary_title(&report.title).element(
+                Snippet::<Annotation>::source(&src)
                     .path(match sp.span_location {
                         SpanLocation::FilePath(f) => Some(f),
                         _ => None,
                     })
                     .annotation(
-                        AnnotationKind::Context
+                        AnnotationKind::Primary
                             .span(bytes_range.unwrap())
-                            .label(label),
-                    ),
+                            .label(report.primary_label),
+                    ).annotations(annotations),
             )]
         } else {
             &[Level::ERROR
-                .primary_title(&title)
-                .element(Level::ERROR.message(label))]
+                .primary_title(&report.title)
+                .element(Level::ERROR.message(report.primary_label))]
         };
         let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
         writeln!(out, "{}", renderer.render(report)).expect("Could not write report.");
@@ -128,7 +179,7 @@ pub(crate) fn create_report(id: Ident, title: String, label: String) -> ! {
             )
         };
         write!(out, "Diplomat error: ").expect("Could not write to report.");
-        writeln!(out, "{title}").expect("Could not write to report.");
+        writeln!(out, "{}", report.title).expect("Could not write to report.");
         writeln!(out, "In {location}:").expect("Could not write to report.");
 
         let excerpt_pre_trimmed = excerpt_pre.trim_start();
@@ -156,12 +207,12 @@ pub(crate) fn create_report(id: Ident, title: String, label: String) -> ! {
             .expect("Could not write to report.");
         }
 
-        write!(out, "{label}").expect("Could not write to report.");
+        write!(out, "{}", report.primary_label).expect("Could not write to report.");
     }
     out.flush().expect("Could not write to output.");
     // Rust-analyzer will not show error messages unless we panic,
     // This just tells rust-analyzer users to check stderr:
-    panic!("Diplomat error: {} (check stderr for more)", title);
+    panic!("Diplomat error: {} (check stderr for more)", report.title);
 }
 
 #[cfg(all(test, not(feature = "pretty-print")))]
@@ -209,7 +260,7 @@ mod tests {
         );
     }
 
-    const FILES_TO_TEST: &[&str] = &["duplicate_attrs.rs", "enum_field_variant.rs", "attr_on_non_pub.rs", "nonstd_result.rs"];
+    const FILES_TO_TEST: &[&str] = &["duplicate_attrs.rs", "enum_field_variant.rs", "attr_on_non_pub.rs", "nonstd_result.rs", "self_in_free_func.rs"];
 
     fn test_file_list(suffix: &'static str) {
         {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -267,7 +267,8 @@ mod tests {
         "nonstd_result.rs",
         "self_in_free_func.rs",
         "lifetime_on_trait.rs",
-        "generic_types.rs"
+        "generic_types.rs",
+        "where_pred.rs"
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -268,7 +268,8 @@ mod tests {
         "self_in_free_func.rs",
         "lifetime_on_trait.rs",
         "generic_types.rs",
-        "where_pred.rs"
+        "where_pred.rs",
+        "lifetime_redefine.rs"
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/macros.rs
+++ b/core/src/ast/macros.rs
@@ -13,7 +13,11 @@ use syn::{
     token, Error, Ident, ImplItem, ImplItemMacro, Item, ItemMacro, Token,
 };
 
-use crate::ast::{SpanLocation, idents::IntoWithSpan, logging::{AstReport, create_report, create_simple_report}};
+use crate::ast::{
+    idents::IntoWithSpan,
+    logging::{create_report, create_simple_report, AstReport},
+    SpanLocation,
+};
 
 #[derive(Default, Debug)]
 pub struct Macros {
@@ -40,7 +44,11 @@ impl Macros {
         }
     }
 
-    pub fn evaluate_item_macro(&self, input: &ItemMacro, module_location : &SpanLocation) -> Vec<Item> {
+    pub fn evaluate_item_macro(
+        &self,
+        input: &ItemMacro,
+        module_location: &SpanLocation,
+    ) -> Vec<Item> {
         // This should never be called without an ident attached:
         assert!(input.ident.is_none(), "Expected macro usage. Got {input:?}");
         let m = input.mac.parse_body::<TokenStream>();
@@ -59,7 +67,11 @@ impl Macros {
         }
     }
 
-    pub fn evaluate_impl_item_macro(&self, input: &ImplItemMacro, module_location : &SpanLocation) -> Vec<ImplItem> {
+    pub fn evaluate_impl_item_macro(
+        &self,
+        input: &ImplItemMacro,
+        module_location: &SpanLocation,
+    ) -> Vec<ImplItem> {
         let m: syn::Result<TokenStream> = input.mac.parse_body();
         // FIXME: Extremely hacky. In the future for importing macros, we'll want to do something else.
         let path_ident = input.mac.path.segments.last().unwrap().ident.clone();
@@ -68,7 +80,6 @@ impl Macros {
             if let Some(def) = self.defs.get(&path_ident) {
                 def.evaluate(matched, module_location)
             } else {
-                
                 create_simple_report((&path_ident).spanned_into(module_location), format!("Macro {path_ident}! undefined."), format!("Suggestion: Create #[diplomat::macro_rules] macro_rules! {path_ident} definition before this item."));
             }
         } else {
@@ -537,7 +548,11 @@ impl MacroDef {
         }
     }
 
-    fn parse_group(matched: &MacroUse, inner: Cursor, group_location : &SpanLocation) -> TokenStream {
+    fn parse_group(
+        matched: &MacroUse,
+        inner: Cursor,
+        group_location: &SpanLocation,
+    ) -> TokenStream {
         let mut stream = TokenStream::new();
 
         let mut c = inner;
@@ -550,25 +565,27 @@ impl MacroDef {
                             c = next;
                         } else {
                             create_report(AstReport::new(
-                                format!("Expected ident when expanding macro argument."),
+                                "Expected ident when expanding macro argument.".to_string(),
                                 tt.span().spanned_into(group_location),
                                 "Need ident after $ to replace with variable".into(),
-                                vec![]
+                                vec![],
                             ));
                         }
                     } else {
                         create_report(AstReport::new(
-                            format!("Expected token tree."),
+                            "Expected token tree.".to_string(),
                             next.span().spanned_into(group_location),
                             "".into(),
-                            vec![]
+                            vec![],
                         ));
                     }
                 }
                 TokenTree::Group(g) => {
                     let (inner, _, next) = c.group(g.delimiter()).unwrap();
-                    let group =
-                        proc_macro2::Group::new(g.delimiter(), Self::parse_group(matched, inner, group_location));
+                    let group = proc_macro2::Group::new(
+                        g.delimiter(),
+                        Self::parse_group(matched, inner, group_location),
+                    );
                     // Once we detect a group, we push it to the array for syn to evaluate.
                     stream.append(group);
                     c = next;
@@ -583,7 +600,7 @@ impl MacroDef {
         stream
     }
 
-    fn evaluate_buf(&self, matched: MacroUse, buf_location : &SpanLocation) -> TokenStream {
+    fn evaluate_buf(&self, matched: MacroUse, buf_location: &SpanLocation) -> TokenStream {
         let mut stream = TokenStream::new();
 
         let buf = TokenBuffer::new2(self.body.clone());
@@ -598,26 +615,28 @@ impl MacroDef {
                             c = next;
                         } else {
                             create_report(AstReport::new(
-                                format!("Expected ident when expanding macro argument."),
+                                "Expected ident when expanding macro argument.".to_string(),
                                 tt.span().spanned_into(buf_location),
                                 "Need ident after $ to replace with variable".into(),
-                                vec![]
+                                vec![],
                             ));
                         }
                     } else {
                         create_report(AstReport::new(
-                            format!("Expected token tree."),
+                            "Expected token tree.".to_string(),
                             next.span().spanned_into(buf_location),
                             "".into(),
-                            vec![]
+                            vec![],
                         ));
                     }
                 }
                 TokenTree::Group(g) => {
                     let (inner, _, next) = c.group(g.delimiter()).unwrap();
                     // We need to read inside of any groups to find and replace `$` idents.
-                    let group =
-                        proc_macro2::Group::new(g.delimiter(), Self::parse_group(&matched, inner, buf_location));
+                    let group = proc_macro2::Group::new(
+                        g.delimiter(),
+                        Self::parse_group(&matched, inner, buf_location),
+                    );
                     stream.append(group);
                     c = next;
                 }
@@ -631,13 +650,17 @@ impl MacroDef {
         stream
     }
 
-    fn evaluate<T: Parse + Debug>(&self, matched: TokenStream, use_location : &SpanLocation) -> Vec<T> {
+    fn evaluate<T: Parse + Debug>(
+        &self,
+        matched: TokenStream,
+        use_location: &SpanLocation,
+    ) -> Vec<T> {
         let macro_use = MacroUse::parse(self, matched).unwrap_or_else(|e| {
             create_report(AstReport::new(
                 e.to_string(),
                 e.span().spanned_into(use_location),
                 "Error parsing macro here".into(),
-                vec![]
+                vec![],
             ));
         });
         let stream = self.evaluate_buf(macro_use, use_location);
@@ -652,7 +675,7 @@ impl MacroDef {
                 e.to_string(),
                 e.span().spanned_into(use_location),
                 "Error expanding macro here".into(),
-                vec![]
+                vec![],
             ));
         }
     }

--- a/core/src/ast/macros.rs
+++ b/core/src/ast/macros.rs
@@ -13,6 +13,8 @@ use syn::{
     token, Error, Ident, ImplItem, ImplItemMacro, Item, ItemMacro, Token,
 };
 
+use crate::ast::{SpanLocation, idents::IntoWithSpan, logging::create_simple_report};
+
 #[derive(Default, Debug)]
 pub struct Macros {
     pub(crate) defs: BTreeMap<Ident, MacroDef>,
@@ -37,7 +39,8 @@ impl Macros {
         }
     }
 
-    pub fn evaluate_item_macro(&self, input: &ItemMacro) -> Vec<Item> {
+    pub fn evaluate_item_macro(&self, input: &ItemMacro, module_location : &SpanLocation) -> Vec<Item> {
+        // This should never be called without an ident attached:
         assert!(input.ident.is_none(), "Expected macro usage. Got {input:?}");
         let m = input.mac.parse_body::<TokenStream>();
         if let Ok(mac) = m {
@@ -47,7 +50,7 @@ impl Macros {
             if let Some(def) = self.defs.get(&ident) {
                 def.evaluate(mac)
             } else {
-                panic!("Could not find definition for {ident}. Have you tried creating a #[diplomat::macro_rules] macro_rules! {ident} definition?");
+                create_simple_report((&ident).spanned_into(module_location), format!("Macro {ident}! undefined."), format!("Suggestion: Create #[diplomat::macro_rules] macro_rules! {ident} definition before this item."));
             }
         } else {
             // We handle errors automatically in `diplomat/macro`
@@ -55,7 +58,7 @@ impl Macros {
         }
     }
 
-    pub fn evaluate_impl_item_macro(&self, input: &ImplItemMacro) -> Vec<ImplItem> {
+    pub fn evaluate_impl_item_macro(&self, input: &ImplItemMacro, module_location : &SpanLocation) -> Vec<ImplItem> {
         let m: syn::Result<TokenStream> = input.mac.parse_body();
         // FIXME: Extremely hacky. In the future for importing macros, we'll want to do something else.
         let path_ident = input.mac.path.segments.last().unwrap().ident.clone();
@@ -64,7 +67,8 @@ impl Macros {
             if let Some(def) = self.defs.get(&path_ident) {
                 def.evaluate(matched)
             } else {
-                panic!("Could not find definition for {path_ident}. Have you tried creating a #[diplomat::macro_rules] macro_rules! {path_ident} definition?");
+                
+                create_simple_report((&path_ident).spanned_into(module_location), format!("Macro {path_ident}! undefined."), format!("Suggestion: Create #[diplomat::macro_rules] macro_rules! {path_ident} definition before this item."));
             }
         } else {
             // We handle errors automatically in `diplomat/macro`

--- a/core/src/ast/macros.rs
+++ b/core/src/ast/macros.rs
@@ -13,7 +13,7 @@ use syn::{
     token, Error, Ident, ImplItem, ImplItemMacro, Item, ItemMacro, Token,
 };
 
-use crate::ast::{SpanLocation, idents::IntoWithSpan, logging::create_simple_report};
+use crate::ast::{SpanLocation, idents::IntoWithSpan, logging::{AstReport, create_report, create_simple_report}};
 
 #[derive(Default, Debug)]
 pub struct Macros {
@@ -28,6 +28,7 @@ impl Macros {
     }
 
     pub fn add_item_macro(&mut self, input: &ItemMacro) {
+        // This should never be called without a macro_rules! def:
         assert!(
             input.ident.is_some(),
             "Expected macro_rules! def. Got {input:?}"
@@ -48,7 +49,7 @@ impl Macros {
             let ident = input.mac.path.segments.last().unwrap().ident.clone();
 
             if let Some(def) = self.defs.get(&ident) {
-                def.evaluate(mac)
+                def.evaluate(mac, module_location)
             } else {
                 create_simple_report((&ident).spanned_into(module_location), format!("Macro {ident}! undefined."), format!("Suggestion: Create #[diplomat::macro_rules] macro_rules! {ident} definition before this item."));
             }
@@ -65,7 +66,7 @@ impl Macros {
 
         if let Ok(matched) = m {
             if let Some(def) = self.defs.get(&path_ident) {
-                def.evaluate(matched)
+                def.evaluate(matched, module_location)
             } else {
                 
                 create_simple_report((&path_ident).spanned_into(module_location), format!("Macro {path_ident}! undefined."), format!("Suggestion: Create #[diplomat::macro_rules] macro_rules! {path_ident} definition before this item."));
@@ -536,7 +537,7 @@ impl MacroDef {
         }
     }
 
-    fn parse_group(matched: &MacroUse, inner: Cursor) -> TokenStream {
+    fn parse_group(matched: &MacroUse, inner: Cursor, group_location : &SpanLocation) -> TokenStream {
         let mut stream = TokenStream::new();
 
         let mut c = inner;
@@ -548,16 +549,26 @@ impl MacroDef {
                             matched.args[&i].to_tokens(&mut stream);
                             c = next;
                         } else {
-                            panic!("Expected ident next to $, got {tt:?}");
+                            create_report(AstReport::new(
+                                format!("Expected ident when expanding macro argument."),
+                                tt.span().spanned_into(group_location),
+                                "Need ident after $ to replace with variable".into(),
+                                vec![]
+                            ));
                         }
                     } else {
-                        panic!("Expected token tree.");
+                        create_report(AstReport::new(
+                            format!("Expected token tree."),
+                            next.span().spanned_into(group_location),
+                            "".into(),
+                            vec![]
+                        ));
                     }
                 }
                 TokenTree::Group(g) => {
                     let (inner, _, next) = c.group(g.delimiter()).unwrap();
                     let group =
-                        proc_macro2::Group::new(g.delimiter(), Self::parse_group(matched, inner));
+                        proc_macro2::Group::new(g.delimiter(), Self::parse_group(matched, inner, group_location));
                     // Once we detect a group, we push it to the array for syn to evaluate.
                     stream.append(group);
                     c = next;
@@ -572,7 +583,7 @@ impl MacroDef {
         stream
     }
 
-    fn evaluate_buf(&self, matched: MacroUse) -> TokenStream {
+    fn evaluate_buf(&self, matched: MacroUse, buf_location : &SpanLocation) -> TokenStream {
         let mut stream = TokenStream::new();
 
         let buf = TokenBuffer::new2(self.body.clone());
@@ -586,17 +597,27 @@ impl MacroDef {
                             matched.args[&i].to_tokens(&mut stream);
                             c = next;
                         } else {
-                            panic!("Expected ident next to $, got {tt:?}");
+                            create_report(AstReport::new(
+                                format!("Expected ident when expanding macro argument."),
+                                tt.span().spanned_into(buf_location),
+                                "Need ident after $ to replace with variable".into(),
+                                vec![]
+                            ));
                         }
                     } else {
-                        panic!("Expected token tree.");
+                        create_report(AstReport::new(
+                            format!("Expected token tree."),
+                            next.span().spanned_into(buf_location),
+                            "".into(),
+                            vec![]
+                        ));
                     }
                 }
                 TokenTree::Group(g) => {
                     let (inner, _, next) = c.group(g.delimiter()).unwrap();
                     // We need to read inside of any groups to find and replace `$` idents.
                     let group =
-                        proc_macro2::Group::new(g.delimiter(), Self::parse_group(&matched, inner));
+                        proc_macro2::Group::new(g.delimiter(), Self::parse_group(&matched, inner, buf_location));
                     stream.append(group);
                     c = next;
                 }
@@ -610,16 +631,29 @@ impl MacroDef {
         stream
     }
 
-    fn evaluate<T: Parse + Debug>(&self, matched: TokenStream) -> Vec<T> {
-        let macro_use = MacroUse::parse(self, matched).unwrap_or_else(|e| panic!("{}", e));
-        let stream = self.evaluate_buf(macro_use);
+    fn evaluate<T: Parse + Debug>(&self, matched: TokenStream, use_location : &SpanLocation) -> Vec<T> {
+        let macro_use = MacroUse::parse(self, matched).unwrap_or_else(|e| {
+            create_report(AstReport::new(
+                e.to_string(),
+                e.span().spanned_into(use_location),
+                "Error parsing macro here".into(),
+                vec![]
+            ));
+        });
+        let stream = self.evaluate_buf(macro_use, use_location);
 
         // Now we have a stream to read through. We read through the whole thing and assume each thing we read is a top level item.
         let maybe_list = syn::parse_str::<ItemList<T>>(&stream.to_string());
         if let Ok(i) = maybe_list {
             i.items
         } else {
-            panic!("Macro expansion error: {:?}", maybe_list.unwrap_err());
+            let e = maybe_list.unwrap_err();
+            create_report(AstReport::new(
+                e.to_string(),
+                e.span().spanned_into(use_location),
+                "Error expanding macro here".into(),
+                vec![]
+            ));
         }
     }
 }

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -11,7 +11,7 @@ use super::{
     OpaqueType, Path, PathType, RustLink, Struct, Trait,
 };
 use crate::ast::idents::{FromWithSpan, IntoWithSpan};
-use crate::ast::logging::create_report;
+use crate::ast::logging::create_simple_report;
 use crate::ast::{Function, SpanLocation};
 use crate::environment::*;
 
@@ -209,7 +209,7 @@ impl<'a> ModuleBuilder<'a> {
                         self.module_location,
                     )),
                     Err(errors) => {
-                        create_report((&strct.ident).spanned_into(self.module_location), "Multiple conflicting Diplomat struct attributes, there can be at most one.".into(), format!("{errors:?}"));
+                        create_simple_report((&strct.ident).spanned_into(self.module_location), "Multiple conflicting Diplomat struct attributes, there can be at most one.".into(), format!("{errors:?}"));
                     }
                 };
 
@@ -250,7 +250,7 @@ impl<'a> ModuleBuilder<'a> {
                         ))
                     }
                     Err(errors) => {
-                        create_report((&enm.ident).spanned_into(self.module_location), "Multiple conflicting Diplomat enum attributes, there can be at most one.".into(), format!("{errors:?}"));
+                        create_simple_report((&enm.ident).spanned_into(self.module_location), "Multiple conflicting Diplomat enum attributes, there can be at most one.".into(), format!("{errors:?}"));
                     }
                 };
                 self.custom_types_by_name.insert(ident, custom_enum);
@@ -296,7 +296,7 @@ impl<'a> ModuleBuilder<'a> {
                             .iter()
                             .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
                         if !is_public && has_diplomat_attrs {
-                            create_report((&m.sig.ident).spanned_into(self.module_location), "Found non-public method with diplomat attrs".into(), "Remove #[diplomat::*] attributes.".into());
+                            create_simple_report((&m.sig.ident).spanned_into(self.module_location), "Found non-public method with diplomat attrs".into(), "Remove #[diplomat::*] attributes.".into());
                         }
                         is_public
                     })
@@ -368,7 +368,7 @@ impl<'a> ModuleBuilder<'a> {
                     .iter()
                     .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
                 if !is_public && has_diplomat_attrs {
-                    create_report((&f.sig.ident).spanned_into(self.module_location), "Found non-public method with diplomat attrs".into(), "Remove #[diplomat::*] attributes.".into());
+                    create_simple_report((&f.sig.ident).spanned_into(self.module_location), "Found non-public method with diplomat attrs".into(), "Remove #[diplomat::*] attributes.".into());
                 }
                 if is_public {
                     let parent_attrs = self

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -295,11 +295,9 @@ impl<'a> ModuleBuilder<'a> {
                             .attrs
                             .iter()
                             .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
-                        assert!(
-                            is_public || !has_diplomat_attrs,
-                            "Non-public method with diplomat attrs found: {self_ident}::{}",
-                            m.sig.ident
-                        );
+                        if !is_public && has_diplomat_attrs {
+                            create_report((&m.sig.ident).spanned_into(self.module_location), "Found non-public method with diplomat attrs".into(), "Remove #[diplomat::*] attributes.".into());
+                        }
                         is_public
                     })
                     .map(|m| {
@@ -369,11 +367,9 @@ impl<'a> ModuleBuilder<'a> {
                     .attrs
                     .iter()
                     .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
-                assert!(
-                    is_public || !has_diplomat_attrs,
-                    "Non-public function with diplomat attrs found: {}",
-                    f.sig.ident
-                );
+                if !is_public && has_diplomat_attrs {
+                    create_report((&f.sig.ident).spanned_into(self.module_location), "Found non-public method with diplomat attrs".into(), "Remove #[diplomat::*] attributes.".into());
+                }
                 if is_public {
                     let parent_attrs = self
                         .impl_parent_attrs

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -275,7 +275,9 @@ impl<'a> ModuleBuilder<'a> {
                             impl_item_vec.push(ImplItem::Fn(f.clone()));
                         }
                         ImplItem::Macro(mac) => {
-                            let mut items = self.mod_macros.evaluate_impl_item_macro(mac, self.module_location);
+                            let mut items = self
+                                .mod_macros
+                                .evaluate_impl_item_macro(mac, self.module_location);
                             impl_item_vec.append(&mut items);
                         }
                         _ => {}
@@ -296,7 +298,11 @@ impl<'a> ModuleBuilder<'a> {
                             .iter()
                             .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
                         if !is_public && has_diplomat_attrs {
-                            create_simple_report((&m.sig.ident).spanned_into(self.module_location), "Found non-public method with diplomat attrs".into(), "Remove #[diplomat::*] attributes.".into());
+                            create_simple_report(
+                                (&m.sig.ident).spanned_into(self.module_location),
+                                "Found non-public method with diplomat attrs".into(),
+                                "Remove #[diplomat::*] attributes.".into(),
+                            );
                         }
                         is_public
                     })
@@ -355,7 +361,9 @@ impl<'a> ModuleBuilder<'a> {
                         );
                     }
                 } else {
-                    let items = self.mod_macros.evaluate_item_macro(mac, self.module_location);
+                    let items = self
+                        .mod_macros
+                        .evaluate_item_macro(mac, self.module_location);
                     for i in items {
                         self.add(&i);
                     }
@@ -368,7 +376,11 @@ impl<'a> ModuleBuilder<'a> {
                     .iter()
                     .any(|a| a.path().segments.iter().next().unwrap().ident == "diplomat");
                 if !is_public && has_diplomat_attrs {
-                    create_simple_report((&f.sig.ident).spanned_into(self.module_location), "Found non-public method with diplomat attrs".into(), "Remove #[diplomat::*] attributes.".into());
+                    create_simple_report(
+                        (&f.sig.ident).spanned_into(self.module_location),
+                        "Found non-public method with diplomat attrs".into(),
+                        "Remove #[diplomat::*] attributes.".into(),
+                    );
                 }
                 if is_public {
                     let parent_attrs = self

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -275,7 +275,7 @@ impl<'a> ModuleBuilder<'a> {
                             impl_item_vec.push(ImplItem::Fn(f.clone()));
                         }
                         ImplItem::Macro(mac) => {
-                            let mut items = self.mod_macros.evaluate_impl_item_macro(mac);
+                            let mut items = self.mod_macros.evaluate_impl_item_macro(mac, self.module_location);
                             impl_item_vec.append(&mut items);
                         }
                         _ => {}
@@ -355,7 +355,7 @@ impl<'a> ModuleBuilder<'a> {
                         );
                     }
                 } else {
-                    let items = self.mod_macros.evaluate_item_macro(mac);
+                    let items = self.mod_macros.evaluate_item_macro(mac, self.module_location);
                     for i in items {
                         self.add(&i);
                     }

--- a/core/src/ast/snapshots/span_testing/attr_on_non_pub.rs
+++ b/core/src/ast/snapshots/span_testing/attr_on_non_pub.rs
@@ -1,0 +1,9 @@
+#[diplomat::bridge]
+mod ffi {
+    pub struct Test {}
+
+    impl Test {
+        #[diplomat::attr(*, disable)]
+        fn hidden_fn() {}
+    }
+}

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@attr_on_non_pub.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@attr_on_non_pub.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Found non-public method with diplomat attrs
+In src/ast/snapshots/span_testing/attr_on_non_pub.rs:7:12:
+...fn hidden_fn() {}...
+      ^^^^^^^^^
+Remove #[diplomat::*] attributes.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@generic_types.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@generic_types.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Generic types are unsupported.
+In src/ast/snapshots/span_testing/generic_types.rs:5:30:
+...rics<T> ()...
+        ^
+Suggestion: Remove generic type.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@lifetime_on_trait.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@lifetime_on_trait.rs_ugly.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Diplomat traits are not allowed to have any lifetime parameters.
+In src/ast/snapshots/span_testing/lifetime_on_trait.rs:3:15:
+...rait Trait<'a>...
+        ^^^^^

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@lifetime_redefine.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@lifetime_redefine.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Lifetime declared twice in the same scope
+In src/ast/snapshots/span_testing/lifetime_redefine.rs:3:35:
+...'a, 'a>() {...
+        ^
+Lifetime 'a already exists.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@macro_expansion_error.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@macro_expansion_error.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Expected ident when expanding macro argument.
+In src/ast/snapshots/span_testing/macro_expansion_error.rs:6:14:
+...$123...
+    ^^^
+Need ident after $ to replace with variable

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@macro_parse_error.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@macro_parse_error.rs_ugly.snap
@@ -1,0 +1,10 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: expected identifier
+In src/ast/snapshots/span_testing/macro_parse_error.rs:8:11:
+...est!(123);
+}...
+        ^^^
+Error parsing macro here

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@nonstd_result.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@nonstd_result.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Not enough arguments given to Result<T,E>. Are you using a non-std Result type?
+In src/ast/snapshots/span_testing/nonstd_result.rs:4:31:
+...) -> Result<T> {...
+        ^^^^^^
+Expected 2 generic arguments.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@self_in_free_func.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@self_in_free_func.rs_ugly.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Cannot use self parameter in free function.
+In src/ast/snapshots/span_testing/self_in_free_func.rs:3:12:
+...b fn takes_self(&sel...
+        ^^^^^^^^^^

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@undefined_macro.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@undefined_macro.rs_ugly.snap
@@ -1,10 +1,9 @@
 ---
 source: core/src/ast/logging.rs
-assertion_line: 234
 expression: self.buf
 ---
-Diplomat error: Macro test undefined.
+Diplomat error: Macro test! undefined.
 In src/ast/snapshots/span_testing/undefined_macro.rs:3:5:
 ...test!();...
    ^^^^
-Create #[diplomat::macro_rules] macro_rules! test definition before this item.
+Suggestion: Create #[diplomat::macro_rules] macro_rules! test definition before this item.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@undefined_macro.rs_ugly.snap.new
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@undefined_macro.rs_ugly.snap.new
@@ -1,0 +1,10 @@
+---
+source: core/src/ast/logging.rs
+assertion_line: 234
+expression: self.buf
+---
+Diplomat error: Macro test undefined.
+In src/ast/snapshots/span_testing/undefined_macro.rs:3:5:
+...test!();...
+   ^^^^
+Create #[diplomat::macro_rules] macro_rules! test definition before this item.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@where_pred.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@where_pred.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Trait bounds are unsupported.
+In src/ast/snapshots/span_testing/where_pred.rs:3:27:
+...here T: U {}...
+        ^^^^
+Suggestion: Remove type predicate.

--- a/core/src/ast/snapshots/span_testing/generic_types.rs
+++ b/core/src/ast/snapshots/span_testing/generic_types.rs
@@ -1,0 +1,7 @@
+#[diplomat::bridge]
+mod ffi {
+    pub struct Test {}
+    impl Test {
+        pub fn with_generics<T> () {}
+    }
+}

--- a/core/src/ast/snapshots/span_testing/lifetime_on_trait.rs
+++ b/core/src/ast/snapshots/span_testing/lifetime_on_trait.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub trait Trait<'a> {}
+}

--- a/core/src/ast/snapshots/span_testing/lifetime_redefine.rs
+++ b/core/src/ast/snapshots/span_testing/lifetime_redefine.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn lifetime_redefine<'a, 'a>() {}
+}

--- a/core/src/ast/snapshots/span_testing/macro_expansion_error.rs
+++ b/core/src/ast/snapshots/span_testing/macro_expansion_error.rs
@@ -1,0 +1,11 @@
+#[diplomat::bridge]
+mod ffi {
+    #[diplomat::macro_rules]
+    macro_rules! test {
+        ($arg:ident) => {
+            $123
+        };
+    }
+
+    test!(test);
+}

--- a/core/src/ast/snapshots/span_testing/macro_parse_error.rs
+++ b/core/src/ast/snapshots/span_testing/macro_parse_error.rs
@@ -1,0 +1,9 @@
+#[diplomat::bridge]
+mod ffi {
+    #[diplomat::macro_rules]
+    macro_rules! test {
+        ($t:ident) => {};
+    }
+
+    test!(123);
+}

--- a/core/src/ast/snapshots/span_testing/nonstd_result.rs
+++ b/core/src/ast/snapshots/span_testing/nonstd_result.rs
@@ -1,0 +1,5 @@
+#[diplomat::bridge]
+mod ffi {
+    fn hidden() -> Result<T> {}
+    pub fn return_result() -> Result<T> {}
+}

--- a/core/src/ast/snapshots/span_testing/self_in_free_func.rs
+++ b/core/src/ast/snapshots/span_testing/self_in_free_func.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn takes_self(&self) {}
+}

--- a/core/src/ast/snapshots/span_testing/undefined_macro.rs
+++ b/core/src/ast/snapshots/span_testing/undefined_macro.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    test!();
+}

--- a/core/src/ast/snapshots/span_testing/where_pred.rs
+++ b/core/src/ast/snapshots/span_testing/where_pred.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub struct Test where T: U {} 
+}

--- a/core/src/ast/traits.rs
+++ b/core/src/ast/traits.rs
@@ -144,7 +144,7 @@ impl Trait {
             name: (&trt.ident).spanned_into(module_location),
             methods: trait_fcts,
             docs: Docs::from_attrs(&trt.attrs),
-            lifetimes: LifetimeEnv::from_trait(trt), // TODO
+            lifetimes: LifetimeEnv::from_trait(trt, module_location), // TODO
             attrs,
             is_send,
             is_sync,

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -12,9 +12,12 @@ use super::{
     OpaqueType, Path, RustLink, Struct, Trait,
 };
 use crate::{
-    Env, ast::{
-        Function, idents::{FromWithSpan, IntoWithSpan, SpanLocation}, logging::create_simple_report
-    }
+    ast::{
+        idents::{FromWithSpan, IntoWithSpan, SpanLocation},
+        logging::create_simple_report,
+        Function,
+    },
+    Env,
 };
 
 /// A type declared inside a Diplomat-annotated module.

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -12,11 +12,9 @@ use super::{
     OpaqueType, Path, RustLink, Struct, Trait,
 };
 use crate::{
-    ast::{
-        idents::{FromWithSpan, IntoWithSpan, SpanLocation},
-        Function,
-    },
-    Env,
+    Env, ast::{
+        Function, idents::{FromWithSpan, IntoWithSpan, SpanLocation}, logging::create_report
+    }
 };
 
 /// A type declared inside a Diplomat-annotated module.
@@ -1023,10 +1021,9 @@ impl TypeName {
                     if let syn::PathArguments::AngleBracketed(type_args) =
                         &p.path.segments.last().unwrap().arguments
                     {
-                        assert!(
-                            type_args.args.len() > 1,
-                            "Not enough arguments given to Result<T,E>. Are you using a non-std Result type?"
-                        );
+                        if type_args.args.len() != 2 {
+                            create_report((&p.path.segments.last().unwrap().ident).spanned_into(module_location), "Not enough arguments given to Result<T,E>. Are you using a non-std Result type?".into(), "Expected 2 generic arguments.".into());
+                        }
 
                         if let (syn::GenericArgument::Type(ok), syn::GenericArgument::Type(err)) =
                             (&type_args.args[0], &type_args.args[1])

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     Env, ast::{
-        Function, idents::{FromWithSpan, IntoWithSpan, SpanLocation}, logging::create_report
+        Function, idents::{FromWithSpan, IntoWithSpan, SpanLocation}, logging::create_simple_report
     }
 };
 
@@ -1022,7 +1022,7 @@ impl TypeName {
                         &p.path.segments.last().unwrap().arguments
                     {
                         if type_args.args.len() != 2 {
-                            create_report((&p.path.segments.last().unwrap().ident).spanned_into(module_location), "Not enough arguments given to Result<T,E>. Are you using a non-std Result type?".into(), "Expected 2 generic arguments.".into());
+                            create_simple_report((&p.path.segments.last().unwrap().ident).spanned_into(module_location), "Not enough arguments given to Result<T,E>. Are you using a non-std Result type?".into(), "Expected 2 generic arguments.".into());
                         }
 
                         if let (syn::GenericArgument::Type(ok), syn::GenericArgument::Type(err)) =


### PR DESCRIPTION
Continued progress on #111.

This addresses `ast/lifetimes.rs` and `ast/macros.rs`, with a few other files changed. I've also included some more advanced error features (like being able to point to different spans for additional context).