### PR TITLE
AST location errors final pass

### DIFF
--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -2,11 +2,16 @@
 
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
+use syn::spanned::Spanned;
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::str::FromStr;
 use syn::parse::{Error as ParseError, Parse, ParseStream};
 use syn::{Attribute, Expr, Ident, Lit, LitStr, Meta, MetaList, MetaNameValue, Token};
+
+use crate::ast::SpanLocation;
+use crate::ast::idents::{FromWithSpan, IntoWithSpan};
+use crate::ast::logging::{AstReport, create_report};
 
 /// The list of attributes on a type. All attributes except `attrs` (HIR attrs) are
 /// potentially read by the diplomat macro and the AST backends, anything that is not should
@@ -106,21 +111,21 @@ impl Attrs {
         }
     }
 
-    pub(crate) fn add_attrs(&mut self, attrs: &[Attribute]) {
-        for attr in syn_attr_to_ast_attr(attrs) {
+    pub(crate) fn add_attrs(&mut self, attrs: &[Attribute], attrs_location : &SpanLocation) {
+        for attr in syn_attr_to_ast_attr(attrs, attrs_location) {
             self.add_attr(attr)
         }
     }
-    pub(crate) fn from_attrs(attrs: &[Attribute]) -> Self {
+    pub(crate) fn from_attrs(attrs: &[Attribute], attrs_location : &SpanLocation) -> Self {
         let mut this = Self::default();
-        this.add_attrs(attrs);
+        this.add_attrs(attrs, attrs_location);
         this
     }
 }
 
-impl From<&[Attribute]> for Attrs {
-    fn from(other: &[Attribute]) -> Self {
-        Self::from_attrs(other)
+impl FromWithSpan<&[Attribute]> for Attrs {
+    fn spanned_from(other: &[Attribute], module_location: &SpanLocation) -> Self {
+        Self::from_attrs(other, module_location)
     }
 }
 
@@ -135,7 +140,7 @@ enum Attr {
     // More goes here
 }
 
-fn syn_attr_to_ast_attr(attrs: &[Attribute]) -> impl Iterator<Item = Attr> + '_ {
+fn syn_attr_to_ast_attr<'a>(attrs: &'a [Attribute], attrs_location : &'a SpanLocation) -> impl Iterator<Item = Attr> + 'a {
     let cfg_path: syn::Path = syn::parse_str("cfg").unwrap();
     let dattr_path: syn::Path = syn::parse_str("diplomat::attr").unwrap();
     let diplomat_cfg_path: syn::Path = syn::parse_str("diplomat::cfg").unwrap();

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -215,7 +215,16 @@ fn syn_attr_to_ast_attr<'a>(attrs: &'a [Attribute], attrs_location : &'a SpanLoc
         } else if a.path() == &include_path {
             Some(Attr::Include(
                 a.parse_args()
-                    .expect("Failed to parse malformed diplomat::include"),
+                    .unwrap_or_else(|e| {
+                        create_report(AstReport::new(
+                            "Failed to parse diplomat::include".into(),
+                            Some(e.span().spanned_into(attrs_location)),
+                            e.to_string(),
+                            vec![
+                                ContextLocation::new(a.span().spanned_into(attrs_location), "".into())
+                            ]
+                        ));
+                    }),
             ))
         } else {
             None

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -184,7 +184,16 @@ fn syn_attr_to_ast_attr<'a>(attrs: &'a [Attribute], attrs_location : &'a SpanLoc
         } else if a.path() == &demo_path {
             Some(Attr::DemoBackend(
                 a.parse_args()
-                    .expect("Failed to parse malformed diplomat::demo"),
+                    .unwrap_or_else(|e| {
+                        create_report(AstReport::new(
+                            "Failed to parse diplomat::demo".into(),
+                            Some(e.span().spanned_into(attrs_location)),
+                            e.to_string(),
+                            vec![
+                                ContextLocation::new(a.span().spanned_into(attrs_location), "".into())
+                            ]
+                        ));
+                    }),
             ))
         } else if a.path() == &deprecated {
             if let Some(Meta::NameValue(MetaNameValue {

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -168,7 +168,16 @@ fn syn_attr_to_ast_attr<'a>(attrs: &'a [Attribute], attrs_location : &'a SpanLoc
         } else if a.path() == &diplomat_cfg_path {
             Some(Attr::DiplomatCFGBackend(
                 a.parse_args()
-                    .expect("Failed to parse malformed diplomat::cfg"),
+                    .unwrap_or_else(|e| {
+                        create_report(AstReport::new(
+                            "Failed to parse diplomat::cfg".into(),
+                            Some(e.span().spanned_into(attrs_location)),
+                            e.to_string(),
+                            vec![
+                                ContextLocation::new(a.span().spanned_into(attrs_location), "".into())
+                            ]
+                        ));
+                    }),
             ))
         } else if a.path() == &crename_attr {
             Some(Attr::CRename(RenameAttr::from_meta(&a.meta).unwrap()))

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -2,16 +2,16 @@
 
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
-use syn::spanned::Spanned;
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::str::FromStr;
 use syn::parse::{Error as ParseError, Parse, ParseStream};
+use syn::spanned::Spanned;
 use syn::{Attribute, Expr, Ident, Lit, LitStr, Meta, MetaList, MetaNameValue, Token};
 
-use crate::ast::SpanLocation;
 use crate::ast::idents::{FromWithSpan, IntoWithSpan};
-use crate::ast::logging::{AstReport, ContextLocation, create_report};
+use crate::ast::logging::{create_report, AstReport, ContextLocation};
+use crate::ast::SpanLocation;
 
 /// The list of attributes on a type. All attributes except `attrs` (HIR attrs) are
 /// potentially read by the diplomat macro and the AST backends, anything that is not should
@@ -111,12 +111,12 @@ impl Attrs {
         }
     }
 
-    pub(crate) fn add_attrs(&mut self, attrs: &[Attribute], attrs_location : &SpanLocation) {
+    pub(crate) fn add_attrs(&mut self, attrs: &[Attribute], attrs_location: &SpanLocation) {
         for attr in syn_attr_to_ast_attr(attrs, attrs_location) {
             self.add_attr(attr)
         }
     }
-    pub(crate) fn from_attrs(attrs: &[Attribute], attrs_location : &SpanLocation) -> Self {
+    pub(crate) fn from_attrs(attrs: &[Attribute], attrs_location: &SpanLocation) -> Self {
         let mut this = Self::default();
         this.add_attrs(attrs, attrs_location);
         this
@@ -140,7 +140,10 @@ enum Attr {
     // More goes here
 }
 
-fn syn_attr_to_ast_attr<'a>(attrs: &'a [Attribute], attrs_location : &'a SpanLocation) -> impl Iterator<Item = Attr> + 'a {
+fn syn_attr_to_ast_attr<'a>(
+    attrs: &'a [Attribute],
+    attrs_location: &'a SpanLocation,
+) -> impl Iterator<Item = Attr> + 'a {
     let cfg_path: syn::Path = syn::parse_str("cfg").unwrap();
     let dattr_path: syn::Path = syn::parse_str("diplomat::attr").unwrap();
     let diplomat_cfg_path: syn::Path = syn::parse_str("diplomat::cfg").unwrap();
@@ -152,49 +155,45 @@ fn syn_attr_to_ast_attr<'a>(attrs: &'a [Attribute], attrs_location : &'a SpanLoc
         if a.path() == &cfg_path {
             Some(Attr::Cfg(a.clone()))
         } else if a.path() == &dattr_path {
-            Some(Attr::DiplomatBackend(
-                a.parse_args()
-                    .unwrap_or_else(|e| {
-                        create_report(AstReport::new(
-                            "Failed to parse diplomat::attr".into(),
-                            Some(e.span().spanned_into(attrs_location)),
-                            e.to_string(),
-                            vec![
-                                ContextLocation::new(a.span().spanned_into(attrs_location), "".into())
-                            ]
-                        ));
-                    }),
-            ))
+            Some(Attr::DiplomatBackend(a.parse_args().unwrap_or_else(|e| {
+                create_report(AstReport::new(
+                    "Failed to parse diplomat::attr".into(),
+                    Some(e.span().spanned_into(attrs_location)),
+                    e.to_string(),
+                    vec![ContextLocation::new(
+                        a.span().spanned_into(attrs_location),
+                        "".into(),
+                    )],
+                ));
+            })))
         } else if a.path() == &diplomat_cfg_path {
-            Some(Attr::DiplomatCFGBackend(
-                a.parse_args()
-                    .unwrap_or_else(|e| {
-                        create_report(AstReport::new(
-                            "Failed to parse diplomat::cfg".into(),
-                            Some(e.span().spanned_into(attrs_location)),
-                            e.to_string(),
-                            vec![
-                                ContextLocation::new(a.span().spanned_into(attrs_location), "".into())
-                            ]
-                        ));
-                    }),
-            ))
+            Some(Attr::DiplomatCFGBackend(a.parse_args().unwrap_or_else(
+                |e| {
+                    create_report(AstReport::new(
+                        "Failed to parse diplomat::cfg".into(),
+                        Some(e.span().spanned_into(attrs_location)),
+                        e.to_string(),
+                        vec![ContextLocation::new(
+                            a.span().spanned_into(attrs_location),
+                            "".into(),
+                        )],
+                    ));
+                },
+            )))
         } else if a.path() == &crename_attr {
             Some(Attr::CRename(RenameAttr::from_meta(&a.meta).unwrap()))
         } else if a.path() == &demo_path {
-            Some(Attr::DemoBackend(
-                a.parse_args()
-                    .unwrap_or_else(|e| {
-                        create_report(AstReport::new(
-                            "Failed to parse diplomat::demo".into(),
-                            Some(e.span().spanned_into(attrs_location)),
-                            e.to_string(),
-                            vec![
-                                ContextLocation::new(a.span().spanned_into(attrs_location), "".into())
-                            ]
-                        ));
-                    }),
-            ))
+            Some(Attr::DemoBackend(a.parse_args().unwrap_or_else(|e| {
+                create_report(AstReport::new(
+                    "Failed to parse diplomat::demo".into(),
+                    Some(e.span().spanned_into(attrs_location)),
+                    e.to_string(),
+                    vec![ContextLocation::new(
+                        a.span().spanned_into(attrs_location),
+                        "".into(),
+                    )],
+                ));
+            })))
         } else if a.path() == &deprecated {
             if let Some(Meta::NameValue(MetaNameValue {
                 value:
@@ -213,19 +212,17 @@ fn syn_attr_to_ast_attr<'a>(attrs: &'a [Attribute], attrs_location : &'a SpanLoc
                 Some(Attr::Deprecated("deprecated".into()))
             }
         } else if a.path() == &include_path {
-            Some(Attr::Include(
-                a.parse_args()
-                    .unwrap_or_else(|e| {
-                        create_report(AstReport::new(
-                            "Failed to parse diplomat::include".into(),
-                            Some(e.span().spanned_into(attrs_location)),
-                            e.to_string(),
-                            vec![
-                                ContextLocation::new(a.span().spanned_into(attrs_location), "".into())
-                            ]
-                        ));
-                    }),
-            ))
+            Some(Attr::Include(a.parse_args().unwrap_or_else(|e| {
+                create_report(AstReport::new(
+                    "Failed to parse diplomat::include".into(),
+                    Some(e.span().spanned_into(attrs_location)),
+                    e.to_string(),
+                    vec![ContextLocation::new(
+                        a.span().spanned_into(attrs_location),
+                        "".into(),
+                    )],
+                ));
+            })))
         } else {
             None
         }

--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -11,7 +11,7 @@ use syn::{Attribute, Expr, Ident, Lit, LitStr, Meta, MetaList, MetaNameValue, To
 
 use crate::ast::SpanLocation;
 use crate::ast::idents::{FromWithSpan, IntoWithSpan};
-use crate::ast::logging::{AstReport, create_report};
+use crate::ast::logging::{AstReport, ContextLocation, create_report};
 
 /// The list of attributes on a type. All attributes except `attrs` (HIR attrs) are
 /// potentially read by the diplomat macro and the AST backends, anything that is not should
@@ -154,7 +154,16 @@ fn syn_attr_to_ast_attr<'a>(attrs: &'a [Attribute], attrs_location : &'a SpanLoc
         } else if a.path() == &dattr_path {
             Some(Attr::DiplomatBackend(
                 a.parse_args()
-                    .expect("Failed to parse malformed diplomat::attr"),
+                    .unwrap_or_else(|e| {
+                        create_report(AstReport::new(
+                            "Failed to parse diplomat::attr".into(),
+                            Some(e.span().spanned_into(attrs_location)),
+                            e.to_string(),
+                            vec![
+                                ContextLocation::new(a.span().spanned_into(attrs_location), "".into())
+                            ]
+                        ));
+                    }),
             ))
         } else if a.path() == &diplomat_cfg_path {
             Some(Attr::DiplomatCFGBackend(

--- a/core/src/ast/docs.rs
+++ b/core/src/ast/docs.rs
@@ -1,7 +1,7 @@
-use crate::ast::SpanLocation;
 use crate::ast::attrs::DiplomatBackendAttrCfg;
 use crate::ast::idents::IntoWithSpan;
-use crate::ast::logging::{AstReport, ContextLocation, create_report};
+use crate::ast::logging::{create_report, AstReport, ContextLocation};
+use crate::ast::SpanLocation;
 
 use super::Path;
 use core::fmt;
@@ -31,8 +31,11 @@ impl Default for DocumentationSection {
 pub struct Docs(pub Vec<DocumentationSection>, pub Vec<RustLink>);
 
 impl Docs {
-    pub fn from_attrs(attrs: &[Attribute], attrs_location : &SpanLocation) -> Self {
-        Self(Self::get_doc_lines(attrs), Self::get_rust_link(attrs, attrs_location))
+    pub fn from_attrs(attrs: &[Attribute], attrs_location: &SpanLocation) -> Self {
+        Self(
+            Self::get_doc_lines(attrs),
+            Self::get_rust_link(attrs, attrs_location),
+        )
     }
 
     fn get_doc_lines(attrs: &[Attribute]) -> Vec<DocumentationSection> {
@@ -69,20 +72,23 @@ impl Docs {
         sections
     }
 
-    fn get_rust_link(attrs: &[Attribute], attrs_location : &SpanLocation) -> Vec<RustLink> {
+    fn get_rust_link(attrs: &[Attribute], attrs_location: &SpanLocation) -> Vec<RustLink> {
         attrs
             .iter()
             .filter(|i| i.path().to_token_stream().to_string() == "diplomat :: rust_link")
-            .map(|i| i.parse_args().unwrap_or_else(|e| {
-                create_report(AstReport::new(
-                    "Could not read rust link".into(),
-                    Some(e.span().spanned_into(attrs_location)),
-                    e.to_string(),
-                    vec![
-                        ContextLocation::new(i.span().spanned_into(attrs_location), "".into())
-                    ]
-                ));
-            }))
+            .map(|i| {
+                i.parse_args().unwrap_or_else(|e| {
+                    create_report(AstReport::new(
+                        "Could not read rust link".into(),
+                        Some(e.span().spanned_into(attrs_location)),
+                        e.to_string(),
+                        vec![ContextLocation::new(
+                            i.span().spanned_into(attrs_location),
+                            "".into(),
+                        )],
+                    ));
+                })
+            })
             .collect()
     }
 

--- a/core/src/ast/docs.rs
+++ b/core/src/ast/docs.rs
@@ -1,3 +1,4 @@
+use crate::ast::SpanLocation;
 use crate::ast::attrs::DiplomatBackendAttrCfg;
 
 use super::Path;
@@ -27,8 +28,8 @@ impl Default for DocumentationSection {
 pub struct Docs(pub Vec<DocumentationSection>, pub Vec<RustLink>);
 
 impl Docs {
-    pub fn from_attrs(attrs: &[Attribute]) -> Self {
-        Self(Self::get_doc_lines(attrs), Self::get_rust_link(attrs))
+    pub fn from_attrs(attrs: &[Attribute], attrs_location : &SpanLocation) -> Self {
+        Self(Self::get_doc_lines(attrs), Self::get_rust_link(attrs, attrs_location))
     }
 
     fn get_doc_lines(attrs: &[Attribute]) -> Vec<DocumentationSection> {
@@ -65,7 +66,7 @@ impl Docs {
         sections
     }
 
-    fn get_rust_link(attrs: &[Attribute]) -> Vec<RustLink> {
+    fn get_rust_link(attrs: &[Attribute], attrs_location : &SpanLocation) -> Vec<RustLink> {
         attrs
             .iter()
             .filter(|i| i.path().to_token_stream().to_string() == "diplomat :: rust_link")

--- a/core/src/ast/docs.rs
+++ b/core/src/ast/docs.rs
@@ -1,11 +1,14 @@
 use crate::ast::SpanLocation;
 use crate::ast::attrs::DiplomatBackendAttrCfg;
+use crate::ast::idents::IntoWithSpan;
+use crate::ast::logging::{AstReport, ContextLocation, create_report};
 
 use super::Path;
 use core::fmt;
 use quote::ToTokens;
 use serde::{Deserialize, Serialize};
 use syn::parse::{self, Parse, ParseStream};
+use syn::spanned::Spanned;
 use syn::{Attribute, Ident, Meta, Token};
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
@@ -70,7 +73,16 @@ impl Docs {
         attrs
             .iter()
             .filter(|i| i.path().to_token_stream().to_string() == "diplomat :: rust_link")
-            .map(|i| i.parse_args().expect("Malformed attribute"))
+            .map(|i| i.parse_args().unwrap_or_else(|e| {
+                create_report(AstReport::new(
+                    "Could not read rust link".into(),
+                    Some(e.span().spanned_into(attrs_location)),
+                    e.to_string(),
+                    vec![
+                        ContextLocation::new(i.span().spanned_into(attrs_location), "".into())
+                    ]
+                ));
+            }))
             .collect()
     }
 

--- a/core/src/ast/enums.rs
+++ b/core/src/ast/enums.rs
@@ -37,7 +37,7 @@ impl Enum {
         }
 
         let mut attrs = parent_attrs.clone();
-        attrs.add_attrs(&enm.attrs);
+        attrs.add_attrs(&enm.attrs, module_location);
         let variant_parent_attrs = attrs.attrs_for_inheritance(AttrInheritContext::Variant);
 
         Enum {
@@ -75,7 +75,7 @@ impl Enum {
 
                     last_discriminant = new_discriminant;
                     let mut v_attrs = variant_parent_attrs.clone();
-                    v_attrs.add_attrs(&v.attrs);
+                    v_attrs.add_attrs(&v.attrs, module_location);
                     (
                         (&v.ident).spanned_into(module_location),
                         new_discriminant,

--- a/core/src/ast/enums.rs
+++ b/core/src/ast/enums.rs
@@ -42,7 +42,7 @@ impl Enum {
 
         Enum {
             name: (&enm.ident).spanned_into(module_location),
-            docs: Docs::from_attrs(&enm.attrs),
+            docs: Docs::from_attrs(&enm.attrs, module_location),
             variants: enm
                 .variants
                 .iter()
@@ -79,7 +79,7 @@ impl Enum {
                     (
                         (&v.ident).spanned_into(module_location),
                         new_discriminant,
-                        Docs::from_attrs(&v.attrs),
+                        Docs::from_attrs(&v.attrs, module_location),
                         v_attrs,
                     )
                 })

--- a/core/src/ast/functions.rs
+++ b/core/src/ast/functions.rs
@@ -89,7 +89,7 @@ impl Function {
             output_type,
             lifetimes,
             attrs,
-            docs: Docs::from_attrs(&f.attrs),
+            docs: Docs::from_attrs(&f.attrs, module_location),
         }
     }
 }

--- a/core/src/ast/functions.rs
+++ b/core/src/ast/functions.rs
@@ -42,7 +42,7 @@ impl Function {
         }
 
         let mut attrs = parent_attrs.clone();
-        attrs.add_attrs(&f.attrs);
+        attrs.add_attrs(&f.attrs, module_location);
 
         let concat_func_ident = if attrs.abi_rename.is_empty() {
             format!("diplomat_external_{ident}")

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -311,6 +311,7 @@ mod tests {
         "unsupported_type.rs",
         "slice_no_type.rs",
         "malformed_attr.rs",
+        "malformed_cfg.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -231,6 +231,8 @@ pub(crate) fn create_report(report: AstReport) -> ! {
 mod tests {
     use std::fmt::Write;
 
+use crate::ast::ModuleIncludeInfo;
+
     #[derive(Clone, Debug)]
     struct StderrWrapper {
         buf: String,
@@ -254,8 +256,9 @@ mod tests {
 
     fn parse_file_hook_errors(file_loc: &str, suffix: &str) {
         let crate_dir = env!("CARGO_MANIFEST_DIR");
-        let local_path = format!("src/ast/snapshots/span_testing/{file_loc}");
-        let file_path = std::path::Path::new(crate_dir).join(&local_path);
+        let folder_pth_name = format!("src/ast/snapshots/span_testing");
+        let folder_pth = std::path::Path::new(crate_dir).join(&folder_pth_name);
+        let file_path = folder_pth.join(file_loc);
 
         let mut settings = insta::Settings::clone_current();
         settings.set_snapshot_suffix(format!("{file_loc}_{suffix}"));
@@ -267,8 +270,13 @@ mod tests {
         crate::ast::Module::from_syn(
             &p,
             true,
-            None,
-            &crate::ast::SpanLocation::FilePath(local_path),
+            Some(
+                ModuleIncludeInfo {
+                    base_path: &folder_pth,
+                    cache: None
+                }
+            ),
+            &crate::ast::SpanLocation::FilePath(format!("{}/{file_loc}", folder_pth_name)),
         );
     }
 
@@ -315,6 +323,7 @@ mod tests {
         "malformed_demo.rs",
         "malformed_include.rs",
         "malformed_rust_link.rs",
+        "error_in_included.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {
@@ -327,18 +336,18 @@ mod tests {
             let t = std::thread::spawn(|| {
                 parse_file_hook_errors(f, suffix);
             });
-            results.push(t.join());
+            results.push((f, t.join()));
         }
-        for res in results {
+        for (f, res) in results {
             match res {
                 Ok(_) => {}
                 Err(p) => {
                     if let Some(st) = p.downcast_ref::<String>() {
                         if !st.contains("Diplomat error") {
-                            panic!("{st}");
+                            panic!("{f}: {st}");
                         }
                     } else {
-                        panic!("Could not convert error to string.");
+                        panic!("{f}: Could not convert error to string.");
                     }
                 }
             }

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -314,6 +314,7 @@ mod tests {
         "malformed_cfg.rs",
         "malformed_demo.rs",
         "malformed_include.rs",
+        "malformed_rust_link.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -312,6 +312,7 @@ mod tests {
         "slice_no_type.rs",
         "malformed_attr.rs",
         "malformed_cfg.rs",
+        "malformed_demo.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -255,9 +255,8 @@ mod tests {
     }
 
     fn parse_file_hook_errors(file_loc: &str, suffix: &str) {
-        let crate_dir = env!("CARGO_MANIFEST_DIR");
         let folder_pth_name = format!("src/ast/snapshots/span_testing");
-        let folder_pth = std::path::Path::new(crate_dir).join(&folder_pth_name);
+        let folder_pth = std::path::Path::new(&folder_pth_name);
         let file_path = folder_pth.join(file_loc);
 
         let mut settings = insta::Settings::clone_current();

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -231,7 +231,7 @@ pub(crate) fn create_report(report: AstReport) -> ! {
 mod tests {
     use std::fmt::Write;
 
-use crate::ast::ModuleIncludeInfo;
+    use crate::ast::ModuleIncludeInfo;
 
     #[derive(Clone, Debug)]
     struct StderrWrapper {
@@ -270,12 +270,10 @@ use crate::ast::ModuleIncludeInfo;
         crate::ast::Module::from_syn(
             &p,
             true,
-            Some(
-                ModuleIncludeInfo {
-                    base_path: &folder_pth,
-                    cache: None
-                }
-            ),
+            Some(ModuleIncludeInfo {
+                base_path: &folder_pth,
+                cache: None,
+            }),
             &crate::ast::SpanLocation::FilePath(format!("{}/{file_loc}", folder_pth_name)),
         );
     }

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -310,6 +310,7 @@ mod tests {
         "unsupported_bound.rs",
         "unsupported_type.rs",
         "slice_no_type.rs",
+        "malformed_attr.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -313,6 +313,7 @@ mod tests {
         "malformed_attr.rs",
         "malformed_cfg.rs",
         "malformed_demo.rs",
+        "malformed_include.rs",
     ];
 
     fn test_file_list(suffix: &'static str) {

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -107,7 +107,7 @@ impl Method {
 
         Method {
             name: (method_ident).spanned_into(module_location),
-            docs: Docs::from_attrs(&m.attrs),
+            docs: Docs::from_attrs(&m.attrs, module_location),
             abi_name: (&extern_ident).spanned_into(module_location),
             self_param,
             self_type: Some(self_path_type),

--- a/core/src/ast/methods.rs
+++ b/core/src/ast/methods.rs
@@ -56,7 +56,7 @@ impl Method {
         module_location: &SpanLocation,
     ) -> Method {
         let mut attrs = impl_attrs.clone();
-        attrs.add_attrs(&m.attrs);
+        attrs.add_attrs(&m.attrs, module_location);
 
         let self_ident = self_path_type.path.elements.last().unwrap();
         let method_ident = &m.sig.ident;
@@ -270,7 +270,7 @@ impl SelfParam {
                 )
             }),
             path_type,
-            attrs: Attrs::from_attrs(&rec.attrs),
+            attrs: Attrs::from_attrs(&rec.attrs, module_location),
         }
     }
 }
@@ -353,7 +353,7 @@ impl Param {
             }
         };
 
-        let attrs = Attrs::from_attrs(&t.attrs);
+        let attrs = Attrs::from_attrs(&t.attrs, module_location);
 
         Param {
             name: (&ident.ident).spanned_into(module_location),

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -663,8 +663,10 @@ pub fn parse_macro_file(
         {
             inner
         } else {
+            let inc_loc = include_info.base_path.join(i.path.clone());
+            let module_location = &SpanLocation::FilePath(inc_loc.to_string_lossy().into());
             let file_contents =
-                std::fs::read_to_string(include_info.base_path.join(i.path.clone()))?;
+                std::fs::read_to_string(inc_loc)?;
             let syn_file = syn::parse_file(&file_contents)
                 .map_err(|e| std::io::Error::other(e.to_string()))?;
             // Parse the module (we're just interested in the macros, but this is a quick shortcut to do that)

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -488,8 +488,8 @@ impl Module {
         let mod_attrs: Attrs = (&*input.attrs).spanned_into(module_location);
 
         let mod_macros = if let Some(inc) = &include_info {
-            let defs = parse_macro_file(input, force_analyze, inc.clone(), module_location).expect(
-                &format!("Could not parse macro definitions in {:?}", inc.base_path),
+            let defs = parse_macro_file(input, force_analyze, inc.clone(), module_location).unwrap_or_else(|e|
+                panic!("Could not parse macro definitions in {:?}: {e}", inc.base_path),
             );
             Macros { defs }
         } else {

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -489,7 +489,7 @@ impl Module {
 
         let mod_macros = if let Some(inc) = &include_info {
             let defs = parse_macro_file(input, force_analyze, inc.clone(), module_location)
-                .expect("Could not parse macro definitions");
+                .expect(&format!("Could not parse macro definitions in {:?}", inc.base_path));
             Macros { defs }
         } else {
             Macros::new()

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -488,8 +488,9 @@ impl Module {
         let mod_attrs: Attrs = (&*input.attrs).spanned_into(module_location);
 
         let mod_macros = if let Some(inc) = &include_info {
-            let defs = parse_macro_file(input, force_analyze, inc.clone(), module_location)
-                .expect(&format!("Could not parse macro definitions in {:?}", inc.base_path));
+            let defs = parse_macro_file(input, force_analyze, inc.clone(), module_location).expect(
+                &format!("Could not parse macro definitions in {:?}", inc.base_path),
+            );
             Macros { defs }
         } else {
             Macros::new()
@@ -665,16 +666,15 @@ pub fn parse_macro_file(
         } else {
             let inc_loc = include_info.base_path.join(i.path.clone());
             let module_location = &SpanLocation::FilePath(inc_loc.to_string_lossy().into());
-            let file_contents =
-                std::fs::read_to_string(inc_loc)?;
-            let syn_file = syn::parse_file(&file_contents)
-                .unwrap_or_else(|e| 
-                    create_report(AstReport::new(
-                        "Error reading file".into(),
-                        Some(e.span().spanned_into(module_location)),
-                        e.to_string(),
-                    vec![]))
-                );
+            let file_contents = std::fs::read_to_string(inc_loc)?;
+            let syn_file = syn::parse_file(&file_contents).unwrap_or_else(|e| {
+                create_report(AstReport::new(
+                    "Error reading file".into(),
+                    Some(e.span().spanned_into(module_location)),
+                    e.to_string(),
+                    vec![],
+                ))
+            });
             // Parse the module (we're just interested in the macros, but this is a quick shortcut to do that)
             let mut mst = ModuleBuilder {
                 custom_types_by_name: BTreeMap::new(),
@@ -711,7 +711,8 @@ pub fn parse_macro_file(
                     format!("Duplicate macro definition of {id} found"),
                     Some(id.span().spanned_into(module_location)),
                     format!("Previously defined in {pth}"),
-                    vec![]));
+                    vec![],
+                ));
             } else {
                 previously_hit.insert(id.clone(), i.path.clone());
             }

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -270,7 +270,7 @@ impl<'a> ModuleBuilder<'a> {
                     }
                 };
                 let mut impl_attrs = self.impl_parent_attrs.clone();
-                impl_attrs.add_attrs(&imp.attrs);
+                impl_attrs.add_attrs(&imp.attrs, self.module_location);
                 let method_parent_attrs =
                     impl_attrs.attrs_for_inheritance(AttrInheritContext::MethodFromImpl);
                 let self_ident = self_path.path.elements.last().unwrap();
@@ -485,7 +485,7 @@ impl Module {
         include_info: Option<ModuleIncludeInfo<'a>>,
         module_location: &SpanLocation,
     ) -> Module {
-        let mod_attrs: Attrs = (&*input.attrs).into();
+        let mod_attrs: Attrs = (&*input.attrs).spanned_into(module_location);
 
         let mod_macros = if let Some(inc) = &include_info {
             let defs = parse_macro_file(input, force_analyze, inc.clone(), module_location)
@@ -650,7 +650,7 @@ pub fn parse_macro_file(
         return Ok(BTreeMap::new());
     }
 
-    let attrs: Attrs = (*m.attrs).into();
+    let attrs: Attrs = (*m.attrs).spanned_into(module_location);
 
     let mut previously_hit = BTreeMap::<syn::Ident, String>::new();
 

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -488,9 +488,13 @@ impl Module {
         let mod_attrs: Attrs = (&*input.attrs).spanned_into(module_location);
 
         let mod_macros = if let Some(inc) = &include_info {
-            let defs = parse_macro_file(input, force_analyze, inc.clone(), module_location).unwrap_or_else(|e|
-                panic!("Could not parse macro definitions in {:?}: {e}", inc.base_path),
-            );
+            let defs = parse_macro_file(input, force_analyze, inc.clone(), module_location)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Could not parse macro definitions in {:?}: {e}",
+                        inc.base_path
+                    )
+                });
             Macros { defs }
         } else {
             Macros::new()

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -707,7 +707,11 @@ pub fn parse_macro_file(
         // there are no collisions between multiple #[diplomat::include()] files:
         for id in defs.keys() {
             if let Some(pth) = previously_hit.get(id) {
-                return Err(std::io::Error::other(format!("Duplicate macro definition of {id} found in {}: original definition from {pth}", i.path)));
+                create_report(AstReport::new(
+                    format!("Duplicate macro definition of {id} found"),
+                    Some(id.span().spanned_into(module_location)),
+                    format!("Previously defined in {pth}"),
+                    vec![]));
             } else {
                 previously_hit.insert(id.clone(), i.path.clone());
             }

--- a/core/src/ast/modules.rs
+++ b/core/src/ast/modules.rs
@@ -668,7 +668,13 @@ pub fn parse_macro_file(
             let file_contents =
                 std::fs::read_to_string(inc_loc)?;
             let syn_file = syn::parse_file(&file_contents)
-                .map_err(|e| std::io::Error::other(e.to_string()))?;
+                .unwrap_or_else(|e| 
+                    create_report(AstReport::new(
+                        "Error reading file".into(),
+                        Some(e.span().spanned_into(module_location)),
+                        e.to_string(),
+                    vec![]))
+                );
             // Parse the module (we're just interested in the macros, but this is a quick shortcut to do that)
             let mut mst = ModuleBuilder {
                 custom_types_by_name: BTreeMap::new(),

--- a/core/src/ast/opaque.rs
+++ b/core/src/ast/opaque.rs
@@ -31,7 +31,7 @@ impl OpaqueType {
         module_location: &SpanLocation,
     ) -> Self {
         let mut attrs = parent_attrs.clone();
-        attrs.add_attrs(&strct.attrs);
+        attrs.add_attrs(&strct.attrs, module_location);
         let name = (&strct.ident).spanned_into(module_location);
         OpaqueType {
             dtor_abi_name: Self::dtor_abi_name(&name, &attrs),
@@ -52,7 +52,7 @@ impl OpaqueType {
         module_location: &SpanLocation,
     ) -> Self {
         let mut attrs = parent_attrs.clone();
-        attrs.add_attrs(&enm.attrs);
+        attrs.add_attrs(&enm.attrs, module_location);
         let name = (&enm.ident).spanned_into(module_location);
         OpaqueType {
             dtor_abi_name: Self::dtor_abi_name(&name, &attrs),

--- a/core/src/ast/opaque.rs
+++ b/core/src/ast/opaque.rs
@@ -36,7 +36,7 @@ impl OpaqueType {
         OpaqueType {
             dtor_abi_name: Self::dtor_abi_name(&name, &attrs),
             name,
-            docs: Docs::from_attrs(&strct.attrs),
+            docs: Docs::from_attrs(&strct.attrs, module_location),
             lifetimes: LifetimeEnv::from_struct_item(strct, &[], module_location),
             methods: vec![],
             mutability,
@@ -57,7 +57,7 @@ impl OpaqueType {
         OpaqueType {
             dtor_abi_name: Self::dtor_abi_name(&name, &attrs),
             name,
-            docs: Docs::from_attrs(&enm.attrs),
+            docs: Docs::from_attrs(&enm.attrs, module_location),
             lifetimes: LifetimeEnv::from_enum_item(enm, &[], module_location),
             methods: vec![],
             mutability,

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@error_in_included.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@error_in_included.rs_ugly.snap
@@ -3,7 +3,7 @@ source: core/src/ast/logging.rs
 expression: self.buf
 ---
 Diplomat error: Found non-public method with diplomat attrs
-In C:\Users\Tyler\Desktop\diplomat\core\src/ast/snapshots/span_testing\attr_on_non_pub.rs:7:12:
+In src/ast/snapshots/span_testing\attr_on_non_pub.rs:7:12:
 ...fn hidden_fn() {}...
       ^^^^^^^^^
 Remove #[diplomat::*] attributes.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@error_in_included.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@error_in_included.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Found non-public method with diplomat attrs
+In C:\Users\Tyler\Desktop\diplomat\core\src/ast/snapshots/span_testing\attr_on_non_pub.rs:7:12:
+...fn hidden_fn() {}...
+      ^^^^^^^^^
+Remove #[diplomat::*] attributes.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@error_in_included.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@error_in_included.rs_ugly.snap
@@ -3,7 +3,7 @@ source: core/src/ast/logging.rs
 expression: self.buf
 ---
 Diplomat error: Found non-public method with diplomat attrs
-In src/ast/snapshots/span_testing\attr_on_non_pub.rs:7:12:
+In src/ast/snapshots/span_testing/attr_on_non_pub.rs:7:12:
 ...fn hidden_fn() {}...
       ^^^^^^^^^
 Remove #[diplomat::*] attributes.

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_attr.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_attr.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Failed to parse diplomat::attr
+In src/ast/snapshots/span_testing/malformed_attr.rs:3:23:
+...ttr(**)]...
+        ^
+expected `,`

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_cfg.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_cfg.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Failed to parse diplomat::cfg
+In src/ast/snapshots/span_testing/malformed_cfg.rs:3:21:
+...:cfg(;)]...
+        ^
+CFG portion of #[diplomat::attr] fails to parse

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_demo.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_demo.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Failed to parse diplomat::demo
+In src/ast/snapshots/span_testing/malformed_demo.rs:3:22:
+...demo(123)]...
+        ^^^
+expected identifier

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_include.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_include.rs_ugly.snap
@@ -1,0 +1,10 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Failed to parse diplomat::include
+In src/ast/snapshots/span_testing/malformed_include.rs:2:21:
+...lude(abc123)]
+mo...
+        ^^^^^^
+expected string literal

--- a/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_rust_link.rs_ugly.snap
+++ b/core/src/ast/snapshots/span_testing/diplomat_core__ast__logging__tests__flush@malformed_rust_link.rs_ugly.snap
@@ -1,0 +1,9 @@
+---
+source: core/src/ast/logging.rs
+expression: self.buf
+---
+Diplomat error: Could not read rust link
+In src/ast/snapshots/span_testing/malformed_rust_link.rs:3:27:
+...link(*)]...
+        ^
+expected identifier

--- a/core/src/ast/snapshots/span_testing/error_in_included.rs
+++ b/core/src/ast/snapshots/span_testing/error_in_included.rs
@@ -1,0 +1,5 @@
+#[diplomat::bridge]
+#[diplomat::include("attr_on_non_pub.rs")]
+mod ffi {
+
+}

--- a/core/src/ast/snapshots/span_testing/malformed_attr.rs
+++ b/core/src/ast/snapshots/span_testing/malformed_attr.rs
@@ -1,0 +1,5 @@
+#[diplomat::bridge]
+mod ffi {
+    #[diplomat::attr(**)]
+    pub fn malformed_attr() {}
+}

--- a/core/src/ast/snapshots/span_testing/malformed_cfg.rs
+++ b/core/src/ast/snapshots/span_testing/malformed_cfg.rs
@@ -1,0 +1,5 @@
+#[diplomat::bridge]
+mod ffi {
+    #[diplomat::cfg(;)]
+    pub fn malformed_cfg() {}
+}

--- a/core/src/ast/snapshots/span_testing/malformed_demo.rs
+++ b/core/src/ast/snapshots/span_testing/malformed_demo.rs
@@ -1,0 +1,5 @@
+#[diplomat::bridge]
+mod ffi {
+    #[diplomat::demo(123)]
+    pub fn malformed_cfg() {}
+}

--- a/core/src/ast/snapshots/span_testing/malformed_include.rs
+++ b/core/src/ast/snapshots/span_testing/malformed_include.rs
@@ -1,0 +1,5 @@
+#[diplomat::bridge]
+#[diplomat::include(abc123)]
+mod ffi {
+    
+}

--- a/core/src/ast/snapshots/span_testing/malformed_rust_link.rs
+++ b/core/src/ast/snapshots/span_testing/malformed_rust_link.rs
@@ -1,0 +1,5 @@
+#[diplomat::bridge]
+mod ffi {
+    #[diplomat::rust_link(*)]
+    pub fn malformed_rust_link() {}
+}

--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -53,7 +53,12 @@ impl Struct {
                     TypeName::from_syn(&field.ty, Some(self_path_type.clone()), module_location);
                 let docs = Docs::from_attrs(&field.attrs, module_location);
 
-                (name, type_name, docs, Attrs::from_attrs(&field.attrs, module_location))
+                (
+                    name,
+                    type_name,
+                    docs,
+                    Attrs::from_attrs(&field.attrs, module_location),
+                )
             })
             .collect();
 

--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -53,13 +53,13 @@ impl Struct {
                     TypeName::from_syn(&field.ty, Some(self_path_type.clone()), module_location);
                 let docs = Docs::from_attrs(&field.attrs);
 
-                (name, type_name, docs, Attrs::from_attrs(&field.attrs))
+                (name, type_name, docs, Attrs::from_attrs(&field.attrs, module_location))
             })
             .collect();
 
         let lifetimes = LifetimeEnv::from_struct_item(strct, &fields[..], module_location);
         let mut attrs = parent_attrs.clone();
-        attrs.add_attrs(&strct.attrs);
+        attrs.add_attrs(&strct.attrs, module_location);
         Struct {
             name: (&strct.ident).spanned_into(module_location),
             docs: Docs::from_attrs(&strct.attrs),

--- a/core/src/ast/structs.rs
+++ b/core/src/ast/structs.rs
@@ -51,7 +51,7 @@ impl Struct {
                     });
                 let type_name =
                     TypeName::from_syn(&field.ty, Some(self_path_type.clone()), module_location);
-                let docs = Docs::from_attrs(&field.attrs);
+                let docs = Docs::from_attrs(&field.attrs, module_location);
 
                 (name, type_name, docs, Attrs::from_attrs(&field.attrs, module_location))
             })
@@ -62,7 +62,7 @@ impl Struct {
         attrs.add_attrs(&strct.attrs, module_location);
         Struct {
             name: (&strct.ident).spanned_into(module_location),
-            docs: Docs::from_attrs(&strct.attrs),
+            docs: Docs::from_attrs(&strct.attrs, module_location),
             lifetimes,
             fields,
             methods: vec![],

--- a/core/src/ast/traits.rs
+++ b/core/src/ast/traits.rs
@@ -108,7 +108,7 @@ impl Trait {
                     output_type,
                     lifetimes,
                     attrs: fct_attrs,
-                    docs: Docs::from_attrs(&fct.attrs),
+                    docs: Docs::from_attrs(&fct.attrs, module_location),
                 });
             }
         }
@@ -143,7 +143,7 @@ impl Trait {
         Self {
             name: (&trt.ident).spanned_into(module_location),
             methods: trait_fcts,
-            docs: Docs::from_attrs(&trt.attrs),
+            docs: Docs::from_attrs(&trt.attrs, module_location),
             lifetimes: LifetimeEnv::from_trait(trt, module_location), // TODO
             attrs,
             is_send,

--- a/core/src/ast/traits.rs
+++ b/core/src/ast/traits.rs
@@ -37,7 +37,7 @@ impl Trait {
     /// Extract a [`Trait`] metadata value from an AST node.
     pub fn new(trt: &syn::ItemTrait, parent_attrs: &Attrs, module_location: &SpanLocation) -> Self {
         let mut attrs = parent_attrs.clone();
-        attrs.add_attrs(&trt.attrs);
+        attrs.add_attrs(&trt.attrs, module_location);
 
         let mut trait_fcts = Vec::new();
 
@@ -59,7 +59,7 @@ impl Trait {
         for trait_item in trt.items.iter() {
             if let syn::TraitItem::Fn(fct) = trait_item {
                 let mut fct_attrs = attrs.clone();
-                fct_attrs.add_attrs(&fct.attrs);
+                fct_attrs.add_attrs(&fct.attrs, module_location);
                 // copied from the method parsing
                 let fct_ident = &fct.sig.ident;
                 let concat_fct_ident = format!("{self_ident}_{fct_ident}");

--- a/core/src/hir/docs.rs
+++ b/core/src/hir/docs.rs
@@ -302,7 +302,7 @@ fn test_docs_url_generator() {
         assert_eq!(
             DocsUrlGenerator::default().gen_for_rust_link(
                 &Docs::from_ast(
-                    &ast::Docs::from_attrs(&[attr]),
+                    &ast::Docs::from_attrs(&[attr], &ast::SpanLocation::None),
                     &BasicAttributeValidator::default(),
                     &mut ErrorStore::default()
                 )
@@ -321,7 +321,7 @@ fn test_docs_url_generator() {
         )
         .gen_for_rust_link(
             &Docs::from_ast(
-                &ast::Docs::from_attrs(&[test_cases[0].0.clone()]),
+                &ast::Docs::from_attrs(&[test_cases[0].0.clone()], &ast::SpanLocation::None),
                 &BasicAttributeValidator::default(),
                 &mut ErrorStore::default()
             )
@@ -334,7 +334,7 @@ fn test_docs_url_generator() {
         DocsUrlGenerator::with_base_urls(Some("http://std-docs.biz/".to_string()), HashMap::new())
             .gen_for_rust_link(
                 &Docs::from_ast(
-                    &ast::Docs::from_attrs(&[test_cases[0].0.clone()]),
+                    &ast::Docs::from_attrs(&[test_cases[0].0.clone()], &ast::SpanLocation::None),
                     &BasicAttributeValidator::default(),
                     &mut ErrorStore::default()
                 )


### PR DESCRIPTION
Further progress on #111. This handles errors related to attribute parsing, and removes all `.expect(` calls that can be replaced with location-based reports.

Also fixes a bug related to errors from including a separate file.

This is the last of the AST error reports, so next up will be a series of HIR report PRs.