### PR TITLE
dotnet: borrowed opaque returns via a non-owning wrapper

### DIFF
--- a/example/dotnet/Generated/RustHandle.cs
+++ b/example/dotnet/Generated/RustHandle.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Somelib.Diplomat;
+
+#nullable enable
+
+/// <summary>
+/// Frees a Rust-owned <typeparamref name="T"/> by calling its native
+/// destructor. Held by an owned <see cref="RustHandle{T}"/> so the handle can
+/// release the pointer without knowing the concrete type.
+/// </summary>
+internal unsafe delegate void RustDestructor<T>(T* ptr) where T : unmanaged;
+
+/// <summary>
+/// A raw pointer that remembers who's responsible for freeing it. An owned
+/// handle carries the Rust destructor and runs it when you release the handle;
+/// a borrowed handle carries none, so releasing it does nothing — Rust still
+/// owns the memory and will free it itself. That's the whole trick: the
+/// pointer itself says "free me" or "leave me alone", so the wrapper doesn't
+/// need a separate flag bolted onto the class.
+/// </summary>
+internal readonly unsafe struct RustHandle<T> where T : unmanaged
+{
+    private readonly T* _ptr;
+    private readonly RustDestructor<T>? _free;
+
+    private RustHandle(T* ptr, RustDestructor<T>? free)
+    {
+        _ptr = ptr;
+        _free = free;
+    }
+
+    /// <summary>The C# side owns the pointer: <see cref="Release"/> frees it.</summary>
+    public static RustHandle<T> Owned(T* ptr, RustDestructor<T> free) => new RustHandle<T>(ptr, free);
+
+    /// <summary>Rust still owns the pointer: <see cref="Release"/> is a no-op.</summary>
+    public static RustHandle<T> Borrowed(T* ptr) => new RustHandle<T>(ptr, null);
+
+    public T* Ptr => _ptr;
+
+    public bool IsNull => _ptr == null;
+
+    public void Release()
+    {
+        if (_free != null && _ptr != null)
+        {
+            _free(_ptr);
+        }
+    }
+}

--- a/feature_tests/dotnet/Generated/Bar.cs
+++ b/feature_tests/dotnet/Generated/Bar.cs
@@ -10,7 +10,7 @@ namespace Somelib;
 
 public partial class Bar: IDisposable
 {
-    private unsafe Raw.Bar* _inner;
+    private unsafe RustHandle<Raw.Bar> _inner;
 
     /// <summary>
     /// Roots the wrappers this value borrows from so the GC can't finalize
@@ -18,10 +18,7 @@ public partial class Bar: IDisposable
     /// </summary>
     private object[] _edges;
 
-    /// <summary>
-    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
-    /// </summary>
-    private bool _owned;
+    private static readonly unsafe RustDestructor<Raw.Bar> _destroy = Raw.Bar.Destroy;
 
     /// <summary>
     /// Creates a managed <c>Bar</c> from a raw handle.
@@ -34,9 +31,8 @@ public partial class Bar: IDisposable
     /// </remarks>
     internal unsafe Bar(Raw.Bar* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Bar>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-        _owned = true;
     }
 
     /// <remarks>
@@ -44,11 +40,22 @@ public partial class Bar: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe Bar(Raw.Bar* handle, object[] edges, bool owned)
+    internal unsafe Bar(Raw.Bar* handle, object[] edges)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Bar>.Owned(handle, _destroy);
         _edges = edges;
-        _owned = owned;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe Bar(RustHandle<Raw.Bar> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Foo</c> allocated on Rust side.
@@ -61,13 +68,13 @@ public partial class Bar: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("Bar");
             }
             Raw.Foo* result = Raw.Bar.Foo(AsFFI());
             GC.KeepAlive(this);
-            return new Foo(result, new object[] { this }, owned: false);
+            return new Foo(RustHandle<Raw.Foo>.Borrowed(result), new object[] { this });
         }
     }
 
@@ -76,7 +83,7 @@ public partial class Bar: IDisposable
     /// </summary>
     internal unsafe Raw.Bar* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -86,16 +93,13 @@ public partial class Bar: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            if (_owned)
-            {
-                Raw.Bar.Destroy(_inner);
-            }
-            _inner = null;
+            _inner.Release();
+            _inner = default;
             _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);

--- a/feature_tests/dotnet/Generated/Bar.cs
+++ b/feature_tests/dotnet/Generated/Bar.cs
@@ -19,6 +19,11 @@ public partial class Bar: IDisposable
     private object[] _edges;
 
     /// <summary>
+    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
+    /// </summary>
+    private bool _owned;
+
+    /// <summary>
     /// Creates a managed <c>Bar</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -31,6 +36,7 @@ public partial class Bar: IDisposable
     {
         _inner = handle;
         _edges = System.Array.Empty<object>();
+        _owned = true;
     }
 
     /// <remarks>
@@ -38,10 +44,31 @@ public partial class Bar: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe Bar(Raw.Bar* handle, object[] edges)
+    internal unsafe Bar(Raw.Bar* handle, object[] edges, bool owned)
     {
         _inner = handle;
         _edges = edges;
+        _owned = owned;
+    }
+    /// <returns>
+    /// A <c>Foo</c> allocated on Rust side.
+    /// </returns>
+    /// <remarks>
+    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
+    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// </remarks>
+    public Foo Foo()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Bar");
+            }
+            Raw.Foo* result = Raw.Bar.Foo(AsFFI());
+            GC.KeepAlive(this);
+            return new Foo(result, new object[] { this }, owned: false);
+        }
     }
 
     /// <summary>
@@ -64,7 +91,10 @@ public partial class Bar: IDisposable
                 return;
             }
 
-            Raw.Bar.Destroy(_inner);
+            if (_owned)
+            {
+                Raw.Bar.Destroy(_inner);
+            }
             _inner = null;
             _edges = System.Array.Empty<object>();
 

--- a/feature_tests/dotnet/Generated/Foo.cs
+++ b/feature_tests/dotnet/Generated/Foo.cs
@@ -10,7 +10,7 @@ namespace Somelib;
 
 public partial class Foo: IDisposable
 {
-    private unsafe Raw.Foo* _inner;
+    private unsafe RustHandle<Raw.Foo> _inner;
 
     /// <summary>
     /// Roots the wrappers this value borrows from so the GC can't finalize
@@ -18,10 +18,7 @@ public partial class Foo: IDisposable
     /// </summary>
     private object[] _edges;
 
-    /// <summary>
-    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
-    /// </summary>
-    private bool _owned;
+    private static readonly unsafe RustDestructor<Raw.Foo> _destroy = Raw.Foo.Destroy;
 
     /// <summary>
     /// Creates a managed <c>Foo</c> from a raw handle.
@@ -34,9 +31,8 @@ public partial class Foo: IDisposable
     /// </remarks>
     internal unsafe Foo(Raw.Foo* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Foo>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-        _owned = true;
     }
 
     /// <remarks>
@@ -44,11 +40,22 @@ public partial class Foo: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe Foo(Raw.Foo* handle, object[] edges, bool owned)
+    internal unsafe Foo(Raw.Foo* handle, object[] edges)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Foo>.Owned(handle, _destroy);
         _edges = edges;
-        _owned = owned;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe Foo(RustHandle<Raw.Foo> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Bar</c> allocated on Rust side.
@@ -61,13 +68,13 @@ public partial class Foo: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("Foo");
             }
             Raw.Bar* result = Raw.Foo.GetBar(AsFFI());
             GC.KeepAlive(this);
-            return new Bar(result, new object[] { this }, owned: true);
+            return new Bar(result, new object[] { this });
         }
     }
 
@@ -76,7 +83,7 @@ public partial class Foo: IDisposable
     /// </summary>
     internal unsafe Raw.Foo* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -86,16 +93,13 @@ public partial class Foo: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            if (_owned)
-            {
-                Raw.Foo.Destroy(_inner);
-            }
-            _inner = null;
+            _inner.Release();
+            _inner = default;
             _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);

--- a/feature_tests/dotnet/Generated/Foo.cs
+++ b/feature_tests/dotnet/Generated/Foo.cs
@@ -19,6 +19,11 @@ public partial class Foo: IDisposable
     private object[] _edges;
 
     /// <summary>
+    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
+    /// </summary>
+    private bool _owned;
+
+    /// <summary>
     /// Creates a managed <c>Foo</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -31,6 +36,7 @@ public partial class Foo: IDisposable
     {
         _inner = handle;
         _edges = System.Array.Empty<object>();
+        _owned = true;
     }
 
     /// <remarks>
@@ -38,10 +44,11 @@ public partial class Foo: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe Foo(Raw.Foo* handle, object[] edges)
+    internal unsafe Foo(Raw.Foo* handle, object[] edges, bool owned)
     {
         _inner = handle;
         _edges = edges;
+        _owned = owned;
     }
     /// <returns>
     /// A <c>Bar</c> allocated on Rust side.
@@ -60,7 +67,7 @@ public partial class Foo: IDisposable
             }
             Raw.Bar* result = Raw.Foo.GetBar(AsFFI());
             GC.KeepAlive(this);
-            return new Bar(result, new object[] { this });
+            return new Bar(result, new object[] { this }, owned: true);
         }
     }
 
@@ -84,7 +91,10 @@ public partial class Foo: IDisposable
                 return;
             }
 
-            Raw.Foo.Destroy(_inner);
+            if (_owned)
+            {
+                Raw.Foo.Destroy(_inner);
+            }
             _inner = null;
             _edges = System.Array.Empty<object>();
 

