### PR TITLE
dotnet: render stringifiers as ToString() overrides

### DIFF
--- a/feature_tests/dotnet/Tests/StringifierTests.cs
+++ b/feature_tests/dotnet/Tests/StringifierTests.cs
@@ -1,0 +1,31 @@
+using Somelib;
+using Xunit;
+
+namespace Somelib.FeatureTests;
+
+public class StringifierTests
+{
+    [Fact]
+    public void Stringifier_OverridesObjectToString()
+    {
+        using MyOpaqueEnum value = MyOpaqueEnum.New();
+        object boxed = value;
+
+        Assert.Equal("MyOpaqueEnum::A", boxed.ToString());
+    }
+
+    [Fact]
+    public void Stringifier_RendersFloat64VecContents()
+    {
+        byte[] bytes =
+        [
+            0x3f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xc0, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        using Float64Vec vec = Float64Vec.NewF64BeBytes(bytes);
+
+        Assert.Equal("[1.5, -2.25]", vec.ToString());
+        Assert.Equal("[1.5, -2.25]", $"{vec}");
+    }
+}

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -511,8 +511,11 @@ pub(super) struct ReturnLowering {
 pub(super) struct MethodInfo<'ctx> {
     /// `extern "C"` symbol name (e.g. `Color_brightness`).
     pub(super) abi_name: &'ctx str,
-    /// C# method name (PascalCase, e.g. `Brightness`).
+    /// C# method name on the raw interop layer (PascalCase, e.g. `Brightness`).
     pub(super) name: String,
+    /// Method name on the idiomatic wrapper. Same as `name` except when a
+    /// special method claims a C#-native spelling (stringifier → `ToString`).
+    pub(super) idiomatic_name: String,
     /// `"static "` for static methods, `""` for instance. Renders directly
     /// before the return type in the idiomatic method declaration.
     pub(super) static_kw: &'static str,
@@ -603,16 +606,17 @@ impl MethodInfo<'_> {
         }
     }
 
-    /// True when the convenience write overload would emit a
-    /// `public string ToString()` that exactly matches the signature of
-    /// `object.ToString()`. The C# compiler warns (CS0114) on
-    /// signature-matching hides that aren't explicitly `override` or
-    /// `new`; treating it as `override` matches author intent (Rust's
-    /// `to_string` is meant to be THE stringifier) and silences the
-    /// warning. Treating it as `override` matches author intent (Rust's
-    /// `to_string` is meant to be THE stringifier) and silences the warning.
+    /// True when the idiomatic method emits a `public string ToString()`
+    /// matching the signature of `object.ToString()` — a stringifier (renamed
+    /// to `ToString`) or a parameterless write method that happens to be named
+    /// `to_string`. The C# compiler warns (CS0114) on signature-matching hides
+    /// that aren't explicitly `override` or `new`; `override` matches author
+    /// intent (the method is meant to be THE stringifier) and silences the
+    /// warning.
     pub(super) fn is_to_string_override(&self) -> bool {
-        self.is_instance() && self.name == "ToString" && self.inputs.idiomatic_params.is_empty()
+        self.is_instance()
+            && self.idiomatic_name == "ToString"
+            && self.inputs.idiomatic_params.is_empty()
     }
 
     /// C# fragment for the idiomatic method signature's return type —
