### PR TITLE
HIR location errors first pass

### DIFF
--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -6,7 +6,8 @@ use crate::ast::{idents::Span, Ident, SpanLocation};
 static WRITER: RwLock<&(dyn Fn() -> Box<dyn std::io::Write> + Send + Sync)> =
     RwLock::new(&(|| Box::new(std::io::stderr())));
 
-pub(crate) struct ContextLocation {
+#[derive(Debug)]
+pub struct ContextLocation {
     // Allow for pretty-print:
     #[allow(unused)]
     location: Span,
@@ -21,7 +22,8 @@ impl ContextLocation {
     }
 }
 
-pub(crate) struct AstReport {
+#[derive(Debug)]
+pub struct AstReport {
     title: String,
     primary_loc: Option<Span>,
     primary_label: String,
@@ -87,11 +89,33 @@ fn evaluate_bytes(sp: &super::idents::Span, src: &str) -> std::ops::Range<usize>
     }
 }
 
-pub(crate) fn create_report(report: AstReport) -> ! {
-    use std::io::Write;
-    let mut out = WRITER.read().unwrap()();
+pub trait WriteReport {
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), String>;
+    fn flush(&mut self) -> Result<(), String>;
+}
 
-    let span = report.primary_loc;
+impl WriteReport for Box<dyn std::io::Write> {
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), String> {
+        std::io::Write::write_fmt(self, args).map_err(|e| e.to_string())
+    }
+
+    fn flush(&mut self) -> Result<(), String> {
+        std::io::Write::flush(self).map_err(|e| e.to_string())
+    }
+}
+
+impl WriteReport for &mut std::fmt::Formatter<'_> {
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), String> {
+        std::fmt::Write::write_fmt(self, args).map_err(|e| e.to_string())
+    }
+
+    fn flush(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+pub fn write_report(report : &AstReport, mut out : impl WriteReport) -> Result<(), String> {
+    let span = report.primary_loc.as_ref();
     let src = if let Some(sp) = &span {
         match &sp.span_location {
             SpanLocation::FilePath(f) => {
@@ -140,27 +164,28 @@ pub(crate) fn create_report(report: AstReport) -> ! {
 
             &[Level::ERROR.primary_title(&report.title).element(
                 Snippet::<Annotation>::source(&src)
-                    .path(match sp.span_location {
+                    .path(match &sp.span_location {
                         SpanLocation::FilePath(f) => Some(f),
                         _ => None,
                     })
                     .annotation(
                         AnnotationKind::Primary
                             .span(bytes_range.unwrap())
-                            .label(report.primary_label),
+                            .label(&report.primary_label),
                     )
                     .annotations(annotations),
             )]
         } else {
             &[Level::ERROR
                 .primary_title(&report.title)
-                .element(Level::ERROR.message(report.primary_label))]
+                .element(Level::ERROR.message(&report.primary_label))]
         };
         let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
-        writeln!(out, "{}", renderer.render(report)).expect("Could not write report.");
+        writeln!(out, "{}", renderer.render(report))?;
     }
     #[cfg(not(feature = "pretty-print"))]
     {
+        let mut valid_excerpt = true;
         let (location, excerpt_pre, excerpt, excerpt_post) = if let Some(sp) = span {
             let range = bytes_range.unwrap();
             let start = sp.start.line;
@@ -174,7 +199,9 @@ pub(crate) fn create_report(report: AstReport) -> ! {
             let range_pre = range.start.saturating_sub(5);
             let range_post = std::cmp::min(range.end.saturating_add(5), src.len());
             match sp.span_location {
-                SpanLocation::None => (span_location, "", "<Excerpt not available>", ""),
+                SpanLocation::None => {
+                    valid_excerpt = false;
+                    (span_location, "", "<Excerpt not available>", "")},
                 _ => (
                     format!("{span_location}:{start}:{col}"),
                     &src[range_pre..range.start],
@@ -183,6 +210,7 @@ pub(crate) fn create_report(report: AstReport) -> ! {
                 ),
             }
         } else {
+            valid_excerpt = false;
             (
                 "<No associated span>".into(),
                 "",
@@ -190,21 +218,28 @@ pub(crate) fn create_report(report: AstReport) -> ! {
                 "",
             )
         };
-        write!(out, "Diplomat error: ").expect("Could not write to report.");
-        writeln!(out, "{}", report.title).expect("Could not write to report.");
-        writeln!(out, "In {location}:").expect("Could not write to report.");
+        write!(out, "Diplomat error: ")?;
+        writeln!(out, "{}", report.title)?;
+        if !valid_excerpt {
+            writeln!(out, "> {}", report.primary_label)?;
+            out.flush()?;
+            return Ok(());
+        }
+        writeln!(out, "In {location}:")?;
 
         let excerpt_pre_trimmed = excerpt_pre.trim_start();
 
         if !excerpt_pre.is_empty() {
-            write!(out, "...{}", excerpt_pre_trimmed).expect("Could not write to report.");
+            write!(out, "...{}", excerpt_pre_trimmed)?;
         }
 
-        write!(out, "{excerpt}").expect("Could not write to report.");
+        write!(out, "{excerpt}")?;
 
         if !excerpt_post.is_empty() {
-            writeln!(out, "{}...", excerpt_post.trim_end()).expect("Could not write to report.");
+            write!(out, "{}...", excerpt_post.trim_end())?;
         }
+
+        writeln!(out, "")?;
 
         // Add visible separation between the label and the excerpt.
         if !excerpt.is_empty() {
@@ -215,13 +250,19 @@ pub(crate) fn create_report(report: AstReport) -> ! {
                 "{}{}",
                 " ".repeat(3 + excerpt_pre_trimmed.len()),
                 "^".repeat(excerpt.len())
-            )
-            .expect("Could not write to report.");
+            )?;
         }
 
-        write!(out, "{}", report.primary_label).expect("Could not write to report.");
+        write!(out, "{}", report.primary_label)?;
     }
-    out.flush().expect("Could not write to output.");
+    out.flush()?;
+    Ok(())
+}
+
+pub fn create_report(report: AstReport) -> ! {
+    let out = WRITER.read().unwrap()();
+    write_report(&report, out).expect("Could not write report");
+    
     // Rust-analyzer will not show error messages unless we panic,
     // This just tells rust-analyzer users to check stderr:
     panic!("Diplomat error: {} (check stderr for more)", report.title);

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -221,7 +221,9 @@ pub fn write_report(report : &AstReport, mut out : impl WriteReport) -> Result<(
         write!(out, "Diplomat error: ")?;
         writeln!(out, "{}", report.title)?;
         if !valid_excerpt {
-            writeln!(out, "> {}", report.primary_label)?;
+            if !report.primary_label.is_empty() {
+                writeln!(out, "> {}", report.primary_label)?;
+            }
             out.flush()?;
             return Ok(());
         }

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -49,3 +49,4 @@ mod macros;
 pub use macros::{MacroDef, MacroUse, Macros};
 
 mod logging;
+pub use logging::{AstReport, write_report};

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -406,11 +406,14 @@ impl<'ast> LoweringContext<'ast> {
         let methods = if attrs.disable {
             Vec::new()
         } else if ast_struct.fields.is_empty() {
-            if !ast_struct.methods.is_empty() {
-                self.errors.push(LoweringError::Other(format!(
-                    "Methods on ZST structs are not yet implemented: {}",
-                    ast_struct.name
-                )));
+            if let Some(m) = ast_struct.methods.first() {
+                self.errors.push(LoweringError::OtherWithLoc(
+                    AstReport::new(
+                        "Methods on ZST structs are not yet implemented".into(),
+                        m.name.span(),
+                        format!("Remove method {} from {}", m.name, ast_struct.name),
+                        vec![]
+                    )));
                 return Err(());
             } else {
                 Vec::new()

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -8,6 +8,7 @@ use super::{
     StructField, StructPath, SuccessType, TraitDef, TraitParamSelf, TraitPath, TyPosition, Type,
     TypeDef, TypeId,
 };
+use crate::ast::AstReport;
 use crate::ast::attrs::AttrInheritContext;
 use crate::hir::{Docs, StructPathLike, SymbolId, TypingUseInfo};
 use crate::{ast, Env};
@@ -28,12 +29,18 @@ pub enum LoweringError {
     /// instance into an specialized enum variant, generalizing where possible
     /// without losing any information.
     Other(String),
+    OtherWithLoc(ast::AstReport),
 }
 
 impl fmt::Display for LoweringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Other(ref s) => s.fmt(f),
+            Self::OtherWithLoc(ref rep) => {
+                ast::write_report(rep, f).map_err(|_| {
+                    std::fmt::Error{}
+                })
+            }
         }
     }
 }
@@ -353,13 +360,17 @@ impl<'ast> LoweringContext<'ast> {
         );
         // Only compute fields if the type isn't disabled, otherwise we may encounter forbidden types
         if !attrs.disable {
-            for (name, ty, docs, attrs) in ast_struct.fields.iter() {
-                let name = self.lower_ident(name, "struct field name")?;
+            for (name_outer, ty, docs, attrs) in ast_struct.fields.iter() {
+                let name = self.lower_ident(name_outer, "struct field name")?;
                 if !ty.is_ffi_safe() {
                     let ffisafe = ty.ffi_safe_version();
-                    self.errors.push(LoweringError::Other(format!(
-                        "Found FFI-unsafe type {ty} in struct field {struct_name}.{name}, consider using {ffisafe}",
-                    )));
+                    self.errors.push(LoweringError::OtherWithLoc(
+                        AstReport::new(
+                            format!("Found FFI-unsafe type {ty} in struct field {struct_name}.{name}"),
+                            name_outer.span(), format!("Consider using {ffisafe}"),
+                            vec![]
+                        )
+                    ));
                 }
                 let ty = self.lower_type::<Everywhere>(
                     ty,

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
@@ -2,9 +2,13 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in BadStructFields: Found FFI-unsafe type Option<u8> in struct field BadStructFields.field1, consider using DiplomatOption<u8>
+Lowering error in BadStructFields: Diplomat error: Found FFI-unsafe type Option<u8> in struct field BadStructFields.field1
+> Consider using DiplomatOption<u8>
+
 Lowering error in BadStructFields: Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
-Lowering error in BadStructFields: Found FFI-unsafe type Result<u8, u8> in struct field BadStructFields.field2, consider using Result<u8, u8>
+Lowering error in BadStructFields: Diplomat error: Found FFI-unsafe type Result<u8, u8> in struct field BadStructFields.field2
+> Consider using Result<u8, u8>
+
 Lowering error in BadStructFields: Results can only appear as the top-level return type of methods
 Lowering error in InStructWithOutField: found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = OtherOpaque
 Lowering error in InStructWithOutField: found struct in input that is marked with #[diplomat::out]: OutStruct in OutStruct

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_checks_with_safe_use.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_checks_with_safe_use.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in NonOpaqueStruct: Methods on ZST structs are not yet implemented: NonOpaqueStruct
+Lowering error in NonOpaqueStruct: Diplomat error: Methods on ZST structs are not yet implemented
+> Remove method new from NonOpaqueStruct

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
@@ -1,11 +1,14 @@
 ---
 source: core/src/hir/type_context.rs
-assertion_line: 1060
 expression: output
 ---
-Lowering error in BrokenStruct: Found FFI-unsafe type Option<u8> in struct field BrokenStruct.regular_option, consider using DiplomatOption<u8>
+Lowering error in BrokenStruct: Diplomat error: Found FFI-unsafe type Option<u8> in struct field BrokenStruct.regular_option
+> Consider using DiplomatOption<u8>
+
 Lowering error in BrokenStruct: Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
-Lowering error in BrokenStruct: Found FFI-unsafe type Option<CustomStruct> in struct field BrokenStruct.regular_option, consider using DiplomatOption<CustomStruct>
+Lowering error in BrokenStruct: Diplomat error: Found FFI-unsafe type Option<CustomStruct> in struct field BrokenStruct.regular_option
+> Consider using DiplomatOption<CustomStruct>
+
 Lowering error in BrokenStruct: Found Option<T> for struct/enum T in a struct field, please use DiplomatOption<T>
 Lowering error in Foo::diplo_option_ref: found DiplomatOption<&T>, please use Option<&T> (DiplomatOption is for primitives, structs, and enums)
 Lowering error in Foo::diplo_option_box: found DiplomatOption<Box<T>>, please use Option<Box<T>> (DiplomatOption is for primitives, structs, and enums)

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
@@ -2,7 +2,9 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo: Found FFI-unsafe type Option<u8> in struct field Foo.field, consider using DiplomatOption<u8>
+Lowering error in Foo: Diplomat error: Found FFI-unsafe type Option<u8> in struct field Foo.field
+> Consider using DiplomatOption<u8>
+
 Lowering error in Foo: Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 Lowering error in Foo::do_thing: found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = Option<u16>
 Lowering error in Foo::do_thing2: Results can only appear as the top-level return type of methods

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
@@ -2,12 +2,24 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Crimes: Found FFI-unsafe type &'a str in struct field Crimes.slice1, consider using DiplomatUtf8Str<'a>
-Lowering error in Crimes: Found FFI-unsafe type &'a DiplomatStr in struct field Crimes.slice1, consider using DiplomatStrSlice<'a>
-Lowering error in Crimes: Found FFI-unsafe type &'a [u8] in struct field Crimes.slice2, consider using DiplomatSlice<'a,u8>
-Lowering error in Crimes: Found FFI-unsafe type Box<str> in struct field Crimes.slice3, consider using DiplomatOwnedUtf8Str
+Lowering error in Crimes: Diplomat error: Found FFI-unsafe type &'a str in struct field Crimes.slice1
+> Consider using DiplomatUtf8Str<'a>
+
+Lowering error in Crimes: Diplomat error: Found FFI-unsafe type &'a DiplomatStr in struct field Crimes.slice1
+> Consider using DiplomatStrSlice<'a>
+
+Lowering error in Crimes: Diplomat error: Found FFI-unsafe type &'a [u8] in struct field Crimes.slice2
+> Consider using DiplomatSlice<'a,u8>
+
+Lowering error in Crimes: Diplomat error: Found FFI-unsafe type Box<str> in struct field Crimes.slice3
+> Consider using DiplomatOwnedUtf8Str
+
 Lowering error in Crimes: Owned slices are not supported in this backend.
-Lowering error in Crimes: Found FFI-unsafe type Box<DiplomatStr> in struct field Crimes.slice3, consider using DiplomatOwnedStrSlice
+Lowering error in Crimes: Diplomat error: Found FFI-unsafe type Box<DiplomatStr> in struct field Crimes.slice3
+> Consider using DiplomatOwnedStrSlice
+
 Lowering error in Crimes: Owned slices are not supported in this backend.
-Lowering error in Crimes: Found FFI-unsafe type Box<[u8]> in struct field Crimes.slice4, consider using Box<[u8]>
+Lowering error in Crimes: Diplomat error: Found FFI-unsafe type Box<[u8]> in struct field Crimes.slice4
+> Consider using Box<[u8]>
+
 Lowering error in Crimes: Owned slices are not supported in this backend.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__zst_non_opaque.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__zst_non_opaque.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in NonOpaque: Methods on ZST structs are not yet implemented: NonOpaque
+Lowering error in NonOpaque: Diplomat error: Methods on ZST structs are not yet implemented
+> Remove method foo from NonOpaque


### PR DESCRIPTION
This adds a `LoweringError::OtherWithLoc` type for `LoweringError`, which takes in an `AstReport` to show where the error happens in the HIR.

TODO:
- [ ] Add one test for location errors in the HIR. This doesn't need to be as comprehensive as the AST location error tests, but at least one will show that lowering errors can print with locations.