### PR TITLE
AST Location errors pass four

### DIFF
--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -289,6 +289,7 @@ mod tests {
         "param_invalid_type.rs",
         "undefined_type.rs",
         "non_opaque_tuple.rs",
+        "generic_type.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -291,6 +291,7 @@ mod tests {
         "non_opaque_tuple.rs",
         "generic_type.rs",
         "free_func_generics.rs",
+        "trait_bound_generics.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -308,6 +308,7 @@ mod tests {
         "unsupported_fn_type.rs",
         "ns_lifetime.rs",
         "unsupported_bound.rs",
+        "unsupported_type.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -309,6 +309,7 @@ mod tests {
         "ns_lifetime.rs",
         "unsupported_bound.rs",
         "unsupported_type.rs",
+        "slice_no_type.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -290,6 +290,7 @@ mod tests {
         "undefined_type.rs",
         "non_opaque_tuple.rs",
         "generic_type.rs",
+        "free_func_generics.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -305,6 +305,7 @@ mod tests {
         "result_type_args.rs",
         "result_angle_brackets.rs",
         "lifetime_callback_param.rs",
+        "unsupported_fn_type.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -304,6 +304,7 @@ mod tests {
         "multi_traits.rs",
         "result_type_args.rs",
         "result_angle_brackets.rs",
+        "lifetime_callback_param.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -297,6 +297,7 @@ mod tests {
         "owned_slice.rs",
         "box_type_arg.rs",
         "missing_angle_brackets.rs",
+        "option_type_args.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -295,6 +295,7 @@ mod tests {
         "mut_string.rs",
         "slice_of_slice.rs",
         "owned_slice.rs",
+        "box_type_arg.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -298,6 +298,7 @@ mod tests {
         "box_type_arg.rs",
         "missing_angle_brackets.rs",
         "option_type_args.rs",
+        "option_without_angle_brackets.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -293,6 +293,7 @@ mod tests {
         "free_func_generics.rs",
         "trait_bound_generics.rs",
         "mut_string.rs",
+        "slice_of_slice.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -292,6 +292,7 @@ mod tests {
         "generic_type.rs",
         "free_func_generics.rs",
         "trait_bound_generics.rs",
+        "mut_string.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -300,6 +300,7 @@ mod tests {
         "option_type_args.rs",
         "option_without_angle_brackets.rs",
         "invalid_slice.rs",
+        "tuples.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -303,6 +303,7 @@ mod tests {
         "tuples.rs",
         "multi_traits.rs",
         "result_type_args.rs",
+        "result_angle_brackets.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -301,6 +301,7 @@ mod tests {
         "option_without_angle_brackets.rs",
         "invalid_slice.rs",
         "tuples.rs",
+        "multi_traits.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -296,6 +296,7 @@ mod tests {
         "slice_of_slice.rs",
         "owned_slice.rs",
         "box_type_arg.rs",
+        "missing_angle_brackets.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -307,6 +307,7 @@ mod tests {
         "lifetime_callback_param.rs",
         "unsupported_fn_type.rs",
         "ns_lifetime.rs",
+        "unsupported_bound.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -302,6 +302,7 @@ mod tests {
         "invalid_slice.rs",
         "tuples.rs",
         "multi_traits.rs",
+        "result_type_args.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -306,6 +306,7 @@ mod tests {
         "result_angle_brackets.rs",
         "lifetime_callback_param.rs",
         "unsupported_fn_type.rs",
+        "ns_lifetime.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -294,6 +294,7 @@ mod tests {
         "trait_bound_generics.rs",
         "mut_string.rs",
         "slice_of_slice.rs",
+        "owned_slice.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -299,6 +299,7 @@ mod tests {
         "missing_angle_brackets.rs",
         "option_type_args.rs",
         "option_without_angle_brackets.rs",
+        "invalid_slice.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/snapshots/span_testing/box_type_arg.rs
+++ b/core/src/ast/snapshots/span_testing/box_type_arg.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn test(b : Box<32>) {}
+}

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@box_type_arg.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@box_type_arg.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Expected a type in Box type arg
+In src/ast/snapshots/span_testing/box_type_arg.rs:3:24:
+...: Box<32>) {}...
+        ^^^^
+Should be a type

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@free_func_generics.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@free_func_generics.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Generic type arguments are unsupported
+In src/ast/snapshots/span_testing/free_func_generics.rs:3:12:
+...b fn with_generics<T>()...
+        ^^^^^^^^^^^^^
+Functions with generic arguments are unsupported

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@generic_type.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@generic_type.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Generic type arguments are unsupported
+In src/ast/snapshots/span_testing/generic_type.rs:3:10:
+...impl Test<T> {...
+        ^^^^^^^
+Type paths with generic arguments are unsupported.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@invalid_slice.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@invalid_slice.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Found DiplomatSlice without primitive or DiplomatSlice-like generic
+In src/ast/snapshots/span_testing/invalid_slice.rs:3:36:
+...lice<Unknown>) {}...
+        ^^^^^^^
+Must be a primitive or DiplomatSlice-like generic

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@lifetime_callback_param.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@lifetime_callback_param.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Lifetimes are not allowed on callback parameters
+In src/ast/snapshots/span_testing/lifetime_callback_param.rs:3:58:
+...Fn(&'a i32)...
+       ^^
+Suggestion: remove lifetime

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@missing_angle_brackets.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@missing_angle_brackets.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Expected angle brackets for Box type
+In src/ast/snapshots/span_testing/missing_angle_brackets.rs:3:28:
+...ox : Box) {}...
+        ^^^
+Suggestion: add angle brackets

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@multi_traits.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@multi_traits.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Implementing multiple traits currently unsupported
+In src/ast/snapshots/span_testing/multi_traits.rs:3:41:
+...() + FnMut()) {}...
+        ^^^^^^^
+Suggestion: remove extra trait bound

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@mut_string.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@mut_string.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Mutable string references disallowed
+In src/ast/snapshots/span_testing/mut_string.rs:3:30:
+...&mut DiplomatStr) {}...
+        ^^^^^^^^^^^
+Suggestion: make reference immutable

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@ns_lifetime.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@ns_lifetime.rs_ugly.snap
@@ -1,0 +1,10 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Found non-static lifetime on trait
+In src/ast/snapshots/span_testing/ns_lifetime.rs:3:41:
+...) + 'a){}
+}...
+        ^
+Only 'static lifetimes are supported on trait objects right now.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@option_type_args.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@option_type_args.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Expected first argument for Option to be a type
+In src/ast/snapshots/span_testing/option_type_args.rs:3:28:
+...ption<32>) {}...
+        ^^^^
+Should be a type

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@option_without_angle_brackets.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@option_without_angle_brackets.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Expected angle brackets for Option type
+In src/ast/snapshots/span_testing/option_without_angle_brackets.rs:3:23:
+...pt : Option) {}...
+        ^^^^^^
+Suggestion: add angle brackets

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@owned_slice.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@owned_slice.rs_ugly.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Owned slices only support primitives
+In src/ast/snapshots/span_testing/owned_slice.rs:3:30:
+...Box<[Type]>) {...
+        ^^^^

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@result_angle_brackets.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@result_angle_brackets.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Expected angle brackets for Result type
+In src/ast/snapshots/span_testing/result_angle_brackets.rs:3:33:
+...(r : Result) {}...
+        ^^^^^^
+Suggestion: add angle brackets

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@result_type_args.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@result_type_args.rs_ugly.snap
@@ -1,0 +1,8 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Expected both type arguments for Result to be a type
+In src/ast/snapshots/span_testing/result_type_args.rs:3:39:
+...esult<32, i32>) {}...
+        ^^^^^^^^^

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@slice_no_type.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@slice_no_type.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Expected type argument
+In src/ast/snapshots/span_testing/slice_no_type.rs:3:31:
+...sl : DiplomatSlice) {}...
+        ^^^^^^^^^^^^^
+Add slice type specification here

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@slice_of_slice.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@slice_of_slice.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: String slice-of-slice is only supported with DiplomatRuntime slice types
+In src/ast/snapshots/span_testing/slice_of_slice.rs:3:24:
+...: &[&str]) {}...
+       ^^^^
+Supported slice types: DiplomatStrSlice, DiplomatStr16Slice, DiplomatUtf8StrSlice.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@trait_bound_generics.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@trait_bound_generics.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Generic type arguments are unsupported
+In src/ast/snapshots/span_testing/trait_bound_generics.rs:3:26:
+...impl TraitWithGenerics<T>) {}...
+        ^^^^^^^^^^^^^^^^^^^^
+Trait bounds with generic arguments are unsupported

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@tuples.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@tuples.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Tuples unsupported
+In src/ast/snapshots/span_testing/tuples.rs:3:28:
+...(t : (i32, i32)) {}...
+        ^^^^^^^^^^
+https://github.com/rust-diplomat/diplomat/issues/1142

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@unsupported_bound.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@unsupported_bound.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Unsupported trait bound
+In src/ast/snapshots/span_testing/unsupported_bound.rs:3:39:
+...impl use<'a, T> + AB...
+        ^^^^^^^^^^
+Expected lifetime or trait name.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@unsupported_fn_type.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@unsupported_fn_type.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Unsupported function type
+In src/ast/snapshots/span_testing/unsupported_fn_type.rs:3:41:
+...impl Fn<>) {}...
+        ^^^^
+Expected parentheses

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@unsupported_type.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@unsupported_type.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Found unsupported type
+In src/ast/snapshots/span_testing/unsupported_type.rs:3:33:
+...(a : fn()) {}...
+        ^^^^
+See a list of the types Diplomat supports: https://rust-diplomat.github.io/diplomat/types.html