--- a/feature_tests/dotnet/Generated/One.cs
+++ b/feature_tests/dotnet/Generated/One.cs
@@ -10,7 +10,7 @@ namespace Somelib;
 
 public partial class One: IDisposable
 {
-    private unsafe Raw.One* _inner;
+    private unsafe RustHandle<Raw.One> _inner;
 
     /// <summary>
     /// Roots the wrappers this value borrows from so the GC can't finalize
@@ -18,10 +18,7 @@ public partial class One: IDisposable
     /// </summary>
     private object[] _edges;
 
-    /// <summary>
-    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
-    /// </summary>
-    private bool _owned;
+    private static readonly unsafe RustDestructor<Raw.One> _destroy = Raw.One.Destroy;
 
     /// <summary>
     /// Creates a managed <c>One</c> from a raw handle.
@@ -34,9 +31,8 @@ public partial class One: IDisposable
     /// </remarks>
     internal unsafe One(Raw.One* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.One>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-        _owned = true;
     }
 
     /// <remarks>
@@ -44,11 +40,22 @@ public partial class One: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe One(Raw.One* handle, object[] edges, bool owned)
+    internal unsafe One(Raw.One* handle, object[] edges)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.One>.Owned(handle, _destroy);
         _edges = edges;
-        _owned = owned;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe One(RustHandle<Raw.One> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
@@ -70,7 +77,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.Transitivity(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { hold }, owned: true);
+            return new One(result, new object[] { hold });
         }
     }
     /// <returns>
@@ -93,7 +100,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.Cycle(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { hold }, owned: true);
+            return new One(result, new object[] { hold });
         }
     }
     /// <returns>
@@ -128,7 +135,7 @@ public partial class One: IDisposable
             GC.KeepAlive(c);
             GC.KeepAlive(d);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { a, b, c, d }, owned: true);
+            return new One(result, new object[] { a, b, c, d });
         }
     }
     /// <returns>
@@ -151,7 +158,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.ReturnOutlivesParam(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { hold }, owned: true);
+            return new One(result, new object[] { hold });
         }
     }
     /// <returns>
@@ -182,7 +189,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result, new object[] { top, left, right, bottom }, owned: true);
+            return new One(result, new object[] { top, left, right, bottom });
         }
     }
     /// <returns>
@@ -213,7 +220,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result, new object[] { left, bottom }, owned: true);
+            return new One(result, new object[] { left, bottom });
         }
     }
     /// <returns>
@@ -244,7 +251,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result, new object[] { right, bottom }, owned: true);
+            return new One(result, new object[] { right, bottom });
         }
     }
     /// <returns>
@@ -275,7 +282,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result, new object[] { bottom }, owned: true);
+            return new One(result, new object[] { bottom });
         }
     }
     /// <returns>
@@ -310,7 +317,7 @@ public partial class One: IDisposable
             GC.KeepAlive(c);
             GC.KeepAlive(d);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { a, b, c, d }, owned: true);
+            return new One(result, new object[] { a, b, c, d });
         }
     }
     /// <returns>
@@ -337,7 +344,7 @@ public partial class One: IDisposable
             GC.KeepAlive(explicitHold);
             GC.KeepAlive(implicitHold);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { explicitHold, implicitHold }, owned: true);
+            return new One(result, new object[] { explicitHold, implicitHold });
         }
     }
     /// <returns>
@@ -368,7 +375,7 @@ public partial class One: IDisposable
             GC.KeepAlive(implicit1);
             GC.KeepAlive(implicit2);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { @explicit, implicit1, implicit2 }, owned: true);
+            return new One(result, new object[] { @explicit, implicit1, implicit2 });
         }
     }
 
@@ -377,7 +384,7 @@ public partial class One: IDisposable
     /// </summary>
     internal unsafe Raw.One* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -387,16 +394,13 @@ public partial class One: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            if (_owned)
-            {
-                Raw.One.Destroy(_inner);
-            }
-            _inner = null;
+            _inner.Release();
+            _inner = default;
             _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);

--- a/feature_tests/dotnet/Generated/One.cs
+++ b/feature_tests/dotnet/Generated/One.cs
@@ -19,6 +19,11 @@ public partial class One: IDisposable
     private object[] _edges;
 
     /// <summary>
+    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
+    /// </summary>
+    private bool _owned;
+
+    /// <summary>
     /// Creates a managed <c>One</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -31,6 +36,7 @@ public partial class One: IDisposable
     {
         _inner = handle;
         _edges = System.Array.Empty<object>();
+        _owned = true;
     }
 
     /// <remarks>
@@ -38,10 +44,11 @@ public partial class One: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe One(Raw.One* handle, object[] edges)
+    internal unsafe One(Raw.One* handle, object[] edges, bool owned)
     {
         _inner = handle;
         _edges = edges;
+        _owned = owned;
     }
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
@@ -63,7 +70,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.Transitivity(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { hold });
+            return new One(result, new object[] { hold }, owned: true);
         }
     }
     /// <returns>
@@ -86,7 +93,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.Cycle(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { hold });
+            return new One(result, new object[] { hold }, owned: true);
         }
     }
     /// <returns>
@@ -121,7 +128,7 @@ public partial class One: IDisposable
             GC.KeepAlive(c);
             GC.KeepAlive(d);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { a, b, c, d });
+            return new One(result, new object[] { a, b, c, d }, owned: true);
         }
     }
     /// <returns>
@@ -144,7 +151,7 @@ public partial class One: IDisposable
             Raw.One* result = Raw.One.ReturnOutlivesParam(holdRaw, noholdRaw);
             GC.KeepAlive(hold);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { hold });
+            return new One(result, new object[] { hold }, owned: true);
         }
     }
     /// <returns>
@@ -175,7 +182,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result, new object[] { top, left, right, bottom });
+            return new One(result, new object[] { top, left, right, bottom }, owned: true);
         }
     }
     /// <returns>
@@ -206,7 +213,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result, new object[] { left, bottom });
+            return new One(result, new object[] { left, bottom }, owned: true);
         }
     }
     /// <returns>
@@ -237,7 +244,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result, new object[] { right, bottom });
+            return new One(result, new object[] { right, bottom }, owned: true);
         }
     }
     /// <returns>
@@ -268,7 +275,7 @@ public partial class One: IDisposable
             GC.KeepAlive(left);
             GC.KeepAlive(right);
             GC.KeepAlive(bottom);
-            return new One(result, new object[] { bottom });
+            return new One(result, new object[] { bottom }, owned: true);
         }
     }
     /// <returns>
@@ -303,7 +310,7 @@ public partial class One: IDisposable
             GC.KeepAlive(c);
             GC.KeepAlive(d);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { a, b, c, d });
+            return new One(result, new object[] { a, b, c, d }, owned: true);
         }
     }
     /// <returns>
@@ -330,7 +337,7 @@ public partial class One: IDisposable
             GC.KeepAlive(explicitHold);
             GC.KeepAlive(implicitHold);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { explicitHold, implicitHold });
+            return new One(result, new object[] { explicitHold, implicitHold }, owned: true);
         }
     }
     /// <returns>
@@ -361,7 +368,7 @@ public partial class One: IDisposable
             GC.KeepAlive(implicit1);
             GC.KeepAlive(implicit2);
             GC.KeepAlive(nohold);
-            return new One(result, new object[] { @explicit, implicit1, implicit2 });
+            return new One(result, new object[] { @explicit, implicit1, implicit2 }, owned: true);
         }
     }
 
@@ -385,7 +392,10 @@ public partial class One: IDisposable
                 return;
             }
 
-            Raw.One.Destroy(_inner);
+            if (_owned)
+            {
+                Raw.One.Destroy(_inner);
+            }
             _inner = null;
             _edges = System.Array.Empty<object>();
 

--- a/feature_tests/dotnet/Generated/OpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThin.cs
@@ -13,6 +13,17 @@ public partial class OpaqueThin: IDisposable
     private unsafe Raw.OpaqueThin* _inner;
 
     /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    /// <summary>
+    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
+    /// </summary>
+    private bool _owned;
+
+    /// <summary>
     /// Creates a managed <c>OpaqueThin</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -24,6 +35,20 @@ public partial class OpaqueThin: IDisposable
     internal unsafe OpaqueThin(Raw.OpaqueThin* handle)
     {
         _inner = handle;
+        _edges = System.Array.Empty<object>();
+        _owned = true;
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe OpaqueThin(Raw.OpaqueThin* handle, object[] edges, bool owned)
+    {
+        _inner = handle;
+        _edges = edges;
+        _owned = owned;
     }
     public int A()
     {
@@ -93,8 +118,12 @@ public partial class OpaqueThin: IDisposable
                 return;
             }
 
-            Raw.OpaqueThin.Destroy(_inner);
+            if (_owned)
+            {
+                Raw.OpaqueThin.Destroy(_inner);
+            }
             _inner = null;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThin.cs
@@ -10,7 +10,7 @@ namespace Somelib;
 
 public partial class OpaqueThin: IDisposable
 {
-    private unsafe Raw.OpaqueThin* _inner;
+    private unsafe RustHandle<Raw.OpaqueThin> _inner;
 
     /// <summary>
     /// Roots the wrappers this value borrows from so the GC can't finalize
@@ -18,10 +18,7 @@ public partial class OpaqueThin: IDisposable
     /// </summary>
     private object[] _edges;
 
-    /// <summary>
-    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
-    /// </summary>
-    private bool _owned;
+    private static readonly unsafe RustDestructor<Raw.OpaqueThin> _destroy = Raw.OpaqueThin.Destroy;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThin</c> from a raw handle.
@@ -34,9 +31,8 @@ public partial class OpaqueThin: IDisposable
     /// </remarks>
     internal unsafe OpaqueThin(Raw.OpaqueThin* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OpaqueThin>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-        _owned = true;
     }
 
     /// <remarks>
@@ -44,17 +40,28 @@ public partial class OpaqueThin: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe OpaqueThin(Raw.OpaqueThin* handle, object[] edges, bool owned)
+    internal unsafe OpaqueThin(Raw.OpaqueThin* handle, object[] edges)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OpaqueThin>.Owned(handle, _destroy);
         _edges = edges;
-        _owned = owned;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe OpaqueThin(RustHandle<Raw.OpaqueThin> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     public int A()
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueThin");
             }
@@ -67,7 +74,7 @@ public partial class OpaqueThin: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueThin");
             }
@@ -80,7 +87,7 @@ public partial class OpaqueThin: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueThin");
             }
@@ -103,7 +110,7 @@ public partial class OpaqueThin: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThin* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -113,16 +120,13 @@ public partial class OpaqueThin: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            if (_owned)
-            {
-                Raw.OpaqueThin.Destroy(_inner);
-            }
-            _inner = null;
+            _inner.Release();
+            _inner = default;
             _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);

