### PR TITLE
dotnet: remove borrowed_return_targets pre-pass; all opaques unconditionally use RustHandle

### DIFF
--- a/example/dotnet/Generated/DataProvider.cs
+++ b/example/dotnet/Generated/DataProvider.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class DataProvider: IDisposable
 {
-    private unsafe Raw.DataProvider* _inner;
+    private unsafe RustHandle<Raw.DataProvider> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.DataProvider> _destroy = Raw.DataProvider.Destroy;
 
     /// <summary>
     /// Creates a managed <c>DataProvider</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class DataProvider: IDisposable
     /// </remarks>
     internal unsafe DataProvider(Raw.DataProvider* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.DataProvider>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe DataProvider(Raw.DataProvider* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.DataProvider>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe DataProvider(RustHandle<Raw.DataProvider> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>DataProvider</c> allocated on Rust side.
@@ -55,7 +87,7 @@ public partial class DataProvider: IDisposable
     /// </summary>
     internal unsafe Raw.DataProvider* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -65,13 +97,14 @@ public partial class DataProvider: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.DataProvider.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/example/dotnet/Generated/FixedDecimal.cs
+++ b/example/dotnet/Generated/FixedDecimal.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class FixedDecimal: IDisposable
 {
-    private unsafe Raw.FixedDecimal* _inner;
+    private unsafe RustHandle<Raw.FixedDecimal> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.FixedDecimal> _destroy = Raw.FixedDecimal.Destroy;
 
     /// <summary>
     /// Creates a managed <c>FixedDecimal</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class FixedDecimal: IDisposable
     /// </remarks>
     internal unsafe FixedDecimal(Raw.FixedDecimal* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.FixedDecimal>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe FixedDecimal(Raw.FixedDecimal* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.FixedDecimal>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe FixedDecimal(RustHandle<Raw.FixedDecimal> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>FixedDecimal</c> allocated on Rust side.
@@ -40,7 +72,7 @@ public partial class FixedDecimal: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("FixedDecimal");
             }
@@ -53,7 +85,7 @@ public partial class FixedDecimal: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("FixedDecimal");
             }
@@ -80,7 +112,7 @@ public partial class FixedDecimal: IDisposable
     /// </summary>
     internal unsafe Raw.FixedDecimal* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -90,13 +122,14 @@ public partial class FixedDecimal: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.FixedDecimal.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/example/dotnet/Generated/FixedDecimalFormatter.cs
+++ b/example/dotnet/Generated/FixedDecimalFormatter.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class FixedDecimalFormatter: IDisposable
 {
-    private unsafe Raw.FixedDecimalFormatter* _inner;
+    private unsafe RustHandle<Raw.FixedDecimalFormatter> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.FixedDecimalFormatter> _destroy = Raw.FixedDecimalFormatter.Destroy;
 
     /// <summary>
     /// Creates a managed <c>FixedDecimalFormatter</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class FixedDecimalFormatter: IDisposable
     /// </remarks>
     internal unsafe FixedDecimalFormatter(Raw.FixedDecimalFormatter* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.FixedDecimalFormatter>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe FixedDecimalFormatter(Raw.FixedDecimalFormatter* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.FixedDecimalFormatter>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe FixedDecimalFormatter(RustHandle<Raw.FixedDecimalFormatter> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <exception cref="InvalidOperationException"></exception>
     /// <returns>
@@ -53,7 +85,7 @@ public partial class FixedDecimalFormatter: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("FixedDecimalFormatter");
             }
@@ -80,7 +112,7 @@ public partial class FixedDecimalFormatter: IDisposable
     /// </summary>
     internal unsafe Raw.FixedDecimalFormatter* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -90,13 +122,14 @@ public partial class FixedDecimalFormatter: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.FixedDecimalFormatter.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/example/dotnet/Generated/Locale.cs
+++ b/example/dotnet/Generated/Locale.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class Locale: IDisposable
 {
-    private unsafe Raw.Locale* _inner;
+    private unsafe RustHandle<Raw.Locale> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.Locale> _destroy = Raw.Locale.Destroy;
 
     /// <summary>
     /// Creates a managed <c>Locale</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class Locale: IDisposable
     /// </remarks>
     internal unsafe Locale(Raw.Locale* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Locale>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe Locale(Raw.Locale* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.Locale>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe Locale(RustHandle<Raw.Locale> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Locale</c> allocated on Rust side.
@@ -47,7 +79,7 @@ public partial class Locale: IDisposable
     /// </summary>
     internal unsafe Raw.Locale* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -57,13 +89,14 @@ public partial class Locale: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.Locale.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
+++ b/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class AttrOpaque1Renamed: IDisposable
 {
-    private unsafe Raw.AttrOpaque1Renamed* _inner;
+    private unsafe RustHandle<Raw.AttrOpaque1Renamed> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.AttrOpaque1Renamed> _destroy = Raw.AttrOpaque1Renamed.Destroy;
 
     /// <summary>
     /// Creates a managed <c>AttrOpaque1Renamed</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class AttrOpaque1Renamed: IDisposable
     /// </remarks>
     internal unsafe AttrOpaque1Renamed(Raw.AttrOpaque1Renamed* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.AttrOpaque1Renamed>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe AttrOpaque1Renamed(Raw.AttrOpaque1Renamed* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.AttrOpaque1Renamed>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe AttrOpaque1Renamed(RustHandle<Raw.AttrOpaque1Renamed> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>AttrOpaque1Renamed</c> allocated on Rust side.
@@ -65,7 +97,7 @@ public partial class AttrOpaque1Renamed: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("AttrOpaque1Renamed");
             }
@@ -78,7 +110,7 @@ public partial class AttrOpaque1Renamed: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("AttrOpaque1Renamed");
             }
@@ -91,7 +123,7 @@ public partial class AttrOpaque1Renamed: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("AttrOpaque1Renamed");
             }
@@ -107,7 +139,7 @@ public partial class AttrOpaque1Renamed: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("AttrOpaque1Renamed");
             }
@@ -121,7 +153,7 @@ public partial class AttrOpaque1Renamed: IDisposable
     /// </summary>
     internal unsafe Raw.AttrOpaque1Renamed* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -131,13 +163,14 @@ public partial class AttrOpaque1Renamed: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.AttrOpaque1Renamed.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
+++ b/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
@@ -13,8 +13,8 @@ public partial class AttrOpaque1Renamed: IDisposable
     private unsafe RustHandle<Raw.AttrOpaque1Renamed> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -170,7 +170,7 @@ public partial class AttrOpaque1Renamed: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Bar.cs
+++ b/feature_tests/dotnet/Generated/Bar.cs
@@ -13,8 +13,8 @@ public partial class Bar: IDisposable
     private unsafe RustHandle<Raw.Bar> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -100,7 +100,7 @@ public partial class Bar: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Float64Vec.cs
+++ b/feature_tests/dotnet/Generated/Float64Vec.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class Float64Vec: IDisposable
 {
-    private unsafe Raw.Float64Vec* _inner;
+    private unsafe RustHandle<Raw.Float64Vec> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.Float64Vec> _destroy = Raw.Float64Vec.Destroy;
 
     /// <summary>
     /// Creates a managed <c>Float64Vec</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class Float64Vec: IDisposable
     /// </remarks>
     internal unsafe Float64Vec(Raw.Float64Vec* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Float64Vec>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe Float64Vec(Raw.Float64Vec* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.Float64Vec>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe Float64Vec(RustHandle<Raw.Float64Vec> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Float64Vec</c> allocated on Rust side.
@@ -44,7 +76,7 @@ public partial class Float64Vec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("Float64Vec");
             }
@@ -65,7 +97,7 @@ public partial class Float64Vec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("Float64Vec");
             }
@@ -80,7 +112,7 @@ public partial class Float64Vec: IDisposable
     /// </summary>
     internal unsafe Raw.Float64Vec* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -90,13 +122,14 @@ public partial class Float64Vec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.Float64Vec.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Float64Vec.cs
+++ b/feature_tests/dotnet/Generated/Float64Vec.cs
@@ -13,8 +13,8 @@ public partial class Float64Vec: IDisposable
     private unsafe RustHandle<Raw.Float64Vec> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -129,7 +129,7 @@ public partial class Float64Vec: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Foo.cs
+++ b/feature_tests/dotnet/Generated/Foo.cs
@@ -13,8 +13,8 @@ public partial class Foo: IDisposable
     private unsafe RustHandle<Raw.Foo> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -100,7 +100,7 @@ public partial class Foo: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/GcRaceProbe.cs
+++ b/feature_tests/dotnet/Generated/GcRaceProbe.cs
@@ -13,8 +13,8 @@ public partial class GcRaceProbe: IDisposable
     private unsafe RustHandle<Raw.GcRaceProbe> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -104,7 +104,7 @@ public partial class GcRaceProbe: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/GcRaceProbe.cs
+++ b/feature_tests/dotnet/Generated/GcRaceProbe.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class GcRaceProbe: IDisposable
 {
-    private unsafe Raw.GcRaceProbe* _inner;
+    private unsafe RustHandle<Raw.GcRaceProbe> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.GcRaceProbe> _destroy = Raw.GcRaceProbe.Destroy;
 
     /// <summary>
     /// Creates a managed <c>GcRaceProbe</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class GcRaceProbe: IDisposable
     /// </remarks>
     internal unsafe GcRaceProbe(Raw.GcRaceProbe* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.GcRaceProbe>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe GcRaceProbe(Raw.GcRaceProbe* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.GcRaceProbe>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe GcRaceProbe(RustHandle<Raw.GcRaceProbe> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>GcRaceProbe</c> allocated on Rust side.
@@ -40,7 +72,7 @@ public partial class GcRaceProbe: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("GcRaceProbe");
             }
@@ -55,7 +87,7 @@ public partial class GcRaceProbe: IDisposable
     /// </summary>
     internal unsafe Raw.GcRaceProbe* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -65,13 +97,14 @@ public partial class GcRaceProbe: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.GcRaceProbe.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/MethodOverloading.cs
+++ b/feature_tests/dotnet/Generated/MethodOverloading.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class MethodOverloading: IDisposable
 {
-    private unsafe Raw.MethodOverloading* _inner;
+    private unsafe RustHandle<Raw.MethodOverloading> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.MethodOverloading> _destroy = Raw.MethodOverloading.Destroy;
 
     /// <summary>
     /// Creates a managed <c>MethodOverloading</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class MethodOverloading: IDisposable
     /// </remarks>
     internal unsafe MethodOverloading(Raw.MethodOverloading* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.MethodOverloading>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe MethodOverloading(Raw.MethodOverloading* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.MethodOverloading>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe MethodOverloading(RustHandle<Raw.MethodOverloading> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>MethodOverloading</c> allocated on Rust side.
@@ -64,7 +96,7 @@ public partial class MethodOverloading: IDisposable
     /// </summary>
     internal unsafe Raw.MethodOverloading* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -74,13 +106,14 @@ public partial class MethodOverloading: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.MethodOverloading.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/MethodOverloading.cs
+++ b/feature_tests/dotnet/Generated/MethodOverloading.cs
@@ -13,8 +13,8 @@ public partial class MethodOverloading: IDisposable
     private unsafe RustHandle<Raw.MethodOverloading> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -113,7 +113,7 @@ public partial class MethodOverloading: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class MyOpaqueEnum: IDisposable
 {
-    private unsafe Raw.MyOpaqueEnum* _inner;
+    private unsafe RustHandle<Raw.MyOpaqueEnum> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.MyOpaqueEnum> _destroy = Raw.MyOpaqueEnum.Destroy;
 
     /// <summary>
     /// Creates a managed <c>MyOpaqueEnum</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class MyOpaqueEnum: IDisposable
     /// </remarks>
     internal unsafe MyOpaqueEnum(Raw.MyOpaqueEnum* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.MyOpaqueEnum>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe MyOpaqueEnum(Raw.MyOpaqueEnum* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.MyOpaqueEnum>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe MyOpaqueEnum(RustHandle<Raw.MyOpaqueEnum> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>MyOpaqueEnum</c> allocated on Rust side.
@@ -40,7 +72,7 @@ public partial class MyOpaqueEnum: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("MyOpaqueEnum");
             }
@@ -63,7 +95,7 @@ public partial class MyOpaqueEnum: IDisposable
     /// </summary>
     internal unsafe Raw.MyOpaqueEnum* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -73,13 +105,14 @@ public partial class MyOpaqueEnum: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.MyOpaqueEnum.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
@@ -13,8 +13,8 @@ public partial class MyOpaqueEnum: IDisposable
     private unsafe RustHandle<Raw.MyOpaqueEnum> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -112,7 +112,7 @@ public partial class MyOpaqueEnum: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/MyString.cs
+++ b/feature_tests/dotnet/Generated/MyString.cs
@@ -13,8 +13,8 @@ public partial class MyString: IDisposable
     private unsafe RustHandle<Raw.MyString> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -171,7 +171,7 @@ public partial class MyString: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/MyString.cs
+++ b/feature_tests/dotnet/Generated/MyString.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class MyString: IDisposable
 {
-    private unsafe Raw.MyString* _inner;
+    private unsafe RustHandle<Raw.MyString> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.MyString> _destroy = Raw.MyString.Destroy;
 
     /// <summary>
     /// Creates a managed <c>MyString</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class MyString: IDisposable
     /// </remarks>
     internal unsafe MyString(Raw.MyString* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.MyString>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe MyString(Raw.MyString* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.MyString>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe MyString(RustHandle<Raw.MyString> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>MyString</c> allocated on Rust side.
@@ -61,7 +93,7 @@ public partial class MyString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("MyString");
             }
@@ -78,7 +110,7 @@ public partial class MyString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("MyString");
             }
@@ -122,7 +154,7 @@ public partial class MyString: IDisposable
     /// </summary>
     internal unsafe Raw.MyString* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -132,13 +164,14 @@ public partial class MyString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.MyString.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/One.cs
+++ b/feature_tests/dotnet/Generated/One.cs
@@ -13,8 +13,8 @@ public partial class One: IDisposable
     private unsafe RustHandle<Raw.One> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -401,7 +401,7 @@ public partial class One: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class Opaque: IDisposable
 {
-    private unsafe Raw.Opaque* _inner;
+    private unsafe RustHandle<Raw.Opaque> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.Opaque> _destroy = Raw.Opaque.Destroy;
 
     /// <summary>
     /// Creates a managed <c>Opaque</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class Opaque: IDisposable
     /// </remarks>
     internal unsafe Opaque(Raw.Opaque* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Opaque>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe Opaque(Raw.Opaque* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.Opaque>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe Opaque(RustHandle<Raw.Opaque> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Opaque</c> allocated on Rust side.
@@ -72,7 +104,7 @@ public partial class Opaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("Opaque");
             }
@@ -93,7 +125,7 @@ public partial class Opaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("Opaque");
             }
@@ -122,7 +154,7 @@ public partial class Opaque: IDisposable
     /// </summary>
     internal unsafe Raw.Opaque* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -132,13 +164,14 @@ public partial class Opaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.Opaque.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -13,8 +13,8 @@ public partial class Opaque: IDisposable
     private unsafe RustHandle<Raw.Opaque> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -171,7 +171,7 @@ public partial class Opaque: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueMut.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMut.cs
@@ -13,8 +13,8 @@ public partial class OpaqueMut: IDisposable
     private unsafe RustHandle<Raw.OpaqueMut> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -91,7 +91,7 @@ public partial class OpaqueMut: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueMut.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMut.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class OpaqueMut: IDisposable
 {
-    private unsafe Raw.OpaqueMut* _inner;
+    private unsafe RustHandle<Raw.OpaqueMut> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.OpaqueMut> _destroy = Raw.OpaqueMut.Destroy;
 
     /// <summary>
     /// Creates a managed <c>OpaqueMut</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class OpaqueMut: IDisposable
     /// </remarks>
     internal unsafe OpaqueMut(Raw.OpaqueMut* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OpaqueMut>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe OpaqueMut(Raw.OpaqueMut* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.OpaqueMut>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe OpaqueMut(RustHandle<Raw.OpaqueMut> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OpaqueMut</c> allocated on Rust side.
@@ -42,7 +74,7 @@ public partial class OpaqueMut: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueMut* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -52,13 +84,14 @@ public partial class OpaqueMut: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.OpaqueMut.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
@@ -13,8 +13,8 @@ public partial class OpaqueMutexedString: IDisposable
     private unsafe RustHandle<Raw.OpaqueMutexedString> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -145,7 +145,7 @@ public partial class OpaqueMutexedString: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class OpaqueMutexedString: IDisposable
 {
-    private unsafe Raw.OpaqueMutexedString* _inner;
+    private unsafe RustHandle<Raw.OpaqueMutexedString> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.OpaqueMutexedString> _destroy = Raw.OpaqueMutexedString.Destroy;
 
     /// <summary>
     /// Creates a managed <c>OpaqueMutexedString</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class OpaqueMutexedString: IDisposable
     /// </remarks>
     internal unsafe OpaqueMutexedString(Raw.OpaqueMutexedString* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OpaqueMutexedString>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe OpaqueMutexedString(Raw.OpaqueMutexedString* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.OpaqueMutexedString>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe OpaqueMutexedString(RustHandle<Raw.OpaqueMutexedString> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OpaqueMutexedString</c> allocated on Rust side.
@@ -40,7 +72,7 @@ public partial class OpaqueMutexedString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueMutexedString");
             }
@@ -52,7 +84,7 @@ public partial class OpaqueMutexedString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueMutexedString");
             }
@@ -68,7 +100,7 @@ public partial class OpaqueMutexedString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueMutexedString");
             }
@@ -81,7 +113,7 @@ public partial class OpaqueMutexedString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueMutexedString");
             }
@@ -96,7 +128,7 @@ public partial class OpaqueMutexedString: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueMutexedString* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -106,13 +138,14 @@ public partial class OpaqueMutexedString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.OpaqueMutexedString.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThin.cs
@@ -13,8 +13,8 @@ public partial class OpaqueThin: IDisposable
     private unsafe RustHandle<Raw.OpaqueThin> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -127,7 +127,7 @@ public partial class OpaqueThin: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueThinIter.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinIter.cs
@@ -13,8 +13,8 @@ public partial class OpaqueThinIter: IDisposable
     private unsafe RustHandle<Raw.OpaqueThinIter> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -80,7 +80,7 @@ public partial class OpaqueThinIter: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -13,8 +13,8 @@ public partial class OpaqueThinVec: IDisposable
     private unsafe RustHandle<Raw.OpaqueThinVec> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -186,7 +186,7 @@ public partial class OpaqueThinVec: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class OpaqueThinVec: IDisposable
 {
-    private unsafe Raw.OpaqueThinVec* _inner;
+    private unsafe RustHandle<Raw.OpaqueThinVec> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.OpaqueThinVec> _destroy = Raw.OpaqueThinVec.Destroy;
 
     /// <summary>
     /// Creates a managed <c>OpaqueThinVec</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class OpaqueThinVec: IDisposable
     /// </remarks>
     internal unsafe OpaqueThinVec(Raw.OpaqueThinVec* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OpaqueThinVec>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe OpaqueThinVec(Raw.OpaqueThinVec* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.OpaqueThinVec>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe OpaqueThinVec(RustHandle<Raw.OpaqueThinVec> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OpaqueThinVec</c> allocated on Rust side.
@@ -45,7 +77,7 @@ public partial class OpaqueThinVec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueThinVec");
             }
@@ -69,7 +101,7 @@ public partial class OpaqueThinVec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueThinVec");
             }
@@ -82,7 +114,7 @@ public partial class OpaqueThinVec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueThinVec");
             }
@@ -102,7 +134,7 @@ public partial class OpaqueThinVec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueThinVec");
             }
@@ -122,7 +154,7 @@ public partial class OpaqueThinVec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OpaqueThinVec");
             }
@@ -137,7 +169,7 @@ public partial class OpaqueThinVec: IDisposable
     /// </summary>
     internal unsafe Raw.OpaqueThinVec* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -147,13 +179,14 @@ public partial class OpaqueThinVec: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.OpaqueThinVec.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OptionOpaque.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaque.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class OptionOpaque: IDisposable
 {
-    private unsafe Raw.OptionOpaque* _inner;
+    private unsafe RustHandle<Raw.OptionOpaque> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.OptionOpaque> _destroy = Raw.OptionOpaque.Destroy;
 
     /// <summary>
     /// Creates a managed <c>OptionOpaque</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class OptionOpaque: IDisposable
     /// </remarks>
     internal unsafe OptionOpaque(Raw.OptionOpaque* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OptionOpaque>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe OptionOpaque(Raw.OptionOpaque* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.OptionOpaque>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe OptionOpaque(RustHandle<Raw.OptionOpaque> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OptionOpaque</c> allocated on Rust side.
@@ -51,7 +83,7 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
@@ -64,7 +96,7 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
@@ -77,7 +109,7 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
@@ -90,7 +122,7 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
@@ -103,7 +135,7 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OptionOpaque");
             }
@@ -128,7 +160,7 @@ public partial class OptionOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.OptionOpaque* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -138,13 +170,14 @@ public partial class OptionOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.OptionOpaque.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OptionOpaque.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaque.cs
@@ -13,8 +13,8 @@ public partial class OptionOpaque: IDisposable
     private unsafe RustHandle<Raw.OptionOpaque> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -177,7 +177,7 @@ public partial class OptionOpaque: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
@@ -13,8 +13,8 @@ public partial class OptionOpaqueChar: IDisposable
     private unsafe RustHandle<Raw.OptionOpaqueChar> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -92,7 +92,7 @@ public partial class OptionOpaqueChar: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class OptionOpaqueChar: IDisposable
 {
-    private unsafe Raw.OptionOpaqueChar* _inner;
+    private unsafe RustHandle<Raw.OptionOpaqueChar> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.OptionOpaqueChar> _destroy = Raw.OptionOpaqueChar.Destroy;
 
     /// <summary>
     /// Creates a managed <c>OptionOpaqueChar</c> from a raw handle.
@@ -23,13 +31,37 @@ public partial class OptionOpaqueChar: IDisposable
     /// </remarks>
     internal unsafe OptionOpaqueChar(Raw.OptionOpaqueChar* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OptionOpaqueChar>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe OptionOpaqueChar(Raw.OptionOpaqueChar* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.OptionOpaqueChar>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe OptionOpaqueChar(RustHandle<Raw.OptionOpaqueChar> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     public void AssertChar(uint ch)
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OptionOpaqueChar");
             }
@@ -43,7 +75,7 @@ public partial class OptionOpaqueChar: IDisposable
     /// </summary>
     internal unsafe Raw.OptionOpaqueChar* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -53,13 +85,14 @@ public partial class OptionOpaqueChar: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.OptionOpaqueChar.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OptionString.cs
+++ b/feature_tests/dotnet/Generated/OptionString.cs
@@ -13,8 +13,8 @@ public partial class OptionString: IDisposable
     private unsafe RustHandle<Raw.OptionString> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -122,7 +122,7 @@ public partial class OptionString: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/OptionString.cs
+++ b/feature_tests/dotnet/Generated/OptionString.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class OptionString: IDisposable
 {
-    private unsafe Raw.OptionString* _inner;
+    private unsafe RustHandle<Raw.OptionString> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.OptionString> _destroy = Raw.OptionString.Destroy;
 
     /// <summary>
     /// Creates a managed <c>OptionString</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class OptionString: IDisposable
     /// </remarks>
     internal unsafe OptionString(Raw.OptionString* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.OptionString>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe OptionString(Raw.OptionString* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.OptionString>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe OptionString(RustHandle<Raw.OptionString> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>OptionString</c> allocated on Rust side.
@@ -46,7 +78,7 @@ public partial class OptionString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("OptionString");
             }
@@ -73,7 +105,7 @@ public partial class OptionString: IDisposable
     /// </summary>
     internal unsafe Raw.OptionString* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -83,13 +115,14 @@ public partial class OptionString: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.OptionString.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RefList.cs
+++ b/feature_tests/dotnet/Generated/RefList.cs
@@ -13,8 +13,8 @@ public partial class RefList: IDisposable
     private unsafe RustHandle<Raw.RefList> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -99,7 +99,7 @@ public partial class RefList: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RefListParameter.cs
+++ b/feature_tests/dotnet/Generated/RefListParameter.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RefListParameter: IDisposable
 {
-    private unsafe Raw.RefListParameter* _inner;
+    private unsafe RustHandle<Raw.RefListParameter> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RefListParameter> _destroy = Raw.RefListParameter.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RefListParameter</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RefListParameter: IDisposable
     /// </remarks>
     internal unsafe RefListParameter(Raw.RefListParameter* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RefListParameter>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RefListParameter(Raw.RefListParameter* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RefListParameter>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RefListParameter(RustHandle<Raw.RefListParameter> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 
     /// <summary>
@@ -31,7 +63,7 @@ public partial class RefListParameter: IDisposable
     /// </summary>
     internal unsafe Raw.RefListParameter* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -41,13 +73,14 @@ public partial class RefListParameter: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RefListParameter.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RefListParameter.cs
+++ b/feature_tests/dotnet/Generated/RefListParameter.cs
@@ -13,8 +13,8 @@ public partial class RefListParameter: IDisposable
     private unsafe RustHandle<Raw.RefListParameter> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -80,7 +80,7 @@ public partial class RefListParameter: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
+++ b/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
@@ -13,8 +13,8 @@ public partial class RenamedAttrOpaque2: IDisposable
     private unsafe RustHandle<Raw.RenamedAttrOpaque2> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -80,7 +80,7 @@ public partial class RenamedAttrOpaque2: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
+++ b/feature_tests/dotnet/Generated/RenamedAttrOpaque2.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RenamedAttrOpaque2: IDisposable
 {
-    private unsafe Raw.RenamedAttrOpaque2* _inner;
+    private unsafe RustHandle<Raw.RenamedAttrOpaque2> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RenamedAttrOpaque2> _destroy = Raw.RenamedAttrOpaque2.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RenamedAttrOpaque2</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RenamedAttrOpaque2: IDisposable
     /// </remarks>
     internal unsafe RenamedAttrOpaque2(Raw.RenamedAttrOpaque2* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RenamedAttrOpaque2>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RenamedAttrOpaque2(Raw.RenamedAttrOpaque2* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RenamedAttrOpaque2>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RenamedAttrOpaque2(RustHandle<Raw.RenamedAttrOpaque2> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 
     /// <summary>
@@ -31,7 +63,7 @@ public partial class RenamedAttrOpaque2: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedAttrOpaque2* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -41,13 +73,14 @@ public partial class RenamedAttrOpaque2: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RenamedAttrOpaque2.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RenamedDeprecatedOpaque: IDisposable
 {
-    private unsafe Raw.RenamedDeprecatedOpaque* _inner;
+    private unsafe RustHandle<Raw.RenamedDeprecatedOpaque> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RenamedDeprecatedOpaque> _destroy = Raw.RenamedDeprecatedOpaque.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RenamedDeprecatedOpaque</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     /// </remarks>
     internal unsafe RenamedDeprecatedOpaque(Raw.RenamedDeprecatedOpaque* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RenamedDeprecatedOpaque>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RenamedDeprecatedOpaque(Raw.RenamedDeprecatedOpaque* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RenamedDeprecatedOpaque>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RenamedDeprecatedOpaque(RustHandle<Raw.RenamedDeprecatedOpaque> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 
     /// <summary>
@@ -31,7 +63,7 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedDeprecatedOpaque* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -41,13 +73,14 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RenamedDeprecatedOpaque.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedDeprecatedOpaque.cs
@@ -13,8 +13,8 @@ public partial class RenamedDeprecatedOpaque: IDisposable
     private unsafe RustHandle<Raw.RenamedDeprecatedOpaque> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -80,7 +80,7 @@ public partial class RenamedDeprecatedOpaque: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedMixinTest.cs
@@ -13,8 +13,8 @@ public partial class RenamedMixinTest: IDisposable
     private unsafe RustHandle<Raw.RenamedMixinTest> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -96,7 +96,7 @@ public partial class RenamedMixinTest: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedMixinTest.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RenamedMixinTest: IDisposable
 {
-    private unsafe Raw.RenamedMixinTest* _inner;
+    private unsafe RustHandle<Raw.RenamedMixinTest> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RenamedMixinTest> _destroy = Raw.RenamedMixinTest.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RenamedMixinTest</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RenamedMixinTest: IDisposable
     /// </remarks>
     internal unsafe RenamedMixinTest(Raw.RenamedMixinTest* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RenamedMixinTest>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RenamedMixinTest(Raw.RenamedMixinTest* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RenamedMixinTest>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RenamedMixinTest(RustHandle<Raw.RenamedMixinTest> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     public static string Hello()
     {
@@ -47,7 +79,7 @@ public partial class RenamedMixinTest: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedMixinTest* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -57,13 +89,14 @@ public partial class RenamedMixinTest: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RenamedMixinTest.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedNested.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested.cs
@@ -13,8 +13,8 @@ public partial class RenamedNested: IDisposable
     private unsafe RustHandle<Raw.RenamedNested> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -80,7 +80,7 @@ public partial class RenamedNested: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedNested.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RenamedNested: IDisposable
 {
-    private unsafe Raw.RenamedNested* _inner;
+    private unsafe RustHandle<Raw.RenamedNested> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RenamedNested> _destroy = Raw.RenamedNested.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RenamedNested</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RenamedNested: IDisposable
     /// </remarks>
     internal unsafe RenamedNested(Raw.RenamedNested* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RenamedNested>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RenamedNested(Raw.RenamedNested* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RenamedNested>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RenamedNested(RustHandle<Raw.RenamedNested> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 
     /// <summary>
@@ -31,7 +63,7 @@ public partial class RenamedNested: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedNested* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -41,13 +73,14 @@ public partial class RenamedNested: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RenamedNested.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedNested2.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested2.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RenamedNested2: IDisposable
 {
-    private unsafe Raw.RenamedNested2* _inner;
+    private unsafe RustHandle<Raw.RenamedNested2> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RenamedNested2> _destroy = Raw.RenamedNested2.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RenamedNested2</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RenamedNested2: IDisposable
     /// </remarks>
     internal unsafe RenamedNested2(Raw.RenamedNested2* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RenamedNested2>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RenamedNested2(Raw.RenamedNested2* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RenamedNested2>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RenamedNested2(RustHandle<Raw.RenamedNested2> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 
     /// <summary>
@@ -31,7 +63,7 @@ public partial class RenamedNested2: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedNested2* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -41,13 +73,14 @@ public partial class RenamedNested2: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RenamedNested2.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedNested2.cs
+++ b/feature_tests/dotnet/Generated/RenamedNested2.cs
@@ -13,8 +13,8 @@ public partial class RenamedNested2: IDisposable
     private unsafe RustHandle<Raw.RenamedNested2> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -80,7 +80,7 @@ public partial class RenamedNested2: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
+++ b/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
@@ -13,8 +13,8 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     private unsafe RustHandle<Raw.RenamedOpaqueZSTIndexer> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -107,7 +107,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
+++ b/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RenamedOpaqueZSTIndexer: IDisposable
 {
-    private unsafe Raw.RenamedOpaqueZSTIndexer* _inner;
+    private unsafe RustHandle<Raw.RenamedOpaqueZSTIndexer> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RenamedOpaqueZSTIndexer> _destroy = Raw.RenamedOpaqueZSTIndexer.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RenamedOpaqueZSTIndexer</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// </remarks>
     internal unsafe RenamedOpaqueZSTIndexer(Raw.RenamedOpaqueZSTIndexer* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RenamedOpaqueZSTIndexer>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RenamedOpaqueZSTIndexer(Raw.RenamedOpaqueZSTIndexer* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RenamedOpaqueZSTIndexer>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RenamedOpaqueZSTIndexer(RustHandle<Raw.RenamedOpaqueZSTIndexer> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>RenamedOpaqueZSTIndexer</c> allocated on Rust side.
@@ -43,7 +75,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("RenamedOpaqueZSTIndexer");
             }
@@ -58,7 +90,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedOpaqueZSTIndexer* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -68,13 +100,14 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RenamedOpaqueZSTIndexer.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
@@ -13,8 +13,8 @@ public partial class RenamedTestOpaque: IDisposable
     private unsafe RustHandle<Raw.RenamedTestOpaque> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -80,7 +80,7 @@ public partial class RenamedTestOpaque: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
+++ b/feature_tests/dotnet/Generated/RenamedTestOpaque.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RenamedTestOpaque: IDisposable
 {
-    private unsafe Raw.RenamedTestOpaque* _inner;
+    private unsafe RustHandle<Raw.RenamedTestOpaque> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RenamedTestOpaque> _destroy = Raw.RenamedTestOpaque.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RenamedTestOpaque</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RenamedTestOpaque: IDisposable
     /// </remarks>
     internal unsafe RenamedTestOpaque(Raw.RenamedTestOpaque* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RenamedTestOpaque>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RenamedTestOpaque(Raw.RenamedTestOpaque* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RenamedTestOpaque>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RenamedTestOpaque(RustHandle<Raw.RenamedTestOpaque> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
 
     /// <summary>
@@ -31,7 +63,7 @@ public partial class RenamedTestOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedTestOpaque* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -41,13 +73,14 @@ public partial class RenamedTestOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RenamedTestOpaque.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedVectorTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedVectorTest.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class RenamedVectorTest: IDisposable
 {
-    private unsafe Raw.RenamedVectorTest* _inner;
+    private unsafe RustHandle<Raw.RenamedVectorTest> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.RenamedVectorTest> _destroy = Raw.RenamedVectorTest.Destroy;
 
     /// <summary>
     /// Creates a managed <c>RenamedVectorTest</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class RenamedVectorTest: IDisposable
     /// </remarks>
     internal unsafe RenamedVectorTest(Raw.RenamedVectorTest* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.RenamedVectorTest>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe RenamedVectorTest(Raw.RenamedVectorTest* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.RenamedVectorTest>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe RenamedVectorTest(RustHandle<Raw.RenamedVectorTest> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>RenamedVectorTest</c> allocated on Rust side.
@@ -40,7 +72,7 @@ public partial class RenamedVectorTest: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("RenamedVectorTest");
             }
@@ -53,7 +85,7 @@ public partial class RenamedVectorTest: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("RenamedVectorTest");
             }
@@ -66,7 +98,7 @@ public partial class RenamedVectorTest: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("RenamedVectorTest");
             }
@@ -80,7 +112,7 @@ public partial class RenamedVectorTest: IDisposable
     /// </summary>
     internal unsafe Raw.RenamedVectorTest* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -90,13 +122,14 @@ public partial class RenamedVectorTest: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.RenamedVectorTest.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/RenamedVectorTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedVectorTest.cs
@@ -13,8 +13,8 @@ public partial class RenamedVectorTest: IDisposable
     private unsafe RustHandle<Raw.RenamedVectorTest> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -129,7 +129,7 @@ public partial class RenamedVectorTest: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/ResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/ResultOpaque.cs
@@ -13,8 +13,8 @@ public partial class ResultOpaque: IDisposable
     private unsafe RustHandle<Raw.ResultOpaque> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -211,7 +211,7 @@ public partial class ResultOpaque: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/ResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/ResultOpaque.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class ResultOpaque: IDisposable
 {
-    private unsafe Raw.ResultOpaque* _inner;
+    private unsafe RustHandle<Raw.ResultOpaque> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.ResultOpaque> _destroy = Raw.ResultOpaque.Destroy;
 
     /// <summary>
     /// Creates a managed <c>ResultOpaque</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class ResultOpaque: IDisposable
     /// </remarks>
     internal unsafe ResultOpaque(Raw.ResultOpaque* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.ResultOpaque>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe ResultOpaque(Raw.ResultOpaque* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.ResultOpaque>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe ResultOpaque(RustHandle<Raw.ResultOpaque> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <exception cref="ErrorEnumException"></exception>
     /// <returns>
@@ -148,7 +180,7 @@ public partial class ResultOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("ResultOpaque");
             }
@@ -162,7 +194,7 @@ public partial class ResultOpaque: IDisposable
     /// </summary>
     internal unsafe Raw.ResultOpaque* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -172,13 +204,14 @@ public partial class ResultOpaque: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.ResultOpaque.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Two.cs
+++ b/feature_tests/dotnet/Generated/Two.cs
@@ -13,8 +13,8 @@ public partial class Two: IDisposable
     private unsafe RustHandle<Raw.Two> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -80,7 +80,7 @@ public partial class Two: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Unnamespaced.cs
+++ b/feature_tests/dotnet/Generated/Unnamespaced.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class Unnamespaced: IDisposable
 {
-    private unsafe Raw.Unnamespaced* _inner;
+    private unsafe RustHandle<Raw.Unnamespaced> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.Unnamespaced> _destroy = Raw.Unnamespaced.Destroy;
 
     /// <summary>
     /// Creates a managed <c>Unnamespaced</c> from a raw handle.
@@ -23,7 +31,31 @@ public partial class Unnamespaced: IDisposable
     /// </remarks>
     internal unsafe Unnamespaced(Raw.Unnamespaced* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Unnamespaced>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe Unnamespaced(Raw.Unnamespaced* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.Unnamespaced>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe Unnamespaced(RustHandle<Raw.Unnamespaced> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     /// <returns>
     /// A <c>Unnamespaced</c> allocated on Rust side.
@@ -40,7 +72,7 @@ public partial class Unnamespaced: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("Unnamespaced");
             }
@@ -58,7 +90,7 @@ public partial class Unnamespaced: IDisposable
     /// </summary>
     internal unsafe Raw.Unnamespaced* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -68,13 +100,14 @@ public partial class Unnamespaced: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.Unnamespaced.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Unnamespaced.cs
+++ b/feature_tests/dotnet/Generated/Unnamespaced.cs
@@ -13,8 +13,8 @@ public partial class Unnamespaced: IDisposable
     private unsafe RustHandle<Raw.Unnamespaced> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -107,7 +107,7 @@ public partial class Unnamespaced: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/Utf16Wrap.cs
@@ -10,7 +10,15 @@ namespace Somelib;
 
 public partial class Utf16Wrap: IDisposable
 {
-    private unsafe Raw.Utf16Wrap* _inner;
+    private unsafe RustHandle<Raw.Utf16Wrap> _inner;
+
+    /// <summary>
+    /// Roots the wrappers this value borrows from so the GC can't finalize
+    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// </summary>
+    private object[] _edges;
+
+    private static readonly unsafe RustDestructor<Raw.Utf16Wrap> _destroy = Raw.Utf16Wrap.Destroy;
 
     /// <summary>
     /// Creates a managed <c>Utf16Wrap</c> from a raw handle.
@@ -23,13 +31,37 @@ public partial class Utf16Wrap: IDisposable
     /// </remarks>
     internal unsafe Utf16Wrap(Raw.Utf16Wrap* handle)
     {
-        _inner = handle;
+        _inner = RustHandle<Raw.Utf16Wrap>.Owned(handle, _destroy);
+        _edges = System.Array.Empty<object>();
+    }
+
+    /// <remarks>
+    /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
+    /// <c>Dispose</c>-ing a parent while a borrowing child is in use is still a
+    /// use-after-free and remains the caller's responsibility.
+    /// </remarks>
+    internal unsafe Utf16Wrap(Raw.Utf16Wrap* handle, object[] edges)
+    {
+        _inner = RustHandle<Raw.Utf16Wrap>.Owned(handle, _destroy);
+        _edges = edges;
+    }
+
+    /// <summary>
+    /// Wraps a handle that already knows whether it owns the pointer. A
+    /// borrowed return passes a non-owning handle, so Dispose and the finalizer
+    /// leave Rust's pointer alone; the edges keep the borrowed-from owners alive
+    /// while this view is in use.
+    /// </summary>
+    internal unsafe Utf16Wrap(RustHandle<Raw.Utf16Wrap> inner, object[] edges)
+    {
+        _inner = inner;
+        _edges = edges;
     }
     public string GetDebugStr()
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("Utf16Wrap");
             }
@@ -52,7 +84,7 @@ public partial class Utf16Wrap: IDisposable
     /// </summary>
     internal unsafe Raw.Utf16Wrap* AsFFI()
     {
-        return _inner;
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -62,13 +94,14 @@ public partial class Utf16Wrap: IDisposable
     {
         unsafe
         {
-            if (_inner == null)
+            if (_inner.IsNull)
             {
                 return;
             }
 
-            Raw.Utf16Wrap.Destroy(_inner);
-            _inner = null;
+            _inner.Release();
+            _inner = default;
+            _edges = System.Array.Empty<object>();
 
             GC.SuppressFinalize(this);
         }

--- a/feature_tests/dotnet/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/Utf16Wrap.cs
@@ -13,8 +13,8 @@ public partial class Utf16Wrap: IDisposable
     private unsafe RustHandle<Raw.Utf16Wrap> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
@@ -101,7 +101,7 @@ public partial class Utf16Wrap: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
         }

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -461,13 +461,9 @@ pub(super) struct ReturnLowering {
 /// idiomatic-layer render data — templates pick the side they want.
 ///
 /// TODO(dotnet): Model Rust lifetime relationships on the public C# surface.
-/// Today borrowed inputs are lowered as call-scoped borrows (pinned arrays,
-/// temporary slices, opaque handles), but the generated C# does not enforce
-/// Rust lifetime edges. Borrowed opaque returns/errors are rejected until the
-/// backend has a non-owning wrapper/lifetime strategy. Lifetime-carrying owned
-/// returns that borrow from temporary slice/string params are rejected; those
-/// that borrow from an opaque wrapper are documented so callers know they must
-/// preserve backing storage.
+/// Borrowed inputs are call-scoped. Borrowed opaque returns use non-owning
+/// handles and keep-alive edges; borrowed errors and temporary slice/string
+/// backed returns are rejected.
 #[derive(Clone)]
 pub(super) struct MethodInfo<'ctx> {
     /// `extern "C"` symbol name (e.g. `Color_brightness`).
@@ -816,31 +812,6 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         })
     }
 
-    /// Opaque type names that some generated method returns *borrowed*
-    /// (`&T` / `Option<&T>`). Such a type needs the non-owning constructor
-    /// even when it carries no lifetime of its own (the borrow lives on the
-    /// `&`, not the type) — so it can't be gated on lifetime params alone.
-    pub(crate) fn borrowed_return_targets(&self) -> std::collections::HashSet<String> {
-        let mut targets = std::collections::HashSet::new();
-        for (_, ty) in self.tcx.all_types() {
-            if ty.attrs().disable {
-                continue;
-            }
-            for method in ty.methods() {
-                let success = match &method.output {
-                    hir::ReturnType::Infallible(s) | hir::ReturnType::Nullable(s) => s,
-                    hir::ReturnType::Fallible(s, _) => s,
-                };
-                if let hir::SuccessType::OutType(hir::Type::Opaque(p)) = success {
-                    if !p.is_owned() {
-                        targets.insert(self.opaque_name(p));
-                    }
-                }
-            }
-        }
-        targets
-    }
-
     /// Sometimes a method hands back a value that's really just pointing into
     /// another object instead of owning its own. If the garbage collector frees
     /// that other object too early, the returned value is left pointing at freed
@@ -1022,10 +993,8 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                 DotnetReturnType::Primitive(self.lower_primitive(p)?)
             }
             hir::SuccessType::OutType(hir::Type::Opaque(p)) => {
-                // A borrowed return (`!is_owned`) is constructed non-owning
-                // (`{name}.Borrowed(...)`) so Dispose/finalizer skip Destroy —
-                // Rust still owns the pointer; the keep-alive edges hold the
-                // borrowed-from owner alive.
+                // Borrowed opaque returns use a non-owning handle — Dispose/finalizer
+                // skip Destroy because Rust still owns the pointer.
                 ownership = if p.is_owned() {
                     Ownership::Owned
                 } else {

--- a/tool/src/dotnet/gen/mod.rs
+++ b/tool/src/dotnet/gen/mod.rs
@@ -140,7 +140,6 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         &self,
         display_name: String,
         opaque_def: &'tcx OpaqueDef,
-        borrowed_return_targets: &std::collections::HashSet<String>,
     ) -> Option<(Option<String>, String)> {
         // Lower every method exactly once, then hand the same `MethodInfo`s
         // to both the raw and idiomatic templates. Lowering twice (once per
@@ -154,13 +153,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             .filter_map(|m| self.build_method_info(StructMethodContext::new(m)))
             .collect();
         let raw = self.gen_opaque_raw(display_name.clone(), opaque_def, methods.clone());
-        // Needs the edges/non-owning machinery if it can be a borrowing
-        // return: either an owned borrow (`Box<T<'a>>`, lifetime-carrying) or
-        // a borrowed return (`&T`, tracked by name since the borrow isn't a
-        // lifetime on the type itself).
-        let has_edges = opaque_def.lifetimes.num_lifetimes() != 0
-            || borrowed_return_targets.contains(&display_name);
-        let content = self.gen_opaque_impl(display_name, methods, has_edges);
+        let content = self.gen_opaque_impl(display_name, methods);
         Some((Some(raw), content))
     }
 

--- a/tool/src/dotnet/gen/opaque.rs
+++ b/tool/src/dotnet/gen/opaque.rs
@@ -40,7 +40,6 @@ struct OpaqueImplTemplate<'ctx> {
     namespace: &'ctx str,
     methods: Vec<MethodInfo<'ctx>>,
     properties: Vec<PropertyInfo>,
-    has_edges: bool,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -73,7 +72,6 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         &self,
         display_name: String,
         methods: Vec<MethodInfo<'tcx>>,
-        has_edges: bool,
     ) -> String {
         let properties = method::collect_properties(&methods);
 
@@ -82,7 +80,6 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             namespace: self.namespace,
             methods,
             properties,
-            has_edges,
         }
         .render()
         .unwrap()

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -2,10 +2,9 @@
 //!
 //! Generates C# bindings that call into the Diplomat-generated C ABI via
 //! P/Invoke (`[DllImport]` externs with the `Cdecl` calling convention).
-//! Opaque Rust handles map to an `IDisposable` partial class holding the
-//! raw `Raw.T*` pointer (freed via the generated `Destroy` extern in
-//! `Dispose`/the finalizer); slices and strings copy across the boundary;
-//! callbacks are pinned via `GCHandle` on the managed side.
+//! Opaque Rust handles map to `IDisposable` partial classes backed by
+//! `RustHandle<T>`, which records whether C# or Rust owns the pointer. Slices
+//! and strings copy across the boundary; callbacks are pinned via `GCHandle`.
 //!
 //! This file is the entry point that the Diplomat CLI dispatches to. Codegen
 //! itself lives in [`gen`] and naming/type-formatting concerns live in
@@ -13,24 +12,22 @@
 //!
 //! ## Borrowing / lifetime model
 //!
-//! The backend does not encode Rust lifetimes in C# types. It supports
-//! call-scoped borrows — valid only for the duration of the single P/Invoke
-//! call — and uses HIR lifetime-edge analysis to decide which borrowed outputs
-//! can be documented and which must be rejected:
+//! The backend does not encode Rust lifetimes in C# types. It uses HIR
+//! lifetime-edge analysis to root supported borrowed outputs and reject the
+//! unsafe cases:
 //!
 //! * `&[u8]` / `&[u32]` / `&DiplomatStr` params are pinned with `fixed (...)`
 //!   (or copied into a pinned `byte[]`) for the call and unpinned immediately
 //!   after. If the Rust side stashes the pointer past the call, the C# GC may
 //!   move or free the backing buffer, so any returned value borrowing from
 //!   these temporary slice/string params is rejected with a diagnostic.
-//! * Borrowed opaque **returns** and **errors** (`&T`, `&mut T`, `Option<&T>`,
-//!   `Result<_, &E>`) are rejected outright with a diagnostic, because the
-//!   generated `IDisposable` wrapper would `Destroy` a pointer Rust still
-//!   owns (double-free). Return `Box<T>` / `Option<Box<T>>` instead.
-//! * Lifetime-carrying owned returns (`Box<T<'a>>`) that borrow from `self` or
-//!   another opaque wrapper are generated with XML lifetime remarks. C# cannot
-//!   enforce the relationship, so the caller must keep the borrowed-from wrapper
-//!   alive and undisposed while the returned value is used.
+//! * Borrowed opaque returns (`&T`, `&mut T`, `Option<&T>`) use non-owning
+//!   handles plus keep-alive edges.
+//! * Borrowed opaque errors (`Result<_, &E>`) are rejected; without a success
+//!   arm to carry keep-alive edges, `Dispose` would call `Destroy` on a pointer
+//!   Rust still owns (double-free).
+//! * Lifetime-carrying owned returns (`Box<T<'a>>`) from opaque wrappers get
+//!   XML lifetime remarks.
 
 use askama::Template;
 use diplomat_core::hir::{BackendAttrSupport, DocsUrlGenerator, TypeContext};
@@ -281,8 +278,6 @@ pub(crate) fn run<'tcx>(
         callback_struct_registry: std::cell::RefCell::new(std::collections::HashMap::new()),
     };
 
-    let borrowed_return_targets = ctx.borrowed_return_targets();
-
     for (id, ty) in tcx.all_types() {
         if ty.attrs().disable {
             continue;
@@ -307,7 +302,7 @@ pub(crate) fn run<'tcx>(
             }
             diplomat_core::hir::TypeDef::OutStruct(struct_def) => ctx.gen_out_struct(struct_def),
             diplomat_core::hir::TypeDef::Opaque(opaque_def) => {
-                ctx.gen_opaque(display_name.clone(), opaque_def, &borrowed_return_targets)
+                ctx.gen_opaque(display_name.clone(), opaque_def)
             }
             diplomat_core::hir::TypeDef::Enum(enum_def) => {
                 ctx.gen_enum(display_name.clone(), enum_def)

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -10,19 +10,15 @@ namespace {{ namespace }};
 
 public partial class {{ name }}: IDisposable
 {
-{%- if has_edges %}
     private unsafe RustHandle<Raw.{{ name }}> _inner;
 
     /// <summary>
-    /// Roots the wrappers this value borrows from so the GC can't finalize
-    /// (-> Destroy) a borrowed-from parent while this value is alive.
+    /// Roots the wrappers this value borrows from so the GC cannot finalize
+    /// a borrowed-from parent while this value is alive.
     /// </summary>
     private object[] _edges;
 
     private static readonly unsafe RustDestructor<Raw.{{ name }}> _destroy = Raw.{{ name }}.Destroy;
-{%- else %}
-    private unsafe Raw.{{ name }}* _inner;
-{%- endif %}
     {%- for property in properties %}
 
 {%- if property.lifetime_warning %}
@@ -59,14 +55,9 @@ public partial class {{ name }}: IDisposable
     /// </remarks>
     internal unsafe {{ name }}(Raw.{{ name }}* handle)
     {
-{%- if has_edges %}
         _inner = RustHandle<Raw.{{ name }}>.Owned(handle, _destroy);
         _edges = System.Array.Empty<object>();
-{%- else %}
-        _inner = handle;
-{%- endif %}
     }
-{%- if has_edges %}
 
     /// <remarks>
     /// Edges only keep the borrowed-from objects GC-reachable. Explicitly
@@ -90,7 +81,6 @@ public partial class {{ name }}: IDisposable
         _inner = inner;
         _edges = edges;
     }
-{%- endif %}
     {#- One idiomatic method per HIR method. `DiplomatWrite`-returning
         methods surface as `string` — the writer is allocated, filled, and
         disposed inside the generated body (see method_body.cs.jinja), so
@@ -115,7 +105,7 @@ public partial class {{ name }}: IDisposable
         unsafe
         {
 {%- if method.is_instance() %}
-            if ({% if has_edges %}_inner.IsNull{% else %}_inner == null{% endif %})
+            if (_inner.IsNull)
             {
                 throw new ObjectDisposedException("{{ name }}");
             }
@@ -130,7 +120,7 @@ public partial class {{ name }}: IDisposable
     /// </summary>
     internal unsafe Raw.{{ name }}* AsFFI()
     {
-        return {% if has_edges %}_inner.Ptr{% else %}_inner{% endif %};
+        return _inner.Ptr;
     }
 
     /// <summary>
@@ -140,7 +130,6 @@ public partial class {{ name }}: IDisposable
     {
         unsafe
         {
-{%- if has_edges %}
             if (_inner.IsNull)
             {
                 return;
@@ -148,20 +137,9 @@ public partial class {{ name }}: IDisposable
 
             _inner.Release();
             _inner = default;
-            _edges = System.Array.Empty<object>();
+            _edges = System.Array.Empty<object>(); // release refs so borrowed-from owners can be GC'd
 
             GC.SuppressFinalize(this);
-{%- else %}
-            if (_inner == null)
-            {
-                return;
-            }
-
-            Raw.{{ name }}.Destroy(_inner);
-            _inner = null;
-
-            GC.SuppressFinalize(this);
-{%- endif %}
         }
     }
 


### PR DESCRIPTION
Follow-up to #1189, prompted by @Manishearth's review.

As per the Rust/Postgres (not related here, it's just I like it) community's long-standing correctness-over-performance practice, I replaced the `borrowed_return_targets()` global pre-pass — which scanned every type and method in the TCX to decide which opaques needed the non-owning-wrapper machinery — with the simpler invariant: **all opaque types always use `RustHandle<T>` + `_edges`**.

The pre-pass was fragile: it only caught direct `&T` returns, silently missed `Result<&T, E>` and any future borrowed-return shape, and was a parallel tracking mechanism sitting alongside the existing per-method `borrowing_param` visitor. The two mechanisms answered different questions about the same domain.

Cost: 8 bytes per instance (the `_edges` field; zero heap allocation when unused — `System.Array.Empty<object>()` is a shared global), and one extra indirection through `_destroy` per Dispose call. The `has_edges` conditional in the template is gone entirely, so the generated shape is now uniform across all opaques.