--- a/core/src/ast/snapshots/span_testing/free_func_generics.rs
+++ b/core/src/ast/snapshots/span_testing/free_func_generics.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn with_generics<T>() {}
+}

--- a/core/src/ast/snapshots/span_testing/generic_type.rs
+++ b/core/src/ast/snapshots/span_testing/generic_type.rs
@@ -1,0 +1,6 @@
+#[diplomat::bridge]
+mod ffi {
+    impl Test<T> {
+
+    }
+}

--- a/core/src/ast/snapshots/span_testing/invalid_slice.rs
+++ b/core/src/ast/snapshots/span_testing/invalid_slice.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn test(sl : DiplomatSlice<Unknown>) {}
+}

--- a/core/src/ast/snapshots/span_testing/lifetime_callback_param.rs
+++ b/core/src/ast/snapshots/span_testing/lifetime_callback_param.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn lifetime_callback_params(c : impl for<'a> Fn(&'a i32)) {}
+}

--- a/core/src/ast/snapshots/span_testing/missing_angle_brackets.rs
+++ b/core/src/ast/snapshots/span_testing/missing_angle_brackets.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn test(some_box : Box) {}
+}

--- a/core/src/ast/snapshots/span_testing/multi_traits.rs
+++ b/core/src/ast/snapshots/span_testing/multi_traits.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn multi_traits(t : impl Fn() + FnMut()) {}
+}

--- a/core/src/ast/snapshots/span_testing/mut_string.rs
+++ b/core/src/ast/snapshots/span_testing/mut_string.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn mut_str(st : &mut DiplomatStr) {}
+}