--- a/feature_tests/dotnet/Generated/OpaqueThinIter.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinIter.cs
@@ -10,7 +10,7 @@ namespace Somelib;
 
 public partial class OpaqueThinIter: IDisposable
 {
-    private unsafe Raw.OpaqueThinIter* _inner;
+    private unsafe RustHandle<Raw.OpaqueThinIter> _inner;
 
     /// <summary>
     /// Roots the wrappers this value borrows from so the GC can't finalize
@@ -18,10 +18,7 @@ public partial class OpaqueThinIter: IDisposable
     /// </summary>
     private object[] _edges;
 
-    /// <summary>
-    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
-    /// </summary>
-    private bool _owned;
+    private static readonly unsafe RustDestructor<Raw.OpaqueThinIter> _destroy = Raw.OpaqueThinIter.Destroy;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThinIter</c> from a raw handle.
@@ -34,9 +31,8 @@ public partial class OpaqueThinIter: IDisposable
     /// </remarks>
     internal unsafe OpaqueThinIter(Raw.OpaqueThinIter* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OpaqueThinIter>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-        _owned = true;
     }
 
     /// <remarks>
@@ -44,11 +40,22 @@ public partial class OpaqueThinIter: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe OpaqueThinIter(Raw.OpaqueThinIter* handle, object[] edges, bool owned)
+    internal unsafe OpaqueThinIter(Raw.OpaqueThinIter* handle, object[] edges)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OpaqueThinIter>.Owned(handle, _destroy);
         _edges = edges;
-        _owned = owned;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe OpaqueThinIter(RustHandle<Raw.OpaqueThinIter> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 
     /// <summary>
@@ -56,7 +63,7 @@ public partial class OpaqueThinIter: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThinIter* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -66,16 +73,13 @@ public partial class OpaqueThinIter: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            if (_owned)
-            {
-                Raw.OpaqueThinIter.Destroy(_inner);
-            }
-            _inner = null;
+            _inner.Release();
+            _inner = default;
             _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);

--- a/feature_tests/dotnet/Generated/OpaqueThinIter.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinIter.cs
@@ -19,6 +19,11 @@ public partial class OpaqueThinIter: IDisposable
     private object[] _edges;
 
     /// <summary>
+    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
+    /// </summary>
+    private bool _owned;
+
+    /// <summary>
     /// Creates a managed <c>OpaqueThinIter</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -31,6 +36,7 @@ public partial class OpaqueThinIter: IDisposable
     {
         _inner = handle;
         _edges = System.Array.Empty<object>();
+        _owned = true;
     }
 
     /// <remarks>
@@ -38,10 +44,11 @@ public partial class OpaqueThinIter: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe OpaqueThinIter(Raw.OpaqueThinIter* handle, object[] edges)
+    internal unsafe OpaqueThinIter(Raw.OpaqueThinIter* handle, object[] edges, bool owned)
     {
         _inner = handle;
         _edges = edges;
+        _owned = owned;
     }
 
     /// <summary>
@@ -64,7 +71,10 @@ public partial class OpaqueThinIter: IDisposable
                 return;
             }
 
-            Raw.OpaqueThinIter.Destroy(_inner);
+            if (_owned)
+            {
+                Raw.OpaqueThinIter.Destroy(_inner);
+            }
             _inner = null;
             _edges = System.Array.Empty<object>();
 

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -41,18 +41,6 @@ public partial class OpaqueThinVec: IDisposable
             }
         }
     }
-    public void SetFirstA(int value)
-    {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                throw new ObjectDisposedException("OpaqueThinVec");
-            }
-            Raw.OpaqueThinVec.SetFirstA(AsFFI(), value);
-            GC.KeepAlive(this);
-        }
-    }
     public void SetFirstC(string value)
     {
         unsafe
@@ -101,6 +89,26 @@ public partial class OpaqueThinVec: IDisposable
             var result = Raw.OpaqueThinVec.Len(AsFFI());
             GC.KeepAlive(this);
             return result;
+        }
+    }
+    /// <returns>
+    /// A <c>OpaqueThin</c> allocated on Rust side.
+    /// </returns>
+    /// <remarks>
+    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
+    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// </remarks>
+    public OpaqueThin? Get(nuint idx)
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("OpaqueThinVec");
+            }
+            Raw.OpaqueThin* result = Raw.OpaqueThinVec.Get(AsFFI(), idx);
+            GC.KeepAlive(this);
+            return result == null ? null : new OpaqueThin(RustHandle<Raw.OpaqueThin>.Borrowed(result), new object[] { this });
         }
     }
     /// <returns>

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -26,6 +26,51 @@ public partial class OpaqueThinVec: IDisposable
         _inner = handle;
     }
     /// <returns>
+    /// A <c>OpaqueThinVec</c> allocated on Rust side.
+    /// </returns>
+    public static OpaqueThinVec CreateSingle(int a, float b, string c)
+    {
+        unsafe
+        {
+            if (c == null) throw new ArgumentNullException(nameof(c));
+            byte[] cBytes = System.Text.Encoding.UTF8.GetBytes(c);
+            fixed (byte* cPtr = cBytes)
+            {
+                Raw.OpaqueThinVec* result = Raw.OpaqueThinVec.CreateSingle(a, b, new DiplomatSliceU8 { Ptr = cPtr, Len = (nuint)cBytes.Length });
+                return new OpaqueThinVec(result);
+            }
+        }
+    }
+    public void SetFirstA(int value)
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("OpaqueThinVec");
+            }
+            Raw.OpaqueThinVec.SetFirstA(AsFFI(), value);
+            GC.KeepAlive(this);
+        }
+    }
+    public void SetFirstC(string value)
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("OpaqueThinVec");
+            }
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            byte[] valueBytes = System.Text.Encoding.UTF8.GetBytes(value);
+            fixed (byte* valuePtr = valueBytes)
+            {
+                Raw.OpaqueThinVec.SetFirstC(AsFFI(), new DiplomatSliceU8 { Ptr = valuePtr, Len = (nuint)valueBytes.Length });
+                GC.KeepAlive(this);
+            }
+        }
+    }
+    /// <returns>
     /// A <c>OpaqueThinIter</c> allocated on Rust side.
     /// </returns>
     /// <remarks>

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -42,7 +42,7 @@ public partial class OpaqueThinVec: IDisposable
             }
             Raw.OpaqueThinIter* result = Raw.OpaqueThinVec.Iter(AsFFI());
             GC.KeepAlive(this);
-            return new OpaqueThinIter(result, new object[] { this });
+            return new OpaqueThinIter(result, new object[] { this }, owned: true);
         }
     }
     public nuint Len()
@@ -56,6 +56,26 @@ public partial class OpaqueThinVec: IDisposable
             var result = Raw.OpaqueThinVec.Len(AsFFI());
             GC.KeepAlive(this);
             return result;
+        }
+    }
+    /// <returns>
+    /// A <c>OpaqueThin</c> allocated on Rust side.
+    /// </returns>
+    /// <remarks>
+    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
+    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// </remarks>
+    public OpaqueThin? First()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("OpaqueThinVec");
+            }
+            Raw.OpaqueThin* result = Raw.OpaqueThinVec.First(AsFFI());
+            GC.KeepAlive(this);
+            return result == null ? null : new OpaqueThin(result, new object[] { this }, owned: false);
         }
     }
 

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -42,7 +42,7 @@ public partial class OpaqueThinVec: IDisposable
             }
             Raw.OpaqueThinIter* result = Raw.OpaqueThinVec.Iter(AsFFI());
             GC.KeepAlive(this);
-            return new OpaqueThinIter(result, new object[] { this }, owned: true);
+            return new OpaqueThinIter(result, new object[] { this });
         }
     }
     public nuint Len()
@@ -75,7 +75,7 @@ public partial class OpaqueThinVec: IDisposable
             }
             Raw.OpaqueThin* result = Raw.OpaqueThinVec.First(AsFFI());
             GC.KeepAlive(this);
-            return result == null ? null : new OpaqueThin(result, new object[] { this }, owned: false);
+            return result == null ? null : new OpaqueThin(RustHandle<Raw.OpaqueThin>.Borrowed(result), new object[] { this });
         }
     }
 

--- a/feature_tests/dotnet/Generated/RawBar.cs
+++ b/feature_tests/dotnet/Generated/RawBar.cs
@@ -9,6 +9,9 @@ namespace Somelib.Raw;
 internal partial struct Bar
 {
 
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "Bar_foo", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern Foo* Foo(Bar* handle);
+
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Bar_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Bar* handle);
 }

--- a/feature_tests/dotnet/Generated/RawOpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueThinVec.cs
@@ -9,6 +9,15 @@ namespace Somelib.Raw;
 internal partial struct OpaqueThinVec
 {
 
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_create_single", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern OpaqueThinVec* CreateSingle(int a, float b, DiplomatSliceU8 c);
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_set_first_a", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern void SetFirstA(OpaqueThinVec* handle, int value);
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_set_first_c", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern void SetFirstC(OpaqueThinVec* handle, DiplomatSliceU8 value);
+
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_iter", CallingConvention = CallingConvention.Cdecl)]
 internal static unsafe extern OpaqueThinIter* Iter(OpaqueThinVec* handle);
 

--- a/feature_tests/dotnet/Generated/RawOpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueThinVec.cs
@@ -15,6 +15,9 @@ internal static unsafe extern OpaqueThinIter* Iter(OpaqueThinVec* handle);
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_len", CallingConvention = CallingConvention.Cdecl)]
 internal static unsafe extern nuint Len(OpaqueThinVec* handle);
 
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_first", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern OpaqueThin* First(OpaqueThinVec* handle);
+
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OpaqueThinVec* handle);
 }

--- a/feature_tests/dotnet/Generated/RawOpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueThinVec.cs
@@ -12,9 +12,6 @@ internal partial struct OpaqueThinVec
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_create_single", CallingConvention = CallingConvention.Cdecl)]
 internal static unsafe extern OpaqueThinVec* CreateSingle(int a, float b, DiplomatSliceU8 c);
 
