### PR TITLE
AST Errors Pass Three

### DIFF
--- a/core/src/ast/functions.rs
+++ b/core/src/ast/functions.rs
@@ -32,7 +32,7 @@ impl Function {
         if let Some(recv) = f.sig.receiver() {
             create_report(AstReport::new(
                 "Cannot use self parameter in free function.".into(),
-                f.sig.ident.span().spanned_into(module_location),
+                Some(f.sig.ident.span().spanned_into(module_location)),
                 "".into(),
                 vec![ContextLocation::new(
                     recv.self_token.span.spanned_into(module_location),

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -151,6 +151,8 @@ impl LifetimeEnv {
                 this.extend_implicit_lifetime_bounds(return_type, None);
             }
         } else {
+            // Currently this is impossible to reach,
+            // we only call from_trait_item when trait_fct_item is syn::TraitItem::Fn
             panic!(
                 "Diplomat traits can only have associated methods and no other associated items."
             )

--- a/core/src/ast/lifetimes.rs
+++ b/core/src/ast/lifetimes.rs
@@ -164,7 +164,7 @@ impl LifetimeEnv {
         if let Some(lt) = trt.generics.lifetimes().next() {
             create_report(AstReport::new(
                 "Diplomat traits are not allowed to have any lifetime parameters.".into(),
-                trt.ident.span().spanned_into(module_location),
+                Some(trt.ident.span().spanned_into(module_location)),
                 "".into(),
                 vec![ContextLocation::new(
                     lt.span().spanned_into(module_location),
@@ -274,7 +274,7 @@ impl LifetimeEnv {
             syn::GenericParam::Type(_) => {
                 create_report(AstReport::new(
                     "Generic types are unsupported.".into(),
-                    generic.span().spanned_into(module_location),
+                    Some(generic.span().spanned_into(module_location)),
                     "Suggestion: Remove generic type.".into(),
                     vec![],
                 ));
@@ -283,7 +283,7 @@ impl LifetimeEnv {
             syn::GenericParam::Const(_) => {
                 create_report(AstReport::new(
                     "Const generics are unsupported.".into(),
-                    generic.span().spanned_into(module_location),
+                    Some(generic.span().spanned_into(module_location)),
                     "Suggestion: Remove const generic.".into(),
                     vec![],
                 ));
@@ -299,14 +299,14 @@ impl LifetimeEnv {
             self.extend_bounds(where_clause.predicates.iter().map(|pred| match pred {
                 syn::WherePredicate::Type(_) => create_report(AstReport::new(
                     "Trait bounds are unsupported.".into(),
-                    pred.span().spanned_into(module_location),
+                    Some(pred.span().spanned_into(module_location)),
                     "Suggestion: Remove type predicate.".into(),
                     vec![],
                 )),
                 syn::WherePredicate::Lifetime(pred) => (&pred.lifetime, &pred.bounds),
                 _ => create_report(AstReport::new(
                     "Unrecognized where predicate.".into(),
-                    pred.span().spanned_into(module_location),
+                    Some(pred.span().spanned_into(module_location)),
                     "".into(),
                     vec![],
                 )),
@@ -366,7 +366,7 @@ impl LifetimeEnv {
                 let lt = NamedLifetime::spanned_from(lifetime, module_location);
                 create_report(AstReport::new(
                     "Lifetime declared twice in the same scope".into(),
-                    lt.0.span().unwrap(),
+                    lt.0.span(),
                     format!("Lifetime {lt} already exists."),
                     context_locations,
                 ));

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -33,13 +33,13 @@ pub(crate) struct AstReport {
 impl AstReport {
     pub fn new(
         title: String,
-        primary_loc: Span,
+        primary_loc: Option<Span>,
         primary_label: String,
         context_locations: Vec<ContextLocation>,
     ) -> Self {
         Self {
             title,
-            primary_loc: Some(primary_loc),
+            primary_loc,
             primary_label,
             context_locations,
         }

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -288,6 +288,7 @@ mod tests {
         "self_type.rs",
         "param_invalid_type.rs",
         "undefined_type.rs",
+        "non_opaque_tuple.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -285,6 +285,7 @@ mod tests {
         "undefined_macro.rs",
         "macro_parse_error.rs",
         "macro_expansion_error.rs",
+        "self_type.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -287,6 +287,7 @@ mod tests {
         "macro_expansion_error.rs",
         "self_type.rs",
         "param_invalid_type.rs",
+        "undefined_type.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -286,6 +286,7 @@ mod tests {
         "macro_parse_error.rs",
         "macro_expansion_error.rs",
         "self_type.rs",
+        "param_invalid_type.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/macros.rs
+++ b/core/src/ast/macros.rs
@@ -566,7 +566,7 @@ impl MacroDef {
                         } else {
                             create_report(AstReport::new(
                                 "Expected ident when expanding macro argument.".to_string(),
-                                tt.span().spanned_into(group_location),
+                                Some(tt.span().spanned_into(group_location)),
                                 "Need ident after $ to replace with variable".into(),
                                 vec![],
                             ));
@@ -574,7 +574,7 @@ impl MacroDef {
                     } else {
                         create_report(AstReport::new(
                             "Expected token tree.".to_string(),
-                            next.span().spanned_into(group_location),
+                            Some(next.span().spanned_into(group_location)),
                             "".into(),
                             vec![],
                         ));
@@ -616,7 +616,7 @@ impl MacroDef {
                         } else {
                             create_report(AstReport::new(
                                 "Expected ident when expanding macro argument.".to_string(),
-                                tt.span().spanned_into(buf_location),
+                                Some(tt.span().spanned_into(buf_location)),
                                 "Need ident after $ to replace with variable".into(),
                                 vec![],
                             ));
@@ -624,7 +624,7 @@ impl MacroDef {
                     } else {
                         create_report(AstReport::new(
                             "Expected token tree.".to_string(),
-                            next.span().spanned_into(buf_location),
+                            Some(next.span().spanned_into(buf_location)),
                             "".into(),
                             vec![],
                         ));
@@ -658,7 +658,7 @@ impl MacroDef {
         let macro_use = MacroUse::parse(self, matched).unwrap_or_else(|e| {
             create_report(AstReport::new(
                 e.to_string(),
-                e.span().spanned_into(use_location),
+                Some(e.span().spanned_into(use_location)),
                 "Error parsing macro here".into(),
                 vec![],
             ));
@@ -673,7 +673,7 @@ impl MacroDef {
             let e = maybe_list.unwrap_err();
             create_report(AstReport::new(
                 e.to_string(),
-                e.span().spanned_into(use_location),
+                Some(e.span().spanned_into(use_location)),
                 "Error expanding macro here".into(),
                 vec![],
             ));

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
-use syn::spanned::Spanned;
 use std::ops::ControlFlow;
+use syn::spanned::Spanned;
 
 use crate::ast::idents::IntoWithSpan;
+use crate::ast::logging::{create_report, AstReport};
 use crate::ast::SpanLocation;
-use crate::ast::logging::{AstReport, create_report};
 
 use super::docs::Docs;
 use super::{Attrs, Ident, Lifetime, LifetimeEnv, Mutability, PathType, TypeName};
@@ -346,9 +346,11 @@ impl Param {
             _ => {
                 create_report(AstReport::new(
                     "Unexpected param type".into(),
-                Some(t.pat.span().spanned_into(module_location)),
-                "Expected ident".into(), vec![]));
-            },
+                    Some(t.pat.span().spanned_into(module_location)),
+                    "Expected ident".into(),
+                    vec![],
+                ));
+            }
         };
 
         let attrs = Attrs::from_attrs(&t.attrs);

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -346,7 +346,7 @@ impl Param {
             _ => {
                 create_report(AstReport::new(
                     "Unexpected param type".into(),
-                t.pat.span().spanned_into(module_location),
+                Some(t.pat.span().spanned_into(module_location)),
                 "Expected ident".into(), vec![]));
             },
         };

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
+use syn::spanned::Spanned;
 use std::ops::ControlFlow;
 
 use crate::ast::idents::IntoWithSpan;
 use crate::ast::SpanLocation;
+use crate::ast::logging::{AstReport, create_report};
 
 use super::docs::Docs;
 use super::{Attrs, Ident, Lifetime, LifetimeEnv, Mutability, PathType, TypeName};
@@ -341,7 +343,12 @@ impl Param {
     ) -> Self {
         let ident = match t.pat.as_ref() {
             syn::Pat::Ident(ident) => ident,
-            _ => panic!("Unexpected param type"),
+            _ => {
+                create_report(AstReport::new(
+                    "Unexpected param type".into(),
+                t.pat.span().spanned_into(module_location),
+                "Expected ident".into(), vec![]));
+            },
         };
 
         let attrs = Attrs::from_attrs(&t.attrs);

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -12,7 +12,7 @@ use super::{
     OpaqueType, Path, PathType, RustLink, Struct, Trait,
 };
 use crate::ast::idents::{FromWithSpan, IntoWithSpan};
-use crate::ast::logging::{AstReport, ContextLocation, create_report, create_simple_report};
+use crate::ast::logging::{create_report, create_simple_report, AstReport};
 use crate::ast::{Function, SpanLocation};
 use crate::environment::*;
 
@@ -265,9 +265,9 @@ impl<'a> ModuleBuilder<'a> {
                             "Self type not found".into(),
                             Some(imp.self_ty.span().spanned_into(self.module_location)),
                             "Expected Path type".into(),
-                            vec![]
+                            vec![],
                         ));
-                    },
+                    }
                 };
                 let mut impl_attrs = self.impl_parent_attrs.clone();
                 impl_attrs.add_attrs(&imp.attrs);
@@ -329,20 +329,26 @@ impl<'a> ModuleBuilder<'a> {
                     return;
                 }
 
-                match self.custom_types_by_name.get_mut(self_ident)
-                                                .unwrap_or_else(|| {
-                                                    create_simple_report(self_ident.clone(), "Diplomat requires impls to be in the same module as their type".into(), format!("{self_ident} should be defined in the same module."));
-                                                }) {
-                        CustomType::Struct(strct) => {
-                            strct.methods.append(&mut new_methods);
-                        }
-                        CustomType::Opaque(strct) => {
-                            strct.methods.append(&mut new_methods);
-                        }
-                        CustomType::Enum(enm) => {
-                            enm.methods.append(&mut new_methods);
-                        }
+                match self
+                    .custom_types_by_name
+                    .get_mut(self_ident)
+                    .unwrap_or_else(|| {
+                        create_simple_report(
+                            self_ident.clone(),
+                            "Diplomat requires impls to be in the same module as their type".into(),
+                            format!("{self_ident} should be defined in the same module."),
+                        );
+                    }) {
+                    CustomType::Struct(strct) => {
+                        strct.methods.append(&mut new_methods);
                     }
+                    CustomType::Opaque(strct) => {
+                        strct.methods.append(&mut new_methods);
+                    }
+                    CustomType::Enum(enm) => {
+                        enm.methods.append(&mut new_methods);
+                    }
+                }
             }
             Item::Mod(item_mod) => {
                 self.sub_modules.push(Module::from_syn(
@@ -431,7 +437,12 @@ impl Module {
                 .insert(k.clone(), ModSymbol::CustomType(v.clone()))
                 .is_some()
             {
-                create_simple_report(k.clone(), "Two types were declared with the same name (this is currently unsupported)".into(), "Duplicate type".into());
+                create_simple_report(
+                    k.clone(),
+                    "Two types were declared with the same name (this is currently unsupported)"
+                        .into(),
+                    "Duplicate type".into(),
+                );
             }
         });
 
@@ -440,7 +451,12 @@ impl Module {
                 .insert(k.clone(), ModSymbol::Trait(v.clone()))
                 .is_some()
             {
-                create_simple_report(k.clone(), "Two traits were declared with the same name (this is currently unsupported)".into(), "Duplicate trait".into());
+                create_simple_report(
+                    k.clone(),
+                    "Two traits were declared with the same name (this is currently unsupported)"
+                        .into(),
+                    "Duplicate trait".into(),
+                );
             }
         });
 

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -12,7 +12,7 @@ use super::{
     OpaqueType, Path, PathType, RustLink, Struct, Trait,
 };
 use crate::ast::idents::{FromWithSpan, IntoWithSpan};
-use crate::ast::logging::{AstReport, create_report, create_simple_report};
+use crate::ast::logging::{AstReport, ContextLocation, create_report, create_simple_report};
 use crate::ast::{Function, SpanLocation};
 use crate::environment::*;
 
@@ -263,7 +263,7 @@ impl<'a> ModuleBuilder<'a> {
                     _ => {
                         create_report(AstReport::new(
                             "Self type not found".into(),
-                            imp.self_ty.span().spanned_into(self.module_location),
+                            Some(imp.self_ty.span().spanned_into(self.module_location)),
                             "Expected Path type".into(),
                             vec![]
                         ));
@@ -431,7 +431,7 @@ impl Module {
                 .insert(k.clone(), ModSymbol::CustomType(v.clone()))
                 .is_some()
             {
-                panic!("Two types were declared with the same name, this needs to be implemented (key: {k})");
+                create_simple_report(k.clone(), "Two types were declared with the same name (this is currently unsupported)".into(), "Duplicate type".into());
             }
         });
 
@@ -440,13 +440,13 @@ impl Module {
                 .insert(k.clone(), ModSymbol::Trait(v.clone()))
                 .is_some()
             {
-                panic!("Two traits were declared with the same name, this needs to be implemented (key: {k})");
+                create_simple_report(k.clone(), "Two traits were declared with the same name (this is currently unsupported)".into(), "Duplicate trait".into());
             }
         });
 
         self.declared_functions.iter().for_each(|(k, f)| {
             if mod_symbols.insert(k.clone(), ModSymbol::Function(f.clone())).is_some() {
-                panic!("Two functions were declared with the same name, this needs to be implemented (key: {k})")
+                create_simple_report(k.clone(), "Two functions were declared with the same name (this is currently unsupported)".into(), "Duplicate function".into());
             }
         });
 

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -4,6 +4,7 @@ use std::fmt::Write as _;
 
 use quote::ToTokens;
 use serde::Serialize;
+use syn::spanned::Spanned;
 use syn::{ImplItem, Item, ItemMod, UseTree, Visibility};
 
 use super::{
@@ -11,7 +12,7 @@ use super::{
     OpaqueType, Path, PathType, RustLink, Struct, Trait,
 };
 use crate::ast::idents::{FromWithSpan, IntoWithSpan};
-use crate::ast::logging::create_simple_report;
+use crate::ast::logging::{AstReport, create_report, create_simple_report};
 use crate::ast::{Function, SpanLocation};
 use crate::environment::*;
 
@@ -259,7 +260,14 @@ impl<'a> ModuleBuilder<'a> {
             Item::Impl(imp) if self.analyze_types && imp.trait_.is_none() => {
                 let self_path = match imp.self_ty.as_ref() {
                     syn::Type::Path(s) => PathType::spanned_from(s, self.module_location),
-                    _ => panic!("Self type not found"),
+                    _ => {
+                        create_report(AstReport::new(
+                            "Self type not found".into(),
+                            imp.self_ty.span().spanned_into(self.module_location),
+                            "Expected Path type".into(),
+                            vec![]
+                        ));
+                    },
                 };
                 let mut impl_attrs = self.impl_parent_attrs.clone();
                 impl_attrs.add_attrs(&imp.attrs);

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -330,7 +330,9 @@ impl<'a> ModuleBuilder<'a> {
                 }
 
                 match self.custom_types_by_name.get_mut(self_ident)
-                                                .unwrap_or_else(|| panic!("Diplomat currently requires impls to be in the same module as their self type ({self_ident})")) {
+                                                .unwrap_or_else(|| {
+                                                    create_simple_report(self_ident.clone(), "Diplomat requires impls to be in the same module as their type".into(), format!("{self_ident} should be defined in the same module."));
+                                                }) {
                         CustomType::Struct(strct) => {
                             strct.methods.append(&mut new_methods);
                         }

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@non_opaque_tuple.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@non_opaque_tuple.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Non-opaque tuple structs are disallowed
+In src/ast/snapshots/span_testing/non_opaque_tuple.rs:3:22:
+...uple(i32, i32...
+        ^^^
+If struct is not opaque, fields must have idents

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@param_invalid_type.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@param_invalid_type.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Unexpected param type
+In src/ast/snapshots/span_testing/param_invalid_type.rs:3:20:
+...e_fn(0 : I)...
+        ^
+Expected ident

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@self_type.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@self_type.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Self type not found
+In src/ast/snapshots/span_testing/self_type.rs:3:10:
+...impl [usize; 1] {...
+        ^^^^^^^^^^
+Expected Path type

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@undefined_type.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@undefined_type.rs_ugly.snap
@@ -1,0 +1,10 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Diplomat requires impls to be in the same module as their type
+In src/ast/snapshots/span_testing/undefined_type.rs:3:10:
+...impl Undefined {}
+}...
+        ^^^^^^^^^
+Undefined should be defined in the same module.

--- a/core/src/ast/snapshots/span_testing/non_opaque_tuple.rs
+++ b/core/src/ast/snapshots/span_testing/non_opaque_tuple.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub struct Tuple(i32, i32);
+}

--- a/core/src/ast/snapshots/span_testing/param_invalid_type.rs
+++ b/core/src/ast/snapshots/span_testing/param_invalid_type.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn some_fn(0 : I) {}
+}

--- a/core/src/ast/snapshots/span_testing/self_type.rs
+++ b/core/src/ast/snapshots/span_testing/self_type.rs
@@ -1,0 +1,6 @@
+#[diplomat::bridge]
+mod ffi {
+    impl [usize; 1] {
+
+    }
+}

--- a/core/src/ast/snapshots/span_testing/undefined_type.rs
+++ b/core/src/ast/snapshots/span_testing/undefined_type.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    impl Undefined {}
+}

--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
+use syn::spanned::Spanned;
 
 use crate::ast::idents::{IntoWithSpan, SpanLocation};
+use crate::ast::logging::{AstReport, ContextLocation, create_report};
 
 use super::docs::Docs;
 use super::{Attrs, Ident, LifetimeEnv, Method, PathType, TypeName};
@@ -31,17 +33,18 @@ impl Struct {
             .fields
             .iter()
             .map(|field| {
-                use quote::ToTokens;
                 // Non-opaque tuple structs will never be allowed
                 let name = field
                     .ident
                     .as_ref()
                     .map(|i| i.spanned_into(module_location))
                     .unwrap_or_else(|| {
-                        panic!(
-                            "non-opaque tuples structs are disallowed ({:?})",
-                            field.ty.to_token_stream().to_string()
-                        )
+                        create_report(AstReport::new(
+                            "Non-opaque tuple structs are disallowed".into(),
+                            Some(field.ty.span().spanned_into(module_location)),
+                            "If struct is not opaque, fields must have idents".into(),
+                            vec![ContextLocation::new(strct.ident.span().spanned_into(module_location), "Suggestion: mark with #[diplomat::opaque]".into())]
+                        ));
                     });
                 let type_name =
                     TypeName::from_syn(&field.ty, Some(self_path_type.clone()), module_location);

--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use syn::spanned::Spanned;
 
 use crate::ast::idents::{IntoWithSpan, SpanLocation};
-use crate::ast::logging::{AstReport, ContextLocation, create_report};
+use crate::ast::logging::{create_report, AstReport, ContextLocation};
 
 use super::docs::Docs;
 use super::{Attrs, Ident, LifetimeEnv, Method, PathType, TypeName};
@@ -43,7 +43,10 @@ impl Struct {
                             "Non-opaque tuple structs are disallowed".into(),
                             Some(field.ty.span().spanned_into(module_location)),
                             "If struct is not opaque, fields must have idents".into(),
-                            vec![ContextLocation::new(strct.ident.span().spanned_into(module_location), "Suggestion: mark with #[diplomat::opaque]".into())]
+                            vec![ContextLocation::new(
+                                strct.ident.span().spanned_into(module_location),
+                                "Suggestion: mark with #[diplomat::opaque]".into(),
+                            )],
                         ));
                     });
                 let type_name =

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -201,17 +201,33 @@ impl PathType {
                         if i == local_path.elements.len() - 1 {
                             return (cur_path, t);
                         } else {
-                            create_simple_report(elem.clone(), "Unexpected custom type found".into(), format!("Could not resolve {o}"));
+                            create_simple_report(
+                                elem.clone(),
+                                "Unexpected custom type found".into(),
+                                format!("Could not resolve {o}"),
+                            );
                         }
                     }
                     Some(ModSymbol::Trait(trt)) => {
-                        create_simple_report(elem.clone(), "Found trait, but expected a type".into(), format!("Found trait {}", trt.name));
+                        create_simple_report(
+                            elem.clone(),
+                            "Found trait, but expected a type".into(),
+                            format!("Found trait {}", trt.name),
+                        );
                     }
                     Some(ModSymbol::Function(f)) => {
-                        create_simple_report(elem.clone(), "Found function, but expected a type".into(), format!("Found function {}", f.name));
+                        create_simple_report(
+                            elem.clone(),
+                            "Found function, but expected a type".into(),
+                            format!("Found function {}", f.name),
+                        );
                     }
                     None => {
-                        create_simple_report(elem.clone(), "Could not resolve symbol".into(), format!("Could not resolve {o}"));
+                        create_simple_report(
+                            elem.clone(),
+                            "Could not resolve symbol".into(),
+                            format!("Could not resolve {o}"),
+                        );
                     }
                 },
             }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -201,24 +201,18 @@ impl PathType {
                         if i == local_path.elements.len() - 1 {
                             return (cur_path, t);
                         } else {
-                            panic!(
-                                "Unexpected custom type when resolving symbol {} in {}",
-                                o,
-                                cur_path.elements.join("::")
-                            )
+                            create_simple_report(elem.clone(), "Unexpected custom type found".into(), format!("Could not resolve {o}"));
                         }
                     }
                     Some(ModSymbol::Trait(trt)) => {
-                        panic!("Found trait {} but expected a type", trt.name);
+                        create_simple_report(elem.clone(), "Found trait, but expected a type".into(), format!("Found trait {}", trt.name));
                     }
                     Some(ModSymbol::Function(f)) => {
-                        panic!("Found function {} but expected a type", f.name);
+                        create_simple_report(elem.clone(), "Found function, but expected a type".into(), format!("Found function {}", f.name));
                     }
-                    None => panic!(
-                        "Could not resolve symbol {} in {}",
-                        o,
-                        cur_path.elements.join("::")
-                    ),
+                    None => {
+                        create_simple_report(elem.clone(), "Could not resolve symbol".into(), format!("Could not resolve {o}"));
+                    }
                 },
             }
         }


### PR DESCRIPTION
Almost resolves most of the location-based errors in the AST for #111. There's just a few more left, but this pass finally adds report info for `Could not resolve {} in {}`, which is usually not helpful.