--- a/core/src/ast/snapshots/span_testing/ns_lifetime.rs
+++ b/core/src/ast/snapshots/span_testing/ns_lifetime.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn ns_lifetime(t : impl Fn() + 'a){}
+}

--- a/core/src/ast/snapshots/span_testing/option_type_args.rs
+++ b/core/src/ast/snapshots/span_testing/option_type_args.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn test(opt: Option<32>) {}
+}

--- a/core/src/ast/snapshots/span_testing/option_without_angle_brackets.rs
+++ b/core/src/ast/snapshots/span_testing/option_without_angle_brackets.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn test(opt : Option) {}
+}

--- a/core/src/ast/snapshots/span_testing/owned_slice.rs
+++ b/core/src/ast/snapshots/span_testing/owned_slice.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn test(owned : Box<[Type]>) {}
+}

--- a/core/src/ast/snapshots/span_testing/result_angle_brackets.rs
+++ b/core/src/ast/snapshots/span_testing/result_angle_brackets.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn result_type_args(r : Result) {}
+}

--- a/core/src/ast/snapshots/span_testing/result_type_args.rs
+++ b/core/src/ast/snapshots/span_testing/result_type_args.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn result_type_args(r : Result<32, i32>) {}
+}

--- a/core/src/ast/snapshots/span_testing/slice_no_type.rs
+++ b/core/src/ast/snapshots/span_testing/slice_no_type.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn slice_no_type(sl : DiplomatSlice) {}
+}

--- a/core/src/ast/snapshots/span_testing/slice_of_slice.rs
+++ b/core/src/ast/snapshots/span_testing/slice_of_slice.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn test(sl : &[&str]) {}
+}

--- a/core/src/ast/snapshots/span_testing/trait_bound_generics.rs
+++ b/core/src/ast/snapshots/span_testing/trait_bound_generics.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn test(t : impl TraitWithGenerics<T>) {}
+}

--- a/core/src/ast/snapshots/span_testing/tuples.rs
+++ b/core/src/ast/snapshots/span_testing/tuples.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn takes_tuple(t : (i32, i32)) {}
+}

--- a/core/src/ast/snapshots/span_testing/unsupported_bound.rs
+++ b/core/src/ast/snapshots/span_testing/unsupported_bound.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn unsupported_bound(b : impl use<'a, T> + ABC) {}
+}

--- a/core/src/ast/snapshots/span_testing/unsupported_fn_type.rs
+++ b/core/src/ast/snapshots/span_testing/unsupported_fn_type.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn unsupported_fn_type(f : impl Fn<>) {}
+}

--- a/core/src/ast/snapshots/span_testing/unsupported_type.rs
+++ b/core/src/ast/snapshots/span_testing/unsupported_type.rs
@@ -1,0 +1,4 @@
+#[diplomat::bridge]
+mod ffi {
+    pub fn unsupported_type(a : fn()) {}
+}

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1224,7 +1224,12 @@ impl TypeName {
                                             ..
                                         }) = input_type
                                         {
-                                            panic!("Lifetimes are not allowed on callback parameters: lifetime '{} on trait {} ", in_lifetime.ident, path_seg.ident);
+                                            create_report(AstReport::new(
+                                                "Lifetimes are not allowed on callback parameters".into(),
+                                                Some(in_lifetime.span().spanned_into(module_location)),
+                                                "Suggestion: remove lifetime".into(),
+                                                vec![ContextLocation::new(path_seg.span().spanned_into(module_location), "Defined on trait".into())]
+                                            ));
                                         }
                                     }
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1141,7 +1141,19 @@ impl TypeName {
                                 },
                             )
                         } else {
-                            panic!("Expected both type arguments for Result to be a type")
+                            let mut locations = vec![];
+                            if !matches!(&type_args.args[0], syn::GenericArgument::Type(..)) {
+                                locations.push(ContextLocation::new(type_args.args[0].span().spanned_into(module_location), "Must be a type arg".into()));
+                            }
+                            if !matches!(&type_args.args[1], syn::GenericArgument::Type(..)) {
+                                locations.push(ContextLocation::new(type_args.args[1].span().spanned_into(module_location), "Must be a type arg".into()));
+                            }
+                            create_report(AstReport::new(
+                                "Expected both type arguments for Result to be a type".into(),
+                                Some(type_args.span().spanned_into(module_location)),
+                                "".into(),
+                                locations
+                            ));
                         }
                     } else {
                         panic!("Expected angle brackets for Result type")

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -392,7 +392,16 @@ impl FromWithSpan<&syn::TraitBound> for PathType {
                                 syn::GenericArgument::Lifetime(lifetime) => {
                                     lifetime.spanned_into(module_location)
                                 }
-                                _ => panic!("generic type arguments are unsupported {other:?}"),
+                                _ => {
+                                    create_report(AstReport::new(
+                                        "Generic type arguments are unsupported".into(),
+                                        Some(other.span().spanned_into(module_location)),
+                                        "Trait bounds with generic arguments are unsupported".into(),
+                                        vec![ContextLocation::new(
+                                            generic_arg.span().spanned_into(module_location), "Suggestion: remove generic type arguments.".into()
+                                        )]
+                                    ));
+                                },
                             })
                             .collect(),
                     )

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1109,7 +1109,12 @@ impl TypeName {
                             }
                         }
                     }
