### PR TITLE
dotnet: keep-alive edges for lifetime-carrying owned opaque returns

### DIFF
--- a/example/dotnet/Generated/DataProvider.cs
+++ b/example/dotnet/Generated/DataProvider.cs
@@ -10,7 +10,40 @@ namespace Somelib;
 
 public partial class DataProvider: IDisposable
 {
-    private unsafe Raw.DataProvider* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.DataProvider*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class DataProviderHandle : SafeHandle
+    {
+        public DataProviderHandle() : base(IntPtr.Zero, true) { }
+
+        public DataProviderHandle(Raw.DataProvider* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.DataProvider.Destroy((Raw.DataProvider*)handle);
+            return true;
+        }
+    }
+
+    private readonly DataProviderHandle _handle;
+
+    /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>DataProvider</c> from a raw handle.
@@ -23,7 +56,24 @@ public partial class DataProvider: IDisposable
     /// </remarks>
     internal unsafe DataProvider(Raw.DataProvider* handle)
     {
-        _inner = handle;
+        _handle = new DataProviderHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>DataProvider</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe DataProvider(Raw.DataProvider* handle, object[] edges)
+    {
+        _handle = new DataProviderHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>DataProvider</c> allocated on Rust side.
@@ -55,30 +105,27 @@ public partial class DataProvider: IDisposable
     /// </summary>
     internal unsafe Raw.DataProvider* AsFFI()
     {
-        return _inner;
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.DataProvider*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.DataProvider.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~DataProvider()
-    {
-        Dispose();
+        _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/example/dotnet/Generated/FixedDecimal.cs
+++ b/example/dotnet/Generated/FixedDecimal.cs
@@ -10,7 +10,40 @@ namespace Somelib;
 
 public partial class FixedDecimal: IDisposable
 {
-    private unsafe Raw.FixedDecimal* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.FixedDecimal*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class FixedDecimalHandle : SafeHandle
+    {
+        public FixedDecimalHandle() : base(IntPtr.Zero, true) { }
+
+        public FixedDecimalHandle(Raw.FixedDecimal* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.FixedDecimal.Destroy((Raw.FixedDecimal*)handle);
+            return true;
+        }
+    }
+
+    private readonly FixedDecimalHandle _handle;
+
+    /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>FixedDecimal</c> from a raw handle.
@@ -23,7 +56,24 @@ public partial class FixedDecimal: IDisposable
     /// </remarks>
     internal unsafe FixedDecimal(Raw.FixedDecimal* handle)
     {
-        _inner = handle;
+        _handle = new FixedDecimalHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>FixedDecimal</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe FixedDecimal(Raw.FixedDecimal* handle, object[] edges)
+    {
+        _handle = new FixedDecimalHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>FixedDecimal</c> allocated on Rust side.
@@ -40,11 +90,12 @@ public partial class FixedDecimal: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("FixedDecimal");
             }
-            Raw.FixedDecimal.MultiplyPow10(_inner, power);
+            Raw.FixedDecimal.MultiplyPow10(AsFFI(), power);
+            GC.KeepAlive(this);
         }
     }
     /// <exception cref="InvalidOperationException"></exception>
@@ -52,14 +103,15 @@ public partial class FixedDecimal: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("FixedDecimal");
             }
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                var result = Raw.FixedDecimal.ToString(_inner, &writeable);
+                var result = Raw.FixedDecimal.ToString(AsFFI(), &writeable);
+                GC.KeepAlive(this);
                 if (!result.IsOk)
                 {
                     throw new InvalidOperationException("FFI function failed with unit error");
@@ -78,30 +130,27 @@ public partial class FixedDecimal: IDisposable
     /// </summary>
     internal unsafe Raw.FixedDecimal* AsFFI()
     {
-        return _inner;
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.FixedDecimal*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.FixedDecimal.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~FixedDecimal()
-    {
-        Dispose();
+        _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/example/dotnet/Generated/FixedDecimalFormatter.cs
+++ b/example/dotnet/Generated/FixedDecimalFormatter.cs
@@ -10,7 +10,40 @@ namespace Somelib;
 
 public partial class FixedDecimalFormatter: IDisposable
 {
-    private unsafe Raw.FixedDecimalFormatter* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.FixedDecimalFormatter*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class FixedDecimalFormatterHandle : SafeHandle
+    {
+        public FixedDecimalFormatterHandle() : base(IntPtr.Zero, true) { }
+
+        public FixedDecimalFormatterHandle(Raw.FixedDecimalFormatter* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.FixedDecimalFormatter.Destroy((Raw.FixedDecimalFormatter*)handle);
+            return true;
+        }
+    }
+
+    private readonly FixedDecimalFormatterHandle _handle;
+
+    /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>FixedDecimalFormatter</c> from a raw handle.
@@ -23,7 +56,24 @@ public partial class FixedDecimalFormatter: IDisposable
     /// </remarks>
     internal unsafe FixedDecimalFormatter(Raw.FixedDecimalFormatter* handle)
     {
-        _inner = handle;
+        _handle = new FixedDecimalFormatterHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>FixedDecimalFormatter</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe FixedDecimalFormatter(Raw.FixedDecimalFormatter* handle, object[] edges)
+    {
+        _handle = new FixedDecimalFormatterHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <exception cref="InvalidOperationException"></exception>
     /// <returns>
@@ -40,6 +90,8 @@ public partial class FixedDecimalFormatter: IDisposable
             Raw.DataProvider* providerRaw = provider.AsFFI();
             if (providerRaw == null) throw new ObjectDisposedException(nameof(DataProvider));
             var result = Raw.FixedDecimalFormatter.TryNew(localeRaw, providerRaw, options.AsFFI());
+            GC.KeepAlive(locale);
+            GC.KeepAlive(provider);
             if (!result.IsOk)
             {
                 throw new InvalidOperationException("FFI function failed with unit error");
@@ -51,7 +103,7 @@ public partial class FixedDecimalFormatter: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("FixedDecimalFormatter");
             }
@@ -61,7 +113,9 @@ public partial class FixedDecimalFormatter: IDisposable
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                Raw.FixedDecimalFormatter.FormatWrite(_inner, valueRaw, &writeable);
+                Raw.FixedDecimalFormatter.FormatWrite(AsFFI(), valueRaw, &writeable);
+                GC.KeepAlive(this);
+                GC.KeepAlive(value);
                 return writeable.ToUnicode();
             }
             finally
@@ -76,30 +130,27 @@ public partial class FixedDecimalFormatter: IDisposable
     /// </summary>
     internal unsafe Raw.FixedDecimalFormatter* AsFFI()
     {
-        return _inner;
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.FixedDecimalFormatter*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.FixedDecimalFormatter.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~FixedDecimalFormatter()
-    {
-        Dispose();
+        _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/example/dotnet/Generated/Locale.cs
+++ b/example/dotnet/Generated/Locale.cs
@@ -10,7 +10,40 @@ namespace Somelib;
 
 public partial class Locale: IDisposable
 {
-    private unsafe Raw.Locale* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.Locale*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class LocaleHandle : SafeHandle
+    {
+        public LocaleHandle() : base(IntPtr.Zero, true) { }
+
+        public LocaleHandle(Raw.Locale* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.Locale.Destroy((Raw.Locale*)handle);
+            return true;
+        }
+    }
+
+    private readonly LocaleHandle _handle;
+
+    /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>Locale</c> from a raw handle.
@@ -23,7 +56,24 @@ public partial class Locale: IDisposable
     /// </remarks>
     internal unsafe Locale(Raw.Locale* handle)
     {
-        _inner = handle;
+        _handle = new LocaleHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>Locale</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe Locale(Raw.Locale* handle, object[] edges)
+    {
+        _handle = new LocaleHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Locale</c> allocated on Rust side.
@@ -47,30 +97,27 @@ public partial class Locale: IDisposable
     /// </summary>
     internal unsafe Raw.Locale* AsFFI()
     {
-        return _inner;
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.Locale*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.Locale.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~Locale()
-    {
-        Dispose();
+        _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
+++ b/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class AttrOpaque1Renamed: IDisposable
 {
-    private unsafe Raw.AttrOpaque1Renamed* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.AttrOpaque1Renamed*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class AttrOpaque1RenamedHandle : SafeHandle
+    {
+        public AttrOpaque1RenamedHandle() : base(IntPtr.Zero, true) { }
+
+        public AttrOpaque1RenamedHandle(Raw.AttrOpaque1Renamed* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.AttrOpaque1Renamed.Destroy((Raw.AttrOpaque1Renamed*)handle);
+            return true;
+        }
+    }
+
+    private readonly AttrOpaque1RenamedHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>AttrOpaque1Renamed</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class AttrOpaque1Renamed: IDisposable
     /// </remarks>
     internal unsafe AttrOpaque1Renamed(Raw.AttrOpaque1Renamed* handle)
     {
-        _inner = handle;
+        _handle = new AttrOpaque1RenamedHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>AttrOpaque1Renamed</c> allocated on Rust side.
@@ -65,47 +90,54 @@ public partial class AttrOpaque1Renamed: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("AttrOpaque1Renamed");
             }
-            return Raw.AttrOpaque1Renamed.method_renamed(_inner);
+            var result = Raw.AttrOpaque1Renamed.method_renamed(AsFFI());
+            GC.KeepAlive(this);
+            return result;
         }
     }
     public byte Abirenamed()
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("AttrOpaque1Renamed");
             }
-            return Raw.AttrOpaque1Renamed.Abirenamed(_inner);
+            var result = Raw.AttrOpaque1Renamed.Abirenamed(AsFFI());
+            GC.KeepAlive(this);
+            return result;
         }
     }
     public void UseUnnamespaced(Unnamespaced un)
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("AttrOpaque1Renamed");
             }
             if (un == null) throw new ArgumentNullException(nameof(un));
             Raw.Unnamespaced* unRaw = un.AsFFI();
             if (unRaw == null) throw new ObjectDisposedException(nameof(Unnamespaced));
-            Raw.AttrOpaque1Renamed.UseUnnamespaced(_inner, unRaw);
+            Raw.AttrOpaque1Renamed.UseUnnamespaced(AsFFI(), unRaw);
+            GC.KeepAlive(this);
+            GC.KeepAlive(un);
         }
     }
     public void UseNamespaced(RenamedAttrEnum n)
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("AttrOpaque1Renamed");
             }
-            Raw.AttrOpaque1Renamed.UseNamespaced(_inner, n);
+            Raw.AttrOpaque1Renamed.UseNamespaced(AsFFI(), n);
+            GC.KeepAlive(this);
         }
     }
 
@@ -114,30 +146,19 @@ public partial class AttrOpaque1Renamed: IDisposable
     /// </summary>
     internal unsafe Raw.AttrOpaque1Renamed* AsFFI()
     {
-        return _inner;
+        return (Raw.AttrOpaque1Renamed*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.AttrOpaque1Renamed.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~AttrOpaque1Renamed()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
+++ b/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
@@ -38,6 +38,14 @@ public partial class AttrOpaque1Renamed: IDisposable
     private readonly AttrOpaque1RenamedHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>AttrOpaque1Renamed</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class AttrOpaque1Renamed: IDisposable
     internal unsafe AttrOpaque1Renamed(Raw.AttrOpaque1Renamed* handle)
     {
         _handle = new AttrOpaque1RenamedHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>AttrOpaque1Renamed</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe AttrOpaque1Renamed(Raw.AttrOpaque1Renamed* handle, object[] edges)
+    {
+        _handle = new AttrOpaque1RenamedHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>AttrOpaque1Renamed</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
+++ b/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
@@ -43,7 +43,7 @@ public partial class AttrOpaque1Renamed: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>AttrOpaque1Renamed</c> from a raw handle.
@@ -171,7 +171,12 @@ public partial class AttrOpaque1Renamed: IDisposable
     /// </summary>
     internal unsafe Raw.AttrOpaque1Renamed* AsFFI()
     {
-        return (Raw.AttrOpaque1Renamed*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.AttrOpaque1Renamed*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -185,5 +190,8 @@ public partial class AttrOpaque1Renamed: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/Bar.cs
+++ b/feature_tests/dotnet/Generated/Bar.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class Bar: IDisposable
 {
-    private unsafe Raw.Bar* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.Bar*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class BarHandle : SafeHandle
+    {
+        public BarHandle() : base(IntPtr.Zero, true) { }
+
+        public BarHandle(Raw.Bar* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.Bar.Destroy((Raw.Bar*)handle);
+            return true;
+        }
+    }
+
+    private readonly BarHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>Bar</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class Bar: IDisposable
     /// </remarks>
     internal unsafe Bar(Raw.Bar* handle)
     {
-        _inner = handle;
+        _handle = new BarHandle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class Bar: IDisposable
     /// </summary>
     internal unsafe Raw.Bar* AsFFI()
     {
-        return _inner;
+        return (Raw.Bar*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.Bar.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~Bar()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/Bar.cs
+++ b/feature_tests/dotnet/Generated/Bar.cs
@@ -38,6 +38,14 @@ public partial class Bar: IDisposable
     private readonly BarHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>Bar</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class Bar: IDisposable
     internal unsafe Bar(Raw.Bar* handle)
     {
         _handle = new BarHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>Bar</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe Bar(Raw.Bar* handle, object[] edges)
+    {
+        _handle = new BarHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/Bar.cs
+++ b/feature_tests/dotnet/Generated/Bar.cs
@@ -43,7 +43,7 @@ public partial class Bar: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>Bar</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class Bar: IDisposable
     /// </summary>
     internal unsafe Raw.Bar* AsFFI()
     {
-        return (Raw.Bar*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.Bar*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class Bar: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/BorrowChild.cs
+++ b/feature_tests/dotnet/Generated/BorrowChild.cs
@@ -43,7 +43,7 @@ public partial class BorrowChild: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>BorrowChild</c> from a raw handle.
@@ -94,7 +94,12 @@ public partial class BorrowChild: IDisposable
     /// </summary>
     internal unsafe Raw.BorrowChild* AsFFI()
     {
-        return (Raw.BorrowChild*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.BorrowChild*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -108,5 +113,8 @@ public partial class BorrowChild: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/BorrowChild.cs
+++ b/feature_tests/dotnet/Generated/BorrowChild.cs
@@ -8,20 +8,20 @@ namespace Somelib;
 
 #nullable enable
 
-public partial class RenamedOpaqueZSTIndexer: IDisposable
+public partial class BorrowChild: IDisposable
 {
     /// <summary>
-    /// Owns the native <c>Raw.RenamedOpaqueZSTIndexer*</c> handle. Deriving from
+    /// Owns the native <c>Raw.BorrowChild*</c> handle. Deriving from
     /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
     /// finalizer) gives a once-only, thread-safe release and — through its
     /// critical finalizer — prevents the GC from freeing the pointer while a
     /// native call that reads it is still in flight.
     /// </summary>
-    internal sealed unsafe class RenamedOpaqueZSTIndexerHandle : SafeHandle
+    internal sealed unsafe class BorrowChildHandle : SafeHandle
     {
-        public RenamedOpaqueZSTIndexerHandle() : base(IntPtr.Zero, true) { }
+        public BorrowChildHandle() : base(IntPtr.Zero, true) { }
 
-        public RenamedOpaqueZSTIndexerHandle(Raw.RenamedOpaqueZSTIndexer* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        public BorrowChildHandle(Raw.BorrowChild* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
         {
             SetHandle((IntPtr)h);
         }
@@ -30,12 +30,12 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
 
         protected override bool ReleaseHandle()
         {
-            Raw.RenamedOpaqueZSTIndexer.Destroy((Raw.RenamedOpaqueZSTIndexer*)handle);
+            Raw.BorrowChild.Destroy((Raw.BorrowChild*)handle);
             return true;
         }
     }
 
-    private readonly RenamedOpaqueZSTIndexerHandle _handle;
+    private readonly BorrowChildHandle _handle;
 
     /// <summary>
     /// Strong references to the wrappers this value borrows from (its
@@ -46,7 +46,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     private readonly object[] _edges;
 
     /// <summary>
-    /// Creates a managed <c>RenamedOpaqueZSTIndexer</c> from a raw handle.
+    /// Creates a managed <c>BorrowChild</c> from a raw handle.
     /// </summary>
     /// <remarks>
     /// Safety: you should not build two managed objects using the same raw handle (may cause use-after-free and double-free).
@@ -54,14 +54,14 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// This constructor assumes the raw struct is allocated on Rust side.
     /// If implemented, the custom Drop implementation on Rust side WILL run on destruction.
     /// </remarks>
-    internal unsafe RenamedOpaqueZSTIndexer(Raw.RenamedOpaqueZSTIndexer* handle)
+    internal unsafe BorrowChild(Raw.BorrowChild* handle)
     {
-        _handle = new RenamedOpaqueZSTIndexerHandle(handle, ownsHandle: true);
+        _handle = new BorrowChildHandle(handle, ownsHandle: true);
         _edges = System.Array.Empty<object>();
     }
 
     /// <summary>
-    /// Creates a managed <c>RenamedOpaqueZSTIndexer</c> from a raw handle, retaining
+    /// Creates a managed <c>BorrowChild</c> from a raw handle, retaining
     /// strong references to the wrappers it borrows from (its keep-alive
     /// edges) so they outlive this value.
     /// </summary>
@@ -70,45 +70,31 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// the borrowed-from objects GC-reachable so they are not collected and
     /// finalized (-> Destroy) while this value is alive.
     /// </remarks>
-    internal unsafe RenamedOpaqueZSTIndexer(Raw.RenamedOpaqueZSTIndexer* handle, object[] edges)
+    internal unsafe BorrowChild(Raw.BorrowChild* handle, object[] edges)
     {
-        _handle = new RenamedOpaqueZSTIndexerHandle(handle, ownsHandle: true);
+        _handle = new BorrowChildHandle(handle, ownsHandle: true);
         _edges = edges;
     }
-    /// <returns>
-    /// A <c>RenamedOpaqueZSTIndexer</c> allocated on Rust side.
-    /// </returns>
-    public static RenamedOpaqueZSTIndexer New()
-    {
-        unsafe
-        {
-            Raw.RenamedOpaqueZSTIndexer* result = Raw.RenamedOpaqueZSTIndexer.New();
-            return new RenamedOpaqueZSTIndexer(result);
-        }
-    }
-    /// <returns>
-    /// A <c>RenamedOpaqueZSTIndexer</c> allocated on Rust side.
-    /// </returns>
-    public RenamedOpaqueZSTIndexer? Index(nuint idx)
+    public uint Get()
     {
         unsafe
         {
             if (_handle.IsInvalid || _handle.IsClosed)
             {
-                throw new ObjectDisposedException("RenamedOpaqueZSTIndexer");
+                throw new ObjectDisposedException("BorrowChild");
             }
-            Raw.RenamedOpaqueZSTIndexer* result = Raw.RenamedOpaqueZSTIndexer.Index(AsFFI(), idx);
+            var result = Raw.BorrowChild.Get(AsFFI());
             GC.KeepAlive(this);
-            return result == null ? null : new RenamedOpaqueZSTIndexer(result);
+            return result;
         }
     }
 
     /// <summary>
     /// Returns the underlying raw handle.
     /// </summary>
-    internal unsafe Raw.RenamedOpaqueZSTIndexer* AsFFI()
+    internal unsafe Raw.BorrowChild* AsFFI()
     {
-        return (Raw.RenamedOpaqueZSTIndexer*)_handle.DangerousGetHandle();
+        return (Raw.BorrowChild*)_handle.DangerousGetHandle();
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/BorrowParent.cs
+++ b/feature_tests/dotnet/Generated/BorrowParent.cs
@@ -90,8 +90,9 @@ public partial class BorrowParent: IDisposable
     /// A <c>BorrowChild</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public BorrowChild View()
     {

--- a/feature_tests/dotnet/Generated/BorrowParent.cs
+++ b/feature_tests/dotnet/Generated/BorrowParent.cs
@@ -43,7 +43,7 @@ public partial class BorrowParent: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>BorrowParent</c> from a raw handle.
@@ -126,7 +126,12 @@ public partial class BorrowParent: IDisposable
     /// </summary>
     internal unsafe Raw.BorrowParent* AsFFI()
     {
-        return (Raw.BorrowParent*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.BorrowParent*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -140,5 +145,8 @@ public partial class BorrowParent: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/BorrowParent.cs
+++ b/feature_tests/dotnet/Generated/BorrowParent.cs
@@ -8,20 +8,20 @@ namespace Somelib;
 
 #nullable enable
 
-public partial class RenamedOpaqueZSTIndexer: IDisposable
+public partial class BorrowParent: IDisposable
 {
     /// <summary>
-    /// Owns the native <c>Raw.RenamedOpaqueZSTIndexer*</c> handle. Deriving from
+    /// Owns the native <c>Raw.BorrowParent*</c> handle. Deriving from
     /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
     /// finalizer) gives a once-only, thread-safe release and — through its
     /// critical finalizer — prevents the GC from freeing the pointer while a
     /// native call that reads it is still in flight.
     /// </summary>
-    internal sealed unsafe class RenamedOpaqueZSTIndexerHandle : SafeHandle
+    internal sealed unsafe class BorrowParentHandle : SafeHandle
     {
-        public RenamedOpaqueZSTIndexerHandle() : base(IntPtr.Zero, true) { }
+        public BorrowParentHandle() : base(IntPtr.Zero, true) { }
 
-        public RenamedOpaqueZSTIndexerHandle(Raw.RenamedOpaqueZSTIndexer* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        public BorrowParentHandle(Raw.BorrowParent* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
         {
             SetHandle((IntPtr)h);
         }
@@ -30,12 +30,12 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
 
         protected override bool ReleaseHandle()
         {
-            Raw.RenamedOpaqueZSTIndexer.Destroy((Raw.RenamedOpaqueZSTIndexer*)handle);
+            Raw.BorrowParent.Destroy((Raw.BorrowParent*)handle);
             return true;
         }
     }
 
-    private readonly RenamedOpaqueZSTIndexerHandle _handle;
+    private readonly BorrowParentHandle _handle;
 
     /// <summary>
     /// Strong references to the wrappers this value borrows from (its
@@ -46,7 +46,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     private readonly object[] _edges;
 
     /// <summary>
-    /// Creates a managed <c>RenamedOpaqueZSTIndexer</c> from a raw handle.
+    /// Creates a managed <c>BorrowParent</c> from a raw handle.
     /// </summary>
     /// <remarks>
     /// Safety: you should not build two managed objects using the same raw handle (may cause use-after-free and double-free).
@@ -54,14 +54,14 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// This constructor assumes the raw struct is allocated on Rust side.
     /// If implemented, the custom Drop implementation on Rust side WILL run on destruction.
     /// </remarks>
-    internal unsafe RenamedOpaqueZSTIndexer(Raw.RenamedOpaqueZSTIndexer* handle)
+    internal unsafe BorrowParent(Raw.BorrowParent* handle)
     {
-        _handle = new RenamedOpaqueZSTIndexerHandle(handle, ownsHandle: true);
+        _handle = new BorrowParentHandle(handle, ownsHandle: true);
         _edges = System.Array.Empty<object>();
     }
 
     /// <summary>
-    /// Creates a managed <c>RenamedOpaqueZSTIndexer</c> from a raw handle, retaining
+    /// Creates a managed <c>BorrowParent</c> from a raw handle, retaining
     /// strong references to the wrappers it borrows from (its keep-alive
     /// edges) so they outlive this value.
     /// </summary>
@@ -70,45 +70,62 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// the borrowed-from objects GC-reachable so they are not collected and
     /// finalized (-> Destroy) while this value is alive.
     /// </remarks>
-    internal unsafe RenamedOpaqueZSTIndexer(Raw.RenamedOpaqueZSTIndexer* handle, object[] edges)
+    internal unsafe BorrowParent(Raw.BorrowParent* handle, object[] edges)
     {
-        _handle = new RenamedOpaqueZSTIndexerHandle(handle, ownsHandle: true);
+        _handle = new BorrowParentHandle(handle, ownsHandle: true);
         _edges = edges;
     }
     /// <returns>
-    /// A <c>RenamedOpaqueZSTIndexer</c> allocated on Rust side.
+    /// A <c>BorrowParent</c> allocated on Rust side.
     /// </returns>
-    public static RenamedOpaqueZSTIndexer New()
+    public static BorrowParent Create(uint value)
     {
         unsafe
         {
-            Raw.RenamedOpaqueZSTIndexer* result = Raw.RenamedOpaqueZSTIndexer.New();
-            return new RenamedOpaqueZSTIndexer(result);
+            Raw.BorrowParent* result = Raw.BorrowParent.Create(value);
+            return new BorrowParent(result);
         }
     }
     /// <returns>
-    /// A <c>RenamedOpaqueZSTIndexer</c> allocated on Rust side.
+    /// A <c>BorrowChild</c> allocated on Rust side.
     /// </returns>
-    public RenamedOpaqueZSTIndexer? Index(nuint idx)
+    /// <remarks>
+    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
+    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// </remarks>
+    public BorrowChild View()
     {
         unsafe
         {
             if (_handle.IsInvalid || _handle.IsClosed)
             {
-                throw new ObjectDisposedException("RenamedOpaqueZSTIndexer");
+                throw new ObjectDisposedException("BorrowParent");
             }
-            Raw.RenamedOpaqueZSTIndexer* result = Raw.RenamedOpaqueZSTIndexer.Index(AsFFI(), idx);
+            Raw.BorrowChild* result = Raw.BorrowParent.View(AsFFI());
             GC.KeepAlive(this);
-            return result == null ? null : new RenamedOpaqueZSTIndexer(result);
+            return new BorrowChild(result, new object[] { this });
+        }
+    }
+    public uint Value()
+    {
+        unsafe
+        {
+            if (_handle.IsInvalid || _handle.IsClosed)
+            {
+                throw new ObjectDisposedException("BorrowParent");
+            }
+            var result = Raw.BorrowParent.Value(AsFFI());
+            GC.KeepAlive(this);
+            return result;
         }
     }
 
     /// <summary>
     /// Returns the underlying raw handle.
     /// </summary>
-    internal unsafe Raw.RenamedOpaqueZSTIndexer* AsFFI()
+    internal unsafe Raw.BorrowParent* AsFFI()
     {
-        return (Raw.RenamedOpaqueZSTIndexer*)_handle.DangerousGetHandle();
+        return (Raw.BorrowParent*)_handle.DangerousGetHandle();
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/Float64Vec.cs
+++ b/feature_tests/dotnet/Generated/Float64Vec.cs
@@ -38,6 +38,14 @@ public partial class Float64Vec: IDisposable
     private readonly Float64VecHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>Float64Vec</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class Float64Vec: IDisposable
     internal unsafe Float64Vec(Raw.Float64Vec* handle)
     {
         _handle = new Float64VecHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>Float64Vec</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe Float64Vec(Raw.Float64Vec* handle, object[] edges)
+    {
+        _handle = new Float64VecHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Float64Vec</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/Float64Vec.cs
+++ b/feature_tests/dotnet/Generated/Float64Vec.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class Float64Vec: IDisposable
 {
-    private unsafe Raw.Float64Vec* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.Float64Vec*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class Float64VecHandle : SafeHandle
+    {
+        public Float64VecHandle() : base(IntPtr.Zero, true) { }
+
+        public Float64VecHandle(Raw.Float64Vec* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.Float64Vec.Destroy((Raw.Float64Vec*)handle);
+            return true;
+        }
+    }
+
+    private readonly Float64VecHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>Float64Vec</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class Float64Vec: IDisposable
     /// </remarks>
     internal unsafe Float64Vec(Raw.Float64Vec* handle)
     {
-        _inner = handle;
+        _handle = new Float64VecHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>Float64Vec</c> allocated on Rust side.
@@ -44,14 +69,15 @@ public partial class Float64Vec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("Float64Vec");
             }
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                Raw.Float64Vec.ToString(_inner, &writeable);
+                Raw.Float64Vec.ToString(AsFFI(), &writeable);
+                GC.KeepAlive(this);
                 return writeable.ToUnicode();
             }
             finally
@@ -64,11 +90,12 @@ public partial class Float64Vec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("Float64Vec");
             }
-            var result = Raw.Float64Vec.Get(_inner, i);
+            var result = Raw.Float64Vec.Get(AsFFI(), i);
+            GC.KeepAlive(this);
             return result.IsSome ? result.Value : (double?)null;
         }
     }
@@ -78,30 +105,19 @@ public partial class Float64Vec: IDisposable
     /// </summary>
     internal unsafe Raw.Float64Vec* AsFFI()
     {
-        return _inner;
+        return (Raw.Float64Vec*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.Float64Vec.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~Float64Vec()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/Float64Vec.cs
+++ b/feature_tests/dotnet/Generated/Float64Vec.cs
@@ -43,7 +43,7 @@ public partial class Float64Vec: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>Float64Vec</c> from a raw handle.
@@ -130,7 +130,12 @@ public partial class Float64Vec: IDisposable
     /// </summary>
     internal unsafe Raw.Float64Vec* AsFFI()
     {
-        return (Raw.Float64Vec*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.Float64Vec*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -144,5 +149,8 @@ public partial class Float64Vec: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/Foo.cs
+++ b/feature_tests/dotnet/Generated/Foo.cs
@@ -79,8 +79,9 @@ public partial class Foo: IDisposable
     /// A <c>Bar</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public Bar GetBar()
     {

--- a/feature_tests/dotnet/Generated/Foo.cs
+++ b/feature_tests/dotnet/Generated/Foo.cs
@@ -38,6 +38,14 @@ public partial class Foo: IDisposable
     private readonly FooHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>Foo</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class Foo: IDisposable
     internal unsafe Foo(Raw.Foo* handle)
     {
         _handle = new FooHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>Foo</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe Foo(Raw.Foo* handle, object[] edges)
+    {
+        _handle = new FooHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Bar</c> allocated on Rust side.
@@ -67,7 +92,7 @@ public partial class Foo: IDisposable
             }
             Raw.Bar* result = Raw.Foo.GetBar(AsFFI());
             GC.KeepAlive(this);
-            return new Bar(result);
+            return new Bar(result, new object[] { this });
         }
     }
 

--- a/feature_tests/dotnet/Generated/Foo.cs
+++ b/feature_tests/dotnet/Generated/Foo.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class Foo: IDisposable
 {
-    private unsafe Raw.Foo* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.Foo*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class FooHandle : SafeHandle
+    {
+        public FooHandle() : base(IntPtr.Zero, true) { }
+
+        public FooHandle(Raw.Foo* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.Foo.Destroy((Raw.Foo*)handle);
+            return true;
+        }
+    }
+
+    private readonly FooHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>Foo</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class Foo: IDisposable
     /// </remarks>
     internal unsafe Foo(Raw.Foo* handle)
     {
-        _inner = handle;
+        _handle = new FooHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>Bar</c> allocated on Rust side.
@@ -36,11 +61,12 @@ public partial class Foo: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("Foo");
             }
-            Raw.Bar* result = Raw.Foo.GetBar(_inner);
+            Raw.Bar* result = Raw.Foo.GetBar(AsFFI());
+            GC.KeepAlive(this);
             return new Bar(result);
         }
     }
@@ -50,30 +76,19 @@ public partial class Foo: IDisposable
     /// </summary>
     internal unsafe Raw.Foo* AsFFI()
     {
-        return _inner;
+        return (Raw.Foo*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.Foo.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~Foo()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/Foo.cs
+++ b/feature_tests/dotnet/Generated/Foo.cs
@@ -43,7 +43,7 @@ public partial class Foo: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>Foo</c> from a raw handle.
@@ -102,7 +102,12 @@ public partial class Foo: IDisposable
     /// </summary>
     internal unsafe Raw.Foo* AsFFI()
     {
-        return (Raw.Foo*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.Foo*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -116,5 +121,8 @@ public partial class Foo: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/MethodOverloading.cs
+++ b/feature_tests/dotnet/Generated/MethodOverloading.cs
@@ -43,7 +43,7 @@ public partial class MethodOverloading: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>MethodOverloading</c> from a raw handle.
@@ -114,7 +114,12 @@ public partial class MethodOverloading: IDisposable
     /// </summary>
     internal unsafe Raw.MethodOverloading* AsFFI()
     {
-        return (Raw.MethodOverloading*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.MethodOverloading*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -128,5 +133,8 @@ public partial class MethodOverloading: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/MethodOverloading.cs
+++ b/feature_tests/dotnet/Generated/MethodOverloading.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class MethodOverloading: IDisposable
 {
-    private unsafe Raw.MethodOverloading* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.MethodOverloading*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class MethodOverloadingHandle : SafeHandle
+    {
+        public MethodOverloadingHandle() : base(IntPtr.Zero, true) { }
+
+        public MethodOverloadingHandle(Raw.MethodOverloading* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.MethodOverloading.Destroy((Raw.MethodOverloading*)handle);
+            return true;
+        }
+    }
+
+    private readonly MethodOverloadingHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>MethodOverloading</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class MethodOverloading: IDisposable
     /// </remarks>
     internal unsafe MethodOverloading(Raw.MethodOverloading* handle)
     {
-        _inner = handle;
+        _handle = new MethodOverloadingHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>MethodOverloading</c> allocated on Rust side.
@@ -64,30 +89,19 @@ public partial class MethodOverloading: IDisposable
     /// </summary>
     internal unsafe Raw.MethodOverloading* AsFFI()
     {
-        return _inner;
+        return (Raw.MethodOverloading*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.MethodOverloading.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~MethodOverloading()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/MethodOverloading.cs
+++ b/feature_tests/dotnet/Generated/MethodOverloading.cs
@@ -38,6 +38,14 @@ public partial class MethodOverloading: IDisposable
     private readonly MethodOverloadingHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>MethodOverloading</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class MethodOverloading: IDisposable
     internal unsafe MethodOverloading(Raw.MethodOverloading* handle)
     {
         _handle = new MethodOverloadingHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>MethodOverloading</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe MethodOverloading(Raw.MethodOverloading* handle, object[] edges)
+    {
+        _handle = new MethodOverloadingHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>MethodOverloading</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
@@ -38,6 +38,14 @@ public partial class MyOpaqueEnum: IDisposable
     private readonly MyOpaqueEnumHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>MyOpaqueEnum</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class MyOpaqueEnum: IDisposable
     internal unsafe MyOpaqueEnum(Raw.MyOpaqueEnum* handle)
     {
         _handle = new MyOpaqueEnumHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>MyOpaqueEnum</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe MyOpaqueEnum(Raw.MyOpaqueEnum* handle, object[] edges)
+    {
+        _handle = new MyOpaqueEnumHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>MyOpaqueEnum</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class MyOpaqueEnum: IDisposable
 {
-    private unsafe Raw.MyOpaqueEnum* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.MyOpaqueEnum*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class MyOpaqueEnumHandle : SafeHandle
+    {
+        public MyOpaqueEnumHandle() : base(IntPtr.Zero, true) { }
+
+        public MyOpaqueEnumHandle(Raw.MyOpaqueEnum* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.MyOpaqueEnum.Destroy((Raw.MyOpaqueEnum*)handle);
+            return true;
+        }
+    }
+
+    private readonly MyOpaqueEnumHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>MyOpaqueEnum</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class MyOpaqueEnum: IDisposable
     /// </remarks>
     internal unsafe MyOpaqueEnum(Raw.MyOpaqueEnum* handle)
     {
-        _inner = handle;
+        _handle = new MyOpaqueEnumHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>MyOpaqueEnum</c> allocated on Rust side.
@@ -40,14 +65,15 @@ public partial class MyOpaqueEnum: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("MyOpaqueEnum");
             }
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                Raw.MyOpaqueEnum.ToString(_inner, &writeable);
+                Raw.MyOpaqueEnum.ToString(AsFFI(), &writeable);
+                GC.KeepAlive(this);
                 return writeable.ToUnicode();
             }
             finally
@@ -62,30 +88,19 @@ public partial class MyOpaqueEnum: IDisposable
     /// </summary>
     internal unsafe Raw.MyOpaqueEnum* AsFFI()
     {
-        return _inner;
+        return (Raw.MyOpaqueEnum*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.MyOpaqueEnum.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~MyOpaqueEnum()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
@@ -43,7 +43,7 @@ public partial class MyOpaqueEnum: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>MyOpaqueEnum</c> from a raw handle.
@@ -113,7 +113,12 @@ public partial class MyOpaqueEnum: IDisposable
     /// </summary>
     internal unsafe Raw.MyOpaqueEnum* AsFFI()
     {
-        return (Raw.MyOpaqueEnum*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.MyOpaqueEnum*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -127,5 +132,8 @@ public partial class MyOpaqueEnum: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/MyString.cs
+++ b/feature_tests/dotnet/Generated/MyString.cs
@@ -38,6 +38,14 @@ public partial class MyString: IDisposable
     private readonly MyStringHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>MyString</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class MyString: IDisposable
     internal unsafe MyString(Raw.MyString* handle)
     {
         _handle = new MyStringHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>MyString</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe MyString(Raw.MyString* handle, object[] edges)
+    {
+        _handle = new MyStringHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>MyString</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/MyString.cs
+++ b/feature_tests/dotnet/Generated/MyString.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class MyString: IDisposable
 {
-    private unsafe Raw.MyString* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.MyString*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class MyStringHandle : SafeHandle
+    {
+        public MyStringHandle() : base(IntPtr.Zero, true) { }
+
+        public MyStringHandle(Raw.MyString* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.MyString.Destroy((Raw.MyString*)handle);
+            return true;
+        }
+    }
+
+    private readonly MyStringHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>MyString</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class MyString: IDisposable
     /// </remarks>
     internal unsafe MyString(Raw.MyString* handle)
     {
-        _inner = handle;
+        _handle = new MyStringHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>MyString</c> allocated on Rust side.
@@ -61,7 +86,7 @@ public partial class MyString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("MyString");
             }
@@ -69,7 +94,8 @@ public partial class MyString: IDisposable
             byte[] newStrBytes = System.Text.Encoding.UTF8.GetBytes(newStr);
             fixed (byte* newStrPtr = newStrBytes)
             {
-                Raw.MyString.SetStr(_inner, new DiplomatSliceU8 { Ptr = newStrPtr, Len = (nuint)newStrBytes.Length });
+                Raw.MyString.SetStr(AsFFI(), new DiplomatSliceU8 { Ptr = newStrPtr, Len = (nuint)newStrBytes.Length });
+                GC.KeepAlive(this);
             }
         }
     }
@@ -77,14 +103,15 @@ public partial class MyString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("MyString");
             }
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                Raw.MyString.GetStr(_inner, &writeable);
+                Raw.MyString.GetStr(AsFFI(), &writeable);
+                GC.KeepAlive(this);
                 return writeable.ToUnicode();
             }
             finally
@@ -120,30 +147,19 @@ public partial class MyString: IDisposable
     /// </summary>
     internal unsafe Raw.MyString* AsFFI()
     {
-        return _inner;
+        return (Raw.MyString*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.MyString.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~MyString()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/MyString.cs
+++ b/feature_tests/dotnet/Generated/MyString.cs
@@ -43,7 +43,7 @@ public partial class MyString: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>MyString</c> from a raw handle.
@@ -172,7 +172,12 @@ public partial class MyString: IDisposable
     /// </summary>
     internal unsafe Raw.MyString* AsFFI()
     {
-        return (Raw.MyString*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.MyString*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -186,5 +191,8 @@ public partial class MyString: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/One.cs
+++ b/feature_tests/dotnet/Generated/One.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class One: IDisposable
 {
-    private unsafe Raw.One* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.One*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OneHandle : SafeHandle
+    {
+        public OneHandle() : base(IntPtr.Zero, true) { }
+
+        public OneHandle(Raw.One* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.One.Destroy((Raw.One*)handle);
+            return true;
+        }
+    }
+
+    private readonly OneHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>One</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class One: IDisposable
     /// </remarks>
     internal unsafe One(Raw.One* handle)
     {
-        _inner = handle;
+        _handle = new OneHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
@@ -43,6 +68,8 @@ public partial class One: IDisposable
             Raw.One* noholdRaw = nohold.AsFFI();
             if (noholdRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.Transitivity(holdRaw, noholdRaw);
+            GC.KeepAlive(hold);
+            GC.KeepAlive(nohold);
             return new One(result);
         }
     }
@@ -64,6 +91,8 @@ public partial class One: IDisposable
             Raw.One* noholdRaw = nohold.AsFFI();
             if (noholdRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.Cycle(holdRaw, noholdRaw);
+            GC.KeepAlive(hold);
+            GC.KeepAlive(nohold);
             return new One(result);
         }
     }
@@ -94,6 +123,11 @@ public partial class One: IDisposable
             Raw.Two* noholdRaw = nohold.AsFFI();
             if (noholdRaw == null) throw new ObjectDisposedException(nameof(Two));
             Raw.One* result = Raw.One.ManyDependents(aRaw, bRaw, cRaw, dRaw, noholdRaw);
+            GC.KeepAlive(a);
+            GC.KeepAlive(b);
+            GC.KeepAlive(c);
+            GC.KeepAlive(d);
+            GC.KeepAlive(nohold);
             return new One(result);
         }
     }
@@ -115,6 +149,8 @@ public partial class One: IDisposable
             Raw.One* noholdRaw = nohold.AsFFI();
             if (noholdRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.ReturnOutlivesParam(holdRaw, noholdRaw);
+            GC.KeepAlive(hold);
+            GC.KeepAlive(nohold);
             return new One(result);
         }
     }
@@ -142,6 +178,10 @@ public partial class One: IDisposable
             Raw.One* bottomRaw = bottom.AsFFI();
             if (bottomRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.DiamondTop(topRaw, leftRaw, rightRaw, bottomRaw);
+            GC.KeepAlive(top);
+            GC.KeepAlive(left);
+            GC.KeepAlive(right);
+            GC.KeepAlive(bottom);
             return new One(result);
         }
     }
@@ -169,6 +209,10 @@ public partial class One: IDisposable
             Raw.One* bottomRaw = bottom.AsFFI();
             if (bottomRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.DiamondLeft(topRaw, leftRaw, rightRaw, bottomRaw);
+            GC.KeepAlive(top);
+            GC.KeepAlive(left);
+            GC.KeepAlive(right);
+            GC.KeepAlive(bottom);
             return new One(result);
         }
     }
@@ -196,6 +240,10 @@ public partial class One: IDisposable
             Raw.One* bottomRaw = bottom.AsFFI();
             if (bottomRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.DiamondRight(topRaw, leftRaw, rightRaw, bottomRaw);
+            GC.KeepAlive(top);
+            GC.KeepAlive(left);
+            GC.KeepAlive(right);
+            GC.KeepAlive(bottom);
             return new One(result);
         }
     }
@@ -223,6 +271,10 @@ public partial class One: IDisposable
             Raw.One* bottomRaw = bottom.AsFFI();
             if (bottomRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.DiamondBottom(topRaw, leftRaw, rightRaw, bottomRaw);
+            GC.KeepAlive(top);
+            GC.KeepAlive(left);
+            GC.KeepAlive(right);
+            GC.KeepAlive(bottom);
             return new One(result);
         }
     }
@@ -253,6 +305,11 @@ public partial class One: IDisposable
             Raw.One* noholdRaw = nohold.AsFFI();
             if (noholdRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.DiamondAndNestedTypes(aRaw, bRaw, cRaw, dRaw, noholdRaw);
+            GC.KeepAlive(a);
+            GC.KeepAlive(b);
+            GC.KeepAlive(c);
+            GC.KeepAlive(d);
+            GC.KeepAlive(nohold);
             return new One(result);
         }
     }
@@ -277,6 +334,9 @@ public partial class One: IDisposable
             Raw.One* noholdRaw = nohold.AsFFI();
             if (noholdRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.ImplicitBounds(explicitHoldRaw, implicitHoldRaw, noholdRaw);
+            GC.KeepAlive(explicitHold);
+            GC.KeepAlive(implicitHold);
+            GC.KeepAlive(nohold);
             return new One(result);
         }
     }
@@ -304,6 +364,10 @@ public partial class One: IDisposable
             Raw.One* noholdRaw = nohold.AsFFI();
             if (noholdRaw == null) throw new ObjectDisposedException(nameof(One));
             Raw.One* result = Raw.One.ImplicitBoundsDeep(@explicitRaw, implicit1Raw, implicit2Raw, noholdRaw);
+            GC.KeepAlive(@explicit);
+            GC.KeepAlive(implicit1);
+            GC.KeepAlive(implicit2);
+            GC.KeepAlive(nohold);
             return new One(result);
         }
     }
@@ -313,30 +377,19 @@ public partial class One: IDisposable
     /// </summary>
     internal unsafe Raw.One* AsFFI()
     {
-        return _inner;
+        return (Raw.One*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.One.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~One()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/One.cs
+++ b/feature_tests/dotnet/Generated/One.cs
@@ -79,8 +79,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One Transitivity(One hold, One nohold)
     {
@@ -102,8 +103,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One Cycle(Two hold, One nohold)
     {
@@ -125,8 +127,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One ManyDependents(One a, One b, Two c, Two d, Two nohold)
     {
@@ -160,8 +163,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One ReturnOutlivesParam(Two hold, One nohold)
     {
@@ -183,8 +187,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One DiamondTop(One top, One left, One right, One bottom)
     {
@@ -214,8 +219,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One DiamondLeft(One top, One left, One right, One bottom)
     {
@@ -245,8 +251,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One DiamondRight(One top, One left, One right, One bottom)
     {
@@ -276,8 +283,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One DiamondBottom(One top, One left, One right, One bottom)
     {
@@ -307,8 +315,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One DiamondAndNestedTypes(One a, One b, One c, One d, One nohold)
     {
@@ -342,8 +351,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One ImplicitBounds(One explicitHold, One implicitHold, One nohold)
     {
@@ -369,8 +379,9 @@ public partial class One: IDisposable
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static One ImplicitBoundsDeep(One @explicit, One implicit1, One implicit2, One nohold)
     {

--- a/feature_tests/dotnet/Generated/One.cs
+++ b/feature_tests/dotnet/Generated/One.cs
@@ -38,6 +38,14 @@ public partial class One: IDisposable
     private readonly OneHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>One</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class One: IDisposable
     internal unsafe One(Raw.One* handle)
     {
         _handle = new OneHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>One</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe One(Raw.One* handle, object[] edges)
+    {
+        _handle = new OneHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
@@ -70,7 +95,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.Transitivity(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result);
+            return new One(result, new object[] { hold });
         }
     }
     /// <returns>
@@ -93,7 +118,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.Cycle(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result);
+            return new One(result, new object[] { hold });
         }
     }
     /// <returns>
@@ -128,7 +153,7 @@ public partial class One: IDisposable
             GC.KeepAlive(c);
             GC.KeepAlive(d);
             GC.KeepAlive(nohold);
-            return new One(result);
+            return new One(result, new object[] { a, b, c, d });
         }
     }
     /// <returns>
@@ -151,7 +176,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.ReturnOutlivesParam(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result);
+            return new One(result, new object[] { hold });
         }
     }
     /// <returns>
@@ -182,7 +207,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result);
+            return new One(result, new object[] { top, left, right, bottom });
         }
     }
     /// <returns>
@@ -213,7 +238,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result);
+            return new One(result, new object[] { left, bottom });
         }
     }
     /// <returns>
@@ -244,7 +269,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result);
+            return new One(result, new object[] { right, bottom });
         }
     }
     /// <returns>
@@ -275,7 +300,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result);
+            return new One(result, new object[] { bottom });
         }
     }
     /// <returns>
@@ -310,7 +335,7 @@ public partial class One: IDisposable
             GC.KeepAlive(c);
             GC.KeepAlive(d);
             GC.KeepAlive(nohold);
-            return new One(result);
+            return new One(result, new object[] { a, b, c, d });
         }
     }
     /// <returns>
@@ -337,7 +362,7 @@ public partial class One: IDisposable
             GC.KeepAlive(explicitHold);
             GC.KeepAlive(implicitHold);
             GC.KeepAlive(nohold);
-            return new One(result);
+            return new One(result, new object[] { explicitHold, implicitHold });
         }
     }
     /// <returns>
@@ -368,7 +393,7 @@ public partial class One: IDisposable
             GC.KeepAlive(implicit1);
             GC.KeepAlive(implicit2);
             GC.KeepAlive(nohold);
-            return new One(result);
+            return new One(result, new object[] { @explicit, implicit1, implicit2 });
         }
     }
 

--- a/feature_tests/dotnet/Generated/One.cs
+++ b/feature_tests/dotnet/Generated/One.cs
@@ -43,7 +43,7 @@ public partial class One: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>One</c> from a raw handle.
@@ -413,7 +413,12 @@ public partial class One: IDisposable
     /// </summary>
     internal unsafe Raw.One* AsFFI()
     {
-        return (Raw.One*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.One*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -427,5 +432,8 @@ public partial class One: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class Opaque: IDisposable
 {
-    private unsafe Raw.Opaque* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.Opaque*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OpaqueHandle : SafeHandle
+    {
+        public OpaqueHandle() : base(IntPtr.Zero, true) { }
+
+        public OpaqueHandle(Raw.Opaque* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.Opaque.Destroy((Raw.Opaque*)handle);
+            return true;
+        }
+    }
+
+    private readonly OpaqueHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>Opaque</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class Opaque: IDisposable
     /// </remarks>
     internal unsafe Opaque(Raw.Opaque* handle)
     {
-        _inner = handle;
+        _handle = new OpaqueHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>Opaque</c> allocated on Rust side.
@@ -72,14 +97,15 @@ public partial class Opaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("Opaque");
             }
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                Raw.Opaque.GetDebugStr(_inner, &writeable);
+                Raw.Opaque.GetDebugStr(AsFFI(), &writeable);
+                GC.KeepAlive(this);
                 return writeable.ToUnicode();
             }
             finally
@@ -92,11 +118,12 @@ public partial class Opaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("Opaque");
             }
-            Raw.Opaque.AssertStruct(_inner, s.AsFFI());
+            Raw.Opaque.AssertStruct(AsFFI(), s.AsFFI());
+            GC.KeepAlive(this);
         }
     }
     public static nuint ReturnsUsize()
@@ -120,30 +147,19 @@ public partial class Opaque: IDisposable
     /// </summary>
     internal unsafe Raw.Opaque* AsFFI()
     {
-        return _inner;
+        return (Raw.Opaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.Opaque.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~Opaque()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -38,6 +38,14 @@ public partial class Opaque: IDisposable
     private readonly OpaqueHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>Opaque</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class Opaque: IDisposable
     internal unsafe Opaque(Raw.Opaque* handle)
     {
         _handle = new OpaqueHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>Opaque</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe Opaque(Raw.Opaque* handle, object[] edges)
+    {
+        _handle = new OpaqueHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Opaque</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -43,7 +43,7 @@ public partial class Opaque: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>Opaque</c> from a raw handle.
@@ -172,7 +172,12 @@ public partial class Opaque: IDisposable
     /// </summary>
     internal unsafe Raw.Opaque* AsFFI()
     {
-        return (Raw.Opaque*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.Opaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -186,5 +191,8 @@ public partial class Opaque: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueMut.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMut.cs
@@ -43,7 +43,7 @@ public partial class OpaqueMut: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>OpaqueMut</c> from a raw handle.
@@ -92,7 +92,12 @@ public partial class OpaqueMut: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueMut* AsFFI()
     {
-        return (Raw.OpaqueMut*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.OpaqueMut*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -106,5 +111,8 @@ public partial class OpaqueMut: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueMut.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMut.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class OpaqueMut: IDisposable
 {
-    private unsafe Raw.OpaqueMut* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.OpaqueMut*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OpaqueMutHandle : SafeHandle
+    {
+        public OpaqueMutHandle() : base(IntPtr.Zero, true) { }
+
+        public OpaqueMutHandle(Raw.OpaqueMut* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.OpaqueMut.Destroy((Raw.OpaqueMut*)handle);
+            return true;
+        }
+    }
+
+    private readonly OpaqueMutHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>OpaqueMut</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class OpaqueMut: IDisposable
     /// </remarks>
     internal unsafe OpaqueMut(Raw.OpaqueMut* handle)
     {
-        _inner = handle;
+        _handle = new OpaqueMutHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>OpaqueMut</c> allocated on Rust side.
@@ -42,30 +67,19 @@ public partial class OpaqueMut: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueMut* AsFFI()
     {
-        return _inner;
+        return (Raw.OpaqueMut*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.OpaqueMut.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~OpaqueMut()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueMut.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMut.cs
@@ -38,6 +38,14 @@ public partial class OpaqueMut: IDisposable
     private readonly OpaqueMutHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>OpaqueMut</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class OpaqueMut: IDisposable
     internal unsafe OpaqueMut(Raw.OpaqueMut* handle)
     {
         _handle = new OpaqueMutHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>OpaqueMut</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe OpaqueMut(Raw.OpaqueMut* handle, object[] edges)
+    {
+        _handle = new OpaqueMutHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OpaqueMut</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class OpaqueMutexedString: IDisposable
 {
-    private unsafe Raw.OpaqueMutexedString* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.OpaqueMutexedString*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OpaqueMutexedStringHandle : SafeHandle
+    {
+        public OpaqueMutexedStringHandle() : base(IntPtr.Zero, true) { }
+
+        public OpaqueMutexedStringHandle(Raw.OpaqueMutexedString* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.OpaqueMutexedString.Destroy((Raw.OpaqueMutexedString*)handle);
+            return true;
+        }
+    }
+
+    private readonly OpaqueMutexedStringHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>OpaqueMutexedString</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class OpaqueMutexedString: IDisposable
     /// </remarks>
     internal unsafe OpaqueMutexedString(Raw.OpaqueMutexedString* handle)
     {
-        _inner = handle;
+        _handle = new OpaqueMutexedStringHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>OpaqueMutexedString</c> allocated on Rust side.
@@ -40,22 +65,25 @@ public partial class OpaqueMutexedString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueMutexedString");
             }
-            Raw.OpaqueMutexedString.Change(_inner, number);
+            Raw.OpaqueMutexedString.Change(AsFFI(), number);
+            GC.KeepAlive(this);
         }
     }
     public nuint GetLenAndAdd(nuint other)
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueMutexedString");
             }
-            return Raw.OpaqueMutexedString.GetLenAndAdd(_inner, other);
+            var result = Raw.OpaqueMutexedString.GetLenAndAdd(AsFFI(), other);
+            GC.KeepAlive(this);
+            return result;
         }
     }
     /// <returns>
@@ -65,11 +93,12 @@ public partial class OpaqueMutexedString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueMutexedString");
             }
-            Raw.Utf16Wrap* result = Raw.OpaqueMutexedString.Wrapper(_inner);
+            Raw.Utf16Wrap* result = Raw.OpaqueMutexedString.Wrapper(AsFFI());
+            GC.KeepAlive(this);
             return new Utf16Wrap(result);
         }
     }
@@ -77,11 +106,13 @@ public partial class OpaqueMutexedString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueMutexedString");
             }
-            return Raw.OpaqueMutexedString.ToUnsignedFromUnsigned(_inner, input);
+            var result = Raw.OpaqueMutexedString.ToUnsignedFromUnsigned(AsFFI(), input);
+            GC.KeepAlive(this);
+            return result;
         }
     }
 
@@ -90,30 +121,19 @@ public partial class OpaqueMutexedString: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueMutexedString* AsFFI()
     {
-        return _inner;
+        return (Raw.OpaqueMutexedString*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.OpaqueMutexedString.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~OpaqueMutexedString()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
@@ -43,7 +43,7 @@ public partial class OpaqueMutexedString: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>OpaqueMutexedString</c> from a raw handle.
@@ -146,7 +146,12 @@ public partial class OpaqueMutexedString: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueMutexedString* AsFFI()
     {
-        return (Raw.OpaqueMutexedString*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.OpaqueMutexedString*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -160,5 +165,8 @@ public partial class OpaqueMutexedString: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
@@ -38,6 +38,14 @@ public partial class OpaqueMutexedString: IDisposable
     private readonly OpaqueMutexedStringHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>OpaqueMutexedString</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class OpaqueMutexedString: IDisposable
     internal unsafe OpaqueMutexedString(Raw.OpaqueMutexedString* handle)
     {
         _handle = new OpaqueMutexedStringHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>OpaqueMutexedString</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe OpaqueMutexedString(Raw.OpaqueMutexedString* handle, object[] edges)
+    {
+        _handle = new OpaqueMutexedStringHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OpaqueMutexedString</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/OpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThin.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class OpaqueThin: IDisposable
 {
-    private unsafe Raw.OpaqueThin* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.OpaqueThin*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OpaqueThinHandle : SafeHandle
+    {
+        public OpaqueThinHandle() : base(IntPtr.Zero, true) { }
+
+        public OpaqueThinHandle(Raw.OpaqueThin* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.OpaqueThin.Destroy((Raw.OpaqueThin*)handle);
+            return true;
+        }
+    }
+
+    private readonly OpaqueThinHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThin</c> from a raw handle.
@@ -23,42 +48,47 @@ public partial class OpaqueThin: IDisposable
     /// </remarks>
     internal unsafe OpaqueThin(Raw.OpaqueThin* handle)
     {
-        _inner = handle;
+        _handle = new OpaqueThinHandle(handle, ownsHandle: true);
     }
     public int A()
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueThin");
             }
-            return Raw.OpaqueThin.A(_inner);
+            var result = Raw.OpaqueThin.A(AsFFI());
+            GC.KeepAlive(this);
+            return result;
         }
     }
     public float B()
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueThin");
             }
-            return Raw.OpaqueThin.B(_inner);
+            var result = Raw.OpaqueThin.B(AsFFI());
+            GC.KeepAlive(this);
+            return result;
         }
     }
     public string C()
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueThin");
             }
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                Raw.OpaqueThin.C(_inner, &writeable);
+                Raw.OpaqueThin.C(AsFFI(), &writeable);
+                GC.KeepAlive(this);
                 return writeable.ToUnicode();
             }
             finally
@@ -73,30 +103,19 @@ public partial class OpaqueThin: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThin* AsFFI()
     {
-        return _inner;
+        return (Raw.OpaqueThin*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.OpaqueThin.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~OpaqueThin()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThin.cs
@@ -43,7 +43,7 @@ public partial class OpaqueThin: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThin</c> from a raw handle.
@@ -128,7 +128,12 @@ public partial class OpaqueThin: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThin* AsFFI()
     {
-        return (Raw.OpaqueThin*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.OpaqueThin*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -142,5 +147,8 @@ public partial class OpaqueThin: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThin.cs
@@ -38,6 +38,14 @@ public partial class OpaqueThin: IDisposable
     private readonly OpaqueThinHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>OpaqueThin</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class OpaqueThin: IDisposable
     internal unsafe OpaqueThin(Raw.OpaqueThin* handle)
     {
         _handle = new OpaqueThinHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>OpaqueThin</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe OpaqueThin(Raw.OpaqueThin* handle, object[] edges)
+    {
+        _handle = new OpaqueThinHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     public int A()
     {

--- a/feature_tests/dotnet/Generated/OpaqueThinIter.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinIter.cs
@@ -38,6 +38,14 @@ public partial class OpaqueThinIter: IDisposable
     private readonly OpaqueThinIterHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>OpaqueThinIter</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class OpaqueThinIter: IDisposable
     internal unsafe OpaqueThinIter(Raw.OpaqueThinIter* handle)
     {
         _handle = new OpaqueThinIterHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>OpaqueThinIter</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe OpaqueThinIter(Raw.OpaqueThinIter* handle, object[] edges)
+    {
+        _handle = new OpaqueThinIterHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/OpaqueThinIter.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinIter.cs
@@ -43,7 +43,7 @@ public partial class OpaqueThinIter: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThinIter</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class OpaqueThinIter: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThinIter* AsFFI()
     {
-        return (Raw.OpaqueThinIter*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.OpaqueThinIter*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class OpaqueThinIter: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueThinIter.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinIter.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class OpaqueThinIter: IDisposable
 {
-    private unsafe Raw.OpaqueThinIter* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.OpaqueThinIter*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OpaqueThinIterHandle : SafeHandle
+    {
+        public OpaqueThinIterHandle() : base(IntPtr.Zero, true) { }
+
+        public OpaqueThinIterHandle(Raw.OpaqueThinIter* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.OpaqueThinIter.Destroy((Raw.OpaqueThinIter*)handle);
+            return true;
+        }
+    }
+
+    private readonly OpaqueThinIterHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThinIter</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class OpaqueThinIter: IDisposable
     /// </remarks>
     internal unsafe OpaqueThinIter(Raw.OpaqueThinIter* handle)
     {
-        _inner = handle;
+        _handle = new OpaqueThinIterHandle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class OpaqueThinIter: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThinIter* AsFFI()
     {
-        return _inner;
+        return (Raw.OpaqueThinIter*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.OpaqueThinIter.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~OpaqueThinIter()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -79,8 +79,9 @@ public partial class OpaqueThinVec: IDisposable
     /// A <c>OpaqueThinIter</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public OpaqueThinIter Iter()
     {

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -38,6 +38,14 @@ public partial class OpaqueThinVec: IDisposable
     private readonly OpaqueThinVecHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>OpaqueThinVec</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class OpaqueThinVec: IDisposable
     internal unsafe OpaqueThinVec(Raw.OpaqueThinVec* handle)
     {
         _handle = new OpaqueThinVecHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>OpaqueThinVec</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe OpaqueThinVec(Raw.OpaqueThinVec* handle, object[] edges)
+    {
+        _handle = new OpaqueThinVecHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OpaqueThinIter</c> allocated on Rust side.
@@ -67,7 +92,7 @@ public partial class OpaqueThinVec: IDisposable
             }
             Raw.OpaqueThinIter* result = Raw.OpaqueThinVec.Iter(AsFFI());
             GC.KeepAlive(this);
-            return new OpaqueThinIter(result);
+            return new OpaqueThinIter(result, new object[] { this });
         }
     }
     public nuint Len()

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -43,7 +43,7 @@ public partial class OpaqueThinVec: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThinVec</c> from a raw handle.
@@ -115,7 +115,12 @@ public partial class OpaqueThinVec: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThinVec* AsFFI()
     {
-        return (Raw.OpaqueThinVec*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.OpaqueThinVec*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -129,5 +134,8 @@ public partial class OpaqueThinVec: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class OpaqueThinVec: IDisposable
 {
-    private unsafe Raw.OpaqueThinVec* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.OpaqueThinVec*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OpaqueThinVecHandle : SafeHandle
+    {
+        public OpaqueThinVecHandle() : base(IntPtr.Zero, true) { }
+
+        public OpaqueThinVecHandle(Raw.OpaqueThinVec* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.OpaqueThinVec.Destroy((Raw.OpaqueThinVec*)handle);
+            return true;
+        }
+    }
+
+    private readonly OpaqueThinVecHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThinVec</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class OpaqueThinVec: IDisposable
     /// </remarks>
     internal unsafe OpaqueThinVec(Raw.OpaqueThinVec* handle)
     {
-        _inner = handle;
+        _handle = new OpaqueThinVecHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>OpaqueThinIter</c> allocated on Rust side.
@@ -36,11 +61,12 @@ public partial class OpaqueThinVec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueThinVec");
             }
-            Raw.OpaqueThinIter* result = Raw.OpaqueThinVec.Iter(_inner);
+            Raw.OpaqueThinIter* result = Raw.OpaqueThinVec.Iter(AsFFI());
+            GC.KeepAlive(this);
             return new OpaqueThinIter(result);
         }
     }
@@ -48,11 +74,13 @@ public partial class OpaqueThinVec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OpaqueThinVec");
             }
-            return Raw.OpaqueThinVec.Len(_inner);
+            var result = Raw.OpaqueThinVec.Len(AsFFI());
+            GC.KeepAlive(this);
+            return result;
         }
     }
 
@@ -61,30 +89,19 @@ public partial class OpaqueThinVec: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThinVec* AsFFI()
     {
-        return _inner;
+        return (Raw.OpaqueThinVec*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.OpaqueThinVec.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~OpaqueThinVec()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/OptionOpaque.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaque.cs
@@ -38,6 +38,14 @@ public partial class OptionOpaque: IDisposable
     private readonly OptionOpaqueHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>OptionOpaque</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class OptionOpaque: IDisposable
     internal unsafe OptionOpaque(Raw.OptionOpaque* handle)
     {
         _handle = new OptionOpaqueHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>OptionOpaque</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe OptionOpaque(Raw.OptionOpaque* handle, object[] edges)
+    {
+        _handle = new OptionOpaqueHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OptionOpaque</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/OptionOpaque.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaque.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class OptionOpaque: IDisposable
 {
-    private unsafe Raw.OptionOpaque* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.OptionOpaque*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OptionOpaqueHandle : SafeHandle
+    {
+        public OptionOpaqueHandle() : base(IntPtr.Zero, true) { }
+
+        public OptionOpaqueHandle(Raw.OptionOpaque* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.OptionOpaque.Destroy((Raw.OptionOpaque*)handle);
+            return true;
+        }
+    }
+
+    private readonly OptionOpaqueHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>OptionOpaque</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class OptionOpaque: IDisposable
     /// </remarks>
     internal unsafe OptionOpaque(Raw.OptionOpaque* handle)
     {
-        _inner = handle;
+        _handle = new OptionOpaqueHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>OptionOpaque</c> allocated on Rust side.
@@ -51,11 +76,12 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
-            var result = Raw.OptionOpaque.OptionIsize(_inner);
+            var result = Raw.OptionOpaque.OptionIsize(AsFFI());
+            GC.KeepAlive(this);
             return result.IsSome ? result.Value : (nint?)null;
         }
     }
@@ -63,11 +89,12 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
-            var result = Raw.OptionOpaque.OptionUsize(_inner);
+            var result = Raw.OptionOpaque.OptionUsize(AsFFI());
+            GC.KeepAlive(this);
             return result.IsSome ? result.Value : (nuint?)null;
         }
     }
@@ -75,11 +102,12 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
-            var result = Raw.OptionOpaque.OptionI32(_inner);
+            var result = Raw.OptionOpaque.OptionI32(AsFFI());
+            GC.KeepAlive(this);
             return result.IsSome ? result.Value : (int?)null;
         }
     }
@@ -87,11 +115,12 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
-            var result = Raw.OptionOpaque.OptionU32(_inner);
+            var result = Raw.OptionOpaque.OptionU32(AsFFI());
+            GC.KeepAlive(this);
             return result.IsSome ? result.Value : (uint?)null;
         }
     }
@@ -99,11 +128,12 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
-            Raw.OptionOpaque.AssertInteger(_inner, i);
+            Raw.OptionOpaque.AssertInteger(AsFFI(), i);
+            GC.KeepAlive(this);
         }
     }
     public static bool OptionOpaqueArgument(OptionOpaque? arg)
@@ -112,7 +142,9 @@ public partial class OptionOpaque: IDisposable
         {
             Raw.OptionOpaque* argRaw = arg == null ? null : arg.AsFFI();
             if (arg != null && argRaw == null) throw new ObjectDisposedException(nameof(OptionOpaque));
-            return Raw.OptionOpaque.OptionOpaqueArgument(argRaw);
+            var result = Raw.OptionOpaque.OptionOpaqueArgument(argRaw);
+            GC.KeepAlive(arg);
+            return result;
         }
     }
 
@@ -121,30 +153,19 @@ public partial class OptionOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.OptionOpaque* AsFFI()
     {
-        return _inner;
+        return (Raw.OptionOpaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.OptionOpaque.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~OptionOpaque()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/OptionOpaque.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaque.cs
@@ -43,7 +43,7 @@ public partial class OptionOpaque: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>OptionOpaque</c> from a raw handle.
@@ -178,7 +178,12 @@ public partial class OptionOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.OptionOpaque* AsFFI()
     {
-        return (Raw.OptionOpaque*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.OptionOpaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -192,5 +197,8 @@ public partial class OptionOpaque: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
@@ -38,6 +38,14 @@ public partial class OptionOpaqueChar: IDisposable
     private readonly OptionOpaqueCharHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>OptionOpaqueChar</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class OptionOpaqueChar: IDisposable
     internal unsafe OptionOpaqueChar(Raw.OptionOpaqueChar* handle)
     {
         _handle = new OptionOpaqueCharHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>OptionOpaqueChar</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe OptionOpaqueChar(Raw.OptionOpaqueChar* handle, object[] edges)
+    {
+        _handle = new OptionOpaqueCharHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     public void AssertChar(uint ch)
     {

--- a/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
@@ -43,7 +43,7 @@ public partial class OptionOpaqueChar: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>OptionOpaqueChar</c> from a raw handle.
@@ -93,7 +93,12 @@ public partial class OptionOpaqueChar: IDisposable
     /// </summary>
     internal unsafe Raw.OptionOpaqueChar* AsFFI()
     {
-        return (Raw.OptionOpaqueChar*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.OptionOpaqueChar*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -107,5 +112,8 @@ public partial class OptionOpaqueChar: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class OptionOpaqueChar: IDisposable
 {
-    private unsafe Raw.OptionOpaqueChar* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.OptionOpaqueChar*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OptionOpaqueCharHandle : SafeHandle
+    {
+        public OptionOpaqueCharHandle() : base(IntPtr.Zero, true) { }
+
+        public OptionOpaqueCharHandle(Raw.OptionOpaqueChar* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.OptionOpaqueChar.Destroy((Raw.OptionOpaqueChar*)handle);
+            return true;
+        }
+    }
+
+    private readonly OptionOpaqueCharHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>OptionOpaqueChar</c> from a raw handle.
@@ -23,17 +48,18 @@ public partial class OptionOpaqueChar: IDisposable
     /// </remarks>
     internal unsafe OptionOpaqueChar(Raw.OptionOpaqueChar* handle)
     {
-        _inner = handle;
+        _handle = new OptionOpaqueCharHandle(handle, ownsHandle: true);
     }
     public void AssertChar(uint ch)
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OptionOpaqueChar");
             }
-            Raw.OptionOpaqueChar.AssertChar(_inner, ch);
+            Raw.OptionOpaqueChar.AssertChar(AsFFI(), ch);
+            GC.KeepAlive(this);
         }
     }
 
@@ -42,30 +68,19 @@ public partial class OptionOpaqueChar: IDisposable
     /// </summary>
     internal unsafe Raw.OptionOpaqueChar* AsFFI()
     {
-        return _inner;
+        return (Raw.OptionOpaqueChar*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.OptionOpaqueChar.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~OptionOpaqueChar()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/OptionString.cs
+++ b/feature_tests/dotnet/Generated/OptionString.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class OptionString: IDisposable
 {
-    private unsafe Raw.OptionString* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.OptionString*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class OptionStringHandle : SafeHandle
+    {
+        public OptionStringHandle() : base(IntPtr.Zero, true) { }
+
+        public OptionStringHandle(Raw.OptionString* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.OptionString.Destroy((Raw.OptionString*)handle);
+            return true;
+        }
+    }
+
+    private readonly OptionStringHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>OptionString</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class OptionString: IDisposable
     /// </remarks>
     internal unsafe OptionString(Raw.OptionString* handle)
     {
-        _inner = handle;
+        _handle = new OptionStringHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>OptionString</c> allocated on Rust side.
@@ -46,14 +71,15 @@ public partial class OptionString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("OptionString");
             }
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                var result = Raw.OptionString.Write(_inner, &writeable);
+                var result = Raw.OptionString.Write(AsFFI(), &writeable);
+                GC.KeepAlive(this);
                 if (!result.IsOk)
                 {
                     throw new InvalidOperationException("FFI function failed with unit error");
@@ -72,30 +98,19 @@ public partial class OptionString: IDisposable
     /// </summary>
     internal unsafe Raw.OptionString* AsFFI()
     {
-        return _inner;
+        return (Raw.OptionString*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.OptionString.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~OptionString()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/OptionString.cs
+++ b/feature_tests/dotnet/Generated/OptionString.cs
@@ -43,7 +43,7 @@ public partial class OptionString: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>OptionString</c> from a raw handle.
@@ -123,7 +123,12 @@ public partial class OptionString: IDisposable
     /// </summary>
     internal unsafe Raw.OptionString* AsFFI()
     {
-        return (Raw.OptionString*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.OptionString*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -137,5 +142,8 @@ public partial class OptionString: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/OptionString.cs
+++ b/feature_tests/dotnet/Generated/OptionString.cs
@@ -38,6 +38,14 @@ public partial class OptionString: IDisposable
     private readonly OptionStringHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>OptionString</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class OptionString: IDisposable
     internal unsafe OptionString(Raw.OptionString* handle)
     {
         _handle = new OptionStringHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>OptionString</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe OptionString(Raw.OptionString* handle, object[] edges)
+    {
+        _handle = new OptionStringHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OptionString</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/RawBorrowChild.cs
+++ b/feature_tests/dotnet/Generated/RawBorrowChild.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Runtime.InteropServices;
+using Somelib;
+using Somelib.Diplomat;
+
+namespace Somelib.Raw;
+
+[StructLayout(LayoutKind.Sequential)]
+internal partial struct BorrowChild
+{
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "BorrowChild_get", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern uint Get(BorrowChild* handle);
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "BorrowChild_destroy", CallingConvention = CallingConvention.Cdecl)]
+    internal static unsafe extern void Destroy(BorrowChild* handle);
+}

--- a/feature_tests/dotnet/Generated/RawBorrowParent.cs
+++ b/feature_tests/dotnet/Generated/RawBorrowParent.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Runtime.InteropServices;
+using Somelib;
+using Somelib.Diplomat;
+
+namespace Somelib.Raw;
+
+[StructLayout(LayoutKind.Sequential)]
+internal partial struct BorrowParent
+{
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "BorrowParent_create", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern BorrowParent* Create(uint value);
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "BorrowParent_view", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern BorrowChild* View(BorrowParent* handle);
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "BorrowParent_value", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern uint Value(BorrowParent* handle);
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "BorrowParent_destroy", CallingConvention = CallingConvention.Cdecl)]
+    internal static unsafe extern void Destroy(BorrowParent* handle);
+}

--- a/feature_tests/dotnet/Generated/RefList.cs
+++ b/feature_tests/dotnet/Generated/RefList.cs
@@ -43,7 +43,7 @@ public partial class RefList: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RefList</c> from a raw handle.
@@ -101,7 +101,12 @@ public partial class RefList: IDisposable
     /// </summary>
     internal unsafe Raw.RefList* AsFFI()
     {
-        return (Raw.RefList*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RefList*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -115,5 +120,8 @@ public partial class RefList: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RefList.cs
+++ b/feature_tests/dotnet/Generated/RefList.cs
@@ -38,6 +38,14 @@ public partial class RefList: IDisposable
     private readonly RefListHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RefList</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RefList: IDisposable
     internal unsafe RefList(Raw.RefList* handle)
     {
         _handle = new RefListHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RefList</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RefList(Raw.RefList* handle, object[] edges)
+    {
+        _handle = new RefListHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>RefList</c> allocated on Rust side.
@@ -66,7 +91,7 @@ public partial class RefList: IDisposable
             if (dataRaw == null) throw new ObjectDisposedException(nameof(RefListParameter));
             Raw.RefList* result = Raw.RefList.Node(dataRaw);
             GC.KeepAlive(data);
-            return new RefList(result);
+            return new RefList(result, new object[] { data });
         }
     }
 

--- a/feature_tests/dotnet/Generated/RefList.cs
+++ b/feature_tests/dotnet/Generated/RefList.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RefList: IDisposable
 {
-    private unsafe Raw.RefList* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RefList*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RefListHandle : SafeHandle
+    {
+        public RefListHandle() : base(IntPtr.Zero, true) { }
+
+        public RefListHandle(Raw.RefList* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RefList.Destroy((Raw.RefList*)handle);
+            return true;
+        }
+    }
+
+    private readonly RefListHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>RefList</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RefList: IDisposable
     /// </remarks>
     internal unsafe RefList(Raw.RefList* handle)
     {
-        _inner = handle;
+        _handle = new RefListHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>RefList</c> allocated on Rust side.
@@ -40,6 +65,7 @@ public partial class RefList: IDisposable
             Raw.RefListParameter* dataRaw = data.AsFFI();
             if (dataRaw == null) throw new ObjectDisposedException(nameof(RefListParameter));
             Raw.RefList* result = Raw.RefList.Node(dataRaw);
+            GC.KeepAlive(data);
             return new RefList(result);
         }
     }
@@ -49,30 +75,19 @@ public partial class RefList: IDisposable
     /// </summary>
     internal unsafe Raw.RefList* AsFFI()
     {
-        return _inner;
+        return (Raw.RefList*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RefList.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RefList()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RefList.cs
+++ b/feature_tests/dotnet/Generated/RefList.cs
@@ -79,8 +79,9 @@ public partial class RefList: IDisposable
     /// A <c>RefList</c> allocated on Rust side.
     /// </returns>
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
     public static RefList Node(RefListParameter data)
     {

--- a/feature_tests/dotnet/Generated/RefListParameter.cs
+++ b/feature_tests/dotnet/Generated/RefListParameter.cs
@@ -38,6 +38,14 @@ public partial class RefListParameter: IDisposable
     private readonly RefListParameterHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RefListParameter</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RefListParameter: IDisposable
     internal unsafe RefListParameter(Raw.RefListParameter* handle)
     {
         _handle = new RefListParameterHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RefListParameter</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RefListParameter(Raw.RefListParameter* handle, object[] edges)
+    {
+        _handle = new RefListParameterHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/RefListParameter.cs
+++ b/feature_tests/dotnet/Generated/RefListParameter.cs
@@ -43,7 +43,7 @@ public partial class RefListParameter: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RefListParameter</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class RefListParameter: IDisposable
     /// </summary>
     internal unsafe Raw.RefListParameter* AsFFI()
     {
-        return (Raw.RefListParameter*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RefListParameter*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class RefListParameter: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RefListParameter.cs
+++ b/feature_tests/dotnet/Generated/RefListParameter.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RefListParameter: IDisposable
 {
-    private unsafe Raw.RefListParameter* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RefListParameter*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RefListParameterHandle : SafeHandle
+    {
+        public RefListParameterHandle() : base(IntPtr.Zero, true) { }
+
+        public RefListParameterHandle(Raw.RefListParameter* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RefListParameter.Destroy((Raw.RefListParameter*)handle);
+            return true;
+        }
+    }
+
+    private readonly RefListParameterHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>RefListParameter</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RefListParameter: IDisposable
     /// </remarks>
     internal unsafe RefListParameter(Raw.RefListParameter* handle)
     {
-        _inner = handle;
+        _handle = new RefListParameterHandle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class RefListParameter: IDisposable
     /// </summary>
     internal unsafe Raw.RefListParameter* AsFFI()
     {
-        return _inner;
+        return (Raw.RefListParameter*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RefListParameter.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RefListParameter()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
+++ b/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RenamedAttrOpaque2: IDisposable
 {
-    private unsafe Raw.RenamedAttrOpaque2* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RenamedAttrOpaque2*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RenamedAttrOpaque2Handle : SafeHandle
+    {
+        public RenamedAttrOpaque2Handle() : base(IntPtr.Zero, true) { }
+
+        public RenamedAttrOpaque2Handle(Raw.RenamedAttrOpaque2* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RenamedAttrOpaque2.Destroy((Raw.RenamedAttrOpaque2*)handle);
+            return true;
+        }
+    }
+
+    private readonly RenamedAttrOpaque2Handle _handle;
 
     /// <summary>
     /// Creates a managed <c>RenamedAttrOpaque2</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RenamedAttrOpaque2: IDisposable
     /// </remarks>
     internal unsafe RenamedAttrOpaque2(Raw.RenamedAttrOpaque2* handle)
     {
-        _inner = handle;
+        _handle = new RenamedAttrOpaque2Handle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class RenamedAttrOpaque2: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedAttrOpaque2* AsFFI()
     {
-        return _inner;
+        return (Raw.RenamedAttrOpaque2*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RenamedAttrOpaque2.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RenamedAttrOpaque2()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
+++ b/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
@@ -43,7 +43,7 @@ public partial class RenamedAttrOpaque2: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RenamedAttrOpaque2</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class RenamedAttrOpaque2: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedAttrOpaque2* AsFFI()
     {
-        return (Raw.RenamedAttrOpaque2*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RenamedAttrOpaque2*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class RenamedAttrOpaque2: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
+++ b/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
@@ -38,6 +38,14 @@ public partial class RenamedAttrOpaque2: IDisposable
     private readonly RenamedAttrOpaque2Handle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RenamedAttrOpaque2</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RenamedAttrOpaque2: IDisposable
     internal unsafe RenamedAttrOpaque2(Raw.RenamedAttrOpaque2* handle)
     {
         _handle = new RenamedAttrOpaque2Handle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RenamedAttrOpaque2</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RenamedAttrOpaque2(Raw.RenamedAttrOpaque2* handle, object[] edges)
+    {
+        _handle = new RenamedAttrOpaque2Handle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RenamedDeprecatedOpaque: IDisposable
 {
-    private unsafe Raw.RenamedDeprecatedOpaque* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RenamedDeprecatedOpaque*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RenamedDeprecatedOpaqueHandle : SafeHandle
+    {
+        public RenamedDeprecatedOpaqueHandle() : base(IntPtr.Zero, true) { }
+
+        public RenamedDeprecatedOpaqueHandle(Raw.RenamedDeprecatedOpaque* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RenamedDeprecatedOpaque.Destroy((Raw.RenamedDeprecatedOpaque*)handle);
+            return true;
+        }
+    }
+
+    private readonly RenamedDeprecatedOpaqueHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>RenamedDeprecatedOpaque</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     /// </remarks>
     internal unsafe RenamedDeprecatedOpaque(Raw.RenamedDeprecatedOpaque* handle)
     {
-        _inner = handle;
+        _handle = new RenamedDeprecatedOpaqueHandle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedDeprecatedOpaque* AsFFI()
     {
-        return _inner;
+        return (Raw.RenamedDeprecatedOpaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RenamedDeprecatedOpaque.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RenamedDeprecatedOpaque()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
@@ -38,6 +38,14 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     private readonly RenamedDeprecatedOpaqueHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RenamedDeprecatedOpaque</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     internal unsafe RenamedDeprecatedOpaque(Raw.RenamedDeprecatedOpaque* handle)
     {
         _handle = new RenamedDeprecatedOpaqueHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RenamedDeprecatedOpaque</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RenamedDeprecatedOpaque(Raw.RenamedDeprecatedOpaque* handle, object[] edges)
+    {
+        _handle = new RenamedDeprecatedOpaqueHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
@@ -43,7 +43,7 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RenamedDeprecatedOpaque</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedDeprecatedOpaque* AsFFI()
     {
-        return (Raw.RenamedDeprecatedOpaque*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RenamedDeprecatedOpaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedMixinTest.cs
@@ -38,6 +38,14 @@ public partial class RenamedMixinTest: IDisposable
     private readonly RenamedMixinTestHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RenamedMixinTest</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RenamedMixinTest: IDisposable
     internal unsafe RenamedMixinTest(Raw.RenamedMixinTest* handle)
     {
         _handle = new RenamedMixinTestHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RenamedMixinTest</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RenamedMixinTest(Raw.RenamedMixinTest* handle, object[] edges)
+    {
+        _handle = new RenamedMixinTestHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     public static string Hello()
     {

--- a/feature_tests/dotnet/Generated/RenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedMixinTest.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RenamedMixinTest: IDisposable
 {
-    private unsafe Raw.RenamedMixinTest* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RenamedMixinTest*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RenamedMixinTestHandle : SafeHandle
+    {
+        public RenamedMixinTestHandle() : base(IntPtr.Zero, true) { }
+
+        public RenamedMixinTestHandle(Raw.RenamedMixinTest* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RenamedMixinTest.Destroy((Raw.RenamedMixinTest*)handle);
+            return true;
+        }
+    }
+
+    private readonly RenamedMixinTestHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>RenamedMixinTest</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RenamedMixinTest: IDisposable
     /// </remarks>
     internal unsafe RenamedMixinTest(Raw.RenamedMixinTest* handle)
     {
-        _inner = handle;
+        _handle = new RenamedMixinTestHandle(handle, ownsHandle: true);
     }
     public static string Hello()
     {
@@ -47,30 +72,19 @@ public partial class RenamedMixinTest: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedMixinTest* AsFFI()
     {
-        return _inner;
+        return (Raw.RenamedMixinTest*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RenamedMixinTest.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RenamedMixinTest()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedMixinTest.cs
@@ -43,7 +43,7 @@ public partial class RenamedMixinTest: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RenamedMixinTest</c> from a raw handle.
@@ -97,7 +97,12 @@ public partial class RenamedMixinTest: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedMixinTest* AsFFI()
     {
-        return (Raw.RenamedMixinTest*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RenamedMixinTest*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -111,5 +116,8 @@ public partial class RenamedMixinTest: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedNested.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RenamedNested: IDisposable
 {
-    private unsafe Raw.RenamedNested* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RenamedNested*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RenamedNestedHandle : SafeHandle
+    {
+        public RenamedNestedHandle() : base(IntPtr.Zero, true) { }
+
+        public RenamedNestedHandle(Raw.RenamedNested* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RenamedNested.Destroy((Raw.RenamedNested*)handle);
+            return true;
+        }
+    }
+
+    private readonly RenamedNestedHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>RenamedNested</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RenamedNested: IDisposable
     /// </remarks>
     internal unsafe RenamedNested(Raw.RenamedNested* handle)
     {
-        _inner = handle;
+        _handle = new RenamedNestedHandle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class RenamedNested: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedNested* AsFFI()
     {
-        return _inner;
+        return (Raw.RenamedNested*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RenamedNested.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RenamedNested()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedNested.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested.cs
@@ -38,6 +38,14 @@ public partial class RenamedNested: IDisposable
     private readonly RenamedNestedHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RenamedNested</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RenamedNested: IDisposable
     internal unsafe RenamedNested(Raw.RenamedNested* handle)
     {
         _handle = new RenamedNestedHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RenamedNested</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RenamedNested(Raw.RenamedNested* handle, object[] edges)
+    {
+        _handle = new RenamedNestedHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/RenamedNested.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested.cs
@@ -43,7 +43,7 @@ public partial class RenamedNested: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RenamedNested</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class RenamedNested: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedNested* AsFFI()
     {
-        return (Raw.RenamedNested*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RenamedNested*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class RenamedNested: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedNested2.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested2.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RenamedNested2: IDisposable
 {
-    private unsafe Raw.RenamedNested2* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RenamedNested2*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RenamedNested2Handle : SafeHandle
+    {
+        public RenamedNested2Handle() : base(IntPtr.Zero, true) { }
+
+        public RenamedNested2Handle(Raw.RenamedNested2* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RenamedNested2.Destroy((Raw.RenamedNested2*)handle);
+            return true;
+        }
+    }
+
+    private readonly RenamedNested2Handle _handle;
 
     /// <summary>
     /// Creates a managed <c>RenamedNested2</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RenamedNested2: IDisposable
     /// </remarks>
     internal unsafe RenamedNested2(Raw.RenamedNested2* handle)
     {
-        _inner = handle;
+        _handle = new RenamedNested2Handle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class RenamedNested2: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedNested2* AsFFI()
     {
-        return _inner;
+        return (Raw.RenamedNested2*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RenamedNested2.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RenamedNested2()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedNested2.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested2.cs
@@ -43,7 +43,7 @@ public partial class RenamedNested2: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RenamedNested2</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class RenamedNested2: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedNested2* AsFFI()
     {
-        return (Raw.RenamedNested2*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RenamedNested2*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class RenamedNested2: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedNested2.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested2.cs
@@ -38,6 +38,14 @@ public partial class RenamedNested2: IDisposable
     private readonly RenamedNested2Handle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RenamedNested2</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RenamedNested2: IDisposable
     internal unsafe RenamedNested2(Raw.RenamedNested2* handle)
     {
         _handle = new RenamedNested2Handle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RenamedNested2</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RenamedNested2(Raw.RenamedNested2* handle, object[] edges)
+    {
+        _handle = new RenamedNested2Handle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
+++ b/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RenamedOpaqueZSTIndexer: IDisposable
 {
-    private unsafe Raw.RenamedOpaqueZSTIndexer* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RenamedOpaqueZSTIndexer*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RenamedOpaqueZSTIndexerHandle : SafeHandle
+    {
+        public RenamedOpaqueZSTIndexerHandle() : base(IntPtr.Zero, true) { }
+
+        public RenamedOpaqueZSTIndexerHandle(Raw.RenamedOpaqueZSTIndexer* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RenamedOpaqueZSTIndexer.Destroy((Raw.RenamedOpaqueZSTIndexer*)handle);
+            return true;
+        }
+    }
+
+    private readonly RenamedOpaqueZSTIndexerHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>RenamedOpaqueZSTIndexer</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// </remarks>
     internal unsafe RenamedOpaqueZSTIndexer(Raw.RenamedOpaqueZSTIndexer* handle)
     {
-        _inner = handle;
+        _handle = new RenamedOpaqueZSTIndexerHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>RenamedOpaqueZSTIndexer</c> allocated on Rust side.
@@ -43,11 +68,12 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("RenamedOpaqueZSTIndexer");
             }
-            Raw.RenamedOpaqueZSTIndexer* result = Raw.RenamedOpaqueZSTIndexer.Index(_inner, idx);
+            Raw.RenamedOpaqueZSTIndexer* result = Raw.RenamedOpaqueZSTIndexer.Index(AsFFI(), idx);
+            GC.KeepAlive(this);
             return result == null ? null : new RenamedOpaqueZSTIndexer(result);
         }
     }
@@ -57,30 +83,19 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedOpaqueZSTIndexer* AsFFI()
     {
-        return _inner;
+        return (Raw.RenamedOpaqueZSTIndexer*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RenamedOpaqueZSTIndexer.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RenamedOpaqueZSTIndexer()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
+++ b/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
@@ -43,7 +43,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RenamedOpaqueZSTIndexer</c> from a raw handle.
@@ -108,7 +108,12 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedOpaqueZSTIndexer* AsFFI()
     {
-        return (Raw.RenamedOpaqueZSTIndexer*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RenamedOpaqueZSTIndexer*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -122,5 +127,8 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
@@ -38,6 +38,14 @@ public partial class RenamedTestOpaque: IDisposable
     private readonly RenamedTestOpaqueHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RenamedTestOpaque</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RenamedTestOpaque: IDisposable
     internal unsafe RenamedTestOpaque(Raw.RenamedTestOpaque* handle)
     {
         _handle = new RenamedTestOpaqueHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RenamedTestOpaque</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RenamedTestOpaque(Raw.RenamedTestOpaque* handle, object[] edges)
+    {
+        _handle = new RenamedTestOpaqueHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
@@ -43,7 +43,7 @@ public partial class RenamedTestOpaque: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RenamedTestOpaque</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class RenamedTestOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedTestOpaque* AsFFI()
     {
-        return (Raw.RenamedTestOpaque*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RenamedTestOpaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class RenamedTestOpaque: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RenamedTestOpaque: IDisposable
 {
-    private unsafe Raw.RenamedTestOpaque* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RenamedTestOpaque*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RenamedTestOpaqueHandle : SafeHandle
+    {
+        public RenamedTestOpaqueHandle() : base(IntPtr.Zero, true) { }
+
+        public RenamedTestOpaqueHandle(Raw.RenamedTestOpaque* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RenamedTestOpaque.Destroy((Raw.RenamedTestOpaque*)handle);
+            return true;
+        }
+    }
+
+    private readonly RenamedTestOpaqueHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>RenamedTestOpaque</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RenamedTestOpaque: IDisposable
     /// </remarks>
     internal unsafe RenamedTestOpaque(Raw.RenamedTestOpaque* handle)
     {
-        _inner = handle;
+        _handle = new RenamedTestOpaqueHandle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class RenamedTestOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedTestOpaque* AsFFI()
     {
-        return _inner;
+        return (Raw.RenamedTestOpaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RenamedTestOpaque.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RenamedTestOpaque()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedVectorTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedVectorTest.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class RenamedVectorTest: IDisposable
 {
-    private unsafe Raw.RenamedVectorTest* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.RenamedVectorTest*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class RenamedVectorTestHandle : SafeHandle
+    {
+        public RenamedVectorTestHandle() : base(IntPtr.Zero, true) { }
+
+        public RenamedVectorTestHandle(Raw.RenamedVectorTest* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.RenamedVectorTest.Destroy((Raw.RenamedVectorTest*)handle);
+            return true;
+        }
+    }
+
+    private readonly RenamedVectorTestHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>RenamedVectorTest</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class RenamedVectorTest: IDisposable
     /// </remarks>
     internal unsafe RenamedVectorTest(Raw.RenamedVectorTest* handle)
     {
-        _inner = handle;
+        _handle = new RenamedVectorTestHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>RenamedVectorTest</c> allocated on Rust side.
@@ -40,22 +65,25 @@ public partial class RenamedVectorTest: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("RenamedVectorTest");
             }
-            return Raw.RenamedVectorTest.Len(_inner);
+            var result = Raw.RenamedVectorTest.Len(AsFFI());
+            GC.KeepAlive(this);
+            return result;
         }
     }
     public double? Get(nuint idx)
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("RenamedVectorTest");
             }
-            var result = Raw.RenamedVectorTest.Get(_inner, idx);
+            var result = Raw.RenamedVectorTest.Get(AsFFI(), idx);
+            GC.KeepAlive(this);
             return result.IsSome ? result.Value : (double?)null;
         }
     }
@@ -63,11 +91,12 @@ public partial class RenamedVectorTest: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("RenamedVectorTest");
             }
-            Raw.RenamedVectorTest.Push(_inner, value);
+            Raw.RenamedVectorTest.Push(AsFFI(), value);
+            GC.KeepAlive(this);
         }
     }
 
@@ -76,30 +105,19 @@ public partial class RenamedVectorTest: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedVectorTest* AsFFI()
     {
-        return _inner;
+        return (Raw.RenamedVectorTest*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.RenamedVectorTest.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~RenamedVectorTest()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/RenamedVectorTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedVectorTest.cs
@@ -38,6 +38,14 @@ public partial class RenamedVectorTest: IDisposable
     private readonly RenamedVectorTestHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>RenamedVectorTest</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class RenamedVectorTest: IDisposable
     internal unsafe RenamedVectorTest(Raw.RenamedVectorTest* handle)
     {
         _handle = new RenamedVectorTestHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>RenamedVectorTest</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe RenamedVectorTest(Raw.RenamedVectorTest* handle, object[] edges)
+    {
+        _handle = new RenamedVectorTestHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>RenamedVectorTest</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/RenamedVectorTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedVectorTest.cs
@@ -43,7 +43,7 @@ public partial class RenamedVectorTest: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>RenamedVectorTest</c> from a raw handle.
@@ -130,7 +130,12 @@ public partial class RenamedVectorTest: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedVectorTest* AsFFI()
     {
-        return (Raw.RenamedVectorTest*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.RenamedVectorTest*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -144,5 +149,8 @@ public partial class RenamedVectorTest: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/ResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/ResultOpaque.cs
@@ -38,6 +38,14 @@ public partial class ResultOpaque: IDisposable
     private readonly ResultOpaqueHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>ResultOpaque</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class ResultOpaque: IDisposable
     internal unsafe ResultOpaque(Raw.ResultOpaque* handle)
     {
         _handle = new ResultOpaqueHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>ResultOpaque</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe ResultOpaque(Raw.ResultOpaque* handle, object[] edges)
+    {
+        _handle = new ResultOpaqueHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <exception cref="ErrorEnumException"></exception>
     /// <returns>

--- a/feature_tests/dotnet/Generated/ResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/ResultOpaque.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class ResultOpaque: IDisposable
 {
-    private unsafe Raw.ResultOpaque* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.ResultOpaque*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class ResultOpaqueHandle : SafeHandle
+    {
+        public ResultOpaqueHandle() : base(IntPtr.Zero, true) { }
+
+        public ResultOpaqueHandle(Raw.ResultOpaque* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.ResultOpaque.Destroy((Raw.ResultOpaque*)handle);
+            return true;
+        }
+    }
+
+    private readonly ResultOpaqueHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>ResultOpaque</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class ResultOpaque: IDisposable
     /// </remarks>
     internal unsafe ResultOpaque(Raw.ResultOpaque* handle)
     {
-        _inner = handle;
+        _handle = new ResultOpaqueHandle(handle, ownsHandle: true);
     }
     /// <exception cref="ErrorEnumException"></exception>
     /// <returns>
@@ -148,11 +173,12 @@ public partial class ResultOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("ResultOpaque");
             }
-            Raw.ResultOpaque.AssertInteger(_inner, i);
+            Raw.ResultOpaque.AssertInteger(AsFFI(), i);
+            GC.KeepAlive(this);
         }
     }
 
@@ -161,30 +187,19 @@ public partial class ResultOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.ResultOpaque* AsFFI()
     {
-        return _inner;
+        return (Raw.ResultOpaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.ResultOpaque.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~ResultOpaque()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/ResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/ResultOpaque.cs
@@ -43,7 +43,7 @@ public partial class ResultOpaque: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>ResultOpaque</c> from a raw handle.
@@ -212,7 +212,12 @@ public partial class ResultOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.ResultOpaque* AsFFI()
     {
-        return (Raw.ResultOpaque*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.ResultOpaque*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -226,5 +231,8 @@ public partial class ResultOpaque: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/Two.cs
+++ b/feature_tests/dotnet/Generated/Two.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class Two: IDisposable
 {
-    private unsafe Raw.Two* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.Two*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class TwoHandle : SafeHandle
+    {
+        public TwoHandle() : base(IntPtr.Zero, true) { }
+
+        public TwoHandle(Raw.Two* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.Two.Destroy((Raw.Two*)handle);
+            return true;
+        }
+    }
+
+    private readonly TwoHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>Two</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class Two: IDisposable
     /// </remarks>
     internal unsafe Two(Raw.Two* handle)
     {
-        _inner = handle;
+        _handle = new TwoHandle(handle, ownsHandle: true);
     }
 
     /// <summary>
@@ -31,30 +56,19 @@ public partial class Two: IDisposable
     /// </summary>
     internal unsafe Raw.Two* AsFFI()
     {
-        return _inner;
+        return (Raw.Two*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.Two.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~Two()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/Two.cs
+++ b/feature_tests/dotnet/Generated/Two.cs
@@ -38,6 +38,14 @@ public partial class Two: IDisposable
     private readonly TwoHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>Two</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class Two: IDisposable
     internal unsafe Two(Raw.Two* handle)
     {
         _handle = new TwoHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>Two</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe Two(Raw.Two* handle, object[] edges)
+    {
+        _handle = new TwoHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
 
     /// <summary>

--- a/feature_tests/dotnet/Generated/Two.cs
+++ b/feature_tests/dotnet/Generated/Two.cs
@@ -43,7 +43,7 @@ public partial class Two: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>Two</c> from a raw handle.
@@ -81,7 +81,12 @@ public partial class Two: IDisposable
     /// </summary>
     internal unsafe Raw.Two* AsFFI()
     {
-        return (Raw.Two*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.Two*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -95,5 +100,8 @@ public partial class Two: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/Unnamespaced.cs
+++ b/feature_tests/dotnet/Generated/Unnamespaced.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class Unnamespaced: IDisposable
 {
-    private unsafe Raw.Unnamespaced* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.Unnamespaced*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class UnnamespacedHandle : SafeHandle
+    {
+        public UnnamespacedHandle() : base(IntPtr.Zero, true) { }
+
+        public UnnamespacedHandle(Raw.Unnamespaced* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.Unnamespaced.Destroy((Raw.Unnamespaced*)handle);
+            return true;
+        }
+    }
+
+    private readonly UnnamespacedHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>Unnamespaced</c> from a raw handle.
@@ -23,7 +48,7 @@ public partial class Unnamespaced: IDisposable
     /// </remarks>
     internal unsafe Unnamespaced(Raw.Unnamespaced* handle)
     {
-        _inner = handle;
+        _handle = new UnnamespacedHandle(handle, ownsHandle: true);
     }
     /// <returns>
     /// A <c>Unnamespaced</c> allocated on Rust side.
@@ -40,14 +65,16 @@ public partial class Unnamespaced: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("Unnamespaced");
             }
             if (n == null) throw new ArgumentNullException(nameof(n));
             Raw.AttrOpaque1Renamed* nRaw = n.AsFFI();
             if (nRaw == null) throw new ObjectDisposedException(nameof(AttrOpaque1Renamed));
-            Raw.Unnamespaced.UseNamespaced(_inner, nRaw);
+            Raw.Unnamespaced.UseNamespaced(AsFFI(), nRaw);
+            GC.KeepAlive(this);
+            GC.KeepAlive(n);
         }
     }
 
@@ -56,30 +83,19 @@ public partial class Unnamespaced: IDisposable
     /// </summary>
     internal unsafe Raw.Unnamespaced* AsFFI()
     {
-        return _inner;
+        return (Raw.Unnamespaced*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.Unnamespaced.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~Unnamespaced()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/Unnamespaced.cs
+++ b/feature_tests/dotnet/Generated/Unnamespaced.cs
@@ -43,7 +43,7 @@ public partial class Unnamespaced: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>Unnamespaced</c> from a raw handle.
@@ -108,7 +108,12 @@ public partial class Unnamespaced: IDisposable
     /// </summary>
     internal unsafe Raw.Unnamespaced* AsFFI()
     {
-        return (Raw.Unnamespaced*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.Unnamespaced*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -122,5 +127,8 @@ public partial class Unnamespaced: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Generated/Unnamespaced.cs
+++ b/feature_tests/dotnet/Generated/Unnamespaced.cs
@@ -38,6 +38,14 @@ public partial class Unnamespaced: IDisposable
     private readonly UnnamespacedHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>Unnamespaced</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class Unnamespaced: IDisposable
     internal unsafe Unnamespaced(Raw.Unnamespaced* handle)
     {
         _handle = new UnnamespacedHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>Unnamespaced</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe Unnamespaced(Raw.Unnamespaced* handle, object[] edges)
+    {
+        _handle = new UnnamespacedHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Unnamespaced</c> allocated on Rust side.

--- a/feature_tests/dotnet/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/Utf16Wrap.cs
@@ -38,6 +38,14 @@ public partial class Utf16Wrap: IDisposable
     private readonly Utf16WrapHandle _handle;
 
     /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
+
+    /// <summary>
     /// Creates a managed <c>Utf16Wrap</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -49,6 +57,23 @@ public partial class Utf16Wrap: IDisposable
     internal unsafe Utf16Wrap(Raw.Utf16Wrap* handle)
     {
         _handle = new Utf16WrapHandle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>Utf16Wrap</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe Utf16Wrap(Raw.Utf16Wrap* handle, object[] edges)
+    {
+        _handle = new Utf16WrapHandle(handle, ownsHandle: true);
+        _edges = edges;
     }
     public string GetDebugStr()
     {

--- a/feature_tests/dotnet/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/Utf16Wrap.cs
@@ -10,7 +10,32 @@ namespace Somelib;
 
 public partial class Utf16Wrap: IDisposable
 {
-    private unsafe Raw.Utf16Wrap* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.Utf16Wrap*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class Utf16WrapHandle : SafeHandle
+    {
+        public Utf16WrapHandle() : base(IntPtr.Zero, true) { }
+
+        public Utf16WrapHandle(Raw.Utf16Wrap* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.Utf16Wrap.Destroy((Raw.Utf16Wrap*)handle);
+            return true;
+        }
+    }
+
+    private readonly Utf16WrapHandle _handle;
 
     /// <summary>
     /// Creates a managed <c>Utf16Wrap</c> from a raw handle.
@@ -23,20 +48,21 @@ public partial class Utf16Wrap: IDisposable
     /// </remarks>
     internal unsafe Utf16Wrap(Raw.Utf16Wrap* handle)
     {
-        _inner = handle;
+        _handle = new Utf16WrapHandle(handle, ownsHandle: true);
     }
     public string GetDebugStr()
     {
         unsafe
         {
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("Utf16Wrap");
             }
             DiplomatWriteable writeable = new DiplomatWriteable();
             try
             {
-                Raw.Utf16Wrap.GetDebugStr(_inner, &writeable);
+                Raw.Utf16Wrap.GetDebugStr(AsFFI(), &writeable);
+                GC.KeepAlive(this);
                 return writeable.ToUnicode();
             }
             finally
@@ -51,30 +77,19 @@ public partial class Utf16Wrap: IDisposable
     /// </summary>
     internal unsafe Raw.Utf16Wrap* AsFFI()
     {
-        return _inner;
+        return (Raw.Utf16Wrap*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.Utf16Wrap.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~Utf16Wrap()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/feature_tests/dotnet/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/Utf16Wrap.cs
@@ -43,7 +43,7 @@ public partial class Utf16Wrap: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
 
     /// <summary>
     /// Creates a managed <c>Utf16Wrap</c> from a raw handle.
@@ -102,7 +102,12 @@ public partial class Utf16Wrap: IDisposable
     /// </summary>
     internal unsafe Raw.Utf16Wrap* AsFFI()
     {
-        return (Raw.Utf16Wrap*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.Utf16Wrap*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -116,5 +121,8 @@ public partial class Utf16Wrap: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/feature_tests/dotnet/Tests/BorrowSoundnessTests.cs
+++ b/feature_tests/dotnet/Tests/BorrowSoundnessTests.cs
@@ -38,6 +38,10 @@ public class BorrowSoundnessTests
         Assert.True(
             parentRef.IsAlive,
             "live BorrowChild must keep its borrowed-from BorrowParent alive");
+        // Prove the native pointer (not just the managed wrapper) survived:
+        // Get() reads back through the borrowed `&BorrowParent`, so a freed
+        // parent would surface as a use-after-free here.
+        Assert.Equal(42u, child.Get());
         GC.KeepAlive(child);
     }
 }

--- a/feature_tests/dotnet/Tests/BorrowSoundnessTests.cs
+++ b/feature_tests/dotnet/Tests/BorrowSoundnessTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.CompilerServices;
+using Somelib;
+using Xunit;
+
+namespace Somelib.FeatureTests;
+
+// Borrow-soundness: BorrowParent.View() returns a BorrowChild that borrows the
+// parent (Box<BorrowChild<'a>>). A live child must keep its parent alive so the
+// parent is not collected/finalized (-> Destroy) while the child still reads it.
+public class BorrowSoundnessTests
+{
+    [Fact]
+    public void View_WhileParentAlive_GetReturnsParentValue()
+    {
+        using BorrowParent parent = BorrowParent.Create(42);
+        Assert.Equal(42u, parent.Value());
+        using BorrowChild child = parent.View();
+        Assert.Equal(42u, child.Get());
+        GC.KeepAlive(parent);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference parentRef, BorrowChild child) MakeChildAndDropParent()
+    {
+        BorrowParent parent = BorrowParent.Create(42);
+        BorrowChild child = parent.View();
+        return (new WeakReference(parent), child);
+    }
+
+    [Fact]
+    public void Child_KeepsParent_AliveAcrossGc()
+    {
+        (WeakReference parentRef, BorrowChild child) = MakeChildAndDropParent();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        Assert.True(
+            parentRef.IsAlive,
+            "live BorrowChild must keep its borrowed-from BorrowParent alive");
+        GC.KeepAlive(child);
+    }
+}

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -385,6 +385,35 @@ pub mod ffi {
             self.0.get(0).map(OpaqueThin::transparent_convert)
         }
     }
+
+    // .NET borrow-soundness fixture: a constructible parent and a child opaque
+    // that borrows it (`Box<BorrowChild<'a>>` carries `'a` tied to the parent).
+    // `get()` reads back the parent's value so a use-after-free is observable.
+    #[diplomat::opaque]
+    pub struct BorrowParent(u32);
+
+    #[diplomat::opaque]
+    pub struct BorrowChild<'a>(&'a BorrowParent);
+
+    impl BorrowParent {
+        pub fn create(value: u32) -> Box<Self> {
+            Box::new(BorrowParent(value))
+        }
+
+        pub fn view<'a>(&'a self) -> Box<BorrowChild<'a>> {
+            Box::new(BorrowChild(self))
+        }
+
+        pub fn value(&self) -> u32 {
+            self.0
+        }
+    }
+
+    impl<'a> BorrowChild<'a> {
+        pub fn get(&self) -> u32 {
+            (self.0).0
+        }
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -389,9 +389,12 @@ pub mod ffi {
     // .NET borrow-soundness fixture: a constructible parent and a child opaque
     // that borrows it (`Box<BorrowChild<'a>>` carries `'a` tied to the parent).
     // `get()` reads back the parent's value so a use-after-free is observable.
+    // .NET-only: keep it out of the other backends' generated output.
+    #[diplomat::attr(not(dotnet), disable)]
     #[diplomat::opaque]
     pub struct BorrowParent(u32);
 
+    #[diplomat::attr(not(dotnet), disable)]
     #[diplomat::opaque]
     pub struct BorrowChild<'a>(&'a BorrowParent);
 

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -747,6 +747,22 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         let keep_alive_edges = self.borrowed_output_keep_alive_edges(method)?;
         let lifetime_warning = !keep_alive_edges.is_empty();
 
+        // Keep-alive edges are only plumbed through the opaque-wrapper
+        // constructor. A non-opaque return (e.g. a by-value struct) that
+        // borrows from the receiver or an opaque parameter would have its
+        // edges silently dropped by `idiomatic_value_expr`, leaving the
+        // borrowed-from object unrooted — a use-after-free. Reject such
+        // returns until struct edge-plumbing exists rather than emit unsound
+        // code. (Opaque returns, incl. `Option<Box<T>>`, carry the edges.)
+        if !keep_alive_edges.is_empty() && !matches!(return_type, DotnetReturnType::Opaque(_)) {
+            self.errors.push_error(format!(
+                "[.NET backend] return value of type `{return_type}` borrows from the receiver \
+                 or an opaque parameter; keep-alive edges are only supported for opaque (`Box<T>`) \
+                 returns today. Return an opaque, or disable this API for .NET."
+            ));
+            return None;
+        }
+
         Some(MethodInfo {
             abi_name: method.abi_name.as_str(),
             name: method_name,

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -350,6 +350,13 @@ struct InputLowering {
     /// For inputs that need to convert from string to pointer, basically the DiplomatStr only
     to_bytes_statement: Option<String>,
     idiomatic_param_type: Option<String>,
+
+    /// Idiomatic identifier to `GC.KeepAlive(...)` after the raw call. `Some`
+    /// for opaque self (`"this"`) and opaque params (`"name"`) — their native
+    /// pointer is read via a `SafeHandle`, and without an explicit keep-alive
+    /// the GC could finalize the wrapper (freeing the pointer) while the raw
+    /// call is still in flight. `None` for everything else.
+    keep_alive_target: Option<String>,
 }
 
 /// All of a method's inputs, joined for template substitution.
@@ -369,6 +376,9 @@ pub(super) struct DotnetInputs {
     pub(super) to_bytes_statements: Vec<String>,
     pub(super) first_param_type: Option<String>,
     pub(super) param_count: usize,
+    /// `GC.KeepAlive(...)` targets (opaque self + opaque params), in raw-call
+    /// argument order. Rendered after the raw call in `method_body.cs.jinja`.
+    pub(super) keep_alive_targets: Vec<String>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -556,6 +566,25 @@ impl MethodInfo<'_> {
         format!("return {};", self.raw_call_expr(owner_name))
     }
 
+    /// Whether this method passes any opaque pointer (self and/or opaque
+    /// params) through the raw call. When true the body must `GC.KeepAlive`
+    /// each such wrapper after the call (see [`Self::keep_alive_targets`]),
+    /// so a direct `return Raw...(...)` is rewritten to capture-then-return.
+    pub(super) fn has_keep_alive(&self) -> bool {
+        !self.inputs.keep_alive_targets.is_empty()
+    }
+
+    /// `GC.KeepAlive(x);` statements to emit immediately after the raw call,
+    /// one per opaque wrapper whose pointer the call read. Empty when no
+    /// opaque pointers cross the boundary.
+    pub(super) fn keep_alive_statements(&self) -> Vec<String> {
+        self.inputs
+            .keep_alive_targets
+            .iter()
+            .map(|target| format!("GC.KeepAlive({target});"))
+            .collect()
+    }
+
     pub(super) fn can_return_raw_call_directly(&self) -> bool {
         self.option_info.is_none()
             && matches!(
@@ -571,7 +600,12 @@ impl MethodInfo<'_> {
             .as_ref()
             .and_then(|option| option.raw_option_type.as_ref())
             .is_some();
-        if uses_tagged_option {
+        // Primitive / enum returns have no `Raw.` mirror type — the raw call
+        // already yields the idiomatic C# value. `var` lets the same general
+        // body shape cover the keep-alive case (where a direct
+        // `return Raw...(...)` would skip the post-call `GC.KeepAlive`), without
+        // emitting an invalid `Raw.bool` / `Raw.nint` local declaration.
+        if uses_tagged_option || self.can_return_raw_call_directly() {
             format!("var result = {raw_call};")
         } else {
             format!("Raw.{} result = {raw_call};", self.return_type.raw())
@@ -958,10 +992,14 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         let mut to_bytes_statements = Vec::new();
         let mut first_param_type = None;
         let mut param_count = 0;
+        let mut keep_alive_targets = Vec::new();
 
         if let Some(s) = &self_lowering {
             raw_params.push(s.raw_param.as_str());
             call_args.push(s.raw_call_arg.as_str());
+            if let Some(target) = &s.keep_alive_target {
+                keep_alive_targets.push(target.clone());
+            }
             // self contributes nothing to the idiomatic decl — `this` is implicit.
         }
 
@@ -992,6 +1030,9 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             if let Some(to_bytes) = &p.to_bytes_statement {
                 to_bytes_statements.push(to_bytes.clone());
             }
+            if let Some(target) = &p.keep_alive_target {
+                keep_alive_targets.push(target.clone());
+            }
         }
 
         Some(DotnetInputs {
@@ -1003,6 +1044,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             to_bytes_statements,
             first_param_type,
             param_count,
+            keep_alive_targets,
         })
     }
 
@@ -1013,7 +1055,11 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                 InputLowering {
                     raw_param: format!("{name}* handle"),
                     idiomatic_param: String::new(),
-                    raw_call_arg: "_inner".into(),
+                    // `AsFFI()` reads the pointer out of the `SafeHandle`.
+                    // The matching `GC.KeepAlive(this)` after the call keeps
+                    // the handle (and thus the pointer) alive across it.
+                    raw_call_arg: "AsFFI()".into(),
+                    keep_alive_target: Some("this".into()),
                     ..Default::default()
                 }
             }
@@ -1112,6 +1158,9 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                     raw_call_arg,
                     validation_statement,
                     idiomatic_param_type: Some(idiomatic_ty),
+                    // `{arg}Raw` reads the pointer out of the param's
+                    // `SafeHandle`; keep the wrapper alive across the call.
+                    keep_alive_target: Some(arg_name.to_string()),
                     ..Default::default()
                 }
             }
@@ -1176,6 +1225,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                                     "fixed (byte* {ptr} = {bytes})"
                                 )),
                                 idiomatic_param_type: Some("string".to_string()),
+                                keep_alive_target: None,
                             }
                         }
                     },
@@ -1234,6 +1284,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                             fix_statement: Some(format!("fixed ({ptr_type}* {ptr} = {arg_name})")),
                             to_bytes_statement: None,
                             idiomatic_param_type: Some(format!("{element_type}[]")),
+                            keep_alive_target: None,
                         }
                     }
                     hir::PrimitiveType::Int(int_type) => {

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -286,11 +286,28 @@ impl DotnetReturnType {
         }
     }
 
+    /// Render the keep-alive edge argument suffix for an owned-opaque
+    /// constructor call: `", new object[] { a, b }"` when `edges` is
+    /// non-empty, else empty. The leading comma lets callers append it
+    /// directly after the raw handle argument.
+    fn edge_arg_suffix(edges: &[String]) -> String {
+        if edges.is_empty() {
+            String::new()
+        } else {
+            format!(", new object[] {{ {} }}", edges.join(", "))
+        }
+    }
+
     /// Convert a raw FFI value expression into the public C# value
-    /// expression for this return type.
-    fn idiomatic_value_expr(&self, raw_expr: RawExpr) -> String {
+    /// expression for this return type. `edges` are keep-alive edge
+    /// expressions (see [`MethodInfo::keep_alive_edges`]); for an owned
+    /// opaque return they are passed to the wrapper constructor so it roots
+    /// the borrowed-from wrappers for its lifetime.
+    fn idiomatic_value_expr(&self, raw_expr: RawExpr, edges: &[String]) -> String {
         match self {
-            Self::Opaque(name) => format!("new {name}({raw_expr})"),
+            Self::Opaque(name) => {
+                format!("new {name}({raw_expr}{})", Self::edge_arg_suffix(edges))
+            }
             Self::Struct(name) => format!("{name}.FromFFI({raw_expr})"),
             Self::Unit | Self::Write => String::new(),
             Self::Primitive(_) | Self::Enum(_) => raw_expr.to_string(),
@@ -305,18 +322,21 @@ impl DotnetReturnType {
         }
     }
 
-    fn tagged_option_expr(&self, option_expr: RawExpr) -> String {
+    fn tagged_option_expr(&self, option_expr: RawExpr, edges: &[String]) -> String {
         format!(
             "{} ? {} : {}",
             option_expr.is_some_expr(),
-            self.idiomatic_value_expr(option_expr.option_value()),
+            self.idiomatic_value_expr(option_expr.option_value(), edges),
             self.option_none_expr()
         )
     }
 
-    fn nullable_pointer_option_expr(&self, raw_expr: RawExpr) -> String {
+    fn nullable_pointer_option_expr(&self, raw_expr: RawExpr, edges: &[String]) -> String {
         match self {
-            Self::Opaque(name) => format!("{raw_expr} == null ? null : new {name}({raw_expr})"),
+            Self::Opaque(name) => format!(
+                "{raw_expr} == null ? null : new {name}({raw_expr}{})",
+                Self::edge_arg_suffix(edges)
+            ),
             _ => unreachable!("nullable pointer options only lower from opaque returns"),
         }
     }
@@ -425,6 +445,15 @@ pub(super) struct MethodInfo<'ctx> {
     pub(super) inputs: DotnetInputs,
     pub(super) return_type: DotnetReturnType,
     pub(super) lifetime_warning: bool,
+    /// C# expressions for the wrappers the returned value borrows from
+    /// (`"this"` for the receiver, a param's C# identifier otherwise),
+    /// deduped. When non-empty and the return is an owned opaque, the
+    /// generated wrapper is constructed with these as keep-alive edges
+    /// (`new T(result, new object[] { <edges> })`) so the GC cannot collect
+    /// (and finalize -> Destroy) a borrowed-from parent while the child is
+    /// alive. Distinct from `inputs.keep_alive_targets`, which only roots
+    /// wrappers for the duration of the raw call.
+    pub(super) keep_alive_edges: Vec<String>,
     /// `Some` iff this method returns `Result<T, E>` with a concrete `E`.
     /// Templates branch on `{% if let Some(info) = method.error_info %}` —
     /// no separate `is_fallible()` predicate needed.
@@ -622,11 +651,13 @@ impl MethodInfo<'_> {
     {
         let raw_expr = raw_expr.try_into().unwrap_or_else(|err| panic!("{err}"));
 
+        let edges = self.keep_alive_edges.as_slice();
         if let Some(option_info) = &self.option_info {
             let expr = if option_info.raw_option_type.is_some() {
-                self.return_type.tagged_option_expr(raw_expr)
+                self.return_type.tagged_option_expr(raw_expr, edges)
             } else {
-                self.return_type.nullable_pointer_option_expr(raw_expr)
+                self.return_type
+                    .nullable_pointer_option_expr(raw_expr, edges)
             };
             return format!("return {expr};");
         }
@@ -636,7 +667,7 @@ impl MethodInfo<'_> {
         } else {
             format!(
                 "return {};",
-                self.return_type.idiomatic_value_expr(raw_expr)
+                self.return_type.idiomatic_value_expr(raw_expr, edges)
             )
         }
     }
@@ -713,7 +744,8 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         };
         let property_accessor =
             self.property_accessor(method, &return_type, &return_type_name, &inputs);
-        let lifetime_warning = self.borrowed_output_lifetime_warning(method)?;
+        let keep_alive_edges = self.borrowed_output_keep_alive_edges(method)?;
+        let lifetime_warning = !keep_alive_edges.is_empty();
 
         Some(MethodInfo {
             abi_name: method.abi_name.as_str(),
@@ -722,13 +754,21 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             inputs,
             return_type,
             lifetime_warning,
+            keep_alive_edges,
             error_info,
             option_info,
             property_accessor,
         })
     }
 
-    fn borrowed_output_lifetime_warning(&self, method: &'tcx Method) -> Option<bool> {
+    /// Walk the method's borrows and produce the C# keep-alive edge
+    /// expressions the returned wrapper must retain: `"this"` for the
+    /// receiver, the parameter's C# identifier for an opaque param. Returns
+    /// `None` (with a recorded diagnostic) for borrow shapes the backend
+    /// can't lower soundly yet — borrowing from a slice/string param (only
+    /// pinned for the call) or a struct lifetime (no edge plumbing on the
+    /// .NET surface yet). The returned list is deduped and order-stable.
+    fn borrowed_output_keep_alive_edges(&self, method: &'tcx Method) -> Option<Vec<String>> {
         let mut visitor = method.borrowing_param_visitor(self.tcx, false);
 
         if let Some(param_self) = method.param_self.as_ref() {
@@ -739,33 +779,62 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             visitor.visit_param(&param.ty, param.name.as_str());
         }
 
-        let mut has_borrowed_output_lifetime = false;
-        let mut slice_params = Vec::new();
+        let mut edges = Vec::new();
 
         for edge in visitor
             .borrow_map()
             .into_values()
             .flat_map(|borrow_info| borrow_info.incoming_edges)
         {
-            has_borrowed_output_lifetime = true;
-            if matches!(edge.kind, LifetimeEdgeKind::SliceParam) {
-                slice_params.push(edge.param_name);
+            match edge.kind {
+                // The return borrows from an opaque wrapper (receiver or
+                // param). Root that wrapper for as long as the returned
+                // value lives.
+                LifetimeEdgeKind::OpaqueParam => {
+                    let expr = if edge.param_name == "this" {
+                        "this".to_string()
+                    } else {
+                        self.formatter
+                            .fmt_param_name(edge.param_name.as_str())
+                            .into_owned()
+                    };
+                    if !edges.contains(&expr) {
+                        edges.push(expr);
+                    }
+                }
+                // Slice/string params are only pinned/converted for the
+                // duration of the call, so a returned value borrowing from
+                // them would dangle. Reject rather than emit unsound code.
+                LifetimeEdgeKind::SliceParam => {
+                    self.errors.push_error(format!(
+                        "[.NET backend] return value borrows from slice/string parameter `{}`; \
+                         this is not supported because generated C# only pins or converts those \
+                         inputs for the duration of the call",
+                        edge.param_name
+                    ));
+                    return None;
+                }
+                // Borrowing through a struct's lifetime fields needs edge
+                // plumbing the .NET backend doesn't have yet (PR2 covers
+                // direct opaque receiver/param borrows only).
+                LifetimeEdgeKind::StructLifetime(..) => {
+                    self.errors.push_error(
+                        "[.NET backend] return value borrows through a struct lifetime; \
+                         keep-alive edges for struct-borrowed returns are not yet supported"
+                            .to_string(),
+                    );
+                    return None;
+                }
+                other => {
+                    self.errors.push_error(format!(
+                        "[.NET backend] return value borrow kind not yet supported: {other:?}"
+                    ));
+                    return None;
+                }
             }
         }
 
-        if !slice_params.is_empty() {
-            slice_params.sort();
-            slice_params.dedup();
-            self.errors.push_error(format!(
-                "[.NET backend] return value borrows from slice/string parameter(s) `{}`; \
-                 this is not supported because generated C# only pins or converts those \
-                 inputs for the duration of the call",
-                slice_params.join("`, `")
-            ));
-            return None;
-        }
-
-        Some(has_borrowed_output_lifetime)
+        Some(edges)
     }
 
     fn property_accessor(

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -763,6 +763,22 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             return None;
         }
 
+        // Edges are attached only to the success wrapper. For a fallible
+        // method, edges computed from the whole `Result` output can't be
+        // soundly split across arms here, and the exception/error wrapper is
+        // built without edges — so a borrowing error arm would dangle. Reject
+        // borrowing fallible returns until edges are threaded per-arm.
+        if !keep_alive_edges.is_empty() && error_info.is_some() {
+            self.errors.push_error(
+                "[.NET backend] a fallible method returning a borrowing value is not yet \
+                 supported — keep-alive edges are not threaded into the error/exception arm. \
+                 Make it infallible, return an owned (non-borrowing) value, or disable this \
+                 API for .NET."
+                    .to_string(),
+            );
+            return None;
+        }
+
         Some(MethodInfo {
             abi_name: method.abi_name.as_str(),
             name: method_name,

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -28,9 +28,15 @@
 //!   generated `IDisposable` wrapper would `Destroy` a pointer Rust still
 //!   owns (double-free). Return `Box<T>` / `Option<Box<T>>` instead.
 //! * Lifetime-carrying owned returns (`Box<T<'a>>`) that borrow from `self` or
-//!   another opaque wrapper are generated with XML lifetime remarks. C# cannot
-//!   enforce the relationship, so the caller must keep the borrowed-from wrapper
-//!   alive and undisposed while the returned value is used.
+//!   another opaque wrapper are generated with **keep-alive edges**: the
+//!   returned wrapper stores a strong reference to each borrowed-from wrapper,
+//!   so the GC cannot collect (and `Destroy`) a parent while the borrower is
+//!   reachable. One hole remains that edges cannot close, because C# has no
+//!   borrow checker: explicitly `Dispose()`-ing (or `using`-scoping) a
+//!   borrowed-from wrapper while the borrower is still in use frees the native
+//!   memory early — a use-after-free the backend cannot statically prevent.
+//!   Borrows that flow into a non-opaque return (e.g. a by-value struct) are
+//!   rejected for now, since edges are only plumbed through opaque wrappers.
 
 use askama::Template;
 use diplomat_core::hir::{BackendAttrSupport, DocsUrlGenerator, TypeContext};
@@ -579,7 +585,7 @@ mod test {
     }
 
     #[test]
-    fn lifetime_carrying_owned_return_borrowing_opaque_gets_warning() {
+    fn lifetime_carrying_owned_return_borrowing_opaque_gets_keep_alive_edge() {
         let tk_stream = quote! {
             #[diplomat::bridge]
             mod ffi {
@@ -591,6 +597,10 @@ mod test {
 
                 impl Parent {
                     pub fn child<'a>(&'a self) -> Box<Child<'a>> {
+                        unimplemented!()
+                    }
+
+                    pub fn child_of<'a>(hold: &'a Parent, nohold: &Parent) -> Box<Child<'a>> {
                         unimplemented!()
                     }
                 }
@@ -614,17 +624,25 @@ mod test {
         );
 
         let parent = files.get("Parent.cs").expect("expected Parent.cs output");
+        // A receiver-borrowing return roots `this`.
         assert!(
-            parent.contains("Lifetime: the returned native-backed value may borrow"),
-            "expected lifetime warning in Parent.cs:\n{parent}"
+            parent.contains("new Child(result, new object[] { this })"),
+            "expected keep-alive edge rooting the receiver in Parent.cs:\n{parent}"
+        );
+        // The edge analysis selects only the borrowed-from param: `child_of`
+        // ties the output to `hold`, so `hold` is rooted and `nohold` is not.
+        assert!(
+            parent.contains("new Child(result, new object[] { hold })"),
+            "expected keep-alive edge selecting only `hold` in Parent.cs:\n{parent}"
         );
 
+        // A non-borrowing owned return must not over-retain (would leak).
         let owned_foo = files
             .get("OwnedFoo.cs")
             .expect("expected OwnedFoo.cs output");
         assert!(
-            !owned_foo.contains("Lifetime: the returned native-backed value may borrow"),
-            "unexpected lifetime warning in OwnedFoo.cs:\n{owned_foo}"
+            !owned_foo.contains("new object[]"),
+            "non-borrowing return must not emit keep-alive edges in OwnedFoo.cs:\n{owned_foo}"
         );
     }
 }

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -35,8 +35,13 @@
 //!   borrow checker: explicitly `Dispose()`-ing (or `using`-scoping) a
 //!   borrowed-from wrapper while the borrower is still in use frees the native
 //!   memory early — a use-after-free the backend cannot statically prevent.
-//!   Borrows that flow into a non-opaque return (e.g. a by-value struct) are
-//!   rejected for now, since edges are only plumbed through opaque wrappers.
+//!   The same applies to a concurrent `Dispose()` from another thread racing
+//!   an in-flight call: like the rest of the generated surface, the wrappers
+//!   are not thread-safe against disposal. Closing these holds requires
+//!   runtime borrow-counting / `SafeHandle` ref-count leases (a future,
+//!   opt-in hardening), not just keep-alive edges. Borrows that flow into a
+//!   non-opaque return (e.g. a by-value struct) are rejected for now, since
+//!   edges are only plumbed through opaque wrappers.
 
 use askama::Template;
 use diplomat_core::hir::{BackendAttrSupport, DocsUrlGenerator, TypeContext};

--- a/tool/templates/dotnet/method_body.cs.jinja
+++ b/tool/templates/dotnet/method_body.cs.jinja
@@ -51,12 +51,18 @@
 {{ bi }}{
     {%- if let Some(info) = method.error_info %}
 {{ bi }}    var result = Raw.{{ name }}.{{ method.name }}({{ method.raw_call_args_with_writer() }});
+    {%- for keep_alive in method.keep_alive_statements() %}
+{{ bi }}    {{ keep_alive }}
+    {%- endfor %}
 {{ bi }}    if (!result.IsOk)
 {{ bi }}    {
 {{ bi }}        {{ info.throw_statement("result.Err") }}
 {{ bi }}    }
     {%- else %}
 {{ bi }}    Raw.{{ name }}.{{ method.name }}({{ method.raw_call_args_with_writer() }});
+    {%- for keep_alive in method.keep_alive_statements() %}
+{{ bi }}    {{ keep_alive }}
+    {%- endfor %}
     {%- endif %}
 {{ bi }}    return writeable.ToUnicode();
 {{ bi }}}
@@ -66,6 +72,9 @@
 {{ bi }}}
 {%- else if let Some(info) = method.error_info %}
 {{ bi }}var result = {{ method.raw_call_expr(name) }};
+{%- for keep_alive in method.keep_alive_statements() %}
+{{ bi }}{{ keep_alive }}
+{%- endfor %}
 {{ bi }}if (!result.IsOk)
 {{ bi }}{
 {{ bi }}    {{ info.throw_statement("result.Err") }}
@@ -73,10 +82,16 @@
 {{ bi }}{{ method.success_return_statement("result.Ok") }}
 {%- else if method.return_type.is_void() %}
 {{ bi }}{{ method.raw_call_statement(name) }}
-{%- else if method.can_return_raw_call_directly() %}
+{%- for keep_alive in method.keep_alive_statements() %}
+{{ bi }}{{ keep_alive }}
+{%- endfor %}
+{%- else if method.can_return_raw_call_directly() && !method.has_keep_alive() %}
 {{ bi }}{{ method.direct_raw_return_statement(name) }}
 {%- else %}
 {{ bi }}{{ method.success_result_declaration(name) }}
+{%- for keep_alive in method.keep_alive_statements() %}
+{{ bi }}{{ keep_alive }}
+{%- endfor %}
 {{ bi }}{{ method.success_return_statement("result") }}
 {%- endif %}
 {%- if !method.inputs.fix_statements.is_empty() %}

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -36,6 +36,14 @@ public partial class {{ name }}: IDisposable
     }
 
     private readonly {{ name }}Handle _handle;
+
+    /// <summary>
+    /// Strong references to the wrappers this value borrows from (its
+    /// keep-alive edges). Rooting them here prevents the GC from collecting
+    /// (and finalizing -> Destroy) a borrowed-from parent while this value is
+    /// still alive. Empty for values that borrow from nothing.
+    /// </summary>
+    private readonly object[] _edges;
     {%- for property in properties %}
 
 {%- if property.lifetime_warning %}
@@ -73,6 +81,23 @@ public partial class {{ name }}: IDisposable
     internal unsafe {{ name }}(Raw.{{ name }}* handle)
     {
         _handle = new {{ name }}Handle(handle, ownsHandle: true);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <summary>
+    /// Creates a managed <c>{{ name }}</c> from a raw handle, retaining
+    /// strong references to the wrappers it borrows from (its keep-alive
+    /// edges) so they outlive this value.
+    /// </summary>
+    /// <remarks>
+    /// Still owns the raw box (<c>ownsHandle: true</c>); the edges only keep
+    /// the borrowed-from objects GC-reachable so they are not collected and
+    /// finalized (-> Destroy) while this value is alive.
+    /// </remarks>
+    internal unsafe {{ name }}(Raw.{{ name }}* handle, object[] edges)
+    {
+        _handle = new {{ name }}Handle(handle, ownsHandle: true);
+        _edges = edges;
     }
     {#- One idiomatic method per HIR method. `DiplomatWrite`-returning
         methods surface as `string` — the writer is allocated, filled, and

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -43,7 +43,7 @@ public partial class {{ name }}: IDisposable
     /// (and finalizing -> Destroy) a borrowed-from parent while this value is
     /// still alive. Empty for values that borrow from nothing.
     /// </summary>
-    private readonly object[] _edges;
+    private object[] _edges;
     {%- for property in properties %}
 
 {%- if property.lifetime_warning %}
@@ -140,7 +140,12 @@ public partial class {{ name }}: IDisposable
     /// </summary>
     internal unsafe Raw.{{ name }}* AsFFI()
     {
-        return (Raw.{{ name }}*)_handle.DangerousGetHandle();
+        // Null once disposed (the SafeHandle is closed) so a caller's null
+        // check surfaces a clean ObjectDisposedException rather than handing
+        // a freed pointer to native code.
+        return (_handle.IsClosed || _handle.IsInvalid)
+            ? null
+            : (Raw.{{ name }}*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
@@ -154,5 +159,8 @@ public partial class {{ name }}: IDisposable
     public void Dispose()
     {
         _handle.Dispose();
+        // Stop rooting the borrowed-from wrappers once we're disposed; they
+        // no longer need to outlive this value.
+        _edges = System.Array.Empty<object>();
     }
 }

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -10,7 +10,32 @@ namespace {{ namespace }};
 
 public partial class {{ name }}: IDisposable
 {
-    private unsafe Raw.{{ name }}* _inner;
+    /// <summary>
+    /// Owns the native <c>Raw.{{ name }}*</c> handle. Deriving from
+    /// <c>SafeHandle</c> (instead of holding a raw pointer + a hand-written
+    /// finalizer) gives a once-only, thread-safe release and — through its
+    /// critical finalizer — prevents the GC from freeing the pointer while a
+    /// native call that reads it is still in flight.
+    /// </summary>
+    internal sealed unsafe class {{ name }}Handle : SafeHandle
+    {
+        public {{ name }}Handle() : base(IntPtr.Zero, true) { }
+
+        public {{ name }}Handle(Raw.{{ name }}* h, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            SetHandle((IntPtr)h);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            Raw.{{ name }}.Destroy((Raw.{{ name }}*)handle);
+            return true;
+        }
+    }
+
+    private readonly {{ name }}Handle _handle;
     {%- for property in properties %}
 
 {%- if property.lifetime_warning %}
@@ -47,7 +72,7 @@ public partial class {{ name }}: IDisposable
     /// </remarks>
     internal unsafe {{ name }}(Raw.{{ name }}* handle)
     {
-        _inner = handle;
+        _handle = new {{ name }}Handle(handle, ownsHandle: true);
     }
     {#- One idiomatic method per HIR method. `DiplomatWrite`-returning
         methods surface as `string` — the writer is allocated, filled, and
@@ -73,7 +98,7 @@ public partial class {{ name }}: IDisposable
         unsafe
         {
 {%- if method.is_instance() %}
-            if (_inner == null)
+            if (_handle.IsInvalid || _handle.IsClosed)
             {
                 throw new ObjectDisposedException("{{ name }}");
             }
@@ -88,30 +113,19 @@ public partial class {{ name }}: IDisposable
     /// </summary>
     internal unsafe Raw.{{ name }}* AsFFI()
     {
-        return _inner;
+        return (Raw.{{ name }}*)_handle.DangerousGetHandle();
     }
 
     /// <summary>
     /// Destroys the underlying object immediately.
     /// </summary>
+    /// <remarks>
+    /// Delegated to the <c>SafeHandle</c>, which guarantees a once-only
+    /// release and suppresses its own finalizer — so no hand-written
+    /// finalizer is needed here.
+    /// </remarks>
     public void Dispose()
     {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.{{ name }}.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    ~{{ name }}()
-    {
-        Dispose();
+        _handle.Dispose();
     }
 }

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -48,8 +48,9 @@ public partial class {{ name }}: IDisposable
 
 {%- if property.lifetime_warning %}
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
 {%- endif %}
     public {{ property.property_type }} {{ property.name }}
@@ -114,8 +115,9 @@ public partial class {{ name }}: IDisposable
 {%- endif %}
 {%- if method.lifetime_warning %}
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
 {%- endif %}
     public {{ method.static_kw }}{% if method.is_to_string_override() %}override {% endif %}{{ method.idiomatic_signature_return_type() }} {{ method.name }}({{ method.inputs.idiomatic_params }})

--- a/tool/templates/dotnet/struct.impl.cs.jinja
+++ b/tool/templates/dotnet/struct.impl.cs.jinja
@@ -31,8 +31,9 @@ public partial struct {{ name }}
 
 {%- if property.lifetime_warning %}
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
 {%- endif %}
     public {{ property.property_type }} {{ property.name }}
@@ -57,8 +58,9 @@ public partial struct {{ name }}
 {%- endif %}
 {%- if method.lifetime_warning %}
     /// <remarks>
-    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
-    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// Lifetime: this value borrows from the receiver or one or more inputs, which are kept
+    /// reachable for the garbage collector automatically. Disposing them (explicitly or via a
+    /// <c>using</c> block) while this value is still in use will invalidate it.
     /// </remarks>
 {%- endif %}
 


### PR DESCRIPTION
> ⚠️ **DRAFT / experimental — do not merge.** Part 2 of a stacked pair, **stacked on #1180** (SafeHandle migration). Until #1180 merges, this PR's diff also contains #1180's commit; the net-new change here is the keep-alive edges. Under active review.

## What
When a method returns an owned `Box<Child<'a>>` that borrows from `self` or an opaque parameter, the generated child wrapper now stores strong references (`object[] _edges`) to the borrowed-from wrappers, so the GC cannot collect (and `Destroy`) a parent while the child is alive — mirroring the Dart/Kotlin/JS edge mechanism.

## Details
- Child still **owns** its own box (`ownsHandle: true`); edges only root the parents.
- `OpaqueParam` edges handled, including transitivity (e.g. `diamond_left` → `{ left, bottom }`).
- `SliceParam` and `StructLifetime` borrowing-returns, and **any non-opaque return that carries edges**, are rejected with a diagnostic (deferred / unsound to plumb today).
- Adds a constructible `BorrowParent`/`BorrowChild` fixture + a GC test (`Child_KeepsParent_AliveAcrossGc`) proving red→green.

## Residual (documented, not fixed)
Keep-alive edges defend against **GC collection** only. C# has no borrow checker, so explicitly `Dispose()`-ing (or `using`-scoping) a borrowed-from wrapper while the borrower is still in use frees the native memory early — a use-after-free this approach cannot statically prevent. Documented in the backend module doc.

## Verified
`cargo fmt`/`clippy` clean; 42/42 .NET feature tests (incl. the new GC test); dotnet unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)