@@ -829,11 +833,11 @@ pub(super) fn collect_properties(methods: &[MethodInfo<'_>]) -> Vec<PropertyInfo
         match accessor.kind {
             PropertyAccessorKind::Getter => {
                 property.property_type = accessor.property_type.clone();
-                property.getter = Some(method.name.clone());
+                property.getter = Some(method.idiomatic_name.clone());
                 property.lifetime_warning |= method.lifetime_warning;
             }
             PropertyAccessorKind::Setter => {
-                property.setter = Some(method.name.clone());
+                property.setter = Some(method.idiomatic_name.clone());
             }
         }
     }
@@ -861,6 +865,12 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         // anything pushed while lowering this method. Restored on scope exit.
         let method_name = self.formatter.fmt_method_name(method).into_owned();
         let _guard = self.errors.set_context_method(method_name.clone().into());
+        // Special-method markers the backend doesn't dispatch yet fall through
+        // to the `_` arm and keep rendering as plain named methods.
+        let idiomatic_name = match &method.attrs.special_method {
+            Some(hir::SpecialMethod::Stringifier) => self.stringifier_name(method)?,
+            _ => method_name.clone(),
+        };
         let static_kw = if method.param_self.is_some() {
             ""
         } else {
@@ -913,8 +923,13 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         } else {
             return_type.to_string()
         };
-        let property_accessor =
-            self.property_accessor(method, &return_type, &return_type_name, &inputs);
+        // A renamed special method no longer exists under its prefix-derived
+        // name, so a property getter/setter would call a method that's gone.
+        let property_accessor = if idiomatic_name == method_name {
+            self.property_accessor(method, &return_type, &return_type_name, &inputs)
+        } else {
+            None
+        };
         let (keep_alive_edges, error_keep_alive_edges) =
             self.borrowed_output_keep_alive_edges(method, &inputs, &borrow_map, ownership)?;
         let lifetime_warning = !keep_alive_edges.is_empty();
@@ -948,6 +963,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
         Some(MethodInfo {
             abi_name: method.abi_name.as_str(),
             name: method_name,
+            idiomatic_name,
             static_kw,
             inputs,
             return_type,
@@ -1082,6 +1098,32 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             }
         }
         Some(edges)
+    }
+
+    /// `ToString` for a stringifier the backend can render, or `None`
+    /// (diagnostic recorded) for shapes a C# `ToString()` override can't
+    /// express. HIR validation already guarantees no parameters and a
+    /// `DiplomatWrite` success value.
+    fn stringifier_name(&self, method: &Method) -> Option<String> {
+        if method.param_self.is_none() {
+            self.errors.push_error(
+                "[.NET backend] static stringifier is not supported: `ToString()` can \
+                 only override `object.ToString()` on an instance. Remove the attribute \
+                 or disable this API for .NET."
+                    .to_string(),
+            );
+            return None;
+        }
+        if !matches!(method.output, hir::ReturnType::Infallible(_)) {
+            self.errors.push_error(
+                "[.NET backend] fallible or nullable stringifier is not supported: \
+                 `ToString()` has no error/none arm to surface. Make the method \
+                 infallible or disable this API for .NET."
+                    .to_string(),
+            );
+            return None;
+        }
+        Some("ToString".to_string())
     }
 
     fn property_accessor(

--- a/tool/src/dotnet/gen/mod.rs
+++ b/tool/src/dotnet/gen/mod.rs
@@ -305,9 +305,28 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
     /// (its diagnostic was recorded during lowering); the end-gate aborts the
     /// whole run before any file is written.
     fn build_methods(&self, methods: &'tcx [hir::Method]) -> Vec<MethodInfo<'tcx>> {
+        // Two `override string ToString()` members (a stringifier plus a
+        // parameterless `to_string`, say) would be a C# duplicate-member error.
+        let mut has_to_string_override = false;
         methods
             .iter()
             .filter_map(|m| self.build_method_info(StructMethodContext::new(m)))
+            .filter(|info| {
+                if !info.is_to_string_override() {
+                    return true;
+                }
+                if has_to_string_override {
+                    self.errors.push_error(
+                        "[.NET backend] multiple methods render as the `ToString()` \
+                         override on this type; C# allows only one. Rename or disable \
+                         the extras."
+                            .to_string(),
+                    );
+                    return false;
+                }
+                has_to_string_override = true;
+                true
+            })
             .collect()
     }
 

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -158,7 +158,7 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.fallible_constructors = false;
     a.accessors = false;
     a.static_accessors = false;
-    a.stringifiers = false;
+    a.stringifiers = true;
     a.comparators = false;
     a.iterators = false;
     a.iterables = false;
@@ -1242,6 +1242,132 @@ mod test {
         assert!(
             exc.contains("params object[] edges"),
             "exception class should accept keep-alive edges in its constructor:\n{exc}"
+        );
+    }
+
+    // A stringifier replaces its plain named method with the `ToString()`
+    // override on the idiomatic layer; the raw layer keeps the method's name.
+    #[test]
+    fn stringifier_renders_as_to_string_override() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Person;
+
+                impl Person {
+                    #[diplomat::attr(auto, stringifier)]
+                    pub fn display(&self, w: &mut DiplomatWrite) {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let person = files.get("Person.cs").expect("expected Person.cs output");
+        assert!(
+            person.contains("public override string ToString()"),
+            "stringifier should render as the ToString() override:\n{person}"
+        );
+        assert!(
+            !person.contains("public string Display("),
+            "the plain named method should be replaced, not duplicated:\n{person}"
+        );
+
+        let raw = files
+            .get("RawPerson.cs")
+            .expect("expected RawPerson.cs output");
+        assert!(
+            raw.contains("Display("),
+            "the raw layer should keep the method's own name:\n{raw}"
+        );
+    }
+
+    #[test]
+    fn static_stringifier_is_rejected() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Banner;
+
+                impl Banner {
+                    #[diplomat::attr(auto, stringifier)]
+                    pub fn motd(w: &mut DiplomatWrite) {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (_files, errors) = run_dotnet(tk_stream);
+        let error_str = errors.join("\n");
+        assert!(
+            error_str.contains("static stringifier is not supported"),
+            "unexpected diagnostics: {error_str}"
+        );
+    }
+
+    #[test]
+    fn fallible_stringifier_is_rejected() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Shaky;
+
+                impl Shaky {
+                    #[diplomat::attr(auto, stringifier)]
+                    pub fn stringify(&self, w: &mut DiplomatWrite) -> Result<(), Box<Shaky>> {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (_files, errors) = run_dotnet(tk_stream);
+        let error_str = errors.join("\n");
+        assert!(
+            error_str.contains("fallible or nullable stringifier is not supported"),
+            "unexpected diagnostics: {error_str}"
+        );
+    }
+
+    // A stringifier and a parameterless `to_string` would both emit
+    // `override string ToString()` — a C# duplicate-member error.
+    #[test]
+    fn duplicate_to_string_overrides_are_rejected() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Twice;
+
+                impl Twice {
+                    #[diplomat::attr(auto, stringifier)]
+                    pub fn display(&self, w: &mut DiplomatWrite) {
+                        unimplemented!()
+                    }
+
+                    pub fn to_string(&self, w: &mut DiplomatWrite) {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (_files, errors) = run_dotnet(tk_stream);
+        let error_str = errors.join("\n");
+        assert!(
+            error_str.contains("multiple methods render as the `ToString()` override"),
+            "unexpected diagnostics: {error_str}"
         );
     }
 }

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -104,7 +104,7 @@ public partial class {{ name }}: IDisposable
 {%- endif %}
     /// </remarks>
 {%- endif %}
-    public {{ method.static_kw }}{% if method.is_to_string_override() %}override {% endif %}{{ method.idiomatic_signature_return_type() }} {{ method.name }}({{ method.inputs.idiomatic_params }})
+    public {{ method.static_kw }}{% if method.is_to_string_override() %}override {% endif %}{{ method.idiomatic_signature_return_type() }} {{ method.idiomatic_name }}({{ method.inputs.idiomatic_params }})
     {
         unsafe
         {

--- a/tool/templates/dotnet/struct.impl.cs.jinja
+++ b/tool/templates/dotnet/struct.impl.cs.jinja
@@ -66,7 +66,7 @@ public partial struct {{ name }}
     /// </remarks>
 {%- endif %}
 
-    public {{ method.static_kw }}{% if method.is_to_string_override() %}override {% endif %}{{ method.idiomatic_signature_return_type() }} {{ method.name }}({{ method.inputs.idiomatic_params }})
+    public {{ method.static_kw }}{% if method.is_to_string_override() %}override {% endif %}{{ method.idiomatic_signature_return_type() }} {{ method.idiomatic_name }}({{ method.inputs.idiomatic_params }})
     {
         unsafe
         {


### PR DESCRIPTION
Flips `stringifiers` on for .NET. A `#[diplomat::attr(auto, stringifier)]` method now renders as `public override string ToString()` on the idiomatic wrapper instead of a plain named method — raw layer unchanged. The old name-based stopgap (any parameterless write method literally named `to_string`) runs through the same predicate now, so there's one mechanism, not two.

Shapes C# can't express fail loud instead of emitting broken code: static stringifiers, fallible/nullable ones, and two methods both claiming the `ToString()` override all report a diagnostic and abort generation.

Regen produced zero diff — both feature-test stringifiers were already named `to_string`, so the output is byte-identical, just attr-driven now.

Tests: 4 new tool unit tests (render/replace + all three rejections), 2 new xunit facts including virtual dispatch through an `object`-typed reference.