-                    panic!("Found DiplomatSlice/DiplomatSliceMut/DiplomatOwnedSlice without primitive or DiplomatStrSlice-like generic");
+                    create_report(AstReport::new(
+                        "Found DiplomatSlice without primitive or DiplomatSlice-like generic".into(),
+                        Some(ty.span().spanned_into(module_location)),
+                        "Must be a primitive or DiplomatSlice-like generic".into(),
+                        vec![]
+                    ));
                 } else if p_len == 1 && p.path.segments[0].ident == "Result"
                     || is_runtime_type(p, "DiplomatResult")
                 {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1009,7 +1009,17 @@ impl TypeName {
                             ));
                         }
                     } else {
-                        panic!("Expected angle brackets for Option type")
+                        let suggestion = match &p.path.segments[0].arguments {
+                            syn::PathArguments::None => "add angle brackets",
+                            syn::PathArguments::Parenthesized(..) => "replace parentheses with angle brackets",
+                            _ => unreachable!()
+                        };
+                        create_report(AstReport::new(
+                            "Expected angle brackets for Option type".into(),
+                            Some(p.path.segments[0].span().spanned_into(module_location)),
+                            format!("Suggestion: {suggestion}"),
+                            vec![]
+                        ));
                     }
                 } else if p_len == 1 && p.path.segments[0].ident == "Self" {
                     if let Some(self_path_type) = self_path_type {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1264,7 +1264,12 @@ impl TypeName {
                                     ));
                                     continue;
                                 }
