### PR TITLE
Separate out Nanobind stubgen task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -682,9 +682,29 @@ script = '''
 mkdir vendor
 cd vendor
 nanobind_exists = is_path_exists nanobind
-if not nanobind_exists
+if not ${nanobind_exists}
     exec git clone https://github.com/wjakob/nanobind.git --depth=1 -b "v2.4.0" --recurse-submodules -q
 end
+# Read Nanobind version:
+nanobind_hdr = readfile ./nanobind/pyproject.toml
+nanobind_split = split ${nanobind_hdr} "\n"
+len = array_length ${nanobind_split}
+
+version = set "unknown"
+for i in ${nanobind_split}
+    is_version = starts_with ${i} "version"
+    if ${is_version}
+        version = set ${i}
+        version = replace ${version} "version = \"" " "
+        version = replace ${version} "\"" ""
+        version = trim ${version}
+        goto :stop
+    end
+end
+
+:stop
+echo "Found Nanobind version ${version}"
+assert_eq ${version} "2.4.0"
 '''
 
 [tasks.bench-rust-example]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -611,7 +611,7 @@ exec --fail-on-error cmake --build build --target somelib --config Debug
 
 # Generate stubs
 writefile src/somelib/__init__.py "from .somelib import *"
-exec --fail-on-error python ../../vendor/nanobind/src/stubgen.py -r -q -m somelib -i build/Debug -O src/somelib -M src/somelib/py.typed
+exec --fail-on-error python ../../vendor/nanobind/src/stubgen.py -r -q -m somelib -i build -i build/Debug -O src/somelib -M src/somelib/py.typed
 '''
 
 # Build deps

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -581,7 +581,9 @@ generate_generic example kotlin somelib "--config kotlin.scaffold=false" /src/ma
 
 [tasks.gen-nanobind-feature]
 category = "Code generation"
-dependencies = ["gen-nanobind-bindings", "gen-nanobind-stubs"]
+run_task = [
+    { name = ["gen-nanobind-bindings", "gen-nanobind-stubs"] }
+]
 
 [tasks.gen-nanobind-bindings]
 category = "Code generation"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -581,23 +581,39 @@ generate_generic example kotlin somelib "--config kotlin.scaffold=false" /src/ma
 
 [tasks.gen-nanobind-feature]
 category = "Code generation"
+dependencies = ["gen-nanobind-bindings", "gen-nanobind-stubs"]
+
+[tasks.gen-nanobind-bindings]
+category = "Code generation"
 dependencies = ["fetch-nanobind"]
 script_runner = "@duckscript"
 script = '''
 exit_on_error true
 !include_files ./support/functions.ds
-rm -rf nanobind/src
 
 generate_generic feature_tests nanobind src
+'''
 
-# Build nanobind and generate stubs
-cd nanobind
+[tasks.gen-nanobind-stubs]
+category = "Code generation"
+dependencies = ["fetch-nanobind"]
+script_runner = "@duckscript"
+script = '''
+exit_on_error true
+
+rm -r feature_tests/nanobind/src/somelib
+
+cd feature_tests/nanobind
+
+# Build the lib so that Nanobind can read `__nb_signature__`
 exec --fail-on-error cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 exec --fail-on-error cmake --build build --target somelib --config Debug
 
+# Generate stubs
 writefile src/somelib/__init__.py "from .somelib import *"
-exec --fail-on-error python ../../vendor/nanobind/src/stubgen.py -r -q -m somelib -i build -i build/Debug -i build/Release -O src/somelib -M src/somelib/py.typed
+exec --fail-on-error python ../../vendor/nanobind/src/stubgen.py -r -q -m somelib -i build/Debug -O src/somelib -M src/somelib/py.typed
 '''
+
 # Build deps
 
 [tasks.build-tool]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -681,8 +681,8 @@ script_runner = "@duckscript"
 script = '''
 mkdir vendor
 cd vendor
-nanobind_present = is_path_exists nanobind
-if !nanobind_present
+nanobind_exists = is_path_exists nanobind
+if not nanobind_exists
     exec git clone https://github.com/wjakob/nanobind.git --depth=1 -b "v2.4.0" --recurse-submodules -q
 end
 '''


### PR DESCRIPTION
It's annoying to rebuild in CMake every time the files change when I'm iterating on generation, so this task separates out generating the stubs from the bindings to make iteration faster.