### PR TITLE
Add Typing Usage Info Struct

### DIFF
--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -109,6 +109,7 @@ pub struct ResultUsageInfo<P: TyPosition> {
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+// InputOnly allows for traits and callbacks, which creates a large byte difference (this type is > 900 bytes).
 #[allow(clippy::large_enum_variant)]
 pub enum ResultUsage {
     /// Result is used as the return of a callback:

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -108,6 +108,40 @@ pub struct TypingUseInfo {
     pub optioned : bool
 }
 
+pub(super) trait TypeUsage {
+    fn set_usage(&mut self, usage : super::TypingUseInfo);
+}
+
+impl TypeUsage for StructDef<super::Everywhere> {
+    fn set_usage(&mut self, usage : TypingUseInfo) {
+        self.usage = usage;
+    }
+}
+
+impl TypeUsage for StructDef<super::OutputOnly> {
+    fn set_usage(&mut self, usage : TypingUseInfo) {
+        self.usage = usage;
+    }
+}
+
+impl TypeUsage for OpaqueDef {
+    fn set_usage(&mut self, usage : TypingUseInfo) {
+        self.usage = usage;
+    }
+}
+
+impl TypeUsage for EnumDef {
+    fn set_usage(&mut self, usage : TypingUseInfo) {
+        self.usage = usage;
+    }
+}
+
+impl TypeUsage for TraitDef {
+    fn set_usage(&mut self, usage : TypingUseInfo) {
+        self.usage = usage;
+    }
+}
+
 /// A variant of an [`Enum`].
 #[derive(Debug)]
 #[non_exhaustive]

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -31,7 +31,7 @@ pub struct TraitDef {
     pub methods: Vec<Callback>,
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
-    pub usage : TypingUseInfo,
+    pub usage: TypingUseInfo,
 }
 
 /// Structs that can only be returned from methods.
@@ -48,7 +48,7 @@ pub struct StructDef<P: TyPosition = Everywhere> {
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
     pub special_method_presence: SpecialMethodPresence,
-    pub usage : TypingUseInfo,
+    pub usage: TypingUseInfo,
 }
 
 /// A struct whose contents are opaque across the FFI boundary, and can only
@@ -71,7 +71,7 @@ pub struct OpaqueDef {
 
     /// The ABI name of the generated destructor
     pub dtor_abi_name: IdentBuf,
-    pub usage : TypingUseInfo,
+    pub usage: TypingUseInfo,
 }
 
 /// The enum type.
@@ -84,7 +84,7 @@ pub struct EnumDef {
     pub methods: Vec<Method>,
     pub attrs: Attrs,
     pub special_method_presence: SpecialMethodPresence,
-    pub usage : TypingUseInfo,
+    pub usage: TypingUseInfo,
 }
 
 /// A field on a [`OutStruct`]s.
@@ -102,8 +102,8 @@ pub struct StructField<P: TyPosition = Everywhere> {
 
 #[derive(Debug, Clone)]
 pub struct ResultUsageInfo<P: TyPosition> {
-    pub ok : super::SuccessType<P>,
-    pub err : Option<Type<P>>,
+    pub ok: super::SuccessType<P>,
+    pub err: Option<Type<P>>,
 }
 
 #[derive(Debug, Clone)]
@@ -119,43 +119,43 @@ pub enum ResultUsage {
 #[derive(Debug, Clone, Default)]
 pub struct TypingUseInfo {
     /// If the given type is ever used in a slice.
-    pub sliced : bool,
+    pub sliced: bool,
     /// If the given type is ever used in an option.
-    pub optioned : bool,
+    pub optioned: bool,
     /// The results that this type is used in.
-    pub results : Vec<ResultUsage>,
+    pub results: Vec<ResultUsage>,
 }
 
 pub(super) trait TypeUsage {
-    fn set_usage(&mut self, usage : super::TypingUseInfo);
+    fn set_usage(&mut self, usage: super::TypingUseInfo);
 }
 
 impl TypeUsage for StructDef<super::Everywhere> {
-    fn set_usage(&mut self, usage : TypingUseInfo) {
+    fn set_usage(&mut self, usage: TypingUseInfo) {
         self.usage = usage;
     }
 }
 
 impl TypeUsage for StructDef<super::OutputOnly> {
-    fn set_usage(&mut self, usage : TypingUseInfo) {
+    fn set_usage(&mut self, usage: TypingUseInfo) {
         self.usage = usage;
     }
 }
 
 impl TypeUsage for OpaqueDef {
-    fn set_usage(&mut self, usage : TypingUseInfo) {
+    fn set_usage(&mut self, usage: TypingUseInfo) {
         self.usage = usage;
     }
 }
 
 impl TypeUsage for EnumDef {
-    fn set_usage(&mut self, usage : TypingUseInfo) {
+    fn set_usage(&mut self, usage: TypingUseInfo) {
         self.usage = usage;
     }
 }
 
 impl TypeUsage for TraitDef {
-    fn set_usage(&mut self, usage : TypingUseInfo) {
+    fn set_usage(&mut self, usage: TypingUseInfo) {
         self.usage = usage;
     }
 }

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -101,6 +101,7 @@ pub struct StructField<P: TyPosition = Everywhere> {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ResultUsageInfo<P: TyPosition> {
     pub ok: super::SuccessType<P>,
     pub err: Option<Type<P>>,
@@ -108,6 +109,7 @@ pub struct ResultUsageInfo<P: TyPosition> {
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
 pub enum ResultUsage {
     /// Result is used as the return of a callback:
     Input(ResultUsageInfo<super::InputOnly>),
@@ -117,6 +119,7 @@ pub enum ResultUsage {
 
 /// Information on how a [`TypeDef`] is used across the HIR.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct TypingUseInfo {
     /// If the given type is ever used in a slice.
     pub sliced: bool,

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -31,6 +31,7 @@ pub struct TraitDef {
     pub methods: Vec<Callback>,
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
+    pub usage : TypingUseInfo,
 }
 
 /// Structs that can only be returned from methods.
@@ -47,6 +48,7 @@ pub struct StructDef<P: TyPosition = Everywhere> {
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
     pub special_method_presence: SpecialMethodPresence,
+    pub usage : TypingUseInfo,
 }
 
 /// A struct whose contents are opaque across the FFI boundary, and can only
@@ -69,6 +71,7 @@ pub struct OpaqueDef {
 
     /// The ABI name of the generated destructor
     pub dtor_abi_name: IdentBuf,
+    pub usage : TypingUseInfo,
 }
 
 /// The enum type.
@@ -81,6 +84,7 @@ pub struct EnumDef {
     pub methods: Vec<Method>,
     pub attrs: Attrs,
     pub special_method_presence: SpecialMethodPresence,
+    pub usage : TypingUseInfo,
 }
 
 /// A field on a [`OutStruct`]s.
@@ -94,6 +98,14 @@ pub struct StructField<P: TyPosition = Everywhere> {
     pub name: IdentBuf,
     pub ty: Type<P>,
     pub attrs: Attrs,
+}
+
+/// Information on how a [`TypeDef`] is used across the HIR.
+#[derive(Debug, Clone, Default)]
+pub struct TypingUseInfo {
+    /// If the given type is ever used as a slice.
+    pub sliced : bool,
+    pub optioned : bool
 }
 
 /// A variant of an [`Enum`].
@@ -120,6 +132,7 @@ impl TraitDef {
             methods,
             attrs,
             lifetimes,
+            usage: Default::default(),
         }
     }
 }
@@ -142,6 +155,7 @@ impl<P: TyPosition> StructDef<P> {
             attrs,
             lifetimes,
             special_method_presence,
+            usage: TypingUseInfo::default(),
         }
     }
 }
@@ -164,6 +178,7 @@ impl OpaqueDef {
             lifetimes,
             special_method_presence,
             dtor_abi_name,
+            usage: Default::default(),
         }
     }
 }
@@ -184,6 +199,7 @@ impl EnumDef {
             methods,
             attrs,
             special_method_presence,
+            usage: Default::default(),
         }
     }
 }

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -130,6 +130,7 @@ pub struct TypingUseInfo {
     pub results: Vec<ResultUsage>,
 }
 
+/// Used for setting a type's usage in [`super::LoweringContext::update_usage`]
 pub(super) trait TypeUsage {
     fn set_usage(&mut self, usage: super::TypingUseInfo);
 }

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -103,8 +103,9 @@ pub struct StructField<P: TyPosition = Everywhere> {
 /// Information on how a [`TypeDef`] is used across the HIR.
 #[derive(Debug, Clone, Default)]
 pub struct TypingUseInfo {
-    /// If the given type is ever used as a slice.
+    /// If the given type is ever used in a slice.
     pub sliced : bool,
+    /// If the given type is ever used in an option.
     pub optioned : bool
 }
 

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -100,13 +100,21 @@ pub struct StructField<P: TyPosition = Everywhere> {
     pub attrs: Attrs,
 }
 
+#[derive(Debug, Clone)]
+pub struct ResultUsageInfo {
+    ok : Type<OutputOnly>,
+    err : Type<OutputOnly>,
+}
+
 /// Information on how a [`TypeDef`] is used across the HIR.
 #[derive(Debug, Clone, Default)]
 pub struct TypingUseInfo {
     /// If the given type is ever used in a slice.
     pub sliced : bool,
     /// If the given type is ever used in an option.
-    pub optioned : bool
+    pub optioned : bool,
+    /// The results that this type is used in.
+    pub results : Vec<ResultUsageInfo>,
 }
 
 pub(super) trait TypeUsage {

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -101,9 +101,18 @@ pub struct StructField<P: TyPosition = Everywhere> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ResultUsageInfo {
-    ok : Type<OutputOnly>,
-    err : Type<OutputOnly>,
+pub struct ResultUsageInfo<P: TyPosition> {
+    pub ok : super::SuccessType<P>,
+    pub err : Option<Type<P>>,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum ResultUsage {
+    /// Result is used as the return of a callback:
+    Input(ResultUsageInfo<super::InputOnly>),
+    /// Result is used as the return of a method:
+    Output(ResultUsageInfo<super::OutputOnly>),
 }
 
 /// Information on how a [`TypeDef`] is used across the HIR.
@@ -114,7 +123,7 @@ pub struct TypingUseInfo {
     /// If the given type is ever used in an option.
     pub optioned : bool,
     /// The results that this type is used in.
-    pub results : Vec<ResultUsageInfo>,
+    pub results : Vec<ResultUsage>,
 }
 
 pub(super) trait TypeUsage {

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -127,7 +127,8 @@ pub struct TypingUseInfo {
     /// If the given type is ever used in an option.
     pub optioned: bool,
     /// The results that this type is used in.
-    pub results: Vec<ResultUsage>,
+    /// Boxed so large clones will be on the heap instead of the stack.
+    pub results: Vec<Box<ResultUsage>>,
 }
 
 /// Used for setting a type's usage in [`super::LoweringContext::update_usage`]

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -208,9 +208,9 @@ impl<'ast> LoweringContext<'ast> {
         self.lower_all(ast_defs, Self::lower_function)
     }
 
-    pub(super) fn update_usage<Ast : super::TypeUsage>(&self, defs : &mut Vec<Ast>) {
-        for (idx, d) in defs.iter_mut().enumerate() {
-            if let Some(u) = self.type_usage.get(&Ast::id_from_idx(idx)) {
+    pub(super) fn update_usage<'a, Ast : super::TypeUsage + 'a>(&self, defs : impl ExactSizeIterator<Item = (SymbolId, &'a mut Ast)>) {
+        for (id, d) in defs {
+            if let Some(u) = self.type_usage.get(&id) {
                 d.set_usage(u.clone());
             }
         }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -2031,16 +2031,24 @@ impl<'ast> LoweringContext<'ast> {
                     .map(SuccessType::OutType)
                     .map(ReturnType::Infallible),
                 ast::TypeName::Unit => Ok(ReturnType::Nullable(write_or_unit)),
-                _ => self
+                _ => {
+                    let t = self
                     .lower_out_type(
                         value_ty,
                         &mut return_ltl,
                         in_path,
                         TypeLoweringContext::Method,
                         true,
-                    )
-                    .map(SuccessType::OutType)
-                    .map(ReturnType::Nullable),
+                    );
+                    if let Ok(t) = &t {
+                        if let Some(i) = t.id() {
+                            self.usage_get_or_insert::<super::OutputOnly>(i.into()).optioned = true;
+                        }
+                    }
+
+                    t.map(SuccessType::OutType)
+                    .map(ReturnType::Nullable)
+                },
             },
             ast::TypeName::Unit => Ok(ReturnType::Infallible(write_or_unit)),
             ty => self
@@ -2102,10 +2110,17 @@ impl<'ast> LoweringContext<'ast> {
                         .map(ReturnType::Infallible)
                 }
                 ast::TypeName::Unit => Ok(ReturnType::Nullable(SuccessType::Unit)),
-                _ => self
-                    .lower_type(value_ty, ltl, TypeLoweringContext::Callback, in_path)
-                    .map(SuccessType::OutType)
-                    .map(ReturnType::Nullable),
+                _ => {
+                    let t = self
+                    .lower_type(value_ty, ltl, TypeLoweringContext::Callback, in_path);
+                    if let Ok(t) = &t {
+                        if let Some(i) = t.id() {
+                            self.usage_get_or_insert::<super::OutputOnly>(i.into()).optioned = true;
+                        }
+                    }
+                    t.map(SuccessType::OutType)
+                    .map(ReturnType::Nullable)
+                },
             },
             ast::TypeName::Unit => Ok(ReturnType::Infallible(SuccessType::Unit)),
             ty => self

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1078,6 +1078,9 @@ impl<'ast> LoweringContext<'ast> {
                                     self.errors.push(LoweringError::Other("Options of structs/enums/primitives not supported by this backend".into()));
                                 }
                                 let inner = self.lower_type(opt_ty, ltl, context, in_path)?;
+                                if let Some(i) = inner.id() {
+                                    self.usage_get_or_insert::<P>(i.into()).optioned = true;
+                                }
                                 Ok(Type::DiplomatOption(Box::new(inner)))
                             }
                         }
@@ -1507,6 +1510,9 @@ impl<'ast> LoweringContext<'ast> {
                                 self.errors.push(LoweringError::Other("Options of structs/enums/primitives not supported by this backend".into()));
                             }
                             let inner = self.lower_out_type(opt_ty, ltl, in_path, context, true)?;
+                            if let Some(i) = inner.id() {
+                                self.usage_get_or_insert::<super::OutputOnly>(i.into()).optioned = true;
+                            }
                             Ok(Type::DiplomatOption(Box::new(inner)))
                         }
                     }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -2203,6 +2203,6 @@ impl<'ast> LoweringContext<'ast> {
     fn usage_get_or_insert<'a>(&'a mut self, id: SymbolId) -> &'a mut TypingUseInfo {
         self.type_usage
             .entry(id)
-            .or_insert_with(TypingUseInfo::default)
+            .or_default()
     }
 }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -208,6 +208,11 @@ impl<'ast> LoweringContext<'ast> {
         self.lower_all(ast_defs, Self::lower_function)
     }
 
+    /// After lowering (when all types have been evaluated), we must then update those types
+    /// with their [`TypingUseInfo`].
+    ///
+    /// We're given an iterator of each [`super::TypeUsage`]-like type along with the associated ID of that type.
+    /// If we have typing usage info on that type, then we update that type in the array.
     pub(super) fn update_usage<'a, Ast: super::TypeUsage + 'a>(
         &self,
         defs: impl ExactSizeIterator<Item = (SymbolId, &'a mut Ast)>,
@@ -2200,6 +2205,7 @@ impl<'ast> LoweringContext<'ast> {
         Ok(LifetimeEnv::new(nodes, ast.nodes.len()))
     }
 
+    /// Grab a type's associated [`TypingUseInfo`] (or create an entry for it if it does not exist).
     fn usage_get_or_insert<'a>(&'a mut self, id: SymbolId) -> &'a mut TypingUseInfo {
         self.type_usage.entry(id).or_default()
     }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1480,8 +1480,7 @@ impl<'ast> LoweringContext<'ast> {
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
-                                self.usage_get_or_insert(tcx_id.into())
-                                    .optioned = true;
+                                self.usage_get_or_insert(tcx_id.into()).optioned = true;
 
                                 Ok(OutType::Opaque(OpaquePath::new(
                                     lifetimes,
@@ -1519,8 +1518,7 @@ impl<'ast> LoweringContext<'ast> {
                             }
                             let inner = self.lower_out_type(opt_ty, ltl, in_path, context, true)?;
                             if let Some(i) = inner.id() {
-                                self.usage_get_or_insert(i.into())
-                                    .optioned = true;
+                                self.usage_get_or_insert(i.into()).optioned = true;
                             }
                             Ok(Type::DiplomatOption(Box::new(inner)))
                         }
@@ -1610,8 +1608,7 @@ impl<'ast> LoweringContext<'ast> {
                     self.lower_out_type(type_name, ltl, in_path, context, in_result_option)?;
                 match inner {
                     Type::Struct(st) => {
-                        self.usage_get_or_insert(st.id().into())
-                            .sliced = true;
+                        self.usage_get_or_insert(st.id().into()).sliced = true;
                         Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
                     }
                     Type::Opaque(..) => {
@@ -2024,22 +2021,22 @@ impl<'ast> LoweringContext<'ast> {
                     (Ok(ok_ty), Ok(err_ty)) => {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
-                                self.usage_get_or_insert(i.into())
-                                    .results
-                                    .push(super::ResultUsage::Output(super::ResultUsageInfo {
+                                self.usage_get_or_insert(i.into()).results.push(
+                                    super::ResultUsage::Output(super::ResultUsageInfo {
                                         ok: ok_ty.clone(),
                                         err: err_ty.clone(),
-                                    }));
+                                    }),
+                                );
                             }
                             _ => {}
                         }
                         if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
-                            self.usage_get_or_insert(id.into())
-                                .results
-                                .push(super::ResultUsage::Output(super::ResultUsageInfo {
+                            self.usage_get_or_insert(id.into()).results.push(
+                                super::ResultUsage::Output(super::ResultUsageInfo {
                                     ok: ok_ty.clone(),
                                     err: err_ty.clone(),
-                                }));
+                                }),
+                            );
                         }
                         Ok(ReturnType::Fallible(ok_ty, err_ty))
                     }
@@ -2068,8 +2065,7 @@ impl<'ast> LoweringContext<'ast> {
                     );
                     if let Ok(t) = &t {
                         if let Some(i) = t.id() {
-                            self.usage_get_or_insert(i.into())
-                                .optioned = true;
+                            self.usage_get_or_insert(i.into()).optioned = true;
                         }
                     }
 
@@ -2116,22 +2112,22 @@ impl<'ast> LoweringContext<'ast> {
                     (Ok(ok_ty), Ok(err_ty)) => {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
-                                self.usage_get_or_insert(i.into())
-                                    .results
-                                    .push(super::ResultUsage::Input(super::ResultUsageInfo {
+                                self.usage_get_or_insert(i.into()).results.push(
+                                    super::ResultUsage::Input(super::ResultUsageInfo {
                                         ok: ok_ty.clone(),
                                         err: err_ty.clone(),
-                                    }));
+                                    }),
+                                );
                             }
                             _ => {}
                         }
                         if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
-                            self.usage_get_or_insert(id.into())
-                                .results
-                                .push(super::ResultUsage::Input(super::ResultUsageInfo {
+                            self.usage_get_or_insert(id.into()).results.push(
+                                super::ResultUsage::Input(super::ResultUsageInfo {
                                     ok: ok_ty.clone(),
                                     err: err_ty.clone(),
-                                }));
+                                }),
+                            );
                         }
                         Ok(ReturnType::Fallible(ok_ty, err_ty))
                     }
@@ -2161,8 +2157,7 @@ impl<'ast> LoweringContext<'ast> {
                     let t = self.lower_type(value_ty, ltl, TypeLoweringContext::Callback, in_path);
                     if let Ok(t) = &t {
                         if let Some(i) = t.id() {
-                            self.usage_get_or_insert(i.into())
-                                .optioned = true;
+                            self.usage_get_or_insert(i.into()).optioned = true;
                         }
                     }
                     t.map(SuccessType::OutType).map(ReturnType::Nullable)
@@ -2206,6 +2201,8 @@ impl<'ast> LoweringContext<'ast> {
     }
 
     fn usage_get_or_insert<'a>(&'a mut self, id: SymbolId) -> &'a mut TypingUseInfo {
-        self.type_usage.entry(id).or_insert_with(TypingUseInfo::default)
+        self.type_usage
+            .entry(id)
+            .or_insert_with(TypingUseInfo::default)
     }
 }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -2201,8 +2201,6 @@ impl<'ast> LoweringContext<'ast> {
     }
 
     fn usage_get_or_insert<'a>(&'a mut self, id: SymbolId) -> &'a mut TypingUseInfo {
-        self.type_usage
-            .entry(id)
-            .or_default()
+        self.type_usage.entry(id).or_default()
     }
 }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -2027,20 +2027,20 @@ impl<'ast> LoweringContext<'ast> {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
                                 self.usage_get_or_insert(i.into()).results.push(
-                                    super::ResultUsage::Output(super::ResultUsageInfo {
+                                    Box::new(super::ResultUsage::Output(super::ResultUsageInfo {
                                         ok: ok_ty.clone(),
                                         err: err_ty.clone(),
-                                    }),
+                                    })),
                                 );
                             }
                             _ => {}
                         }
                         if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
                             self.usage_get_or_insert(id.into()).results.push(
-                                super::ResultUsage::Output(super::ResultUsageInfo {
+                                Box::new(super::ResultUsage::Output(super::ResultUsageInfo {
                                     ok: ok_ty.clone(),
                                     err: err_ty.clone(),
-                                }),
+                                })),
                             );
                         }
                         Ok(ReturnType::Fallible(ok_ty, err_ty))
@@ -2118,20 +2118,20 @@ impl<'ast> LoweringContext<'ast> {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
                                 self.usage_get_or_insert(i.into()).results.push(
-                                    super::ResultUsage::Input(super::ResultUsageInfo {
+                                    Box::new(super::ResultUsage::Input(super::ResultUsageInfo {
                                         ok: ok_ty.clone(),
                                         err: err_ty.clone(),
-                                    }),
+                                    })),
                                 );
                             }
                             _ => {}
                         }
                         if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
                             self.usage_get_or_insert(id.into()).results.push(
-                                super::ResultUsage::Input(super::ResultUsageInfo {
+                                Box::new(super::ResultUsage::Input(super::ResultUsageInfo {
                                     ok: ok_ty.clone(),
                                     err: err_ty.clone(),
-                                }),
+                                })),
                             );
                         }
                         Ok(ReturnType::Fallible(ok_ty, err_ty))

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1047,7 +1047,7 @@ impl<'ast> LoweringContext<'ast> {
                                     "can't find opaque in lookup map, which contains all opaques from env",
                                 );
 
-                                self.usage_get_or_insert::<P>(tcx_id.into()).optioned = true;
+                                self.usage_get_or_insert(tcx_id.into()).optioned = true;
 
                                 Ok(Type::Opaque(OpaquePath::new(
                                     lifetimes,
@@ -1084,7 +1084,7 @@ impl<'ast> LoweringContext<'ast> {
                                 }
                                 let inner = self.lower_type(opt_ty, ltl, context, in_path)?;
                                 if let Some(i) = inner.id() {
-                                    self.usage_get_or_insert::<P>(i.into()).optioned = true;
+                                    self.usage_get_or_insert(i.into()).optioned = true;
                                 }
                                 Ok(Type::DiplomatOption(Box::new(inner)))
                             }
@@ -1218,7 +1218,7 @@ impl<'ast> LoweringContext<'ast> {
                 let inner = self.lower_type::<P>(type_name, ltl, context, in_path)?;
                 match inner {
                     Type::Struct(st) => {
-                        self.usage_get_or_insert::<P>(st.tcx_id.into()).sliced = true;
+                        self.usage_get_or_insert(st.tcx_id.into()).sliced = true;
                         Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
                     }
                     Type::Opaque(op) => {
@@ -1243,7 +1243,7 @@ impl<'ast> LoweringContext<'ast> {
                             )));
                         }
 
-                        self.usage_get_or_insert::<P>(op.tcx_id.into()).sliced = true;
+                        self.usage_get_or_insert(op.tcx_id.into()).sliced = true;
 
                         // Currently made simple since right now we don't support borrowing from opaque slices in output: rust-diplomat.github.io/diplomat/attrs/slices.html#opaques
                         Ok(Type::Slice(Slice::Opaque(new_lifetime.into(), op)))
@@ -1480,7 +1480,7 @@ impl<'ast> LoweringContext<'ast> {
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
 
-                                self.usage_get_or_insert::<super::OutputOnly>(tcx_id.into())
+                                self.usage_get_or_insert(tcx_id.into())
                                     .optioned = true;
 
                                 Ok(OutType::Opaque(OpaquePath::new(
@@ -1519,7 +1519,7 @@ impl<'ast> LoweringContext<'ast> {
                             }
                             let inner = self.lower_out_type(opt_ty, ltl, in_path, context, true)?;
                             if let Some(i) = inner.id() {
-                                self.usage_get_or_insert::<super::OutputOnly>(i.into())
+                                self.usage_get_or_insert(i.into())
                                     .optioned = true;
                             }
                             Ok(Type::DiplomatOption(Box::new(inner)))
@@ -1610,7 +1610,7 @@ impl<'ast> LoweringContext<'ast> {
                     self.lower_out_type(type_name, ltl, in_path, context, in_result_option)?;
                 match inner {
                     Type::Struct(st) => {
-                        self.usage_get_or_insert::<super::OutputOnly>(st.id().into())
+                        self.usage_get_or_insert(st.id().into())
                             .sliced = true;
                         Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
                     }
@@ -2024,7 +2024,7 @@ impl<'ast> LoweringContext<'ast> {
                     (Ok(ok_ty), Ok(err_ty)) => {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
-                                self.usage_get_or_insert::<super::OutputOnly>(i.into())
+                                self.usage_get_or_insert(i.into())
                                     .results
                                     .push(super::ResultUsage::Output(super::ResultUsageInfo {
                                         ok: ok_ty.clone(),
@@ -2034,7 +2034,7 @@ impl<'ast> LoweringContext<'ast> {
                             _ => {}
                         }
                         if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
-                            self.usage_get_or_insert::<super::OutputOnly>(id.into())
+                            self.usage_get_or_insert(id.into())
                                 .results
                                 .push(super::ResultUsage::Output(super::ResultUsageInfo {
                                     ok: ok_ty.clone(),
@@ -2068,7 +2068,7 @@ impl<'ast> LoweringContext<'ast> {
                     );
                     if let Ok(t) = &t {
                         if let Some(i) = t.id() {
-                            self.usage_get_or_insert::<super::OutputOnly>(i.into())
+                            self.usage_get_or_insert(i.into())
                                 .optioned = true;
                         }
                     }
@@ -2116,7 +2116,7 @@ impl<'ast> LoweringContext<'ast> {
                     (Ok(ok_ty), Ok(err_ty)) => {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
-                                self.usage_get_or_insert::<super::Everywhere>(i.into())
+                                self.usage_get_or_insert(i.into())
                                     .results
                                     .push(super::ResultUsage::Input(super::ResultUsageInfo {
                                         ok: ok_ty.clone(),
@@ -2126,7 +2126,7 @@ impl<'ast> LoweringContext<'ast> {
                             _ => {}
                         }
                         if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
-                            self.usage_get_or_insert::<super::Everywhere>(id.into())
+                            self.usage_get_or_insert(id.into())
                                 .results
                                 .push(super::ResultUsage::Input(super::ResultUsageInfo {
                                     ok: ok_ty.clone(),
@@ -2161,7 +2161,7 @@ impl<'ast> LoweringContext<'ast> {
                     let t = self.lower_type(value_ty, ltl, TypeLoweringContext::Callback, in_path);
                     if let Ok(t) = &t {
                         if let Some(i) = t.id() {
-                            self.usage_get_or_insert::<super::OutputOnly>(i.into())
+                            self.usage_get_or_insert(i.into())
                                 .optioned = true;
                         }
                     }
@@ -2205,10 +2205,7 @@ impl<'ast> LoweringContext<'ast> {
         Ok(LifetimeEnv::new(nodes, ast.nodes.len()))
     }
 
-    fn usage_get_or_insert<'a, P: TyPosition>(&'a mut self, id: SymbolId) -> &'a mut TypingUseInfo {
-        if !self.type_usage.contains_key(&id) {
-            self.type_usage.insert(id.clone(), TypingUseInfo::default());
-        }
-        self.type_usage.get_mut(&id).unwrap()
+    fn usage_get_or_insert<'a>(&'a mut self, id: SymbolId) -> &'a mut TypingUseInfo {
+        self.type_usage.entry(id).or_insert_with(TypingUseInfo::default)
     }
 }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -9,9 +9,10 @@ use super::{
     TypeDef, TypeId,
 };
 use crate::ast::attrs::AttrInheritContext;
-use crate::hir::Docs;
+use crate::hir::{Docs, StructPathLike, SymbolId, TypingUseInfo};
 use crate::{ast, Env};
 use core::fmt;
+use std::collections::HashMap;
 use strck::IntoCk;
 
 /// An error from lowering the AST to the HIR.
@@ -115,6 +116,7 @@ pub(super) struct LoweringContext<'ast> {
     pub env: &'ast Env,
     pub attr_validator: Box<dyn AttributeValidator>,
     pub cfg: super::LoweringConfig,
+    pub type_usage : HashMap<SymbolId, TypingUseInfo>,
 }
 
 /// An item and the info needed to
@@ -204,6 +206,14 @@ impl<'ast> LoweringContext<'ast> {
         ast_defs: impl ExactSizeIterator<Item = ItemAndInfo<'ast, ast::Function>>,
     ) -> Result<Vec<Method>, ()> {
         self.lower_all(ast_defs, Self::lower_function)
+    }
+
+    pub(super) fn update_usage<Ast : super::TypeUsage>(&self, defs : &mut Vec<Ast>) {
+        for (idx, d) in defs.iter_mut().enumerate() {
+            if let Some(u) = self.type_usage.get(&Ast::id_from_idx(idx)) {
+                d.set_usage(u.clone());
+            }
+        }
     }
 
     fn lower_enum(&mut self, item: ItemAndInfo<'ast, ast::Enum>) -> Result<EnumDef, ()> {
@@ -1199,7 +1209,10 @@ impl<'ast> LoweringContext<'ast> {
 
                 let inner = self.lower_type::<P>(type_name, ltl, context, in_path)?;
                 match inner {
-                    Type::Struct(st) => Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st))),
+                    Type::Struct(st) => {
+                        self.usage_get_or_insert::<P>(st.tcx_id.into()).sliced = true;
+                        Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
+                    },
                     Type::Opaque(op) => {
                         if let Some(lt) = new_lifetime {
                             if lt.mutability.is_mutable() {
@@ -1221,6 +1234,8 @@ impl<'ast> LoweringContext<'ast> {
                                 "Slice of opaque &[{type_name}] is unsupported by this backend."
                             )));
                         }
+                        
+                        self.usage_get_or_insert::<P>(op.tcx_id.into()).sliced = true;
 
                         // Currently made simple since right now we don't support borrowing from opaque slices in output: rust-diplomat.github.io/diplomat/attrs/slices.html#opaques
                         Ok(Type::Slice(Slice::Opaque(new_lifetime.into(), op)))
@@ -1579,7 +1594,10 @@ impl<'ast> LoweringContext<'ast> {
                 let inner =
                     self.lower_out_type(type_name, ltl, in_path, context, in_result_option)?;
                 match inner {
-                    Type::Struct(st) => Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st))),
+                    Type::Struct(st) => {
+                        self.usage_get_or_insert::<super::OutputOnly>(st.id().into()).sliced = true;
+                        Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
+                    },
                     Type::Opaque(..) => {
                         self.errors.push(LoweringError::Other(
                             "Opaque slices are currently disallowed as an output type.".to_string(),
@@ -2114,5 +2132,12 @@ impl<'ast> LoweringContext<'ast> {
             .collect::<Result<_, ()>>()?;
 
         Ok(LifetimeEnv::new(nodes, ast.nodes.len()))
+    }
+
+    fn usage_get_or_insert<'a, P: TyPosition>(&'a mut self, id : SymbolId) -> &'a mut TypingUseInfo {
+        if !self.type_usage.contains_key(&id) {
+            self.type_usage.insert(id.clone(), TypingUseInfo::default());
+        }
+        self.type_usage.get_mut(&id).unwrap()
     }
 }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -116,7 +116,7 @@ pub(super) struct LoweringContext<'ast> {
     pub env: &'ast Env,
     pub attr_validator: Box<dyn AttributeValidator>,
     pub cfg: super::LoweringConfig,
-    pub type_usage : HashMap<SymbolId, TypingUseInfo>,
+    pub type_usage: HashMap<SymbolId, TypingUseInfo>,
 }
 
 /// An item and the info needed to
@@ -208,7 +208,10 @@ impl<'ast> LoweringContext<'ast> {
         self.lower_all(ast_defs, Self::lower_function)
     }
 
-    pub(super) fn update_usage<'a, Ast : super::TypeUsage + 'a>(&self, defs : impl ExactSizeIterator<Item = (SymbolId, &'a mut Ast)>) {
+    pub(super) fn update_usage<'a, Ast: super::TypeUsage + 'a>(
+        &self,
+        defs: impl ExactSizeIterator<Item = (SymbolId, &'a mut Ast)>,
+    ) {
         for (id, d) in defs {
             if let Some(u) = self.type_usage.get(&id) {
                 d.set_usage(u.clone());
@@ -1043,7 +1046,7 @@ impl<'ast> LoweringContext<'ast> {
                                 let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
                                     "can't find opaque in lookup map, which contains all opaques from env",
                                 );
-                                
+
                                 self.usage_get_or_insert::<P>(tcx_id.into()).optioned = true;
 
                                 Ok(Type::Opaque(OpaquePath::new(
@@ -1217,7 +1220,7 @@ impl<'ast> LoweringContext<'ast> {
                     Type::Struct(st) => {
                         self.usage_get_or_insert::<P>(st.tcx_id.into()).sliced = true;
                         Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
-                    },
+                    }
                     Type::Opaque(op) => {
                         if let Some(lt) = new_lifetime {
                             if lt.mutability.is_mutable() {
@@ -1239,7 +1242,7 @@ impl<'ast> LoweringContext<'ast> {
                                 "Slice of opaque &[{type_name}] is unsupported by this backend."
                             )));
                         }
-                        
+
                         self.usage_get_or_insert::<P>(op.tcx_id.into()).sliced = true;
 
                         // Currently made simple since right now we don't support borrowing from opaque slices in output: rust-diplomat.github.io/diplomat/attrs/slices.html#opaques
@@ -1476,8 +1479,9 @@ impl<'ast> LoweringContext<'ast> {
                                 let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
-                        
-                                self.usage_get_or_insert::<super::OutputOnly>(tcx_id.into()).optioned = true;
+
+                                self.usage_get_or_insert::<super::OutputOnly>(tcx_id.into())
+                                    .optioned = true;
 
                                 Ok(OutType::Opaque(OpaquePath::new(
                                     lifetimes,
@@ -1515,7 +1519,8 @@ impl<'ast> LoweringContext<'ast> {
                             }
                             let inner = self.lower_out_type(opt_ty, ltl, in_path, context, true)?;
                             if let Some(i) = inner.id() {
-                                self.usage_get_or_insert::<super::OutputOnly>(i.into()).optioned = true;
+                                self.usage_get_or_insert::<super::OutputOnly>(i.into())
+                                    .optioned = true;
                             }
                             Ok(Type::DiplomatOption(Box::new(inner)))
                         }
@@ -1605,9 +1610,10 @@ impl<'ast> LoweringContext<'ast> {
                     self.lower_out_type(type_name, ltl, in_path, context, in_result_option)?;
                 match inner {
                     Type::Struct(st) => {
-                        self.usage_get_or_insert::<super::OutputOnly>(st.id().into()).sliced = true;
+                        self.usage_get_or_insert::<super::OutputOnly>(st.id().into())
+                            .sliced = true;
                         Ok(Type::Slice(Slice::Struct(new_lifetime.into(), st)))
-                    },
+                    }
                     Type::Opaque(..) => {
                         self.errors.push(LoweringError::Other(
                             "Opaque slices are currently disallowed as an output type.".to_string(),
@@ -2018,19 +2024,25 @@ impl<'ast> LoweringContext<'ast> {
                     (Ok(ok_ty), Ok(err_ty)) => {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
-                                self.usage_get_or_insert::<super::OutputOnly>(i.into()).results.push(super::ResultUsage::Output(
-                                    super::ResultUsageInfo { ok: ok_ty.clone(), err: err_ty.clone() }
-                                ));
+                                self.usage_get_or_insert::<super::OutputOnly>(i.into())
+                                    .results
+                                    .push(super::ResultUsage::Output(super::ResultUsageInfo {
+                                        ok: ok_ty.clone(),
+                                        err: err_ty.clone(),
+                                    }));
                             }
-                            _ => {} 
+                            _ => {}
                         }
-                        if let Some(id) = err_ty.as_ref().and_then(|e| { e.id() }) {
-                            self.usage_get_or_insert::<super::OutputOnly>(id.into()).results.push(super::ResultUsage::Output(
-                                super::ResultUsageInfo { ok: ok_ty.clone(), err: err_ty.clone() }
-                            ));
+                        if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
+                            self.usage_get_or_insert::<super::OutputOnly>(id.into())
+                                .results
+                                .push(super::ResultUsage::Output(super::ResultUsageInfo {
+                                    ok: ok_ty.clone(),
+                                    err: err_ty.clone(),
+                                }));
                         }
                         Ok(ReturnType::Fallible(ok_ty, err_ty))
-                    },
+                    }
                     _ => Err(()),
                 }
             }
@@ -2047,8 +2059,7 @@ impl<'ast> LoweringContext<'ast> {
                     .map(ReturnType::Infallible),
                 ast::TypeName::Unit => Ok(ReturnType::Nullable(write_or_unit)),
                 _ => {
-                    let t = self
-                    .lower_out_type(
+                    let t = self.lower_out_type(
                         value_ty,
                         &mut return_ltl,
                         in_path,
@@ -2057,13 +2068,13 @@ impl<'ast> LoweringContext<'ast> {
                     );
                     if let Ok(t) = &t {
                         if let Some(i) = t.id() {
-                            self.usage_get_or_insert::<super::OutputOnly>(i.into()).optioned = true;
+                            self.usage_get_or_insert::<super::OutputOnly>(i.into())
+                                .optioned = true;
                         }
                     }
 
-                    t.map(SuccessType::OutType)
-                    .map(ReturnType::Nullable)
-                },
+                    t.map(SuccessType::OutType).map(ReturnType::Nullable)
+                }
             },
             ast::TypeName::Unit => Ok(ReturnType::Infallible(write_or_unit)),
             ty => self
@@ -2105,19 +2116,25 @@ impl<'ast> LoweringContext<'ast> {
                     (Ok(ok_ty), Ok(err_ty)) => {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
-                                self.usage_get_or_insert::<super::Everywhere>(i.into()).results.push(super::ResultUsage::Input(
-                                    super::ResultUsageInfo { ok: ok_ty.clone(), err: err_ty.clone() }
-                                ));
+                                self.usage_get_or_insert::<super::Everywhere>(i.into())
+                                    .results
+                                    .push(super::ResultUsage::Input(super::ResultUsageInfo {
+                                        ok: ok_ty.clone(),
+                                        err: err_ty.clone(),
+                                    }));
                             }
-                            _ => {} 
+                            _ => {}
                         }
-                        if let Some(id) = err_ty.as_ref().and_then(|e| { e.id() }) {
-                            self.usage_get_or_insert::<super::Everywhere>(id.into()).results.push(super::ResultUsage::Input(
-                                super::ResultUsageInfo { ok: ok_ty.clone(), err: err_ty.clone() }
-                            ));
+                        if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
+                            self.usage_get_or_insert::<super::Everywhere>(id.into())
+                                .results
+                                .push(super::ResultUsage::Input(super::ResultUsageInfo {
+                                    ok: ok_ty.clone(),
+                                    err: err_ty.clone(),
+                                }));
                         }
                         Ok(ReturnType::Fallible(ok_ty, err_ty))
-                    },
+                    }
                     _ => Err(()),
                 }
             }
@@ -2141,16 +2158,15 @@ impl<'ast> LoweringContext<'ast> {
                 }
                 ast::TypeName::Unit => Ok(ReturnType::Nullable(SuccessType::Unit)),
                 _ => {
-                    let t = self
-                    .lower_type(value_ty, ltl, TypeLoweringContext::Callback, in_path);
+                    let t = self.lower_type(value_ty, ltl, TypeLoweringContext::Callback, in_path);
                     if let Ok(t) = &t {
                         if let Some(i) = t.id() {
-                            self.usage_get_or_insert::<super::OutputOnly>(i.into()).optioned = true;
+                            self.usage_get_or_insert::<super::OutputOnly>(i.into())
+                                .optioned = true;
                         }
                     }
-                    t.map(SuccessType::OutType)
-                    .map(ReturnType::Nullable)
-                },
+                    t.map(SuccessType::OutType).map(ReturnType::Nullable)
+                }
             },
             ast::TypeName::Unit => Ok(ReturnType::Infallible(SuccessType::Unit)),
             ty => self
@@ -2189,7 +2205,7 @@ impl<'ast> LoweringContext<'ast> {
         Ok(LifetimeEnv::new(nodes, ast.nodes.len()))
     }
 
-    fn usage_get_or_insert<'a, P: TyPosition>(&'a mut self, id : SymbolId) -> &'a mut TypingUseInfo {
+    fn usage_get_or_insert<'a, P: TyPosition>(&'a mut self, id: SymbolId) -> &'a mut TypingUseInfo {
         if !self.type_usage.contains_key(&id) {
             self.type_usage.insert(id.clone(), TypingUseInfo::default());
         }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -1043,6 +1043,8 @@ impl<'ast> LoweringContext<'ast> {
                                 let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
                                     "can't find opaque in lookup map, which contains all opaques from env",
                                 );
+                                
+                                self.usage_get_or_insert::<P>(tcx_id.into()).optioned = true;
 
                                 Ok(Type::Opaque(OpaquePath::new(
                                     lifetimes,
@@ -1474,6 +1476,8 @@ impl<'ast> LoweringContext<'ast> {
                                 let tcx_id = self.lookup_id.resolve_opaque(opaque).expect(
                             "can't find opaque in lookup map, which contains all opaques from env",
                         );
+                        
+                                self.usage_get_or_insert::<super::OutputOnly>(tcx_id.into()).optioned = true;
 
                                 Ok(OutType::Opaque(OpaquePath::new(
                                     lifetimes,

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -2026,22 +2026,22 @@ impl<'ast> LoweringContext<'ast> {
                     (Ok(ok_ty), Ok(err_ty)) => {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
-                                self.usage_get_or_insert(i.into()).results.push(
-                                    Box::new(super::ResultUsage::Output(super::ResultUsageInfo {
+                                self.usage_get_or_insert(i.into()).results.push(Box::new(
+                                    super::ResultUsage::Output(super::ResultUsageInfo {
                                         ok: ok_ty.clone(),
                                         err: err_ty.clone(),
-                                    })),
-                                );
+                                    }),
+                                ));
                             }
                             _ => {}
                         }
                         if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
-                            self.usage_get_or_insert(id.into()).results.push(
-                                Box::new(super::ResultUsage::Output(super::ResultUsageInfo {
+                            self.usage_get_or_insert(id.into()).results.push(Box::new(
+                                super::ResultUsage::Output(super::ResultUsageInfo {
                                     ok: ok_ty.clone(),
                                     err: err_ty.clone(),
-                                })),
-                            );
+                                }),
+                            ));
                         }
                         Ok(ReturnType::Fallible(ok_ty, err_ty))
                     }
@@ -2117,22 +2117,22 @@ impl<'ast> LoweringContext<'ast> {
                     (Ok(ok_ty), Ok(err_ty)) => {
                         match &ok_ty {
                             SuccessType::OutType(o) if let Some(i) = o.id() => {
-                                self.usage_get_or_insert(i.into()).results.push(
-                                    Box::new(super::ResultUsage::Input(super::ResultUsageInfo {
+                                self.usage_get_or_insert(i.into()).results.push(Box::new(
+                                    super::ResultUsage::Input(super::ResultUsageInfo {
                                         ok: ok_ty.clone(),
                                         err: err_ty.clone(),
-                                    })),
-                                );
+                                    }),
+                                ));
                             }
                             _ => {}
                         }
                         if let Some(id) = err_ty.as_ref().and_then(|e| e.id()) {
-                            self.usage_get_or_insert(id.into()).results.push(
-                                Box::new(super::ResultUsage::Input(super::ResultUsageInfo {
+                            self.usage_get_or_insert(id.into()).results.push(Box::new(
+                                super::ResultUsage::Input(super::ResultUsageInfo {
                                     ok: ok_ty.clone(),
                                     err: err_ty.clone(),
-                                })),
-                            );
+                                }),
+                            ));
                         }
                         Ok(ReturnType::Fallible(ok_ty, err_ty))
                     }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -2015,7 +2015,22 @@ impl<'ast> LoweringContext<'ast> {
                 };
 
                 match (ok_ty, err_ty) {
-                    (Ok(ok_ty), Ok(err_ty)) => Ok(ReturnType::Fallible(ok_ty, err_ty)),
+                    (Ok(ok_ty), Ok(err_ty)) => {
+                        match &ok_ty {
+                            SuccessType::OutType(o) if let Some(i) = o.id() => {
+                                self.usage_get_or_insert::<super::OutputOnly>(i.into()).results.push(super::ResultUsage::Output(
+                                    super::ResultUsageInfo { ok: ok_ty.clone(), err: err_ty.clone() }
+                                ));
+                            }
+                            _ => {} 
+                        }
+                        if let Some(id) = err_ty.as_ref().and_then(|e| { e.id() }) {
+                            self.usage_get_or_insert::<super::OutputOnly>(id.into()).results.push(super::ResultUsage::Output(
+                                super::ResultUsageInfo { ok: ok_ty.clone(), err: err_ty.clone() }
+                            ));
+                        }
+                        Ok(ReturnType::Fallible(ok_ty, err_ty))
+                    },
                     _ => Err(()),
                 }
             }
@@ -2087,7 +2102,22 @@ impl<'ast> LoweringContext<'ast> {
                 };
 
                 match (ok_ty, err_ty) {
-                    (Ok(ok_ty), Ok(err_ty)) => Ok(ReturnType::Fallible(ok_ty, err_ty)),
+                    (Ok(ok_ty), Ok(err_ty)) => {
+                        match &ok_ty {
+                            SuccessType::OutType(o) if let Some(i) = o.id() => {
+                                self.usage_get_or_insert::<super::Everywhere>(i.into()).results.push(super::ResultUsage::Input(
+                                    super::ResultUsageInfo { ok: ok_ty.clone(), err: err_ty.clone() }
+                                ));
+                            }
+                            _ => {} 
+                        }
+                        if let Some(id) = err_ty.as_ref().and_then(|e| { e.id() }) {
+                            self.usage_get_or_insert::<super::Everywhere>(id.into()).results.push(super::ResultUsage::Input(
+                                super::ResultUsageInfo { ok: ok_ty.clone(), err: err_ty.clone() }
+                            ));
+                        }
+                        Ok(ReturnType::Fallible(ok_ty, err_ty))
+                    },
                     _ => Err(()),
                 }
             }

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -236,6 +236,10 @@ TypeContext {
                 iterator: None,
                 iterable: None,
             },
+            usage: TypingUseInfo {
+                sliced: false,
+                optioned: false,
+            },
         },
     ],
     structs: [
@@ -506,6 +510,10 @@ TypeContext {
                 iterator: None,
                 iterable: None,
             },
+            usage: TypingUseInfo {
+                sliced: false,
+                optioned: false,
+            },
         },
     ],
     opaques: [
@@ -563,6 +571,10 @@ TypeContext {
                 iterable: None,
             },
             dtor_abi_name: "Opaque_destroy",
+            usage: TypingUseInfo {
+                sliced: false,
+                optioned: false,
+            },
         },
     ],
     enums: [],

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -239,6 +239,7 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: false,
                 optioned: false,
+                results: [],
             },
         },
     ],
@@ -513,6 +514,7 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: false,
                 optioned: false,
+                results: [],
             },
         },
     ],
@@ -574,6 +576,7 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: false,
                 optioned: false,
+                results: [],
             },
         },
     ],

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
@@ -230,7 +230,74 @@ TypeContext {
                         num_lifetimes: 1,
                     },
                     param_self: None,
-                    params: [],
+                    params: [
+                        Param {
+                            name: "op",
+                            ty: Slice(
+                                Opaque(
+                                    Borrow(
+                                        Borrow {
+                                            lifetime: NonStatic(
+                                                Lifetime(
+                                                    0,
+                                                ),
+                                            ),
+                                            mutability: Immutable,
+                                        },
+                                    ),
+                                    OpaquePath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        optional: Optional(
+                                            false,
+                                        ),
+                                        owner: Borrow {
+                                            lifetime: NonStatic(
+                                                Lifetime(
+                                                    0,
+                                                ),
+                                            ),
+                                            mutability: Immutable,
+                                        },
+                                        tcx_id: OpaqueId(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ),
+                            attrs: Attrs {
+                                disable: false,
+                                deprecated: None,
+                                namespace: None,
+                                rename: RenameAttr {
+                                    pattern: None,
+                                },
+                                abi_rename: RenameAttr {
+                                    pattern: None,
+                                },
+                                special_method: None,
+                                custom_errors: false,
+                                default: false,
+                                demo_attrs: DemoInfo {
+                                    generate: false,
+                                    default_constructor: false,
+                                    external: false,
+                                    custom_func: None,
+                                    input_cfg: DemoInputCFG {
+                                        label: "",
+                                        default_value: "",
+                                    },
+                                },
+                                generate_mocking_interface: false,
+                                abi_compatible: false,
+                                mut_struct_ref: false,
+                                tuple: false,
+                                custom_extra_code: {},
+                                default_value: None,
+                            },
+                        },
+                    ],
                     output: Infallible(
                         OutType(
                             Slice(
@@ -389,6 +456,59 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: false,
                 optioned: true,
+            },
+        },
+        OpaqueDef {
+            docs: Docs {
+                lines: "",
+                rust_links: [],
+            },
+            name: "UsedInSliceOpaque",
+            methods: [],
+            attrs: Attrs {
+                disable: false,
+                deprecated: None,
+                namespace: None,
+                rename: RenameAttr {
+                    pattern: None,
+                },
+                abi_rename: RenameAttr {
+                    pattern: None,
+                },
+                special_method: None,
+                custom_errors: false,
+                default: false,
+                demo_attrs: DemoInfo {
+                    generate: false,
+                    default_constructor: false,
+                    external: false,
+                    custom_func: None,
+                    input_cfg: DemoInputCFG {
+                        label: "",
+                        default_value: "",
+                    },
+                },
+                generate_mocking_interface: false,
+                abi_compatible: false,
+                mut_struct_ref: false,
+                tuple: false,
+                custom_extra_code: {},
+                default_value: None,
+            },
+            lifetimes: LifetimeEnv {
+                nodes: [],
+                num_lifetimes: 0,
+            },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
+                optional_comparator: false,
+                iterator: None,
+                iterable: None,
+            },
+            dtor_abi_name: "UsedInSliceOpaque_destroy",
+            usage: TypingUseInfo {
+                sliced: true,
+                optioned: false,
             },
         },
     ],

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
@@ -1,0 +1,222 @@
+---
+source: core/src/hir/type_context.rs
+expression: tcx
+---
+TypeContext {
+    out_structs: [],
+    structs: [],
+    opaques: [
+        OpaqueDef {
+            docs: Docs {
+                lines: "",
+                rust_links: [],
+            },
+            name: "Opaque",
+            methods: [
+                Method {
+                    docs: Docs {
+                        lines: "",
+                        rust_links: [],
+                    },
+                    name: "used_in_option",
+                    abi_name: "Opaque_used_in_option",
+                    lifetime_env: LifetimeEnv {
+                        nodes: [],
+                        num_lifetimes: 1,
+                    },
+                    param_self: None,
+                    params: [
+                        Param {
+                            name: "u",
+                            ty: Opaque(
+                                OpaquePath {
+                                    lifetimes: Lifetimes {
+                                        indices: [],
+                                    },
+                                    optional: Optional(
+                                        true,
+                                    ),
+                                    owner: Borrow {
+                                        lifetime: NonStatic(
+                                            Lifetime(
+                                                0,
+                                            ),
+                                        ),
+                                        mutability: Immutable,
+                                    },
+                                    tcx_id: OpaqueId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            attrs: Attrs {
+                                disable: false,
+                                deprecated: None,
+                                namespace: None,
+                                rename: RenameAttr {
+                                    pattern: None,
+                                },
+                                abi_rename: RenameAttr {
+                                    pattern: None,
+                                },
+                                special_method: None,
+                                custom_errors: false,
+                                default: false,
+                                demo_attrs: DemoInfo {
+                                    generate: false,
+                                    default_constructor: false,
+                                    external: false,
+                                    custom_func: None,
+                                    input_cfg: DemoInputCFG {
+                                        label: "",
+                                        default_value: "",
+                                    },
+                                },
+                                generate_mocking_interface: false,
+                                abi_compatible: false,
+                                mut_struct_ref: false,
+                                tuple: false,
+                                custom_extra_code: {},
+                                default_value: None,
+                            },
+                        },
+                    ],
+                    output: Infallible(
+                        Unit,
+                    ),
+                    attrs: Attrs {
+                        disable: false,
+                        deprecated: None,
+                        namespace: None,
+                        rename: RenameAttr {
+                            pattern: None,
+                        },
+                        abi_rename: RenameAttr {
+                            pattern: None,
+                        },
+                        special_method: None,
+                        custom_errors: false,
+                        default: false,
+                        demo_attrs: DemoInfo {
+                            generate: false,
+                            default_constructor: false,
+                            external: false,
+                            custom_func: None,
+                            input_cfg: DemoInputCFG {
+                                label: "",
+                                default_value: "",
+                            },
+                        },
+                        generate_mocking_interface: false,
+                        abi_compatible: false,
+                        mut_struct_ref: false,
+                        tuple: false,
+                        custom_extra_code: {},
+                        default_value: None,
+                    },
+                },
+            ],
+            attrs: Attrs {
+                disable: false,
+                deprecated: None,
+                namespace: None,
+                rename: RenameAttr {
+                    pattern: None,
+                },
+                abi_rename: RenameAttr {
+                    pattern: None,
+                },
+                special_method: None,
+                custom_errors: false,
+                default: false,
+                demo_attrs: DemoInfo {
+                    generate: false,
+                    default_constructor: false,
+                    external: false,
+                    custom_func: None,
+                    input_cfg: DemoInputCFG {
+                        label: "",
+                        default_value: "",
+                    },
+                },
+                generate_mocking_interface: false,
+                abi_compatible: false,
+                mut_struct_ref: false,
+                tuple: false,
+                custom_extra_code: {},
+                default_value: None,
+            },
+            lifetimes: LifetimeEnv {
+                nodes: [],
+                num_lifetimes: 0,
+            },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
+                optional_comparator: false,
+                iterator: None,
+                iterable: None,
+            },
+            dtor_abi_name: "Opaque_destroy",
+            usage: TypingUseInfo {
+                sliced: false,
+                optioned: false,
+            },
+        },
+        OpaqueDef {
+            docs: Docs {
+                lines: "",
+                rust_links: [],
+            },
+            name: "UsedOpaque",
+            methods: [],
+            attrs: Attrs {
+                disable: false,
+                deprecated: None,
+                namespace: None,
+                rename: RenameAttr {
+                    pattern: None,
+                },
+                abi_rename: RenameAttr {
+                    pattern: None,
+                },
+                special_method: None,
+                custom_errors: false,
+                default: false,
+                demo_attrs: DemoInfo {
+                    generate: false,
+                    default_constructor: false,
+                    external: false,
+                    custom_func: None,
+                    input_cfg: DemoInputCFG {
+                        label: "",
+                        default_value: "",
+                    },
+                },
+                generate_mocking_interface: false,
+                abi_compatible: false,
+                mut_struct_ref: false,
+                tuple: false,
+                custom_extra_code: {},
+                default_value: None,
+            },
+            lifetimes: LifetimeEnv {
+                nodes: [],
+                num_lifetimes: 0,
+            },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
+                optional_comparator: false,
+                iterator: None,
+                iterable: None,
+            },
+            dtor_abi_name: "UsedOpaque_destroy",
+            usage: TypingUseInfo {
+                sliced: false,
+                optioned: true,
+            },
+        },
+    ],
+    enums: [],
+    traits: [],
+    functions: [],
+}

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
@@ -10,6 +10,103 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
+            name: "StructOptionUsedInReturn",
+            fields: [
+                StructField {
+                    docs: Docs {
+                        lines: "",
+                        rust_links: [],
+                    },
+                    name: "a",
+                    ty: Primitive(
+                        Int(
+                            I32,
+                        ),
+                    ),
+                    attrs: Attrs {
+                        disable: false,
+                        deprecated: None,
+                        namespace: None,
+                        rename: RenameAttr {
+                            pattern: None,
+                        },
+                        abi_rename: RenameAttr {
+                            pattern: None,
+                        },
+                        special_method: None,
+                        custom_errors: false,
+                        default: false,
+                        demo_attrs: DemoInfo {
+                            generate: false,
+                            default_constructor: false,
+                            external: false,
+                            custom_func: None,
+                            input_cfg: DemoInputCFG {
+                                label: "",
+                                default_value: "",
+                            },
+                        },
+                        generate_mocking_interface: false,
+                        abi_compatible: false,
+                        mut_struct_ref: false,
+                        tuple: false,
+                        custom_extra_code: {},
+                        default_value: None,
+                    },
+                },
+            ],
+            methods: [],
+            attrs: Attrs {
+                disable: false,
+                deprecated: None,
+                namespace: None,
+                rename: RenameAttr {
+                    pattern: None,
+                },
+                abi_rename: RenameAttr {
+                    pattern: None,
+                },
+                special_method: None,
+                custom_errors: false,
+                default: false,
+                demo_attrs: DemoInfo {
+                    generate: false,
+                    default_constructor: false,
+                    external: false,
+                    custom_func: None,
+                    input_cfg: DemoInputCFG {
+                        label: "",
+                        default_value: "",
+                    },
+                },
+                generate_mocking_interface: false,
+                abi_compatible: false,
+                mut_struct_ref: false,
+                tuple: false,
+                custom_extra_code: {},
+                default_value: None,
+            },
+            lifetimes: LifetimeEnv {
+                nodes: [],
+                num_lifetimes: 0,
+            },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
+                optional_comparator: false,
+                iterator: None,
+                iterable: None,
+            },
+            usage: TypingUseInfo {
+                sliced: false,
+                optioned: true,
+                results: [],
+            },
+        },
+        StructDef {
+            docs: Docs {
+                lines: "",
+                rust_links: [],
+            },
             name: "UsedInSlice",
             fields: [
                 StructField {
@@ -99,6 +196,7 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: true,
                 optioned: false,
+                results: [],
             },
         },
     ],
@@ -142,7 +240,7 @@ TypeContext {
                                         mutability: Immutable,
                                     },
                                     tcx_id: OpaqueId(
-                                        1,
+                                        2,
                                     ),
                                 },
                             ),
@@ -179,7 +277,22 @@ TypeContext {
                         },
                     ],
                     output: Infallible(
-                        Unit,
+                        OutType(
+                            Opaque(
+                                OpaquePath {
+                                    lifetimes: Lifetimes {
+                                        indices: [],
+                                    },
+                                    optional: Optional(
+                                        true,
+                                    ),
+                                    owner: Own,
+                                    tcx_id: OpaqueId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ),
                     ),
                     attrs: Attrs {
                         disable: false,
@@ -261,7 +374,7 @@ TypeContext {
                                             mutability: Immutable,
                                         },
                                         tcx_id: OpaqueId(
-                                            2,
+                                            3,
                                         ),
                                     },
                                 ),
@@ -318,11 +431,72 @@ TypeContext {
                                                 indices: [],
                                             },
                                             tcx_id: StructId(
-                                                0,
+                                                1,
                                             ),
                                             owner: Own,
                                         },
                                     ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    attrs: Attrs {
+                        disable: false,
+                        deprecated: None,
+                        namespace: None,
+                        rename: RenameAttr {
+                            pattern: None,
+                        },
+                        abi_rename: RenameAttr {
+                            pattern: None,
+                        },
+                        special_method: None,
+                        custom_errors: false,
+                        default: false,
+                        demo_attrs: DemoInfo {
+                            generate: false,
+                            default_constructor: false,
+                            external: false,
+                            custom_func: None,
+                            input_cfg: DemoInputCFG {
+                                label: "",
+                                default_value: "",
+                            },
+                        },
+                        generate_mocking_interface: false,
+                        abi_compatible: false,
+                        mut_struct_ref: false,
+                        tuple: false,
+                        custom_extra_code: {},
+                        default_value: None,
+                    },
+                },
+                Method {
+                    docs: Docs {
+                        lines: "",
+                        rust_links: [],
+                    },
+                    name: "struct_option_ret",
+                    abi_name: "Opaque_struct_option_ret",
+                    lifetime_env: LifetimeEnv {
+                        nodes: [],
+                        num_lifetimes: 0,
+                    },
+                    param_self: None,
+                    params: [],
+                    output: Nullable(
+                        OutType(
+                            Struct(
+                                Struct(
+                                    StructPath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        tcx_id: StructId(
+                                            0,
+                                        ),
+                                        owner: Own,
+                                    },
                                 ),
                             ),
                         ),
@@ -403,6 +577,61 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: false,
                 optioned: false,
+                results: [],
+            },
+        },
+        OpaqueDef {
+            docs: Docs {
+                lines: "",
+                rust_links: [],
+            },
+            name: "OptionUsedInReturnOpaque",
+            methods: [],
+            attrs: Attrs {
+                disable: false,
+                deprecated: None,
+                namespace: None,
+                rename: RenameAttr {
+                    pattern: None,
+                },
+                abi_rename: RenameAttr {
+                    pattern: None,
+                },
+                special_method: None,
+                custom_errors: false,
+                default: false,
+                demo_attrs: DemoInfo {
+                    generate: false,
+                    default_constructor: false,
+                    external: false,
+                    custom_func: None,
+                    input_cfg: DemoInputCFG {
+                        label: "",
+                        default_value: "",
+                    },
+                },
+                generate_mocking_interface: false,
+                abi_compatible: false,
+                mut_struct_ref: false,
+                tuple: false,
+                custom_extra_code: {},
+                default_value: None,
+            },
+            lifetimes: LifetimeEnv {
+                nodes: [],
+                num_lifetimes: 0,
+            },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
+                optional_comparator: false,
+                iterator: None,
+                iterable: None,
+            },
+            dtor_abi_name: "OptionUsedInReturnOpaque_destroy",
+            usage: TypingUseInfo {
+                sliced: false,
+                optioned: true,
+                results: [],
             },
         },
         OpaqueDef {
@@ -456,6 +685,7 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: false,
                 optioned: true,
+                results: [],
             },
         },
         OpaqueDef {
@@ -509,6 +739,7 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: true,
                 optioned: false,
+                results: [],
             },
         },
     ],

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
@@ -196,7 +196,109 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: true,
                 optioned: false,
-                results: [],
+                results: [
+                    Output(
+                        ResultUsageInfo {
+                            ok: OutType(
+                                Struct(
+                                    Struct(
+                                        StructPath {
+                                            lifetimes: Lifetimes {
+                                                indices: [],
+                                            },
+                                            tcx_id: StructId(
+                                                1,
+                                            ),
+                                            owner: Own,
+                                        },
+                                    ),
+                                ),
+                            ),
+                            err: Some(
+                                Primitive(
+                                    Int(
+                                        I32,
+                                    ),
+                                ),
+                            ),
+                        },
+                    ),
+                    Output(
+                        ResultUsageInfo {
+                            ok: OutType(
+                                Opaque(
+                                    OpaquePath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        optional: Optional(
+                                            false,
+                                        ),
+                                        owner: Own,
+                                        tcx_id: OpaqueId(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ),
+                            err: Some(
+                                Struct(
+                                    Struct(
+                                        StructPath {
+                                            lifetimes: Lifetimes {
+                                                indices: [],
+                                            },
+                                            tcx_id: StructId(
+                                                1,
+                                            ),
+                                            owner: Own,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        },
+                    ),
+                    Input(
+                        ResultUsageInfo {
+                            ok: OutType(
+                                Opaque(
+                                    OpaquePath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        optional: Optional(
+                                            false,
+                                        ),
+                                        owner: Borrow {
+                                            lifetime: NonStatic(
+                                                Lifetime(
+                                                    0,
+                                                ),
+                                            ),
+                                            mutability: Immutable,
+                                        },
+                                        tcx_id: OpaqueId(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ),
+                            err: Some(
+                                Struct(
+                                    StructPath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        tcx_id: StructId(
+                                            1,
+                                        ),
+                                        owner: Own,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ],
             },
         },
     ],
@@ -532,6 +634,279 @@ TypeContext {
                         default_value: None,
                     },
                 },
+                Method {
+                    docs: Docs {
+                        lines: "",
+                        rust_links: [],
+                    },
+                    name: "struct_result_ret",
+                    abi_name: "Opaque_struct_result_ret",
+                    lifetime_env: LifetimeEnv {
+                        nodes: [],
+                        num_lifetimes: 0,
+                    },
+                    param_self: None,
+                    params: [],
+                    output: Fallible(
+                        OutType(
+                            Struct(
+                                Struct(
+                                    StructPath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        tcx_id: StructId(
+                                            1,
+                                        ),
+                                        owner: Own,
+                                    },
+                                ),
+                            ),
+                        ),
+                        Some(
+                            Primitive(
+                                Int(
+                                    I32,
+                                ),
+                            ),
+                        ),
+                    ),
+                    attrs: Attrs {
+                        disable: false,
+                        deprecated: None,
+                        namespace: None,
+                        rename: RenameAttr {
+                            pattern: None,
+                        },
+                        abi_rename: RenameAttr {
+                            pattern: None,
+                        },
+                        special_method: None,
+                        custom_errors: false,
+                        default: false,
+                        demo_attrs: DemoInfo {
+                            generate: false,
+                            default_constructor: false,
+                            external: false,
+                            custom_func: None,
+                            input_cfg: DemoInputCFG {
+                                label: "",
+                                default_value: "",
+                            },
+                        },
+                        generate_mocking_interface: false,
+                        abi_compatible: false,
+                        mut_struct_ref: false,
+                        tuple: false,
+                        custom_extra_code: {},
+                        default_value: None,
+                    },
+                },
+                Method {
+                    docs: Docs {
+                        lines: "",
+                        rust_links: [],
+                    },
+                    name: "option_result_ret",
+                    abi_name: "Opaque_option_result_ret",
+                    lifetime_env: LifetimeEnv {
+                        nodes: [],
+                        num_lifetimes: 0,
+                    },
+                    param_self: None,
+                    params: [],
+                    output: Fallible(
+                        OutType(
+                            Opaque(
+                                OpaquePath {
+                                    lifetimes: Lifetimes {
+                                        indices: [],
+                                    },
+                                    optional: Optional(
+                                        false,
+                                    ),
+                                    owner: Own,
+                                    tcx_id: OpaqueId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ),
+                        Some(
+                            Struct(
+                                Struct(
+                                    StructPath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        tcx_id: StructId(
+                                            1,
+                                        ),
+                                        owner: Own,
+                                    },
+                                ),
+                            ),
+                        ),
+                    ),
+                    attrs: Attrs {
+                        disable: false,
+                        deprecated: None,
+                        namespace: None,
+                        rename: RenameAttr {
+                            pattern: None,
+                        },
+                        abi_rename: RenameAttr {
+                            pattern: None,
+                        },
+                        special_method: None,
+                        custom_errors: false,
+                        default: false,
+                        demo_attrs: DemoInfo {
+                            generate: false,
+                            default_constructor: false,
+                            external: false,
+                            custom_func: None,
+                            input_cfg: DemoInputCFG {
+                                label: "",
+                                default_value: "",
+                            },
+                        },
+                        generate_mocking_interface: false,
+                        abi_compatible: false,
+                        mut_struct_ref: false,
+                        tuple: false,
+                        custom_extra_code: {},
+                        default_value: None,
+                    },
+                },
+                Method {
+                    docs: Docs {
+                        lines: "",
+                        rust_links: [],
+                    },
+                    name: "callback_result",
+                    abi_name: "Opaque_callback_result",
+                    lifetime_env: LifetimeEnv {
+                        nodes: [],
+                        num_lifetimes: 1,
+                    },
+                    param_self: None,
+                    params: [
+                        Param {
+                            name: "f",
+                            ty: Callback(
+                                Callback {
+                                    param_self: None,
+                                    params: [],
+                                    output: Fallible(
+                                        OutType(
+                                            Opaque(
+                                                OpaquePath {
+                                                    lifetimes: Lifetimes {
+                                                        indices: [],
+                                                    },
+                                                    optional: Optional(
+                                                        false,
+                                                    ),
+                                                    owner: Borrow {
+                                                        lifetime: NonStatic(
+                                                            Lifetime(
+                                                                0,
+                                                            ),
+                                                        ),
+                                                        mutability: Immutable,
+                                                    },
+                                                    tcx_id: OpaqueId(
+                                                        2,
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        Some(
+                                            Struct(
+                                                StructPath {
+                                                    lifetimes: Lifetimes {
+                                                        indices: [],
+                                                    },
+                                                    tcx_id: StructId(
+                                                        1,
+                                                    ),
+                                                    owner: Own,
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                    name: None,
+                                    attrs: None,
+                                    docs: None,
+                                },
+                            ),
+                            attrs: Attrs {
+                                disable: false,
+                                deprecated: None,
+                                namespace: None,
+                                rename: RenameAttr {
+                                    pattern: None,
+                                },
+                                abi_rename: RenameAttr {
+                                    pattern: None,
+                                },
+                                special_method: None,
+                                custom_errors: false,
+                                default: false,
+                                demo_attrs: DemoInfo {
+                                    generate: false,
+                                    default_constructor: false,
+                                    external: false,
+                                    custom_func: None,
+                                    input_cfg: DemoInputCFG {
+                                        label: "",
+                                        default_value: "",
+                                    },
+                                },
+                                generate_mocking_interface: false,
+                                abi_compatible: false,
+                                mut_struct_ref: false,
+                                tuple: false,
+                                custom_extra_code: {},
+                                default_value: None,
+                            },
+                        },
+                    ],
+                    output: Infallible(
+                        Unit,
+                    ),
+                    attrs: Attrs {
+                        disable: false,
+                        deprecated: None,
+                        namespace: None,
+                        rename: RenameAttr {
+                            pattern: None,
+                        },
+                        abi_rename: RenameAttr {
+                            pattern: None,
+                        },
+                        special_method: None,
+                        custom_errors: false,
+                        default: false,
+                        demo_attrs: DemoInfo {
+                            generate: false,
+                            default_constructor: false,
+                            external: false,
+                            custom_func: None,
+                            input_cfg: DemoInputCFG {
+                                label: "",
+                                default_value: "",
+                            },
+                        },
+                        generate_mocking_interface: false,
+                        abi_compatible: false,
+                        mut_struct_ref: false,
+                        tuple: false,
+                        custom_extra_code: {},
+                        default_value: None,
+                    },
+                },
             ],
             attrs: Attrs {
                 disable: false,
@@ -685,7 +1060,83 @@ TypeContext {
             usage: TypingUseInfo {
                 sliced: false,
                 optioned: true,
-                results: [],
+                results: [
+                    Output(
+                        ResultUsageInfo {
+                            ok: OutType(
+                                Opaque(
+                                    OpaquePath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        optional: Optional(
+                                            false,
+                                        ),
+                                        owner: Own,
+                                        tcx_id: OpaqueId(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ),
+                            err: Some(
+                                Struct(
+                                    Struct(
+                                        StructPath {
+                                            lifetimes: Lifetimes {
+                                                indices: [],
+                                            },
+                                            tcx_id: StructId(
+                                                1,
+                                            ),
+                                            owner: Own,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        },
+                    ),
+                    Input(
+                        ResultUsageInfo {
+                            ok: OutType(
+                                Opaque(
+                                    OpaquePath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        optional: Optional(
+                                            false,
+                                        ),
+                                        owner: Borrow {
+                                            lifetime: NonStatic(
+                                                Lifetime(
+                                                    0,
+                                                ),
+                                            ),
+                                            mutability: Immutable,
+                                        },
+                                        tcx_id: OpaqueId(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ),
+                            err: Some(
+                                Struct(
+                                    StructPath {
+                                        lifetimes: Lifetimes {
+                                            indices: [],
+                                        },
+                                        tcx_id: StructId(
+                                            1,
+                                        ),
+                                        owner: Own,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ],
             },
         },
         OpaqueDef {

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
@@ -4,7 +4,104 @@ expression: tcx
 ---
 TypeContext {
     out_structs: [],
-    structs: [],
+    structs: [
+        StructDef {
+            docs: Docs {
+                lines: "",
+                rust_links: [],
+            },
+            name: "UsedInSlice",
+            fields: [
+                StructField {
+                    docs: Docs {
+                        lines: "",
+                        rust_links: [],
+                    },
+                    name: "a",
+                    ty: Primitive(
+                        Int(
+                            I32,
+                        ),
+                    ),
+                    attrs: Attrs {
+                        disable: false,
+                        deprecated: None,
+                        namespace: None,
+                        rename: RenameAttr {
+                            pattern: None,
+                        },
+                        abi_rename: RenameAttr {
+                            pattern: None,
+                        },
+                        special_method: None,
+                        custom_errors: false,
+                        default: false,
+                        demo_attrs: DemoInfo {
+                            generate: false,
+                            default_constructor: false,
+                            external: false,
+                            custom_func: None,
+                            input_cfg: DemoInputCFG {
+                                label: "",
+                                default_value: "",
+                            },
+                        },
+                        generate_mocking_interface: false,
+                        abi_compatible: false,
+                        mut_struct_ref: false,
+                        tuple: false,
+                        custom_extra_code: {},
+                        default_value: None,
+                    },
+                },
+            ],
+            methods: [],
+            attrs: Attrs {
+                disable: false,
+                deprecated: None,
+                namespace: None,
+                rename: RenameAttr {
+                    pattern: None,
+                },
+                abi_rename: RenameAttr {
+                    pattern: None,
+                },
+                special_method: None,
+                custom_errors: false,
+                default: false,
+                demo_attrs: DemoInfo {
+                    generate: false,
+                    default_constructor: false,
+                    external: false,
+                    custom_func: None,
+                    input_cfg: DemoInputCFG {
+                        label: "",
+                        default_value: "",
+                    },
+                },
+                generate_mocking_interface: false,
+                abi_compatible: false,
+                mut_struct_ref: false,
+                tuple: false,
+                custom_extra_code: {},
+                default_value: None,
+            },
+            lifetimes: LifetimeEnv {
+                nodes: [],
+                num_lifetimes: 0,
+            },
+            special_method_presence: SpecialMethodPresence {
+                comparator: false,
+                optional_comparator: false,
+                iterator: None,
+                iterable: None,
+            },
+            usage: TypingUseInfo {
+                sliced: true,
+                optioned: false,
+            },
+        },
+    ],
     opaques: [
         OpaqueDef {
             docs: Docs {
@@ -115,6 +212,85 @@ TypeContext {
                         default_value: None,
                     },
                 },
+                Method {
+                    docs: Docs {
+                        lines: "",
+                        rust_links: [],
+                    },
+                    name: "used_in_slice",
+                    abi_name: "Opaque_used_in_slice",
+                    lifetime_env: LifetimeEnv {
+                        nodes: [
+                            BoundedLifetime {
+                                ident: "a",
+                                longer: [],
+                                shorter: [],
+                            },
+                        ],
+                        num_lifetimes: 1,
+                    },
+                    param_self: None,
+                    params: [],
+                    output: Infallible(
+                        OutType(
+                            Slice(
+                                Struct(
+                                    Borrow(
+                                        Borrow {
+                                            lifetime: NonStatic(
+                                                Lifetime(
+                                                    0,
+                                                ),
+                                            ),
+                                            mutability: Immutable,
+                                        },
+                                    ),
+                                    Struct(
+                                        StructPath {
+                                            lifetimes: Lifetimes {
+                                                indices: [],
+                                            },
+                                            tcx_id: StructId(
+                                                0,
+                                            ),
+                                            owner: Own,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    attrs: Attrs {
+                        disable: false,
+                        deprecated: None,
+                        namespace: None,
+                        rename: RenameAttr {
+                            pattern: None,
+                        },
+                        abi_rename: RenameAttr {
+                            pattern: None,
+                        },
+                        special_method: None,
+                        custom_errors: false,
+                        default: false,
+                        demo_attrs: DemoInfo {
+                            generate: false,
+                            default_constructor: false,
+                            external: false,
+                            custom_func: None,
+                            input_cfg: DemoInputCFG {
+                                label: "",
+                                default_value: "",
+                            },
+                        },
+                        generate_mocking_interface: false,
+                        abi_compatible: false,
+                        mut_struct_ref: false,
+                        tuple: false,
+                        custom_extra_code: {},
+                        default_value: None,
+                    },
+                },
             ],
             attrs: Attrs {
                 disable: false,
@@ -167,7 +343,7 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "UsedOpaque",
+            name: "UsedInOptionOpaque",
             methods: [],
             attrs: Attrs {
                 disable: false,
@@ -209,7 +385,7 @@ TypeContext {
                 iterator: None,
                 iterable: None,
             },
-            dtor_abi_name: "UsedOpaque_destroy",
+            dtor_abi_name: "UsedInOptionOpaque_destroy",
             usage: TypingUseInfo {
                 sliced: false,
                 optioned: true,

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1722,11 +1722,18 @@ mod tests {
                 pub struct Opaque(i32);
 
                 impl Opaque {
-                    pub fn used_in_option(u : Option<&UsedOpaque>) {}
+                    pub fn used_in_option(u : Option<&UsedInOptionOpaque>) {}
+                    
+                    pub fn used_in_slice<'a>() -> &'a [UsedInSlice] {}
                 }
 
                 #[diplomat::opaque]
-                pub struct UsedOpaque(i32);
+                pub struct UsedInOptionOpaque(i32);
+
+                pub struct UsedInSlice {
+                    a : i32
+                }
+
             }
 
         }, true, None, &crate::ast::SpanLocation::None);

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1722,9 +1722,11 @@ mod tests {
                 pub struct Opaque(i32);
 
                 impl Opaque {
-                    pub fn used_in_option(u : Option<&UsedInOptionOpaque>) {}
+                    pub fn used_in_option(u : Option<&UsedInOptionOpaque>) -> Option<Box<OptionUsedInReturnOpaque>> {}
                     
                     pub fn used_in_slice<'a>(op: &'a [&'a UsedInSliceOpaque]) -> &'a [UsedInSlice] {}
+                    
+                    pub fn struct_option_ret() -> Option<StructOptionUsedInReturn> {}
                 }
 
                 #[diplomat::opaque]
@@ -1735,6 +1737,13 @@ mod tests {
 
                 pub struct UsedInSlice {
                     a : i32
+                }
+
+                #[diplomat::opaque]
+                pub struct OptionUsedInReturnOpaque(i32);
+
+                pub struct StructOptionUsedInReturn {
+                    a: i32
                 }
 
             }

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1724,11 +1724,14 @@ mod tests {
                 impl Opaque {
                     pub fn used_in_option(u : Option<&UsedInOptionOpaque>) {}
                     
-                    pub fn used_in_slice<'a>() -> &'a [UsedInSlice] {}
+                    pub fn used_in_slice<'a>(op: &'a [&'a UsedInSliceOpaque]) -> &'a [UsedInSlice] {}
                 }
 
                 #[diplomat::opaque]
                 pub struct UsedInOptionOpaque(i32);
+
+                #[diplomat::opaque]
+                pub struct UsedInSliceOpaque(i32);
 
                 pub struct UsedInSlice {
                     a : i32
@@ -1747,6 +1750,7 @@ mod tests {
 
         let mut backend = crate::hir::BasicAttributeValidator::new("test-backend");
         backend.support.static_slices = true;
+        backend.support.opaque_slices = true;
 
         let (_, tcx) = crate::hir::TypeContext::from_ast_without_validation(&env, Default::default(), backend).unwrap();
 

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -348,13 +348,45 @@ impl TypeContext {
         let functions = ctx.lower_all_functions(ast_functions.into_iter());
 
         match (out_structs, structs, opaques, enums, functions, traits) {
-            (Ok(mut out_structs), Ok(mut structs), Ok(mut opaques), Ok(mut enums), Ok(functions), Ok(mut traits)) => {
+            (
+                Ok(mut out_structs),
+                Ok(mut structs),
+                Ok(mut opaques),
+                Ok(mut enums),
+                Ok(functions),
+                Ok(mut traits),
+            ) => {
                 // After lowering, now we update with usage information (and proper indexing into the HashMap):
-                ctx.update_usage(out_structs.iter_mut().enumerate().map(|s| (OutStructId(s.0).into(), s.1)));
-                ctx.update_usage(structs.iter_mut().enumerate().map(|s| (StructId(s.0).into(), s.1)));
-                ctx.update_usage(opaques.iter_mut().enumerate().map(|s| (OpaqueId(s.0).into(), s.1)));
-                ctx.update_usage(enums.iter_mut().enumerate().map(|s| (EnumId(s.0).into(), s.1)));
-                ctx.update_usage(traits.iter_mut().enumerate().map(|s| (TraitId(s.0).into(), s.1)));
+                ctx.update_usage(
+                    out_structs
+                        .iter_mut()
+                        .enumerate()
+                        .map(|s| (OutStructId(s.0).into(), s.1)),
+                );
+                ctx.update_usage(
+                    structs
+                        .iter_mut()
+                        .enumerate()
+                        .map(|s| (StructId(s.0).into(), s.1)),
+                );
+                ctx.update_usage(
+                    opaques
+                        .iter_mut()
+                        .enumerate()
+                        .map(|s| (OpaqueId(s.0).into(), s.1)),
+                );
+                ctx.update_usage(
+                    enums
+                        .iter_mut()
+                        .enumerate()
+                        .map(|s| (EnumId(s.0).into(), s.1)),
+                );
+                ctx.update_usage(
+                    traits
+                        .iter_mut()
+                        .enumerate()
+                        .map(|s| (TraitId(s.0).into(), s.1)),
+                );
 
                 let res = Self {
                     out_structs,
@@ -1715,51 +1747,59 @@ mod tests {
 
     #[test]
     fn test_usage() {
-        let m = crate::ast::Module::from_syn(&syn::parse_quote! { 
-            #[diplomat::bridge]
-            mod ffi {
-                #[diplomat::opaque]
-                pub struct Opaque(i32);
+        let m = crate::ast::Module::from_syn(
+            &syn::parse_quote! {
+                #[diplomat::bridge]
+                mod ffi {
+                    #[diplomat::opaque]
+                    pub struct Opaque(i32);
 
-                impl Opaque {
-                    pub fn used_in_option(u : Option<&UsedInOptionOpaque>) -> Option<Box<OptionUsedInReturnOpaque>> {}
-                    
-                    pub fn used_in_slice<'a>(op: &'a [&'a UsedInSliceOpaque]) -> &'a [UsedInSlice] {}
-                    
-                    pub fn struct_option_ret() -> Option<StructOptionUsedInReturn> {}
+                    impl Opaque {
+                        pub fn used_in_option(u : Option<&UsedInOptionOpaque>) -> Option<Box<OptionUsedInReturnOpaque>> {}
 
-                    pub fn struct_result_ret() -> Result<UsedInSlice, i32> {}
+                        pub fn used_in_slice<'a>(op: &'a [&'a UsedInSliceOpaque]) -> &'a [UsedInSlice] {}
 
-                    pub fn option_result_ret() -> Result<Box<UsedInOptionOpaque>, UsedInSlice> {}
+                        pub fn struct_option_ret() -> Option<StructOptionUsedInReturn> {}
 
-                    pub fn callback_result(f : impl Fn() -> Result<&UsedInOptionOpaque, UsedInSlice>) {}
+                        pub fn struct_result_ret() -> Result<UsedInSlice, i32> {}
+
+                        pub fn option_result_ret() -> Result<Box<UsedInOptionOpaque>, UsedInSlice> {}
+
+                        pub fn callback_result(f : impl Fn() -> Result<&UsedInOptionOpaque, UsedInSlice>) {}
+                    }
+
+                    #[diplomat::opaque]
+                    pub struct UsedInOptionOpaque(i32);
+
+                    #[diplomat::opaque]
+                    pub struct UsedInSliceOpaque(i32);
+
+                    pub struct UsedInSlice {
+                        a : i32
+                    }
+
+                    #[diplomat::opaque]
+                    pub struct OptionUsedInReturnOpaque(i32);
+
+                    pub struct StructOptionUsedInReturn {
+                        a: i32
+                    }
+
                 }
 
-                #[diplomat::opaque]
-                pub struct UsedInOptionOpaque(i32);
-
-                #[diplomat::opaque]
-                pub struct UsedInSliceOpaque(i32);
-
-                pub struct UsedInSlice {
-                    a : i32
-                }
-
-                #[diplomat::opaque]
-                pub struct OptionUsedInReturnOpaque(i32);
-
-                pub struct StructOptionUsedInReturn {
-                    a: i32
-                }
-
-            }
-
-        }, true, None, &crate::ast::SpanLocation::None);
+            },
+            true,
+            None,
+            &crate::ast::SpanLocation::None,
+        );
         let mut env = crate::Env::default();
         let mut top_symbols = crate::ModuleEnv::new(Default::default());
 
         m.insert_all_types(crate::ast::Path::empty(), &mut env);
-        top_symbols.insert(m.name.clone(), crate::ast::ModSymbol::SubModule(m.name.clone()));
+        top_symbols.insert(
+            m.name.clone(),
+            crate::ast::ModSymbol::SubModule(m.name.clone()),
+        );
 
         env.insert(crate::ast::Path::empty(), top_symbols);
 
@@ -1768,7 +1808,9 @@ mod tests {
         backend.support.callbacks = true;
         backend.support.opaque_slices = true;
 
-        let (_, tcx) = crate::hir::TypeContext::from_ast_without_validation(&env, Default::default(), backend).unwrap();
+        let (_, tcx) =
+            crate::hir::TypeContext::from_ast_without_validation(&env, Default::default(), backend)
+                .unwrap();
 
         insta::assert_debug_snapshot!(tcx);
     }

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -83,61 +83,6 @@ enum Param<'a> {
     Return,
 }
 
-pub(super) trait TypeUsage {
-    fn set_usage(&mut self, usage : super::TypingUseInfo);
-    fn id_from_idx(idx : usize) -> super::SymbolId;
-}
-
-impl TypeUsage for StructDef<super::Everywhere> {
-    fn set_usage(&mut self, usage : super::TypingUseInfo) {
-        self.usage = usage;
-    }
-
-    fn id_from_idx(idx : usize) -> super::SymbolId {
-        StructId(idx).into()
-    }
-}
-
-impl TypeUsage for StructDef<super::OutputOnly> {
-    fn set_usage(&mut self, usage : super::TypingUseInfo) {
-        self.usage = usage;
-    }
-
-    fn id_from_idx(idx : usize) -> super::SymbolId {
-        OutStructId(idx).into()
-    }
-}
-
-impl TypeUsage for OpaqueDef {
-    fn set_usage(&mut self, usage : super::TypingUseInfo) {
-        self.usage = usage;
-    }
-
-    fn id_from_idx(idx : usize) -> super::SymbolId {
-        OpaqueId(idx).into()
-    }
-}
-
-impl TypeUsage for EnumDef {
-    fn set_usage(&mut self, usage : hir::TypingUseInfo) {
-        self.usage = usage;
-    }
-
-    fn id_from_idx(idx : usize) -> hir::SymbolId {
-        EnumId(idx).into()
-    }
-}
-
-impl TypeUsage for TraitDef {
-    fn set_usage(&mut self, usage : hir::TypingUseInfo) {
-        self.usage = usage;
-    }
-
-    fn id_from_idx(idx : usize) -> hir::SymbolId {
-        TraitId(idx).into()
-    }
-}
-
 impl Display for Param<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Param::Input(s) = *self {
@@ -404,12 +349,12 @@ impl TypeContext {
 
         match (out_structs, structs, opaques, enums, functions, traits) {
             (Ok(mut out_structs), Ok(mut structs), Ok(mut opaques), Ok(mut enums), Ok(functions), Ok(mut traits)) => {
-                // After lowering, now we update with usage information:
-                ctx.update_usage(&mut out_structs);
-                ctx.update_usage(&mut structs);
-                ctx.update_usage(&mut opaques);
-                ctx.update_usage(&mut enums);
-                ctx.update_usage(&mut traits);
+                // After lowering, now we update with usage information (and proper indexing into the HashMap):
+                ctx.update_usage(out_structs.iter_mut().enumerate().map(|s| (OutStructId(s.0).into(), s.1)));
+                ctx.update_usage(structs.iter_mut().enumerate().map(|s| (StructId(s.0).into(), s.1)));
+                ctx.update_usage(opaques.iter_mut().enumerate().map(|s| (OpaqueId(s.0).into(), s.1)));
+                ctx.update_usage(enums.iter_mut().enumerate().map(|s| (EnumId(s.0).into(), s.1)));
+                ctx.update_usage(traits.iter_mut().enumerate().map(|s| (TraitId(s.0).into(), s.1)));
 
                 let res = Self {
                     out_structs,

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -83,6 +83,61 @@ enum Param<'a> {
     Return,
 }
 
+pub(super) trait TypeUsage {
+    fn set_usage(&mut self, usage : super::TypingUseInfo);
+    fn id_from_idx(idx : usize) -> super::SymbolId;
+}
+
+impl TypeUsage for StructDef<super::Everywhere> {
+    fn set_usage(&mut self, usage : super::TypingUseInfo) {
+        self.usage = usage;
+    }
+
+    fn id_from_idx(idx : usize) -> super::SymbolId {
+        StructId(idx).into()
+    }
+}
+
+impl TypeUsage for StructDef<super::OutputOnly> {
+    fn set_usage(&mut self, usage : super::TypingUseInfo) {
+        self.usage = usage;
+    }
+
+    fn id_from_idx(idx : usize) -> super::SymbolId {
+        OutStructId(idx).into()
+    }
+}
+
+impl TypeUsage for OpaqueDef {
+    fn set_usage(&mut self, usage : super::TypingUseInfo) {
+        self.usage = usage;
+    }
+
+    fn id_from_idx(idx : usize) -> super::SymbolId {
+        OpaqueId(idx).into()
+    }
+}
+
+impl TypeUsage for EnumDef {
+    fn set_usage(&mut self, usage : hir::TypingUseInfo) {
+        self.usage = usage;
+    }
+
+    fn id_from_idx(idx : usize) -> hir::SymbolId {
+        EnumId(idx).into()
+    }
+}
+
+impl TypeUsage for TraitDef {
+    fn set_usage(&mut self, usage : hir::TypingUseInfo) {
+        self.usage = usage;
+    }
+
+    fn id_from_idx(idx : usize) -> hir::SymbolId {
+        TraitId(idx).into()
+    }
+}
+
 impl Display for Param<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Param::Input(s) = *self {
@@ -337,6 +392,7 @@ impl TypeContext {
             errors,
             attr_validator,
             cfg,
+            type_usage: HashMap::new(),
         };
 
         let out_structs = ctx.lower_all_out_structs(ast_out_structs.into_iter());
@@ -347,7 +403,14 @@ impl TypeContext {
         let functions = ctx.lower_all_functions(ast_functions.into_iter());
 
         match (out_structs, structs, opaques, enums, functions, traits) {
-            (Ok(out_structs), Ok(structs), Ok(opaques), Ok(enums), Ok(functions), Ok(traits)) => {
+            (Ok(mut out_structs), Ok(mut structs), Ok(mut opaques), Ok(mut enums), Ok(functions), Ok(mut traits)) => {
+                // After lowering, now we update with usage information:
+                ctx.update_usage(&mut out_structs);
+                ctx.update_usage(&mut structs);
+                ctx.update_usage(&mut opaques);
+                ctx.update_usage(&mut enums);
+                ctx.update_usage(&mut traits);
+
                 let res = Self {
                     out_structs,
                     structs,

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1712,4 +1712,37 @@ mod tests {
         };
         insta::with_settings!({}, { insta::assert_snapshot!(output) });
     }
+
+    #[test]
+    fn test_usage() {
+        let m = crate::ast::Module::from_syn(&syn::parse_quote! { 
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Opaque(i32);
+
+                impl Opaque {
+                    pub fn used_in_option(u : Option<&UsedOpaque>) {}
+                }
+
+                #[diplomat::opaque]
+                pub struct UsedOpaque(i32);
+            }
+
+        }, true, None, &crate::ast::SpanLocation::None);
+        let mut env = crate::Env::default();
+        let mut top_symbols = crate::ModuleEnv::new(Default::default());
+
+        m.insert_all_types(crate::ast::Path::empty(), &mut env);
+        top_symbols.insert(m.name.clone(), crate::ast::ModSymbol::SubModule(m.name.clone()));
+
+        env.insert(crate::ast::Path::empty(), top_symbols);
+
+        let mut backend = crate::hir::BasicAttributeValidator::new("test-backend");
+        backend.support.static_slices = true;
+
+        let (_, tcx) = crate::hir::TypeContext::from_ast_without_validation(&env, Default::default(), backend).unwrap();
+
+        insta::assert_debug_snapshot!(tcx);
+    }
 }

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1727,6 +1727,12 @@ mod tests {
                     pub fn used_in_slice<'a>(op: &'a [&'a UsedInSliceOpaque]) -> &'a [UsedInSlice] {}
                     
                     pub fn struct_option_ret() -> Option<StructOptionUsedInReturn> {}
+
+                    pub fn struct_result_ret() -> Result<UsedInSlice, i32> {}
+
+                    pub fn option_result_ret() -> Result<Box<UsedInOptionOpaque>, UsedInSlice> {}
+
+                    pub fn callback_result(f : impl Fn() -> Result<&UsedInOptionOpaque, UsedInSlice>) {}
                 }
 
                 #[diplomat::opaque]
@@ -1759,6 +1765,7 @@ mod tests {
 
         let mut backend = crate::hir::BasicAttributeValidator::new("test-backend");
         backend.support.static_slices = true;
+        backend.support.callbacks = true;
         backend.support.opaque_slices = true;
 
         let (_, tcx) = crate::hir::TypeContext::from_ast_without_validation(&env, Default::default(), backend).unwrap();


### PR DESCRIPTION
Part of the solution discussed in https://github.com/rust-diplomat/diplomat/issues/1166#issuecomment-4654211517

Once this gets approval, I'll add an implementation for selectively including slice structs based on the presence of slices which use that type.