-                                panic!("Unsupported function type: {:?}", &path_seg.arguments);
+                                create_report(AstReport::new(
+                                    "Unsupported function type".into(),
+                                    Some(path_seg.span().spanned_into(module_location)),
+                                    "Expected parentheses".into(),
+                                    vec![]
+                                ));
                             } else {
                                 ret_type = Some(TypeName::ImplTrait(
                                     (&syn::TraitBound {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1072,7 +1072,14 @@ impl TypeName {
                         Some((lt, mutability))
                     };
 
-                    let ty = get_ty_from_syn_path(p).expect("Expected type argument to DiplomatSlice/DiplomatSliceMut/DiplomatOwnedSlice");
+                    let ty = get_ty_from_syn_path(p).unwrap_or_else(|| {
+                        create_report(AstReport::new(
+                            "Expected type argument".into(),
+                            Some(p.span().spanned_into(module_location)),
+                            "Add slice type specification here".into(),
+                            vec![]
+                        ));
+                    });
 
                     if let syn::Type::Path(p) = &ty {
                         if let Some(ident) = p.path.get_ident() {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -284,10 +284,18 @@ impl PathType {
             }
         }
 
-        panic!(
-            "Path {} does not point to a custom trait",
-            in_path.elements.join("::")
-        )
+        let sp = if let Some(f) = in_path.elements.last() {
+            f.span()
+        } else {
+            None
+        };
+        
+        create_report(AstReport::new(
+            "Path does not point to a custom trait".into(),
+            sp,
+            format!("{} must point to a custom type.", in_path.elements.join("::")),
+            vec![]
+        ));
     }
 
     /// If this is a [`TypeName::Named`], grab the [`CustomType`] it points to from

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1001,7 +1001,12 @@ impl TypeName {
                                 stdlib,
                             )
                         } else {
-                            panic!("Expected first type argument for Option to be a type")
+                            create_report(AstReport::new(
+                                "Expected first argument for Option to be a type".into(),
+                                Some(type_args.span().spanned_into(module_location)),
+                                "Should be a type".into(),
+                                vec![]
+                            ));
                         }
                     } else {
                         panic!("Expected angle brackets for Option type")

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -972,7 +972,17 @@ impl TypeName {
                             ));
                         }
                     } else {
-                        panic!("Expected angle brackets for Box type")
+                        let suggestion = match &p.path.segments[0].arguments {
+                            syn::PathArguments::None => "add angle brackets",
+                            syn::PathArguments::Parenthesized(..) => "replace parentheses with angle brackets",
+                            _ => unreachable!()
+                        };
+                        create_report(AstReport::new(
+                            "Expected angle brackets for Box type".into(),
+                            Some(p.path.segments[0].span().spanned_into(module_location)),
+                            format!("Suggestion: {suggestion}"),
+                            vec![]
+                        ));
                     }
                 } else if p_len == 1 && p.path.segments[0].ident == "Option"
                     || is_runtime_type(p, "DiplomatOption")

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -279,11 +279,7 @@ impl PathType {
                 if i == local_path.elements.len() - 1 {
                     return (cur_path, trt.clone());
                 } else {
-                    panic!(
-                        "Unexpected custom trait when resolving symbol {} in {}",
-                        trt.name,
-                        cur_path.elements.join("::")
-                    )
+                    create_simple_report(elem.clone(), format!("Found unexpected custom trait {} when resolving path", trt.name), "Trait appears before the end of the path.".into());
                 }
             }
         }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1284,10 +1284,14 @@ impl TypeName {
                             }
                         }
                         syn::TypeParamBound::Lifetime(syn::Lifetime { ident, .. }) => {
-                            assert_eq!(
-                                ident, "static",
-                                "only 'static lifetimes are supported on trait objects for now"
-                            );
+                            if ident != "static" {
+                                create_report(AstReport::new(
+                                    "Found non-static lifetime on trait".into(),
+                                    Some(ident.span().spanned_into(module_location)),
+                                    "Only 'static lifetimes are supported on trait objects right now.".into(),
+                                    vec![]
+                                ));
+                            }
                         }
                         _ => {
                             panic!("Unsupported trait component: {trait_bound:?}");

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -12,12 +12,9 @@ use super::{
     OpaqueType, Path, RustLink, Struct, Trait,
 };
 use crate::{
-    ast::{
-        idents::{FromWithSpan, IntoWithSpan, SpanLocation},
-        logging::create_simple_report,
-        Function,
+    Env, ast::{
+        Function, idents::{FromWithSpan, IntoWithSpan, SpanLocation}, logging::{AstReport, create_report, create_simple_report},
     },
-    Env,
 };
 
 /// A type declared inside a Diplomat-annotated module.
@@ -233,10 +230,18 @@ impl PathType {
             }
         }
 
-        panic!(
-            "Path {} does not point to a custom type",
-            in_path.elements.join("::")
-        )
+        let sp = if let Some(f) = in_path.elements.last() {
+            f.span()
+        } else {
+            None
+        };
+        
+        create_report(AstReport::new(
+            "Path does not point to a custom type.".into(),
+            sp,
+            format!("{} must point to a custom type", in_path.elements.join("::")),
+            vec![]
+        ));
     }
 
     /// If this is a [`TypeName::Named`], grab the [`CustomType`] it points to from

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -930,7 +930,12 @@ impl TypeName {
                             {
                                 TypeName::PrimitiveSlice(None, p, StdlibOrDiplomat::Stdlib)
                             } else {
-                                panic!("Owned slices only support primitives.")
+                                create_report(AstReport::new(
+                                    "Owned slices only support primitives".into(),
+                                    Some(slice.elem.span().spanned_into(module_location)),
+                                    "".into(),
+                                    vec![])
+                                );
                             }
                         } else if let syn::GenericArgument::Type(tpe) = &type_args.args[0] {
                             if tpe.to_token_stream().to_string() == "DiplomatStr" {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1305,7 +1305,14 @@ impl TypeName {
                 }
                 ret_type.expect("No valid traits found")
             }
-            other => panic!("Unsupported type: {}", other.to_token_stream()),
+            other => {
+                create_report(AstReport::new(
+                    "Found unsupported type".into(),
+                    Some(other.span().spanned_into(module_location)),
+                    "See a list of the types Diplomat supports: https://rust-diplomat.github.io/diplomat/types.html".into(),
+                    vec![]
+                ));
+        },
         }
     }
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -356,7 +356,16 @@ impl FromWithSpan<&syn::Signature> for PathType {
             .iter()
             .map(|generic_arg| match generic_arg {
                 syn::GenericParam::Lifetime(lt) => (&lt.lifetime).spanned_into(module_location),
-                _ => panic!("generic type arguments are unsupported {other:?}"),
+                _ => {
+                    create_report(AstReport::new(
+                        "Generic type arguments are unsupported".into(),
+                        Some(other.ident.span().spanned_into(module_location)),
+                        "Functions with generic arguments are unsupported".into(),
+                        vec![ContextLocation::new(
+                            generic_arg.span().spanned_into(module_location), "Suggestion: remove generic type arguments.".into()
+                        )]
+                    ));
+                },
             })
             .collect();
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1156,7 +1156,18 @@ impl TypeName {
                             ));
                         }
                     } else {
-                        panic!("Expected angle brackets for Result type")
+                        let args = &p.path.segments.last().unwrap().arguments;
+                        let suggestion = match args {
+                            syn::PathArguments::None => "add angle brackets",
+                            syn::PathArguments::Parenthesized(..) => "replace parentheses with angle brackets",
+                            _ => unreachable!()
+                        };
+                        create_report(AstReport::new(
+                            "Expected angle brackets for Result type".into(),
+                            Some(p.path.segments.span().spanned_into(module_location)),
+                            format!("Suggestion: {suggestion}"),
+                            vec![]
+                        ));
                     }
                 } else if is_runtime_type(p, "DiplomatWrite") {
                     TypeName::Write

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1294,7 +1294,12 @@ impl TypeName {
                             }
                         }
                         _ => {
-                            panic!("Unsupported trait component: {trait_bound:?}");
+                            create_report(AstReport::new(
+                                "Unsupported trait bound".into(),
+                                Some(trait_bound.span().spanned_into(module_location)),
+                                "Expected lifetime or trait name.".into(),
+                                vec![]
+                            ));
                         }
                     }
                 }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1156,7 +1156,7 @@ impl TypeName {
                 if tup.elems.is_empty() {
                     TypeName::Unit
                 } else {
-                    todo!("Tuples are not currently supported: https://github.com/rust-diplomat/diplomat/issues/1142")
+                    create_report(AstReport::new("Tuples unsupported".into(), Some(tup.span().spanned_into(module_location)), "https://github.com/rust-diplomat/diplomat/issues/1142".into(), vec![]));
                 }
             }
             syn::Type::ImplTrait(tr) => {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1,7 +1,7 @@
 use proc_macro2::Span;
 use quote::{ToTokens, TokenStreamExt};
 use serde::{Deserialize, Serialize};
-use syn::{Token, spanned::Spanned};
+use syn::{spanned::Spanned, Token};
 
 use std::fmt;
 use std::ops::ControlFlow;
@@ -12,9 +12,12 @@ use super::{
     OpaqueType, Path, RustLink, Struct, Trait,
 };
 use crate::{
-    Env, ast::{
-        Function, idents::{FromWithSpan, IntoWithSpan, SpanLocation}, logging::{AstReport, ContextLocation, create_report, create_simple_report},
+    ast::{
+        idents::{FromWithSpan, IntoWithSpan, SpanLocation},
+        logging::{create_report, create_simple_report, AstReport, ContextLocation},
+        Function,
     },
+    Env,
 };
 
 /// A type declared inside a Diplomat-annotated module.
@@ -235,12 +238,15 @@ impl PathType {
         } else {
             None
         };
-        
+
         create_report(AstReport::new(
             "Path does not point to a custom type.".into(),
             sp,
-            format!("{} must point to a custom type", in_path.elements.join("::")),
-            vec![]
+            format!(
+                "{} must point to a custom type",
+                in_path.elements.join("::")
+            ),
+            vec![],
         ));
     }
 
@@ -279,7 +285,14 @@ impl PathType {
                 if i == local_path.elements.len() - 1 {
                     return (cur_path, trt.clone());
                 } else {
-                    create_simple_report(elem.clone(), format!("Found unexpected custom trait {} when resolving path", trt.name), "Trait appears before the end of the path.".into());
+                    create_simple_report(
+                        elem.clone(),
+                        format!(
+                            "Found unexpected custom trait {} when resolving path",
+                            trt.name
+                        ),
+                        "Trait appears before the end of the path.".into(),
+                    );
                 }
             }
         }