-    [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_set_first_a", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void SetFirstA(OpaqueThinVec* handle, int value);
-
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_set_first_c", CallingConvention = CallingConvention.Cdecl)]
 internal static unsafe extern void SetFirstC(OpaqueThinVec* handle, DiplomatSliceU8 value);
 
@@ -23,6 +20,9 @@ internal static unsafe extern OpaqueThinIter* Iter(OpaqueThinVec* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_len", CallingConvention = CallingConvention.Cdecl)]
 internal static unsafe extern nuint Len(OpaqueThinVec* handle);
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_get", CallingConvention = CallingConvention.Cdecl)]
+internal static unsafe extern OpaqueThin* Get(OpaqueThinVec* handle, nuint idx);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_first", CallingConvention = CallingConvention.Cdecl)]
 internal static unsafe extern OpaqueThin* First(OpaqueThinVec* handle);

--- a/feature_tests/dotnet/Generated/RefList.cs
+++ b/feature_tests/dotnet/Generated/RefList.cs
@@ -19,6 +19,11 @@ public partial class RefList: IDisposable
     private object[] _edges;
 
     /// <summary>
+    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
+    /// </summary>
+    private bool _owned;
+
+    /// <summary>
     /// Creates a managed <c>RefList</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -31,6 +36,7 @@ public partial class RefList: IDisposable
     {
         _inner = handle;
         _edges = System.Array.Empty<object>();
+        _owned = true;
     }
 
     /// <remarks>
@@ -38,10 +44,11 @@ public partial class RefList: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe RefList(Raw.RefList* handle, object[] edges)
+    internal unsafe RefList(Raw.RefList* handle, object[] edges, bool owned)
     {
         _inner = handle;
         _edges = edges;
+        _owned = owned;
     }
     /// <returns>
     /// A <c>RefList</c> allocated on Rust side.
@@ -59,7 +66,7 @@ public partial class RefList: IDisposable
             if (dataRaw == null) throw new ObjectDisposedException(nameof(RefListParameter));
             Raw.RefList* result = Raw.RefList.Node(dataRaw);
             GC.KeepAlive(data);
-            return new RefList(result, new object[] { data });
+            return new RefList(result, new object[] { data }, owned: true);
         }
     }
 
@@ -83,7 +90,10 @@ public partial class RefList: IDisposable
                 return;
             }
 
-            Raw.RefList.Destroy(_inner);
+            if (_owned)
+            {
+                Raw.RefList.Destroy(_inner);
+            }
             _inner = null;
             _edges = System.Array.Empty<object>();
 

--- a/feature_tests/dotnet/Generated/RefList.cs
+++ b/feature_tests/dotnet/Generated/RefList.cs
@@ -10,7 +10,7 @@ namespace Somelib;
 
 public partial class RefList: IDisposable
 {
-    private unsafe Raw.RefList* _inner;
+    private unsafe RustHandle<Raw.RefList> _inner;
 
     /// <summary>
     /// Roots the wrappers this value borrows from so the GC can't finalize
@@ -18,10 +18,7 @@ public partial class RefList: IDisposable
     /// </summary>
     private object[] _edges;
 
-    /// <summary>
-    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
-    /// </summary>
-    private bool _owned;
+    private static readonly unsafe RustDestructor<Raw.RefList> _destroy = Raw.RefList.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RefList</c> from a raw handle.
@@ -34,9 +31,8 @@ public partial class RefList: IDisposable
     /// </remarks>
     internal unsafe RefList(Raw.RefList* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RefList>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-        _owned = true;
     }
 
     /// <remarks>
@@ -44,11 +40,22 @@ public partial class RefList: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe RefList(Raw.RefList* handle, object[] edges, bool owned)
+    internal unsafe RefList(Raw.RefList* handle, object[] edges)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RefList>.Owned(handle, _destroy);
         _edges = edges;
-        _owned = owned;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RefList(RustHandle<Raw.RefList> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>RefList</c> allocated on Rust side.
@@ -66,7 +73,7 @@ public partial class RefList: IDisposable
             if (dataRaw == null) throw new ObjectDisposedException(nameof(RefListParameter));
             Raw.RefList* result = Raw.RefList.Node(dataRaw);
             GC.KeepAlive(data);
-            return new RefList(result, new object[] { data }, owned: true);
+            return new RefList(result, new object[] { data });
         }
     }
 
@@ -75,7 +82,7 @@ public partial class RefList: IDisposable
     /// </summary>
     internal unsafe Raw.RefList* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -85,16 +92,13 @@ public partial class RefList: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            if (_owned)
-            {
-                Raw.RefList.Destroy(_inner);
-            }
-            _inner = null;
+            _inner.Release();
+            _inner = default;
             _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);

--- a/feature_tests/dotnet/Generated/RustHandle.cs
+++ b/feature_tests/dotnet/Generated/RustHandle.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Somelib.Diplomat;
+
+#nullable enable
+
+/// <summary>
+/// Frees a Rust-owned <typeparamref name="T"/> by calling its native
+/// destructor. Held by an owned <see cref="RustHandle{T}"/> so the handle can
+/// release the pointer without knowing the concrete type.
+/// </summary>
+internal unsafe delegate void RustDestructor<T>(T* ptr) where T : unmanaged;
+
+/// <summary>
+/// A raw pointer that remembers who's responsible for freeing it. An owned
+/// handle carries the Rust destructor and runs it when you release the handle;
+/// a borrowed handle carries none, so releasing it does nothing — Rust still
+/// owns the memory and will free it itself. That's the whole trick: the
+/// pointer itself says "free me" or "leave me alone", so the wrapper doesn't
+/// need a separate flag bolted onto the class.
+/// </summary>
+internal readonly unsafe struct RustHandle<T> where T : unmanaged
+{
+    private readonly T* _ptr;
+    private readonly RustDestructor<T>? _free;
+
+    private RustHandle(T* ptr, RustDestructor<T>? free)
+    {
+        _ptr = ptr;
+        _free = free;
+    }
+
+    /// <summary>The C# side owns the pointer: <see cref="Release"/> frees it.</summary>
+    public static RustHandle<T> Owned(T* ptr, RustDestructor<T> free) => new RustHandle<T>(ptr, free);
+
+    /// <summary>Rust still owns the pointer: <see cref="Release"/> is a no-op.</summary>
+    public static RustHandle<T> Borrowed(T* ptr) => new RustHandle<T>(ptr, null);
+
+    public T* Ptr => _ptr;
+
+    public bool IsNull => _ptr == null;
+
+    public void Release()
+    {
+        if (_free != null && _ptr != null)
+        {
+            _free(_ptr);
+        }
+    }
+}

--- a/feature_tests/dotnet/Generated/Two.cs
+++ b/feature_tests/dotnet/Generated/Two.cs
@@ -19,6 +19,11 @@ public partial class Two: IDisposable
     private object[] _edges;
 
     /// <summary>
+    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
+    /// </summary>
+    private bool _owned;
+
+    /// <summary>
     /// Creates a managed <c>Two</c> from a raw handle.
     /// </summary>
     /// <remarks>
@@ -31,6 +36,7 @@ public partial class Two: IDisposable
     {
         _inner = handle;
         _edges = System.Array.Empty<object>();
+        _owned = true;
     }
 
     /// <remarks>
@@ -38,10 +44,11 @@ public partial class Two: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe Two(Raw.Two* handle, object[] edges)
+    internal unsafe Two(Raw.Two* handle, object[] edges, bool owned)
     {
         _inner = handle;
         _edges = edges;
+        _owned = owned;
     }
 
     /// <summary>
@@ -64,7 +71,10 @@ public partial class Two: IDisposable
                 return;
             }
 
-            Raw.Two.Destroy(_inner);
+            if (_owned)
+            {
+                Raw.Two.Destroy(_inner);
+            }
             _inner = null;
             _edges = System.Array.Empty<object>();
 

--- a/feature_tests/dotnet/Generated/Two.cs
+++ b/feature_tests/dotnet/Generated/Two.cs
@@ -10,7 +10,7 @@ namespace Somelib;
 
 public partial class Two: IDisposable
 {
-    private unsafe Raw.Two* _inner;
+    private unsafe RustHandle<Raw.Two> _inner;
 
     /// <summary>
     /// Roots the wrappers this value borrows from so the GC can't finalize
@@ -18,10 +18,7 @@ public partial class Two: IDisposable
     /// </summary>
     private object[] _edges;
 
-    /// <summary>
-    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
-    /// </summary>
-    private bool _owned;
+    private static readonly unsafe RustDestructor<Raw.Two> _destroy = Raw.Two.Destroy;
 
     /// <summary>
     /// Creates a managed <c>Two</c> from a raw handle.
@@ -34,9 +31,8 @@ public partial class Two: IDisposable
     /// </remarks>
     internal unsafe Two(Raw.Two* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Two>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-        _owned = true;
     }
 
     /// <remarks>
@@ -44,11 +40,22 @@ public partial class Two: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe Two(Raw.Two* handle, object[] edges, bool owned)
+    internal unsafe Two(Raw.Two* handle, object[] edges)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Two>.Owned(handle, _destroy);
         _edges = edges;
-        _owned = owned;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe Two(RustHandle<Raw.Two> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 
     /// <summary>
@@ -56,7 +63,7 @@ public partial class Two: IDisposable
     /// </summary>
     internal unsafe Raw.Two* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -66,16 +73,13 @@ public partial class Two: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            if (_owned)
-            {
-                Raw.Two.Destroy(_inner);
-            }
-            _inner = null;
+            _inner.Release();
+            _inner = default;
             _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);

--- a/feature_tests/dotnet/Tests/BorrowedReturnTests.cs
+++ b/feature_tests/dotnet/Tests/BorrowedReturnTests.cs
@@ -26,19 +26,19 @@ public class BorrowedReturnTests
     }
 
     [Fact]
-    public void First_AliasesOwnerStorage_NotACopy()
+    public void Get_InRangeBorrows_OutOfRangeReturnsNull()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "x");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
 
-        // The borrow is taken BEFORE the mutation and never refreshed.
-        using OpaqueThin borrow = vec.First()!;
-        Assert.Equal(7, borrow.A());
+        // The indexer `get` is a borrowed return just like `First()`: an
+        // in-range index hands back a non-owning view into the Vec slot.
+        using OpaqueThin at0 = vec.Get(0)!;
+        Assert.Equal(7, at0.A());
+        Assert.Equal("hi", at0.C());
 
