### PR TITLE
dotnet: indent raw P/Invoke `extern` declarations in generated bindings

### DIFF
--- a/example/dotnet/Generated/RawDataProvider.cs
+++ b/example/dotnet/Generated/RawDataProvider.cs
@@ -10,10 +10,10 @@ internal partial struct DataProvider
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_DataProvider_new_static_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DataProvider* NewStatic();
+    internal static unsafe extern DataProvider* NewStatic();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_DataProvider_returns_result_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultVoidUnit ReturnsResult();
+    internal static unsafe extern DiplomatResultVoidUnit ReturnsResult();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_DataProvider_destroy_mv1", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(DataProvider* handle);

--- a/example/dotnet/Generated/RawFixedDecimal.cs
+++ b/example/dotnet/Generated/RawFixedDecimal.cs
@@ -10,13 +10,13 @@ internal partial struct FixedDecimal
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimal_new_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern FixedDecimal* New(int v);
+    internal static unsafe extern FixedDecimal* New(int v);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimal_multiply_pow10_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void MultiplyPow10(FixedDecimal* handle, short power);
+    internal static unsafe extern void MultiplyPow10(FixedDecimal* handle, short power);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimal_to_string_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultVoidUnit ToString(FixedDecimal* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern DiplomatResultVoidUnit ToString(FixedDecimal* handle, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimal_destroy_mv1", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(FixedDecimal* handle);

--- a/example/dotnet/Generated/RawFixedDecimalFormatter.cs
+++ b/example/dotnet/Generated/RawFixedDecimalFormatter.cs
@@ -10,10 +10,10 @@ internal partial struct FixedDecimalFormatter
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimalFormatter_try_new_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultFixedDecimalFormatterUnit TryNew(Locale* locale, DataProvider* provider, FixedDecimalFormatterOptions options);
+    internal static unsafe extern DiplomatResultFixedDecimalFormatterUnit TryNew(Locale* locale, DataProvider* provider, FixedDecimalFormatterOptions options);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimalFormatter_format_write_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void FormatWrite(FixedDecimalFormatter* handle, FixedDecimal* value, DiplomatWriteable* writeable);
+    internal static unsafe extern void FormatWrite(FixedDecimalFormatter* handle, FixedDecimal* value, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimalFormatter_destroy_mv1", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(FixedDecimalFormatter* handle);

--- a/example/dotnet/Generated/RawFixedDecimalFormatterOptions.cs
+++ b/example/dotnet/Generated/RawFixedDecimalFormatterOptions.cs
@@ -14,5 +14,5 @@ internal partial struct FixedDecimalFormatterOptions
     public bool SomeOtherConfig;
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimalFormatterOptions_default_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern FixedDecimalFormatterOptions Default();
+    internal static unsafe extern FixedDecimalFormatterOptions Default();
 }

--- a/example/dotnet/Generated/RawLocale.cs
+++ b/example/dotnet/Generated/RawLocale.cs
@@ -10,7 +10,7 @@ internal partial struct Locale
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_Locale_new_mv1", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Locale* New(DiplomatSliceU8 name);
+    internal static unsafe extern Locale* New(DiplomatSliceU8 name);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_Locale_destroy_mv1", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Locale* handle);

--- a/feature_tests/dotnet/Generated/RawAttrOpaque1Renamed.cs
+++ b/feature_tests/dotnet/Generated/RawAttrOpaque1Renamed.cs
@@ -10,28 +10,28 @@ internal partial struct AttrOpaque1Renamed
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_AttrOpaque1_new_overload", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern AttrOpaque1Renamed* NewOverload(int i);
+    internal static unsafe extern AttrOpaque1Renamed* NewOverload(int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_AttrOpaque1_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern AttrOpaque1Renamed* totally_not_New();
+    internal static unsafe extern AttrOpaque1Renamed* totally_not_New();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_AttrOpaque1_mac_test", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern int MacTest();
+    internal static unsafe extern int MacTest();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_AttrOpaque1_hello", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern int Hello();
+    internal static unsafe extern int Hello();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_AttrOpaque1_method", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern byte method_renamed(AttrOpaque1Renamed* handle);
+    internal static unsafe extern byte method_renamed(AttrOpaque1Renamed* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "renamed_on_abi_only", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern byte Abirenamed(AttrOpaque1Renamed* handle);
+    internal static unsafe extern byte Abirenamed(AttrOpaque1Renamed* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_AttrOpaque1_use_unnamespaced", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void UseUnnamespaced(AttrOpaque1Renamed* handle, Unnamespaced* un);
+    internal static unsafe extern void UseUnnamespaced(AttrOpaque1Renamed* handle, Unnamespaced* un);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_AttrOpaque1_use_namespaced", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void UseNamespaced(AttrOpaque1Renamed* handle, RenamedAttrEnum n);
+    internal static unsafe extern void UseNamespaced(AttrOpaque1Renamed* handle, RenamedAttrEnum n);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_AttrOpaque1_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(AttrOpaque1Renamed* handle);

--- a/feature_tests/dotnet/Generated/RawBar.cs
+++ b/feature_tests/dotnet/Generated/RawBar.cs
@@ -10,7 +10,7 @@ internal partial struct Bar
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Bar_foo", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Foo* Foo(Bar* handle);
+    internal static unsafe extern Foo* Foo(Bar* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Bar_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Bar* handle);

--- a/feature_tests/dotnet/Generated/RawFloat64Vec.cs
+++ b/feature_tests/dotnet/Generated/RawFloat64Vec.cs
@@ -10,13 +10,13 @@ internal partial struct Float64Vec
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Float64Vec_new_f64_be_bytes", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Float64Vec* NewF64BeBytes(DiplomatSliceU8 v);
+    internal static unsafe extern Float64Vec* NewF64BeBytes(DiplomatSliceU8 v);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Float64Vec_to_string", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void ToString(Float64Vec* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void ToString(Float64Vec* handle, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Float64Vec_get", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatOptionDouble Get(Float64Vec* handle, nuint i);
+    internal static unsafe extern DiplomatOptionDouble Get(Float64Vec* handle, nuint i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Float64Vec_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Float64Vec* handle);

--- a/feature_tests/dotnet/Generated/RawFoo.cs
+++ b/feature_tests/dotnet/Generated/RawFoo.cs
@@ -10,7 +10,7 @@ internal partial struct Foo
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Foo_get_bar", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Bar* GetBar(Foo* handle);
+    internal static unsafe extern Bar* GetBar(Foo* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Foo_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Foo* handle);

--- a/feature_tests/dotnet/Generated/RawGcRaceProbe.cs
+++ b/feature_tests/dotnet/Generated/RawGcRaceProbe.cs
@@ -10,10 +10,10 @@ internal partial struct GcRaceProbe
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "GcRaceProbe_create", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern GcRaceProbe* Create();
+    internal static unsafe extern GcRaceProbe* Create();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "GcRaceProbe_drops_during_spin", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern ulong DropsDuringSpin(GcRaceProbe* handle, ulong millis);
+    internal static unsafe extern ulong DropsDuringSpin(GcRaceProbe* handle, ulong millis);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "GcRaceProbe_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(GcRaceProbe* handle);

--- a/feature_tests/dotnet/Generated/RawMethodOverloading.cs
+++ b/feature_tests/dotnet/Generated/RawMethodOverloading.cs
@@ -10,13 +10,13 @@ internal partial struct MethodOverloading
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MethodOverloading_from_int32", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern MethodOverloading* from(int v);
+    internal static unsafe extern MethodOverloading* from(int v);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MethodOverloading_from_int64", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern MethodOverloading* from(long v);
+    internal static unsafe extern MethodOverloading* from(long v);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MethodOverloading_from_uint32", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern MethodOverloading* from(uint v);
+    internal static unsafe extern MethodOverloading* from(uint v);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MethodOverloading_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(MethodOverloading* handle);

--- a/feature_tests/dotnet/Generated/RawMyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/RawMyOpaqueEnum.cs
@@ -10,10 +10,10 @@ internal partial struct MyOpaqueEnum
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyOpaqueEnum_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern MyOpaqueEnum* New();
+    internal static unsafe extern MyOpaqueEnum* New();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyOpaqueEnum_to_string", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void ToString(MyOpaqueEnum* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void ToString(MyOpaqueEnum* handle, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyOpaqueEnum_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(MyOpaqueEnum* handle);

--- a/feature_tests/dotnet/Generated/RawMyString.cs
+++ b/feature_tests/dotnet/Generated/RawMyString.cs
@@ -10,19 +10,19 @@ internal partial struct MyString
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern MyString* New(DiplomatSliceU8 v);
+    internal static unsafe extern MyString* New(DiplomatSliceU8 v);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_new_unsafe", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern MyString* NewUnsafe(DiplomatSliceU8 v);
+    internal static unsafe extern MyString* NewUnsafe(DiplomatSliceU8 v);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_set_str", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void SetStr(MyString* handle, DiplomatSliceU8 newStr);
+    internal static unsafe extern void SetStr(MyString* handle, DiplomatSliceU8 newStr);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_get_str", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void GetStr(MyString* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void GetStr(MyString* handle, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_string_transform", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void StringTransform(DiplomatSliceU8 foo, DiplomatWriteable* writeable);
+    internal static unsafe extern void StringTransform(DiplomatSliceU8 foo, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(MyString* handle);

--- a/feature_tests/dotnet/Generated/RawMyStruct.cs
+++ b/feature_tests/dotnet/Generated/RawMyStruct.cs
@@ -19,17 +19,17 @@ internal partial struct MyStruct
     public MyEnum G;
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyStruct_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern MyStruct New();
+    internal static unsafe extern MyStruct New();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyStruct_new_overload", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern MyStruct NewOverload(int i);
+    internal static unsafe extern MyStruct NewOverload(int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyStruct_into_a", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern byte IntoA(MyStruct self);
+    internal static unsafe extern byte IntoA(MyStruct self);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyStruct_returns_zst_result", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultVoidMyZst ReturnsZstResult();
+    internal static unsafe extern DiplomatResultVoidMyZst ReturnsZstResult();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyStruct_fails_zst_result", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultVoidMyZst FailsZstResult();
+    internal static unsafe extern DiplomatResultVoidMyZst FailsZstResult();
 }

--- a/feature_tests/dotnet/Generated/RawOne.cs
+++ b/feature_tests/dotnet/Generated/RawOne.cs
@@ -10,37 +10,37 @@ internal partial struct One
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_transitivity", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* Transitivity(One* hold, One* nohold);
+    internal static unsafe extern One* Transitivity(One* hold, One* nohold);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_cycle", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* Cycle(Two* hold, One* nohold);
+    internal static unsafe extern One* Cycle(Two* hold, One* nohold);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_many_dependents", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* ManyDependents(One* a, One* b, Two* c, Two* d, Two* nohold);
+    internal static unsafe extern One* ManyDependents(One* a, One* b, Two* c, Two* d, Two* nohold);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_return_outlives_param", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* ReturnOutlivesParam(Two* hold, One* nohold);
+    internal static unsafe extern One* ReturnOutlivesParam(Two* hold, One* nohold);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_diamond_top", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* DiamondTop(One* top, One* left, One* right, One* bottom);
+    internal static unsafe extern One* DiamondTop(One* top, One* left, One* right, One* bottom);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_diamond_left", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* DiamondLeft(One* top, One* left, One* right, One* bottom);
+    internal static unsafe extern One* DiamondLeft(One* top, One* left, One* right, One* bottom);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_diamond_right", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* DiamondRight(One* top, One* left, One* right, One* bottom);
+    internal static unsafe extern One* DiamondRight(One* top, One* left, One* right, One* bottom);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_diamond_bottom", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* DiamondBottom(One* top, One* left, One* right, One* bottom);
+    internal static unsafe extern One* DiamondBottom(One* top, One* left, One* right, One* bottom);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_diamond_and_nested_types", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* DiamondAndNestedTypes(One* a, One* b, One* c, One* d, One* nohold);
+    internal static unsafe extern One* DiamondAndNestedTypes(One* a, One* b, One* c, One* d, One* nohold);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_implicit_bounds", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* ImplicitBounds(One* explicitHold, One* implicitHold, One* nohold);
+    internal static unsafe extern One* ImplicitBounds(One* explicitHold, One* implicitHold, One* nohold);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_implicit_bounds_deep", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern One* ImplicitBoundsDeep(One* @explicit, One* implicit1, One* implicit2, One* nohold);
+    internal static unsafe extern One* ImplicitBoundsDeep(One* @explicit, One* implicit1, One* implicit2, One* nohold);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "One_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(One* handle);

--- a/feature_tests/dotnet/Generated/RawOpaque.cs
+++ b/feature_tests/dotnet/Generated/RawOpaque.cs
@@ -10,25 +10,25 @@ internal partial struct Opaque
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Opaque* New();
+    internal static unsafe extern Opaque* New();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_try_from_utf8", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Opaque* TryFromUtf8(DiplomatSliceU8 input);
+    internal static unsafe extern Opaque* TryFromUtf8(DiplomatSliceU8 input);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_from_str", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Opaque* FromStr(DiplomatSliceU8 input);
+    internal static unsafe extern Opaque* FromStr(DiplomatSliceU8 input);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_get_debug_str", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void GetDebugStr(Opaque* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void GetDebugStr(Opaque* handle, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_assert_struct", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void AssertStruct(Opaque* handle, MyStruct s);
+    internal static unsafe extern void AssertStruct(Opaque* handle, MyStruct s);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_returns_usize", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern nuint ReturnsUsize();
+    internal static unsafe extern nuint ReturnsUsize();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_returns_imported", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern ImportedStruct ReturnsImported();
+    internal static unsafe extern ImportedStruct ReturnsImported();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Opaque* handle);

--- a/feature_tests/dotnet/Generated/RawOpaqueMut.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueMut.cs
@@ -10,7 +10,7 @@ internal partial struct OpaqueMut
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMut_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OpaqueMut* New();
+    internal static unsafe extern OpaqueMut* New();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMut_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OpaqueMut* handle);

--- a/feature_tests/dotnet/Generated/RawOpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueMutexedString.cs
@@ -10,19 +10,19 @@ internal partial struct OpaqueMutexedString
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_from_usize", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OpaqueMutexedString* FromUsize(nuint number);
+    internal static unsafe extern OpaqueMutexedString* FromUsize(nuint number);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_change", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void Change(OpaqueMutexedString* handle, nuint number);
+    internal static unsafe extern void Change(OpaqueMutexedString* handle, nuint number);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_get_len_and_add", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern nuint GetLenAndAdd(OpaqueMutexedString* handle, nuint other);
+    internal static unsafe extern nuint GetLenAndAdd(OpaqueMutexedString* handle, nuint other);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_wrapper", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Utf16Wrap* Wrapper(OpaqueMutexedString* handle);
+    internal static unsafe extern Utf16Wrap* Wrapper(OpaqueMutexedString* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_to_unsigned_from_unsigned", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern ushort ToUnsignedFromUnsigned(OpaqueMutexedString* handle, ushort input);
+    internal static unsafe extern ushort ToUnsignedFromUnsigned(OpaqueMutexedString* handle, ushort input);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OpaqueMutexedString* handle);

--- a/feature_tests/dotnet/Generated/RawOpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueThin.cs
@@ -10,13 +10,13 @@ internal partial struct OpaqueThin
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThin_a", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern int A(OpaqueThin* handle);
+    internal static unsafe extern int A(OpaqueThin* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThin_b", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern float B(OpaqueThin* handle);
+    internal static unsafe extern float B(OpaqueThin* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThin_c", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void C(OpaqueThin* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void C(OpaqueThin* handle, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThin_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OpaqueThin* handle);

--- a/feature_tests/dotnet/Generated/RawOpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueThinVec.cs
@@ -10,22 +10,22 @@ internal partial struct OpaqueThinVec
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_create_single", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OpaqueThinVec* CreateSingle(int a, float b, DiplomatSliceU8 c);
+    internal static unsafe extern OpaqueThinVec* CreateSingle(int a, float b, DiplomatSliceU8 c);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_set_first_c", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void SetFirstC(OpaqueThinVec* handle, DiplomatSliceU8 value);
+    internal static unsafe extern void SetFirstC(OpaqueThinVec* handle, DiplomatSliceU8 value);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_iter", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OpaqueThinIter* Iter(OpaqueThinVec* handle);
+    internal static unsafe extern OpaqueThinIter* Iter(OpaqueThinVec* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_len", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern nuint Len(OpaqueThinVec* handle);
+    internal static unsafe extern nuint Len(OpaqueThinVec* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_get", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OpaqueThin* Get(OpaqueThinVec* handle, nuint idx);
+    internal static unsafe extern OpaqueThin* Get(OpaqueThinVec* handle, nuint idx);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_first", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OpaqueThin* First(OpaqueThinVec* handle);
+    internal static unsafe extern OpaqueThin* First(OpaqueThinVec* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThinVec_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OpaqueThinVec* handle);

--- a/feature_tests/dotnet/Generated/RawOptionOpaque.cs
+++ b/feature_tests/dotnet/Generated/RawOptionOpaque.cs
@@ -10,29 +10,29 @@ internal partial struct OptionOpaque
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OptionOpaque* New(int i);
+    internal static unsafe extern OptionOpaque* New(int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_new_none", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OptionOpaque* NewNone();
+    internal static unsafe extern OptionOpaque* NewNone();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_option_isize", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatOptionNInt OptionIsize(OptionOpaque* handle);
+    internal static unsafe extern DiplomatOptionNInt OptionIsize(OptionOpaque* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_option_usize", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatOptionNUInt OptionUsize(OptionOpaque* handle);
+    internal static unsafe extern DiplomatOptionNUInt OptionUsize(OptionOpaque* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_option_i32", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatOptionInt OptionI32(OptionOpaque* handle);
+    internal static unsafe extern DiplomatOptionInt OptionI32(OptionOpaque* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_option_u32", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatOptionUInt OptionU32(OptionOpaque* handle);
+    internal static unsafe extern DiplomatOptionUInt OptionU32(OptionOpaque* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_assert_integer", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void AssertInteger(OptionOpaque* handle, int i);
+    internal static unsafe extern void AssertInteger(OptionOpaque* handle, int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_option_opaque_argument", CallingConvention = CallingConvention.Cdecl)]
-[return: MarshalAs(UnmanagedType.U1)]
-internal static unsafe extern bool OptionOpaqueArgument(OptionOpaque* arg);
+    [return: MarshalAs(UnmanagedType.U1)]
+    internal static unsafe extern bool OptionOpaqueArgument(OptionOpaque* arg);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaque_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OptionOpaque* handle);

--- a/feature_tests/dotnet/Generated/RawOptionOpaqueChar.cs
+++ b/feature_tests/dotnet/Generated/RawOptionOpaqueChar.cs
@@ -10,7 +10,7 @@ internal partial struct OptionOpaqueChar
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaqueChar_assert_char", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void AssertChar(OptionOpaqueChar* handle, uint ch);
+    internal static unsafe extern void AssertChar(OptionOpaqueChar* handle, uint ch);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionOpaqueChar_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OptionOpaqueChar* handle);

--- a/feature_tests/dotnet/Generated/RawOptionString.cs
+++ b/feature_tests/dotnet/Generated/RawOptionString.cs
@@ -10,10 +10,10 @@ internal partial struct OptionString
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionString_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern OptionString* New(DiplomatSliceU8 diplomatStr);
+    internal static unsafe extern OptionString* New(DiplomatSliceU8 diplomatStr);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionString_write", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultVoidUnit Write(OptionString* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern DiplomatResultVoidUnit Write(OptionString* handle, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionString_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OptionString* handle);

--- a/feature_tests/dotnet/Generated/RawRefList.cs
+++ b/feature_tests/dotnet/Generated/RawRefList.cs
@@ -10,7 +10,7 @@ internal partial struct RefList
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "RefList_node", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern RefList* Node(RefListParameter* data);
+    internal static unsafe extern RefList* Node(RefListParameter* data);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "RefList_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(RefList* handle);

--- a/feature_tests/dotnet/Generated/RawRenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RawRenamedMixinTest.cs
@@ -10,7 +10,7 @@ internal partial struct RenamedMixinTest
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_MixinTest_hello", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void Hello(DiplomatWriteable* writeable);
+    internal static unsafe extern void Hello(DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_MixinTest_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(RenamedMixinTest* handle);

--- a/feature_tests/dotnet/Generated/RawRenamedOpaqueZSTIndexer.cs
+++ b/feature_tests/dotnet/Generated/RawRenamedOpaqueZSTIndexer.cs
@@ -10,10 +10,10 @@ internal partial struct RenamedOpaqueZSTIndexer
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_OpaqueZSTIndexer_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern RenamedOpaqueZSTIndexer* New();
+    internal static unsafe extern RenamedOpaqueZSTIndexer* New();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_OpaqueZSTIndexer_index", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern RenamedOpaqueZSTIndexer* Index(RenamedOpaqueZSTIndexer* handle, nuint idx);
+    internal static unsafe extern RenamedOpaqueZSTIndexer* Index(RenamedOpaqueZSTIndexer* handle, nuint idx);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_OpaqueZSTIndexer_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(RenamedOpaqueZSTIndexer* handle);

--- a/feature_tests/dotnet/Generated/RawRenamedStructWithAttrs.cs
+++ b/feature_tests/dotnet/Generated/RawRenamedStructWithAttrs.cs
@@ -14,11 +14,11 @@ internal partial struct RenamedStructWithAttrs
     public uint B;
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_StructWithAttrs_new_fallible", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultRenamedStructWithAttrsUnit NewFallible([MarshalAs(UnmanagedType.U1)] bool a, uint b);
+    internal static unsafe extern DiplomatResultRenamedStructWithAttrsUnit NewFallible([MarshalAs(UnmanagedType.U1)] bool a, uint b);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_StructWithAttrs_c", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern uint C(RenamedStructWithAttrs self);
+    internal static unsafe extern uint C(RenamedStructWithAttrs self);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_StructWithAttrs_deprecated", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void Deprecated(RenamedStructWithAttrs self);
+    internal static unsafe extern void Deprecated(RenamedStructWithAttrs self);
 }

--- a/feature_tests/dotnet/Generated/RawRenamedTestMacroStruct.cs
+++ b/feature_tests/dotnet/Generated/RawRenamedTestMacroStruct.cs
@@ -12,8 +12,8 @@ internal partial struct RenamedTestMacroStruct
     public nuint A;
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_TestMacroStruct_test_func", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern nuint TestFunc();
+    internal static unsafe extern nuint TestFunc();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_TestMacroStruct_test_meta", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern RenamedTestMacroStruct TestMeta();
+    internal static unsafe extern RenamedTestMacroStruct TestMeta();
 }

--- a/feature_tests/dotnet/Generated/RawRenamedVectorTest.cs
+++ b/feature_tests/dotnet/Generated/RawRenamedVectorTest.cs
@@ -10,16 +10,16 @@ internal partial struct RenamedVectorTest
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_VectorTest_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern RenamedVectorTest* New();
+    internal static unsafe extern RenamedVectorTest* New();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_VectorTest_len", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern nuint Len(RenamedVectorTest* handle);
+    internal static unsafe extern nuint Len(RenamedVectorTest* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_VectorTest_get", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatOptionDouble Get(RenamedVectorTest* handle, nuint idx);
+    internal static unsafe extern DiplomatOptionDouble Get(RenamedVectorTest* handle, nuint idx);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_VectorTest_push", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void Push(RenamedVectorTest* handle, double value);
+    internal static unsafe extern void Push(RenamedVectorTest* handle, double value);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_VectorTest_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(RenamedVectorTest* handle);

--- a/feature_tests/dotnet/Generated/RawResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/RawResultOpaque.cs
@@ -10,31 +10,31 @@ internal partial struct ResultOpaque
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_new", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultResultOpaqueErrorEnum New(int i);
+    internal static unsafe extern DiplomatResultResultOpaqueErrorEnum New(int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_new_failing_foo", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultResultOpaqueErrorEnum NewFailingFoo();
+    internal static unsafe extern DiplomatResultResultOpaqueErrorEnum NewFailingFoo();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_new_failing_bar", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultResultOpaqueErrorEnum NewFailingBar();
+    internal static unsafe extern DiplomatResultResultOpaqueErrorEnum NewFailingBar();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_new_failing_unit", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultResultOpaqueUnit NewFailingUnit();
+    internal static unsafe extern DiplomatResultResultOpaqueUnit NewFailingUnit();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_new_failing_struct", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultResultOpaqueErrorStruct NewFailingStruct(int i);
+    internal static unsafe extern DiplomatResultResultOpaqueErrorStruct NewFailingStruct(int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_new_in_err", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultVoidResultOpaque NewInErr(int i);
+    internal static unsafe extern DiplomatResultVoidResultOpaque NewInErr(int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_new_int", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultIntUnit NewInt(int i);
+    internal static unsafe extern DiplomatResultIntUnit NewInt(int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_new_in_enum_err", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern DiplomatResultErrorEnumResultOpaque NewInEnumErr(int i);
+    internal static unsafe extern DiplomatResultErrorEnumResultOpaque NewInEnumErr(int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_assert_integer", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void AssertInteger(ResultOpaque* handle, int i);
+    internal static unsafe extern void AssertInteger(ResultOpaque* handle, int i);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "ResultOpaque_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(ResultOpaque* handle);

--- a/feature_tests/dotnet/Generated/RawUnnamespaced.cs
+++ b/feature_tests/dotnet/Generated/RawUnnamespaced.cs
@@ -10,10 +10,10 @@ internal partial struct Unnamespaced
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_Unnamespaced_make", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern Unnamespaced* Make(RenamedAttrEnum e);
+    internal static unsafe extern Unnamespaced* Make(RenamedAttrEnum e);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_Unnamespaced_use_namespaced", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void UseNamespaced(Unnamespaced* handle, AttrOpaque1Renamed* n);
+    internal static unsafe extern void UseNamespaced(Unnamespaced* handle, AttrOpaque1Renamed* n);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_Unnamespaced_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Unnamespaced* handle);

--- a/feature_tests/dotnet/Generated/RawUtf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/RawUtf16Wrap.cs
@@ -10,7 +10,7 @@ internal partial struct Utf16Wrap
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Utf16Wrap_get_debug_str", CallingConvention = CallingConvention.Cdecl)]
-internal static unsafe extern void GetDebugStr(Utf16Wrap* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void GetDebugStr(Utf16Wrap* handle, DiplomatWriteable* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Utf16Wrap_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Utf16Wrap* handle);

--- a/tool/templates/dotnet/raw_extern.cs.jinja
+++ b/tool/templates/dotnet/raw_extern.cs.jinja
@@ -15,21 +15,21 @@
         E>` returns a result struct on the wire, with the writer as an
         out-param appended via raw_params_with_writer. #}
     {%- if method.return_type.is_write() %}
-internal static unsafe extern {{ info.raw_return_type }} {{ method.name }}({{ method.raw_params_with_writer() }});
+    internal static unsafe extern {{ info.raw_return_type }} {{ method.name }}({{ method.raw_params_with_writer() }});
     {%- else %}
-internal static unsafe extern {{ info.raw_return_type }} {{ method.name }}({{ method.inputs.raw_params }});
+    internal static unsafe extern {{ info.raw_return_type }} {{ method.name }}({{ method.inputs.raw_params }});
     {%- endif %}
 {%- else if method.return_type.is_write() %}
-internal static unsafe extern void {{ method.name }}({{ method.raw_params_with_writer() }});
+    internal static unsafe extern void {{ method.name }}({{ method.raw_params_with_writer() }});
 {%- else if let Some(opt) = method.option_info %}
     {%- if let Some(opt_struct) = opt.raw_option_type %}
-internal static unsafe extern {{ opt_struct }} {{ method.name }}({{ method.inputs.raw_params }});
+    internal static unsafe extern {{ opt_struct }} {{ method.name }}({{ method.inputs.raw_params }});
     {%- else %}
-internal static unsafe extern {{ method.return_type.raw() }} {{ method.name }}({{ method.inputs.raw_params }});
+    internal static unsafe extern {{ method.return_type.raw() }} {{ method.name }}({{ method.inputs.raw_params }});
     {%- endif %}
 {%- else %}
-{%- if method.return_type.is_bool() %}
-[return: MarshalAs(UnmanagedType.U1)]
-{%- endif %}
-internal static unsafe extern {{ method.return_type.raw() }} {{ method.name }}({{ method.inputs.raw_params }});
+    {%- if method.return_type.is_bool() %}
+    [return: MarshalAs(UnmanagedType.U1)]
+    {%- endif %}
+    internal static unsafe extern {{ method.return_type.raw() }} {{ method.name }}({{ method.inputs.raw_params }});
 {%- endif %}


### PR DESCRIPTION
Follow-up to #1193 (Copilot's note on `RawOpaqueThinIter.cs`).

`raw_extern.cs.jinja` emitted the `internal static unsafe extern …` method signatures flush-left, while the `[DllImport]` attribute above them and the hand-written `Destroy` signature were indented. That left every generated `Raw*.cs` opaque/struct file internally inconsistent and produced noisy diffs on regeneration.

This indents the `extern` (and `[return: MarshalAs]`) lines to match, so each raw method declaration lines up with its `[DllImport]` and with `Destroy`. Pure whitespace in the generated output — no behavioral change.

Regenerated all dotnet bindings (`cargo make gen-dotnet`); dotnet feature tests pass.

Kept separate from #1193 since the fix re-indents every raw `.cs` file.