@@ -289,12 +302,15 @@ impl PathType {
         } else {
             None
         };
-        
+
         create_report(AstReport::new(
             "Path does not point to a custom trait".into(),
             sp,
-            format!("{} must point to a custom type.", in_path.elements.join("::")),
-            vec![]
+            format!(
+                "{} must point to a custom type.",
+                in_path.elements.join("::")
+            ),
+            vec![],
         ));
     }
 
@@ -321,17 +337,20 @@ impl FromWithSpan<&syn::TypePath> for PathType {
                             .args
                             .iter()
                             .map(|generic_arg| match generic_arg {
-                                syn::GenericArgument::Lifetime(lifetime) => lifetime.spanned_into(module_location),
+                                syn::GenericArgument::Lifetime(lifetime) => {
+                                    lifetime.spanned_into(module_location)
+                                }
                                 _ => {
                                     create_report(AstReport::new(
                                         "Generic type arguments are unsupported".into(),
                                         Some(other.span().spanned_into(module_location)),
                                         "Type paths with generic arguments are unsupported.".into(),
                                         vec![ContextLocation::new(
-                                            generic_arg.span().spanned_into(module_location), "Suggestion: remove generic type arguments".into()
-                                        )]
+                                            generic_arg.span().spanned_into(module_location),
+                                            "Suggestion: remove generic type arguments".into(),
+                                        )],
                                     ));
-                                },
+                                }
                             })
                             .collect(),
                     )
@@ -362,10 +381,11 @@ impl FromWithSpan<&syn::Signature> for PathType {
                         Some(other.ident.span().spanned_into(module_location)),
                         "Functions with generic arguments are unsupported".into(),
                         vec![ContextLocation::new(
-                            generic_arg.span().spanned_into(module_location), "Suggestion: remove generic type arguments.".into()
-                        )]
+                            generic_arg.span().spanned_into(module_location),
+                            "Suggestion: remove generic type arguments.".into(),
+                        )],
                     ));
-                },
+                }
             })
             .collect();
 
@@ -396,12 +416,14 @@ impl FromWithSpan<&syn::TraitBound> for PathType {
                                     create_report(AstReport::new(
                                         "Generic type arguments are unsupported".into(),
                                         Some(other.span().spanned_into(module_location)),
-                                        "Trait bounds with generic arguments are unsupported".into(),
+                                        "Trait bounds with generic arguments are unsupported"
+                                            .into(),
                                         vec![ContextLocation::new(
-                                            generic_arg.span().spanned_into(module_location), "Suggestion: remove generic type arguments.".into()
-                                        )]
+                                            generic_arg.span().spanned_into(module_location),
+                                            "Suggestion: remove generic type arguments.".into(),
+                                        )],
                                     ));
-                                },
+                                }
                             })
                             .collect(),
                     )
@@ -833,7 +855,7 @@ impl TypeName {
                             "Mutable string references disallowed".into(),
                             Some(r.elem.span().spanned_into(module_location)),
                             "Suggestion: make reference immutable".into(),
-                            vec![]
+                            vec![],
                         ));
                     }
                     if name == "DiplomatStr" {
@@ -934,8 +956,8 @@ impl TypeName {
                                     "Owned slices only support primitives".into(),
                                     Some(slice.elem.span().spanned_into(module_location)),
                                     "".into(),
-                                    vec![])
-                                );
+                                    vec![],
+                                ));
                             }
                         } else if let syn::GenericArgument::Type(tpe) = &type_args.args[0] {
                             if tpe.to_token_stream().to_string() == "DiplomatStr" {
@@ -968,20 +990,22 @@ impl TypeName {
                                 "Expected a type in Box type arg".into(),
                                 Some(type_args.span().spanned_into(module_location)),
                                 "Should be a type".into(),
-                                vec![]
+                                vec![],
                             ));
                         }
                     } else {
                         let suggestion = match &p.path.segments[0].arguments {
                             syn::PathArguments::None => "add angle brackets",
-                            syn::PathArguments::Parenthesized(..) => "replace parentheses with angle brackets",
-                            _ => unreachable!()
+                            syn::PathArguments::Parenthesized(..) => {
+                                "replace parentheses with angle brackets"
+                            }
+                            _ => unreachable!(),
                         };
                         create_report(AstReport::new(
                             "Expected angle brackets for Box type".into(),
                             Some(p.path.segments[0].span().spanned_into(module_location)),
                             format!("Suggestion: {suggestion}"),
-                            vec![]
+                            vec![],
                         ));
                     }
                 } else if p_len == 1 && p.path.segments[0].ident == "Option"