-        // Mutate the owner's element 0 in place. If `First()` had handed back a
-        // copy, the borrow would still read 7. Seeing 99 proves the borrow is an
-        // interior reference into the same Vec slot the owner just wrote.
-        vec.SetFirstA(99);
-        Assert.Equal(99, borrow.A());
+        // Out-of-range is Rust's `Option::None` path — a null return, not a
+        // throw and not a borrow of freed/garbage memory.
+        Assert.Null(vec.Get(1));
     }
 
     [Fact]
@@ -46,13 +46,15 @@ public class BorrowedReturnTests
     {
         using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "before");
 
+        // The borrow is taken BEFORE the mutation and never refreshed.
         using OpaqueThin borrow = vec.First()!;
         Assert.Equal("before", borrow.C());
 
-        // The heap-backed `String` aliases through the borrow exactly like the
-        // primitive `a`: replacing it on the owner (which drops the old buffer)
-        // is observed through the same outstanding borrow, which re-reads the
-        // field. So mutation IS visible for the string field, not just a/b.
+        // Replacing the heap-backed `String` on the owner (which drops the old
+        // buffer) is observed through the same outstanding borrow, which
+        // re-reads the field. If `First()` had handed back a copy, the borrow
+        // would still read "before"; seeing "after" proves it is an interior
+        // reference into the same Vec slot the owner just wrote.
         vec.SetFirstC("after");
         Assert.Equal("after", borrow.C());
     }

--- a/feature_tests/dotnet/Tests/BorrowedReturnTests.cs
+++ b/feature_tests/dotnet/Tests/BorrowedReturnTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Runtime.CompilerServices;
+using Somelib;
+using Xunit;
+
+namespace Somelib.FeatureTests;
+
+// Borrowed opaque returns. `OpaqueThinVec` owns a `Vec<Internal>`; `First()`
+// hands back a *borrowed* `OpaqueThin` (`&T`) wrapped in a non-owning
+// RustHandle. These tests pin the three things that make that safe: the borrow
+// is readable, disposing it never frees Rust's memory (no double-free), and the
+// `_edges` root keeps the owner alive while a borrow is still outstanding.
+public class BorrowedReturnTests
+{
+    [Fact]
+    public void First_ReturnsReadableBorrowedView()
+    {
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hello");
+        Assert.Equal((nuint)1, vec.Len());
+
+        using OpaqueThin first = vec.First()!;
+        Assert.NotNull(first);
+        Assert.Equal(7, first.A());
+        Assert.Equal(1.5f, first.B());
+        Assert.Equal("hello", first.C());
+    }
+
+    [Fact]
+    public void First_AliasesOwnerStorage_NotACopy()
+    {
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "x");
+
+        // The borrow is taken BEFORE the mutation and never refreshed.
+        using OpaqueThin borrow = vec.First()!;
+        Assert.Equal(7, borrow.A());
+
+        // Mutate the owner's element 0 in place. If `First()` had handed back a
+        // copy, the borrow would still read 7. Seeing 99 proves the borrow is an
+        // interior reference into the same Vec slot the owner just wrote.
+        vec.SetFirstA(99);
+        Assert.Equal(99, borrow.A());
+    }
+
+    [Fact]
+    public void First_AliasesOwnerStorage_StringField()
+    {
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "before");
+
+        using OpaqueThin borrow = vec.First()!;
+        Assert.Equal("before", borrow.C());
+
+        // The heap-backed `String` aliases through the borrow exactly like the
+        // primitive `a`: replacing it on the owner (which drops the old buffer)
+        // is observed through the same outstanding borrow, which re-reads the
+        // field. So mutation IS visible for the string field, not just a/b.
+        vec.SetFirstC("after");
+        Assert.Equal("after", borrow.C());
+    }
+
+    [Fact]
+    public void DisposingBorrowedView_DoesNotFreeOwnersMemory()
+    {
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
+
+        // A borrowed handle owns nothing, so Dispose must be a no-op on Rust's
+        // pointer — even called twice, it must not double-free.
+        OpaqueThin first = vec.First()!;
+        first.Dispose();
+        first.Dispose();
+
+        // The owner is untouched: a fresh borrow still reads correctly.
+        using OpaqueThin again = vec.First()!;
+        Assert.Equal(7, again.A());
+    }
+
+    // Tier1's precise liveness can drop the `OpaqueThinVec` local at its last
+    // use (the `First()` call). If `_edges` didn't root it, GC -> finalizer ->
+    // Destroy would free the Vec out from under the returned borrow.
+    // AggressiveOptimization forces that liveness so the race can surface.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static OpaqueThin BorrowAndDropOwner()
+    {
+        return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").First()!;
+    }
+
+    [Fact]
+    public void BorrowedView_KeepsOwnerAliveAcrossGc()
+    {
+        OpaqueThin borrow = BorrowAndDropOwner();
+
+        // Pressure the GC: only `_edges` keeps the now-unreferenced owner alive.
+        for (int i = 0; i < 10; i++)
+        {
+            _ = new byte[256 * 1024];
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        // If the owner had been finalized, these read freed memory (UAF).
+        Assert.Equal(42, borrow.A());
+        Assert.Equal("rooted", borrow.C());
+        GC.KeepAlive(borrow);
+    }
+}

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -135,7 +135,6 @@ pub mod ffi {
     // FIXME(#191): This test breaks the C++ codegen
     impl<'b, 'a: 'b> Bar<'b, 'a> {
         #[diplomat::attr(auto, getter)]
-        #[diplomat::attr(dotnet, disable)]
         pub fn foo(&'b self) -> &'b Foo<'a> {
             self.0
         }
@@ -380,7 +379,6 @@ pub mod ffi {
 
         #[diplomat::attr(auto, getter)]
         #[diplomat::attr(dart, rename = "firstelement")]
-        #[diplomat::attr(dotnet, disable)]
         pub fn first<'a>(&'a self) -> Option<&'a OpaqueThin> {
             self.0.get(0).map(OpaqueThin::transparent_convert)
         }

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -371,17 +371,9 @@ pub mod ffi {
             }]))
         }
 
-        // dotnet-only: the borrowed-return aliasing test mutates the owner here
-        // and reads it back through `First()` to prove the borrow isn't a copy.
-        #[diplomat::attr(not(dotnet), disable)]
-        pub fn set_first_a(&mut self, value: i32) {
-            if let Some(first) = self.0.first_mut() {
-                first.a = value;
-            }
-        }
-
-        // dotnet-only: same aliasing proof for the heap-backed `String` field —
-        // replacing it must still be observed through an outstanding borrow.
+        // dotnet-only: the borrowed-return aliasing test replaces the owner's
+        // heap-backed `String` here and reads it back through `First()` to prove
+        // the borrow isn't a copy.
         #[diplomat::attr(not(dotnet), disable)]
         pub fn set_first_c(&mut self, value: &DiplomatStr) {
             if let Some(first) = self.0.first_mut() {
@@ -402,7 +394,6 @@ pub mod ffi {
         }
 
         #[diplomat::attr(auto, indexer)]
-        #[diplomat::attr(dotnet, disable)]
         pub fn get<'a>(&'a self, idx: usize) -> Option<&'a OpaqueThin> {
             self.0.get(idx).map(OpaqueThin::transparent_convert)
         }

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -339,7 +339,7 @@ pub mod ffi {
         }
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     pub struct OpaqueThinVec(std::vec::Vec<crate::lifetimes::Internal>);
 
     impl OpaqueThinVec {
@@ -357,6 +357,36 @@ pub mod ffi {
                     })
                     .collect(),
             ))