@@ -1005,20 +1029,22 @@ impl TypeName {
                                 "Expected first argument for Option to be a type".into(),
                                 Some(type_args.span().spanned_into(module_location)),
                                 "Should be a type".into(),
-                                vec![]
+                                vec![],
                             ));
                         }
                     } else {
                         let suggestion = match &p.path.segments[0].arguments {
                             syn::PathArguments::None => "add angle brackets",
-                            syn::PathArguments::Parenthesized(..) => "replace parentheses with angle brackets",
-                            _ => unreachable!()
+                            syn::PathArguments::Parenthesized(..) => {
+                                "replace parentheses with angle brackets"
+                            }
+                            _ => unreachable!(),
                         };
                         create_report(AstReport::new(
                             "Expected angle brackets for Option type".into(),
                             Some(p.path.segments[0].span().spanned_into(module_location)),
                             format!("Suggestion: {suggestion}"),
-                            vec![]
+                            vec![],
                         ));
                     }
                 } else if p_len == 1 && p.path.segments[0].ident == "Self" {
@@ -1077,7 +1103,7 @@ impl TypeName {
                             "Expected type argument".into(),
                             Some(p.span().spanned_into(module_location)),
                             "Add slice type specification here".into(),
-                            vec![]
+                            vec![],
                         ));
                     });
 
@@ -1117,10 +1143,11 @@ impl TypeName {
                         }
                     }
                     create_report(AstReport::new(
-                        "Found DiplomatSlice without primitive or DiplomatSlice-like generic".into(),
+                        "Found DiplomatSlice without primitive or DiplomatSlice-like generic"
+                            .into(),
                         Some(ty.span().spanned_into(module_location)),
                         "Must be a primitive or DiplomatSlice-like generic".into(),
-                        vec![]
+                        vec![],
                     ));
                 } else if p_len == 1 && p.path.segments[0].ident == "Result"
                     || is_runtime_type(p, "DiplomatResult")
@@ -1150,30 +1177,38 @@ impl TypeName {
                         } else {
                             let mut locations = vec![];
                             if !matches!(&type_args.args[0], syn::GenericArgument::Type(..)) {
-                                locations.push(ContextLocation::new(type_args.args[0].span().spanned_into(module_location), "Must be a type arg".into()));
+                                locations.push(ContextLocation::new(
+                                    type_args.args[0].span().spanned_into(module_location),
+                                    "Must be a type arg".into(),
+                                ));
                             }
                             if !matches!(&type_args.args[1], syn::GenericArgument::Type(..)) {
-                                locations.push(ContextLocation::new(type_args.args[1].span().spanned_into(module_location), "Must be a type arg".into()));
+                                locations.push(ContextLocation::new(
+                                    type_args.args[1].span().spanned_into(module_location),
+                                    "Must be a type arg".into(),
+                                ));
                             }
                             create_report(AstReport::new(
                                 "Expected both type arguments for Result to be a type".into(),
                                 Some(type_args.span().spanned_into(module_location)),
                                 "".into(),
-                                locations
+                                locations,
                             ));
                         }
                     } else {
                         let args = &p.path.segments.last().unwrap().arguments;
                         let suggestion = match args {
                             syn::PathArguments::None => "add angle brackets",
-                            syn::PathArguments::Parenthesized(..) => "replace parentheses with angle brackets",
-                            _ => unreachable!()
+                            syn::PathArguments::Parenthesized(..) => {
+                                "replace parentheses with angle brackets"
+                            }
+                            _ => unreachable!(),
                         };
                         create_report(AstReport::new(
                             "Expected angle brackets for Result type".into(),
                             Some(p.path.segments.span().spanned_into(module_location)),
                             format!("Suggestion: {suggestion}"),
-                            vec![]
+                            vec![],
                         ));
                     }
                 } else if is_runtime_type(p, "DiplomatWrite") {
@@ -1186,7 +1221,12 @@ impl TypeName {
                 if tup.elems.is_empty() {
                     TypeName::Unit
                 } else {
-                    create_report(AstReport::new("Tuples unsupported".into(), Some(tup.span().spanned_into(module_location)), "https://github.com/rust-diplomat/diplomat/issues/1142".into(), vec![]));
+                    create_report(AstReport::new(
+                        "Tuples unsupported".into(),
+                        Some(tup.span().spanned_into(module_location)),
+                        "https://github.com/rust-diplomat/diplomat/issues/1142".into(),
+                        vec![],
+                    ));
                 }
             }
             syn::Type::ImplTrait(tr) => {
@@ -1199,7 +1239,7 @@ impl TypeName {
                                     "Implementing multiple traits currently unsupported".into(),
                                     Some(trait_bound.span().spanned_into(module_location)),
                                     "Suggestion: remove extra trait bound".into(),
-                                    vec![]
+                                    vec![],
                                 ));
                             }
                             let rel_segs = &p.segments;
@@ -1232,10 +1272,18 @@ impl TypeName {
                                         }) = input_type
                                         {
                                             create_report(AstReport::new(
-                                                "Lifetimes are not allowed on callback parameters".into(),
-                                                Some(in_lifetime.span().spanned_into(module_location)),
+                                                "Lifetimes are not allowed on callback parameters"
+                                                    .into(),
+                                                Some(
+                                                    in_lifetime
+                                                        .span()
+                                                        .spanned_into(module_location),
+                                                ),
                                                 "Suggestion: remove lifetime".into(),
-                                                vec![ContextLocation::new(path_seg.span().spanned_into(module_location), "Defined on trait".into())]
+                                                vec![ContextLocation::new(
+                                                    path_seg.span().spanned_into(module_location),
+                                                    "Defined on trait".into(),
+                                                )],
                                             ));
                                         }
                                     }
@@ -1275,7 +1323,7 @@ impl TypeName {
                                     "Unsupported function type".into(),
                                     Some(path_seg.span().spanned_into(module_location)),
                                     "Expected parentheses".into(),
-                                    vec![]
+                                    vec![],
                                 ));
                             } else {
                                 ret_type = Some(TypeName::ImplTrait(
@@ -1305,7 +1353,7 @@ impl TypeName {
                                 "Unsupported trait bound".into(),
                                 Some(trait_bound.span().spanned_into(module_location)),
                                 "Expected lifetime or trait name.".into(),
-                                vec![]
+                                vec![],
                             ));
                         }
                     }