+        }
+
+        // The .NET backend disables the slice-based `create`, so the dotnet
+        // borrowed-return tests need a constructor they can call from C# to get
+        // a real owner to borrow `First()`/`Get()` out of.
+        #[diplomat::attr(not(dotnet), disable)]
+        pub fn create_single(a: i32, b: f32, c: &DiplomatStr) -> Box<Self> {
+            Box::new(Self(vec![crate::lifetimes::Internal {
+                a,
+                b,
+                c: String::from_utf8(c.to_vec()).unwrap(),
+            }]))
+        }
+
+        // dotnet-only: the borrowed-return aliasing test mutates the owner here
+        // and reads it back through `First()` to prove the borrow isn't a copy.
+        #[diplomat::attr(not(dotnet), disable)]
+        pub fn set_first_a(&mut self, value: i32) {
+            if let Some(first) = self.0.first_mut() {
+                first.a = value;
+            }
+        }
+
+        // dotnet-only: same aliasing proof for the heap-backed `String` field —
+        // replacing it must still be observed through an outstanding borrow.
+        #[diplomat::attr(not(dotnet), disable)]
+        pub fn set_first_c(&mut self, value: &DiplomatStr) {
+            if let Some(first) = self.0.first_mut() {
+                first.c = String::from_utf8(value.to_vec()).unwrap();
+            }
         }
 
         #[diplomat::attr(auto, iterable)]

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -308,7 +308,10 @@ impl DotnetReturnType {
     fn idiomatic_value_expr(&self, raw_expr: RawExpr, edges: &[String], owned: bool) -> String {
         match self {
             Self::Opaque(name) => {
-                format!("new {name}({raw_expr}{})", Self::edge_arg_suffix(edges, owned))
+                format!(
+                    "new {name}({raw_expr}{})",
+                    Self::edge_arg_suffix(edges, owned)
+                )
             }
             Self::Struct(name) => format!("{name}.FromFFI({raw_expr})"),
             Self::Unit | Self::Write => String::new(),
@@ -333,7 +336,12 @@ impl DotnetReturnType {
         )
     }
 
-    fn nullable_pointer_option_expr(&self, raw_expr: RawExpr, edges: &[String], owned: bool) -> String {
+    fn nullable_pointer_option_expr(
+        &self,
+        raw_expr: RawExpr,
+        edges: &[String],
+        owned: bool,
+    ) -> String {
         match self {
             Self::Opaque(name) => format!(
                 "{raw_expr} == null ? null : new {name}({raw_expr}{})",
@@ -658,7 +666,8 @@ impl MethodInfo<'_> {
         } else {
             format!(
                 "return {};",
-                self.return_type.idiomatic_value_expr(raw_expr, edges, owned)
+                self.return_type
+                    .idiomatic_value_expr(raw_expr, edges, owned)
             )
         }
     }

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -286,20 +286,29 @@ impl DotnetReturnType {
         }
     }
 
-    fn edge_arg_suffix(edges: &[String]) -> String {
-        if edges.is_empty() {
+    fn edge_arg_suffix(edges: &[String], owned: bool) -> String {
+        // Owned with no edges → the 1-arg ctor (which sets `_owned = true`).
+        // Anything else must pass `owned` explicitly, so a borrowed return
+        // with no edges (e.g. `&'static T`) can't fall back to the owning
+        // ctor and double-free.
+        if edges.is_empty() && owned {
             String::new()
         } else {
-            format!(", new object[] {{ {} }}", edges.join(", "))
+            let array = if edges.is_empty() {
+                "System.Array.Empty<object>()".to_string()
+            } else {
+                format!("new object[] {{ {} }}", edges.join(", "))
+            };
+            format!(", {array}, owned: {owned}")
         }
     }
 
     /// Convert a raw FFI value expression into the public C# value
     /// expression for this return type.
-    fn idiomatic_value_expr(&self, raw_expr: RawExpr, edges: &[String]) -> String {
+    fn idiomatic_value_expr(&self, raw_expr: RawExpr, edges: &[String], owned: bool) -> String {
         match self {
             Self::Opaque(name) => {
-                format!("new {name}({raw_expr}{})", Self::edge_arg_suffix(edges))
+                format!("new {name}({raw_expr}{})", Self::edge_arg_suffix(edges, owned))
             }
             Self::Struct(name) => format!("{name}.FromFFI({raw_expr})"),
             Self::Unit | Self::Write => String::new(),
@@ -315,20 +324,20 @@ impl DotnetReturnType {
         }
     }
 
-    fn tagged_option_expr(&self, option_expr: RawExpr, edges: &[String]) -> String {
+    fn tagged_option_expr(&self, option_expr: RawExpr, edges: &[String], owned: bool) -> String {
         format!(
             "{} ? {} : {}",
             option_expr.is_some_expr(),
-            self.idiomatic_value_expr(option_expr.option_value(), edges),
+            self.idiomatic_value_expr(option_expr.option_value(), edges, owned),
             self.option_none_expr()
         )
     }
 
-    fn nullable_pointer_option_expr(&self, raw_expr: RawExpr, edges: &[String]) -> String {
+    fn nullable_pointer_option_expr(&self, raw_expr: RawExpr, edges: &[String], owned: bool) -> String {
         match self {
             Self::Opaque(name) => format!(
                 "{raw_expr} == null ? null : new {name}({raw_expr}{})",
-                Self::edge_arg_suffix(edges)
+                Self::edge_arg_suffix(edges, owned)
             ),
             _ => unreachable!("nullable pointer options only lower from opaque returns"),
         }
@@ -405,6 +414,7 @@ pub(super) struct ReturnLowering {
     pub(super) return_type: DotnetReturnType,
     pub(super) error_info: Option<ErrorInfo>,
     pub(super) option_info: Option<OptionInfo>,
+    pub(super) owned_return: bool,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -437,6 +447,9 @@ pub(super) struct MethodInfo<'ctx> {
     /// Rooted by the returned wrapper so the GC can't free a borrowed-from
     /// parent while the child lives. Cf. `keep_alive_targets` (per-call only).
     pub(super) keep_alive_edges: Vec<String>,
+    /// `false` for a borrowed opaque return — the wrapper is built non-owning
+    /// so it never frees a pointer Rust still owns.
+    pub(super) owned_return: bool,
     /// `Some` iff this method returns `Result<T, E>` with a concrete `E`.
     /// Templates branch on `{% if let Some(info) = method.error_info %}` —
     /// no separate `is_fallible()` predicate needed.
@@ -628,13 +641,14 @@ impl MethodInfo<'_> {
     {
         let raw_expr = raw_expr.try_into().unwrap_or_else(|err| panic!("{err}"));
         let edges = self.keep_alive_edges.as_slice();
+        let owned = self.owned_return;
 
         if let Some(option_info) = &self.option_info {
             let expr = if option_info.raw_option_type.is_some() {
-                self.return_type.tagged_option_expr(raw_expr, edges)
+                self.return_type.tagged_option_expr(raw_expr, edges, owned)
             } else {
                 self.return_type
-                    .nullable_pointer_option_expr(raw_expr, edges)
+                    .nullable_pointer_option_expr(raw_expr, edges, owned)
             };
             return format!("return {expr};");
         }
@@ -644,7 +658,7 @@ impl MethodInfo<'_> {
         } else {
             format!(
                 "return {};",
-                self.return_type.idiomatic_value_expr(raw_expr, edges)
+                self.return_type.idiomatic_value_expr(raw_expr, edges, owned)
             )
         }
     }
@@ -711,6 +725,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             return_type,
             error_info,
             option_info,
+            owned_return,
         } = self.lower_return(&method.output)?;
 
         let inputs = self.lower_inputs(method_context)?;
@@ -756,10 +771,36 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             return_type,
             lifetime_warning,
             keep_alive_edges,
+            owned_return,
             error_info,
             option_info,
             property_accessor,
         })
+    }
+
+    /// Opaque type names that some generated method returns *borrowed*
+    /// (`&T` / `Option<&T>`). Such a type needs the non-owning constructor
+    /// even when it carries no lifetime of its own (the borrow lives on the
+    /// `&`, not the type) — so it can't be gated on lifetime params alone.
+    pub(crate) fn borrowed_return_targets(&self) -> std::collections::HashSet<String> {
+        let mut targets = std::collections::HashSet::new();
+        for (_, ty) in self.tcx.all_types() {
+            if ty.attrs().disable {
+                continue;
+            }
+            for method in ty.methods() {
+                let success = match &method.output {
+                    hir::ReturnType::Infallible(s) | hir::ReturnType::Nullable(s) => s,
+                    hir::ReturnType::Fallible(s, _) => s,
+                };
+                if let hir::SuccessType::OutType(hir::Type::Opaque(p)) = success {
+                    if !p.is_owned() {
+                        targets.insert(self.opaque_name(p));
+                    }
+                }
+            }
+        }
+        targets
     }
 
     /// Sometimes a method hands back a value that's really just pointing into
@@ -935,6 +976,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         //    originally Option<Box<T>>" via the Optional marker on the
         //    opaque path — this is Path A (pointer-nullable) for Option.
         let mut pointer_nullable = false;
+        let mut owned_return = true;
         let return_type = match success {
             hir::SuccessType::Unit => DotnetReturnType::Unit,
             hir::SuccessType::Write => DotnetReturnType::Write,
@@ -942,24 +984,11 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                 DotnetReturnType::Primitive(self.lower_primitive(p)?)
             }
             hir::SuccessType::OutType(hir::Type::Opaque(p)) => {
-                // Reject borrowed opaque returns. The idiomatic wrapper
-                // (`new T(ptr)`) and its `IDisposable.Dispose()` /
-                // finalizer unconditionally call `Raw.T.Destroy(_inner)`
-                // — wiring that to a pointer Rust still owns is a
-                // double-free / use-after-free. A proper fix needs a
-                // non-owning wrapper variant; until that lands, refuse
-                // codegen with a clear message rather than emitting
-                // unsafe code.
-                if !p.is_owned() {
-                    self.errors.push_error(
-                        "[.NET backend] borrowed opaque return (`&T` / `&mut T` / \
-                         `Option<&T>`) is not yet supported — the generated \
-                         IDisposable wrapper would double-free the Rust-owned \
-                         pointer. Return `Box<T>` or `Option<Box<T>>` instead."
-                            .to_string(),
-                    );
-                    return None;
-                }
+                // A borrowed return (`!is_owned`) is constructed non-owning
+                // (`owned: false`) so Dispose/finalizer skip Destroy — Rust
+                // still owns the pointer; the keep-alive edges hold the
+                // borrowed-from owner alive.
+                owned_return = p.is_owned();
                 if p.is_optional() {
                     pointer_nullable = true;
                 }
@@ -1027,6 +1056,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             return_type,
             error_info,
             option_info,
+            owned_return,
         })
     }
 

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -164,6 +164,16 @@ impl<'ctx> MethodInputContext<'ctx> {
 // Return type
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Who frees the pointer behind a returned opaque wrapper. An owned return
+/// (`Box<T>`) is the C# side's to free; a borrowed return (`&T`) belongs to
+/// Rust, so the wrapper must never free it. We carry this as a named pair
+/// rather than a bare `bool` so the construction site reads as what it means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Ownership {
+    Owned,
+    Borrowed,
+}
+
 /// The return type of a method, expressed once. The variant names the
 /// *kind*; [`Display`] writes the bare C# name; templates branch on kind
 /// via `is_*` predicates and supply the kind-specific bits (the `*` for
@@ -286,33 +296,46 @@ impl DotnetReturnType {
         }
     }
 
-    fn edge_arg_suffix(edges: &[String], owned: bool) -> String {
-        // Owned with no edges → the 1-arg ctor (which sets `_owned = true`).
-        // Anything else must pass `owned` explicitly, so a borrowed return
-        // with no edges (e.g. `&'static T`) can't fall back to the owning
-        // ctor and double-free.
-        if edges.is_empty() && owned {
-            String::new()
-        } else {
-            let array = if edges.is_empty() {
+    /// Build the C# expression that wraps a raw opaque pointer. An owned
+    /// return uses the owning constructor; a borrowed return uses the
+    /// `Borrowed` factory so the wrapper never frees Rust's pointer. The
+    /// caller decides which via [`Ownership`] — no `owned` flag leaks into the
+    /// generated arguments.
+    fn opaque_construction(
+        name: &str,
+        raw_expr: &RawExpr,
+        edges: &[String],
+        ownership: Ownership,
+    ) -> String {
+        let edges_array = || {
+            if edges.is_empty() {
                 "System.Array.Empty<object>()".to_string()
             } else {
                 format!("new object[] {{ {} }}", edges.join(", "))
-            };
-            format!(", {array}, owned: {owned}")
+            }
+        };
+        match ownership {
+            Ownership::Owned if edges.is_empty() => format!("new {name}({raw_expr})"),
+            Ownership::Owned => format!("new {name}({raw_expr}, {})", edges_array()),
+            // `new {name}(...)` (not `{name}.Borrowed(...)`) so the type always
+            // resolves even when the wrapper has a same-named method.
+            Ownership::Borrowed => format!(
+                "new {name}(RustHandle<Raw.{name}>.Borrowed({raw_expr}), {})",
+                edges_array()
+            ),
         }
     }
 
     /// Convert a raw FFI value expression into the public C# value
     /// expression for this return type.
-    fn idiomatic_value_expr(&self, raw_expr: RawExpr, edges: &[String], owned: bool) -> String {
+    fn idiomatic_value_expr(
+        &self,
+        raw_expr: RawExpr,
+        edges: &[String],
+        ownership: Ownership,
+    ) -> String {
         match self {
-            Self::Opaque(name) => {
-                format!(
-                    "new {name}({raw_expr}{})",
-                    Self::edge_arg_suffix(edges, owned)
-                )
-            }
+            Self::Opaque(name) => Self::opaque_construction(name, &raw_expr, edges, ownership),
             Self::Struct(name) => format!("{name}.FromFFI({raw_expr})"),
             Self::Unit | Self::Write => String::new(),
             Self::Primitive(_) | Self::Enum(_) => raw_expr.to_string(),
@@ -327,11 +350,16 @@ impl DotnetReturnType {
         }
     }
 
-    fn tagged_option_expr(&self, option_expr: RawExpr, edges: &[String], owned: bool) -> String {
+    fn tagged_option_expr(
+        &self,
+        option_expr: RawExpr,
+        edges: &[String],
+        ownership: Ownership,
+    ) -> String {
         format!(
             "{} ? {} : {}",
             option_expr.is_some_expr(),
-            self.idiomatic_value_expr(option_expr.option_value(), edges, owned),
+            self.idiomatic_value_expr(option_expr.option_value(), edges, ownership),
             self.option_none_expr()
         )
     }
@@ -340,12 +368,12 @@ impl DotnetReturnType {
         &self,
         raw_expr: RawExpr,
         edges: &[String],
-        owned: bool,
+        ownership: Ownership,
     ) -> String {
         match self {
             Self::Opaque(name) => format!(
-                "{raw_expr} == null ? null : new {name}({raw_expr}{})",
-                Self::edge_arg_suffix(edges, owned)
+                "{raw_expr} == null ? null : {}",
+                Self::opaque_construction(name, &raw_expr, edges, ownership)
             ),
             _ => unreachable!("nullable pointer options only lower from opaque returns"),
         }
@@ -422,7 +450,7 @@ pub(super) struct ReturnLowering {
     pub(super) return_type: DotnetReturnType,
     pub(super) error_info: Option<ErrorInfo>,
     pub(super) option_info: Option<OptionInfo>,
-    pub(super) owned_return: bool,
+    pub(super) ownership: Ownership,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -455,9 +483,9 @@ pub(super) struct MethodInfo<'ctx> {
     /// Rooted by the returned wrapper so the GC can't free a borrowed-from
     /// parent while the child lives. Cf. `keep_alive_targets` (per-call only).
     pub(super) keep_alive_edges: Vec<String>,
-    /// `false` for a borrowed opaque return — the wrapper is built non-owning
-    /// so it never frees a pointer Rust still owns.
-    pub(super) owned_return: bool,
+    /// `Borrowed` for a borrowed opaque return — the wrapper is built
+    /// non-owning so it never frees a pointer Rust still owns.
+    pub(super) ownership: Ownership,
     /// `Some` iff this method returns `Result<T, E>` with a concrete `E`.
     /// Templates branch on `{% if let Some(info) = method.error_info %}` —
     /// no separate `is_fallible()` predicate needed.
@@ -649,14 +677,15 @@ impl MethodInfo<'_> {
     {
         let raw_expr = raw_expr.try_into().unwrap_or_else(|err| panic!("{err}"));
         let edges = self.keep_alive_edges.as_slice();
-        let owned = self.owned_return;
+        let ownership = self.ownership;
 
         if let Some(option_info) = &self.option_info {
             let expr = if option_info.raw_option_type.is_some() {
-                self.return_type.tagged_option_expr(raw_expr, edges, owned)
+                self.return_type
+                    .tagged_option_expr(raw_expr, edges, ownership)
             } else {
                 self.return_type
-                    .nullable_pointer_option_expr(raw_expr, edges, owned)
+                    .nullable_pointer_option_expr(raw_expr, edges, ownership)
             };
             return format!("return {expr};");
         }
@@ -667,7 +696,7 @@ impl MethodInfo<'_> {
             format!(
                 "return {};",
                 self.return_type
-                    .idiomatic_value_expr(raw_expr, edges, owned)
+                    .idiomatic_value_expr(raw_expr, edges, ownership)
             )
         }
     }
@@ -734,7 +763,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             return_type,
             error_info,
             option_info,
-            owned_return,
+            ownership,
         } = self.lower_return(&method.output)?;
 
         let inputs = self.lower_inputs(method_context)?;
@@ -780,7 +809,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             return_type,
             lifetime_warning,
             keep_alive_edges,
-            owned_return,
+            ownership,
             error_info,
             option_info,
             property_accessor,
@@ -985,7 +1014,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         //    originally Option<Box<T>>" via the Optional marker on the
         //    opaque path — this is Path A (pointer-nullable) for Option.
         let mut pointer_nullable = false;
-        let mut owned_return = true;
+        let mut ownership = Ownership::Owned;
         let return_type = match success {
             hir::SuccessType::Unit => DotnetReturnType::Unit,
             hir::SuccessType::Write => DotnetReturnType::Write,
@@ -994,10 +1023,14 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             }
             hir::SuccessType::OutType(hir::Type::Opaque(p)) => {
                 // A borrowed return (`!is_owned`) is constructed non-owning
-                // (`owned: false`) so Dispose/finalizer skip Destroy — Rust
-                // still owns the pointer; the keep-alive edges hold the
+                // (`{name}.Borrowed(...)`) so Dispose/finalizer skip Destroy —
+                // Rust still owns the pointer; the keep-alive edges hold the
                 // borrowed-from owner alive.
-                owned_return = p.is_owned();
+                ownership = if p.is_owned() {
+                    Ownership::Owned
+                } else {
+                    Ownership::Borrowed
+                };
                 if p.is_optional() {
                     pointer_nullable = true;
                 }
@@ -1065,7 +1098,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             return_type,
             error_info,
             option_info,
-            owned_return,
+            ownership,
         })
     }
 

--- a/tool/src/dotnet/gen/mod.rs
+++ b/tool/src/dotnet/gen/mod.rs
@@ -140,6 +140,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         &self,
         display_name: String,
         opaque_def: &'tcx OpaqueDef,
+        borrowed_return_targets: &std::collections::HashSet<String>,
     ) -> Option<(Option<String>, String)> {
         // Lower every method exactly once, then hand the same `MethodInfo`s
         // to both the raw and idiomatic templates. Lowering twice (once per
@@ -153,9 +154,12 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             .filter_map(|m| self.build_method_info(StructMethodContext::new(m)))
             .collect();
         let raw = self.gen_opaque_raw(display_name.clone(), opaque_def, methods.clone());
-        // Only lifetime-carrying opaques can be a borrowing return, so only
-        // they need keep-alive edge storage.
-        let has_edges = opaque_def.lifetimes.num_lifetimes() != 0;
+        // Needs the edges/non-owning machinery if it can be a borrowing
+        // return: either an owned borrow (`Box<T<'a>>`, lifetime-carrying) or
+        // a borrowed return (`&T`, tracked by name since the borrow isn't a
+        // lifetime on the type itself).
+        let has_edges = opaque_def.lifetimes.num_lifetimes() != 0
+            || borrowed_return_targets.contains(&display_name);
         let content = self.gen_opaque_impl(display_name, methods, has_edges);
         Some((Some(raw), content))
     }

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -96,6 +96,15 @@ struct NativeLibTemplate<'a> {
     dylib_name: &'a str,
 }
 
+/// `RustHandle<T>` — a pointer that carries its own free decision (owned
+/// runs the destructor, borrowed doesn't), so a borrow-returning wrapper
+/// doesn't need an ownership flag field.
+#[derive(Template)]
+#[template(path = "dotnet/RustHandle.cs.jinja", escape = "none")]
+struct RustHandleTemplate<'a> {
+    namespace: &'a str,
+}
+
 pub(crate) fn attr_support() -> BackendAttrSupport {
     let mut a = BackendAttrSupport::default();
 
@@ -429,6 +438,15 @@ pub(crate) fn run<'tcx>(
         .render()
         .expect("NativeLib template render failed"),
     );
+    add_cs_file(
+        &files,
+        "RustHandle.cs".to_string(),
+        RustHandleTemplate {
+            namespace: &namespace,
+        }
+        .render()
+        .expect("RustHandle template render failed"),
+    );
 
     (files, errors)
 }
@@ -553,12 +571,16 @@ mod test {
 
         let foo = files.get("Foo.cs").expect("expected Foo.cs output");
         assert!(
-            foo.contains("owned: false"),
-            "borrowed return should build a non-owning wrapper:\n{foo}"
+            foo.contains(".Borrowed("),
+            "borrowed return should build the wrapper via the non-owning Borrowed factory:\n{foo}"
         );
         assert!(
-            foo.contains("if (_owned)"),
-            "a borrow-target wrapper should gate Destroy on _owned:\n{foo}"
+            foo.contains("RustHandle<Raw.Foo>") && foo.contains("_inner.Release()"),
+            "a borrow-target wrapper should carry ownership in the handle and free via Release:\n{foo}"
+        );
+        assert!(
+            !foo.contains("_owned"),
+            "the ownership flag field should be gone — ownership lives in the handle:\n{foo}"
         );
     }
 

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -272,6 +272,8 @@ pub(crate) fn run<'tcx>(
         callback_struct_registry: std::cell::RefCell::new(std::collections::HashMap::new()),
     };
 
+    let borrowed_return_targets = ctx.borrowed_return_targets();
+
     for (id, ty) in tcx.all_types() {
         if ty.attrs().disable {
             continue;
@@ -296,7 +298,7 @@ pub(crate) fn run<'tcx>(
             }
             diplomat_core::hir::TypeDef::OutStruct(struct_def) => ctx.gen_out_struct(struct_def),
             diplomat_core::hir::TypeDef::Opaque(opaque_def) => {
-                ctx.gen_opaque(display_name.clone(), opaque_def)
+                ctx.gen_opaque(display_name.clone(), opaque_def, &borrowed_return_targets)
             }
             diplomat_core::hir::TypeDef::Enum(enum_def) => {
                 ctx.gen_enum(display_name.clone(), enum_def)
@@ -527,7 +529,7 @@ mod test {
     }
 
     #[test]
-    fn borrowed_opaque_return_is_rejected() {
+    fn borrowed_opaque_return_generates_non_owning() {
         let tk_stream = quote! {
             #[diplomat::bridge]
             mod ffi {
@@ -542,12 +544,21 @@ mod test {
             }
         };
 
-        let (_files, errors) = run_dotnet(tk_stream);
-        assert_eq!(errors.len(), 1);
-        let error_str = errors.join("\n");
+        let (files, errors) = run_dotnet(tk_stream);
         assert!(
-            errors[0].contains("borrowed opaque return"),
-            "unexpected diagnostics: {error_str}"
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let foo = files.get("Foo.cs").expect("expected Foo.cs output");
+        assert!(
+            foo.contains("owned: false"),
+            "borrowed return should build a non-owning wrapper:\n{foo}"
+        );
+        assert!(
+            foo.contains("if (_owned)"),
+            "a borrow-target wrapper should gate Destroy on _owned:\n{foo}"
         );
     }
 

--- a/tool/templates/dotnet/RustHandle.cs.jinja
+++ b/tool/templates/dotnet/RustHandle.cs.jinja
@@ -1,0 +1,50 @@
+using System;
+
+namespace {{ namespace }}.Diplomat;
+
+#nullable enable
+
+/// <summary>
+/// Frees a Rust-owned <typeparamref name="T"/> by calling its native
+/// destructor. Held by an owned <see cref="RustHandle{T}"/> so the handle can
+/// release the pointer without knowing the concrete type.
+/// </summary>
+internal unsafe delegate void RustDestructor<T>(T* ptr) where T : unmanaged;
+
+/// <summary>
+/// A raw pointer that remembers who's responsible for freeing it. An owned
+/// handle carries the Rust destructor and runs it when you release the handle;
+/// a borrowed handle carries none, so releasing it does nothing — Rust still
+/// owns the memory and will free it itself. That's the whole trick: the
+/// pointer itself says "free me" or "leave me alone", so the wrapper doesn't
+/// need a separate flag bolted onto the class.
+/// </summary>
+internal readonly unsafe struct RustHandle<T> where T : unmanaged
+{
+    private readonly T* _ptr;
+    private readonly RustDestructor<T>? _free;
+
+    private RustHandle(T* ptr, RustDestructor<T>? free)
+    {
+        _ptr = ptr;
+        _free = free;
+    }
+
+    /// <summary>The C# side owns the pointer: <see cref="Release"/> frees it.</summary>
+    public static RustHandle<T> Owned(T* ptr, RustDestructor<T> free) => new RustHandle<T>(ptr, free);
+
+    /// <summary>Rust still owns the pointer: <see cref="Release"/> is a no-op.</summary>
+    public static RustHandle<T> Borrowed(T* ptr) => new RustHandle<T>(ptr, null);
+
+    public T* Ptr => _ptr;
+
+    public bool IsNull => _ptr == null;
+
+    public void Release()
+    {
+        if (_free != null && _ptr != null)
+        {
+            _free(_ptr);
+        }
+    }
+}

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -10,8 +10,8 @@ namespace {{ namespace }};
 
 public partial class {{ name }}: IDisposable
 {
-    private unsafe Raw.{{ name }}* _inner;
 {%- if has_edges %}
+    private unsafe RustHandle<Raw.{{ name }}> _inner;
 
     /// <summary>
     /// Roots the wrappers this value borrows from so the GC can't finalize
@@ -19,10 +19,9 @@ public partial class {{ name }}: IDisposable
     /// </summary>
     private object[] _edges;
 
-    /// <summary>
-    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
-    /// </summary>
-    private bool _owned;
+    private static readonly unsafe RustDestructor<Raw.{{ name }}> _destroy = Raw.{{ name }}.Destroy;
+{%- else %}
+    private unsafe Raw.{{ name }}* _inner;
 {%- endif %}
     {%- for property in properties %}
 
@@ -60,10 +59,11 @@ public partial class {{ name }}: IDisposable
     /// </remarks>
     internal unsafe {{ name }}(Raw.{{ name }}* handle)
     {
-        _inner = handle;
 {%- if has_edges %}
+        _inner = RustHandle<Raw.{{ name }}>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-        _owned = true;
+{%- else %}
+        _inner = handle;
 {%- endif %}
     }
 {%- if has_edges %}
@@ -73,11 +73,22 @@ public partial class {{ name }}: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe {{ name }}(Raw.{{ name }}* handle, object[] edges, bool owned)
+    internal unsafe {{ name }}(Raw.{{ name }}* handle, object[] edges)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.{{ name }}>.Owned(handle, _destroy);
         _edges = edges;
-        _owned = owned;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe {{ name }}(RustHandle<Raw.{{ name }}> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 {%- endif %}
     {#- One idiomatic method per HIR method. `DiplomatWrite`-returning
@@ -104,7 +115,7 @@ public partial class {{ name }}: IDisposable
         unsafe
         {
 {%- if method.is_instance() %}
-            if (_inner == null)
+            if ({% if has_edges %}_inner.IsNull{% else %}_inner == null{% endif %})
             {
                 throw new ObjectDisposedException("{{ name }}");
             }
@@ -119,7 +130,7 @@ public partial class {{ name }}: IDisposable
     /// </summary>
     internal unsafe Raw.{{ name }}* AsFFI()
     {
-        return _inner;
+        return {% if has_edges %}_inner.Ptr{% else %}_inner{% endif %};
     }
 
     /// <summary>
@@ -129,26 +140,28 @@ public partial class {{ name }}: IDisposable
     {
         unsafe
         {
+{%- if has_edges %}
+            if (_inner.IsNull)
+            {
+                return;
+            }
+
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
+
+            GC.SuppressFinalize(this);
+{%- else %}
             if (_inner == null)
             {
                 return;
             }
-{%- if has_edges %}
-
-            if (_owned)
-            {
-                Raw.{{ name }}.Destroy(_inner);
-            }
-{%- else %}
 
             Raw.{{ name }}.Destroy(_inner);
-{%- endif %}
             _inner = null;
-{%- if has_edges %}
-            _edges = System.Array.Empty<object>();
-{%- endif %}
 
             GC.SuppressFinalize(this);
+{%- endif %}
         }
     }
 

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -18,6 +18,11 @@ public partial class {{ name }}: IDisposable
     /// (-> Destroy) a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
+
+    /// <summary>
+    /// False for a borrowed return — Rust owns the pointer, so we must not free it.
+    /// </summary>
+    private bool _owned;
 {%- endif %}
     {%- for property in properties %}
 
@@ -58,6 +63,7 @@ public partial class {{ name }}: IDisposable
         _inner = handle;
 {%- if has_edges %}
         _edges = System.Array.Empty<object>();
+        _owned = true;
 {%- endif %}
     }
 {%- if has_edges %}
@@ -67,10 +73,11 @@ public partial class {{ name }}: IDisposable
     /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
     /// use-after-free and remains the caller's responsibility.
     /// </remarks>
-    internal unsafe {{ name }}(Raw.{{ name }}* handle, object[] edges)
+    internal unsafe {{ name }}(Raw.{{ name }}* handle, object[] edges, bool owned)
     {
         _inner = handle;
         _edges = edges;
+        _owned = owned;
     }
 {%- endif %}
     {#- One idiomatic method per HIR method. `DiplomatWrite`-returning
@@ -126,8 +133,16 @@ public partial class {{ name }}: IDisposable
             {
                 return;
             }
+{%- if has_edges %}
+
+            if (_owned)
+            {
+                Raw.{{ name }}.Destroy(_inner);
+            }
+{%- else %}
 
             Raw.{{ name }}.Destroy(_inner);
+{%- endif %}
             _inner = null;
 {%- if has_edges %}
             _edges = System.Array.Empty<object>();


### PR DESCRIPTION
Closes #1187.

## What

Borrowed opaque returns — `&T` / `&mut T` / `Option<&T>` — in the .NET backend, via a non-owning wrapper.

## How

The raw handle lives in a `RustHandle<T>` that carries the Rust destructor for **owned** returns and **null for borrowed** ones — so `Dispose`/the finalizer free the pointer only when C# owns it (no separate `_owned` flag). Borrowed returns are built with `RustHandle.Borrowed(...)`; the keep-alive `_edges` (from #1186) root the borrowed-from owner so the borrow stays valid. A pre-pass (`borrowed_return_targets`) marks every opaque ever returned `&T`, so it gets the non-owning path even when it carries no lifetime of its own. Owned returns are unchanged.

## Tests

New `BorrowedReturnTests` cover the runtime contract end-to-end:
- the borrowed value is readable;
- interior aliasing — mutating the owner is observed through an outstanding borrow (proves it's a reference, not a copy);
- a borrowed `Dispose` is a no-op (no double-free);
- `_edges` keeps the owner alive across a forced GC.

Also enables the `get` indexer, which now lowers as a plain `Get(...)` method.

## Deferred — rejected with a clear diagnostic, not silently mis-compiled

- Fallible borrowing returns (`Result<&T, E>`) — needs per-arm edge analysis.
- Borrowing from slice/string params — those buffers are only pinned for the call, so there's no edge to root yet.