@@ -1320,7 +1368,7 @@ impl TypeName {
                     "See a list of the types Diplomat supports: https://rust-diplomat.github.io/diplomat/types.html".into(),
                     vec![]
                 ));
-        },
+            }
         }
     }
 

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1025,6 +1025,7 @@ impl TypeName {
                     if let Some(self_path_type) = self_path_type {
                         TypeName::SelfType(self_path_type)
                     } else {
+                        // Note that this is currently unreachable, we never provide any value to `self_path_type` other than `Some`.
                         panic!("Cannot have `Self` type outside of a method");
                     }
                 } else if is_runtime_type(p, "DiplomatOwnedStrSlice")

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1,7 +1,7 @@
 use proc_macro2::Span;
 use quote::{ToTokens, TokenStreamExt};
 use serde::{Deserialize, Serialize};
-use syn::Token;
+use syn::{Token, spanned::Spanned};
 
 use std::fmt;
 use std::ops::ControlFlow;
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     Env, ast::{
-        Function, idents::{FromWithSpan, IntoWithSpan, SpanLocation}, logging::{AstReport, create_report, create_simple_report},
+        Function, idents::{FromWithSpan, IntoWithSpan, SpanLocation}, logging::{AstReport, ContextLocation, create_report, create_simple_report},
     },
 };
 
@@ -322,7 +322,16 @@ impl FromWithSpan<&syn::TypePath> for PathType {
                             .iter()
                             .map(|generic_arg| match generic_arg {
                                 syn::GenericArgument::Lifetime(lifetime) => lifetime.spanned_into(module_location),
-                                _ => panic!("generic type arguments are unsupported (type: {other:?}, arg: {generic_arg:?})"),
+                                _ => {
+                                    create_report(AstReport::new(
+                                        "Generic type arguments are unsupported".into(),
+                                        Some(other.span().spanned_into(module_location)),
+                                        "Type paths with generic arguments are unsupported.".into(),
+                                        vec![ContextLocation::new(
+                                            generic_arg.span().spanned_into(module_location), "Suggestion: remove generic type arguments".into()
+                                        )]
+                                    ));
+                                },
                             })
                             .collect(),
                     )

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -829,7 +829,12 @@ impl TypeName {
                 let name = r.elem.to_token_stream().to_string();
                 if name.starts_with("DiplomatStr") || name == "str" {
                     if mutability.is_mutable() {
-                        panic!("mutable string references are disallowed");
+                        create_report(AstReport::new(
+                            "Mutable string references disallowed".into(),
+                            Some(r.elem.span().spanned_into(module_location)),
+                            "Suggestion: make reference immutable".into(),
+                            vec![]
+                        ));
                     }
                     if name == "DiplomatStr" {
                         return TypeName::StrReference(

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1310,6 +1310,7 @@ impl TypeName {
                         }
                     }
                 }
+                // `.expect` currently unreachable, as we either error before this point or set ret_type to be Some.
                 ret_type.expect("No valid traits found")
             }
             other => {

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -877,7 +877,12 @@ impl TypeName {
                     ) = TypeName::from_syn(&slice.elem, self_path_type.clone(), module_location)
                     {
                         if is_stdlib_type == StdlibOrDiplomat::Stdlib {
-                            panic!("Slice-of-slice is only supported with DiplomatRuntime slice types (DiplomatStrSlice, DiplomatStr16Slice, DiplomatUtf8StrSlice)");
+                            create_report(AstReport::new(
+                                "String slice-of-slice is only supported with DiplomatRuntime slice types".into(),
+                                Some(slice.elem.span().spanned_into(module_location)),
+                                "Supported slice types: DiplomatStrSlice, DiplomatStr16Slice, DiplomatUtf8StrSlice.".into(),
+                                vec![]
+                            ));
                         }
                         return TypeName::StrSlice(encoding, StdlibOrDiplomat::Stdlib);
                     }

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -964,7 +964,12 @@ impl TypeName {
                                 )))
                             }
                         } else {
-                            panic!("Expected first type argument for Box to be a type")
+                            create_report(AstReport::new(
+                                "Expected a type in Box type arg".into(),
+                                Some(type_args.span().spanned_into(module_location)),
+                                "Should be a type".into(),
+                                vec![]
+                            ));
                         }
                     } else {
                         panic!("Expected angle brackets for Box type")

--- a/core/src/ast/types.rs
+++ b/core/src/ast/types.rs
@@ -1165,7 +1165,12 @@ impl TypeName {
                     match trait_bound {
                         syn::TypeParamBound::Trait(syn::TraitBound { path: p, .. }) => {
                             if ret_type.is_some() {
-                                todo!("Currently don't support implementing multiple traits");
+                                create_report(AstReport::new(
+                                    "Implementing multiple traits currently unsupported".into(),
+                                    Some(trait_bound.span().spanned_into(module_location)),
+                                    "Suggestion: remove extra trait bound".into(),
+                                    vec![]
+                                ));
                             }
                             let rel_segs = &p.segments;
                             let path_seg = &rel_segs[0];


### PR DESCRIPTION
There are a few stragglers to get for the AST half of https://github.com/rust-diplomat/diplomat/issues/111 (I forgot about `.expect(...)`), but this covers most of the remaining AST `panic!`s.

Will do one more pass later, but next up will come HIR errors. After those HIR passes (with maybe even some tool passes?) we'll be able to finish https://github.com/rust-diplomat/diplomat/issues/111.