### PR TITLE
dotnet: rename generated DiplomatWriteable to DiplomatWrite

### DIFF
--- a/example/dotnet/Generated/DiplomatWrite.cs
+++ b/example/dotnet/Generated/DiplomatWrite.cs
@@ -24,7 +24,7 @@ internal delegate bool WriteableGrow(IntPtr self, nuint capacity);
 // field corresponds to Rust's `grow_failed: bool`; Sequential layout pads
 // it to the next 8-byte boundary so `flush`/`grow` land at offsets 40/48.
 [StructLayout(LayoutKind.Sequential)]
-internal struct DiplomatWriteable : IDisposable
+internal struct DiplomatWrite : IDisposable
 {
     IntPtr context;
     IntPtr buf;
@@ -34,7 +34,7 @@ internal struct DiplomatWriteable : IDisposable
     readonly IntPtr flush;
     readonly IntPtr grow;
 
-    public DiplomatWriteable()
+    public DiplomatWrite()
     {
         WriteableFlush flushFunc = Flush;
         WriteableGrow growFunc = Grow;
@@ -45,7 +45,7 @@ internal struct DiplomatWriteable : IDisposable
         // Hold the delegate objects alive for as long as the function-pointer
         // form is in use. Without this, the GC could free the thunks and
         // Rust's callback into them would crash.
-        DiplomatWriteableContext ctx = new DiplomatWriteableContext
+        DiplomatWriteContext ctx = new DiplomatWriteContext
         {
             flushFunc = flushFunc,
             growFunc = growFunc,
@@ -65,7 +65,7 @@ internal struct DiplomatWriteable : IDisposable
     {
         if (len > int.MaxValue)
         {
-            throw new IndexOutOfRangeException("DiplomatWriteable buffer is too big");
+            throw new IndexOutOfRangeException("DiplomatWrite buffer is too big");
         }
         byte[] managedArray = new byte[(int)len];
         Marshal.Copy(buf, managedArray, 0, (int)len);
@@ -76,7 +76,7 @@ internal struct DiplomatWriteable : IDisposable
     {
         if (len > int.MaxValue)
         {
-            throw new IndexOutOfRangeException("DiplomatWriteable buffer is too big");
+            throw new IndexOutOfRangeException("DiplomatWrite buffer is too big");
         }
 #if NET6_0_OR_GREATER
         return Marshal.PtrToStringUTF8(buf, (int)len) ?? string.Empty;
@@ -123,7 +123,7 @@ internal struct DiplomatWriteable : IDisposable
         {
             return false;
         }
-        DiplomatWriteable* self = (DiplomatWriteable*)writeable;
+        DiplomatWrite* self = (DiplomatWrite*)writeable;
 
         nuint newCap = capacity;
         if (newCap > int.MaxValue)
@@ -159,7 +159,7 @@ internal struct DiplomatWriteable : IDisposable
     }
 }
 
-internal struct DiplomatWriteableContext
+internal struct DiplomatWriteContext
 {
     internal WriteableFlush flushFunc;
     internal WriteableGrow growFunc;

--- a/example/dotnet/Generated/FixedDecimal.cs
+++ b/example/dotnet/Generated/FixedDecimal.cs
@@ -89,7 +89,7 @@ public partial class FixedDecimal: IDisposable
             {
                 throw new ObjectDisposedException("FixedDecimal");
             }
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 var result = Raw.FixedDecimal.ToString(AsFFI(), &writeable);

--- a/example/dotnet/Generated/FixedDecimalFormatter.cs
+++ b/example/dotnet/Generated/FixedDecimalFormatter.cs
@@ -92,7 +92,7 @@ public partial class FixedDecimalFormatter: IDisposable
             if (value == null) throw new ArgumentNullException(nameof(value));
             Raw.FixedDecimal* valueRaw = value.AsFFI();
             if (valueRaw == null) throw new ObjectDisposedException(nameof(FixedDecimal));
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 Raw.FixedDecimalFormatter.FormatWrite(AsFFI(), valueRaw, &writeable);

--- a/example/dotnet/Generated/RawFixedDecimal.cs
+++ b/example/dotnet/Generated/RawFixedDecimal.cs
@@ -16,7 +16,7 @@ internal partial struct FixedDecimal
     internal static unsafe extern void MultiplyPow10(FixedDecimal* handle, short power);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimal_to_string_mv1", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern DiplomatResultVoidUnit ToString(FixedDecimal* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern DiplomatResultVoidUnit ToString(FixedDecimal* handle, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimal_destroy_mv1", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(FixedDecimal* handle);

--- a/example/dotnet/Generated/RawFixedDecimalFormatter.cs
+++ b/example/dotnet/Generated/RawFixedDecimalFormatter.cs
@@ -13,7 +13,7 @@ internal partial struct FixedDecimalFormatter
     internal static unsafe extern DiplomatResultFixedDecimalFormatterUnit TryNew(Locale* locale, DataProvider* provider, FixedDecimalFormatterOptions options);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimalFormatter_format_write_mv1", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void FormatWrite(FixedDecimalFormatter* handle, FixedDecimal* value, DiplomatWriteable* writeable);
+    internal static unsafe extern void FormatWrite(FixedDecimalFormatter* handle, FixedDecimal* value, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimalFormatter_destroy_mv1", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(FixedDecimalFormatter* handle);

--- a/feature_tests/dotnet/Generated/DiplomatWrite.cs
+++ b/feature_tests/dotnet/Generated/DiplomatWrite.cs
@@ -24,7 +24,7 @@ internal delegate bool WriteableGrow(IntPtr self, nuint capacity);
 // field corresponds to Rust's `grow_failed: bool`; Sequential layout pads
 // it to the next 8-byte boundary so `flush`/`grow` land at offsets 40/48.
 [StructLayout(LayoutKind.Sequential)]
-internal struct DiplomatWriteable : IDisposable
+internal struct DiplomatWrite : IDisposable
 {
     IntPtr context;
     IntPtr buf;
@@ -34,7 +34,7 @@ internal struct DiplomatWriteable : IDisposable
     readonly IntPtr flush;
     readonly IntPtr grow;
 
-    public DiplomatWriteable()
+    public DiplomatWrite()
     {
         WriteableFlush flushFunc = Flush;
         WriteableGrow growFunc = Grow;
@@ -45,7 +45,7 @@ internal struct DiplomatWriteable : IDisposable
         // Hold the delegate objects alive for as long as the function-pointer
         // form is in use. Without this, the GC could free the thunks and
         // Rust's callback into them would crash.
-        DiplomatWriteableContext ctx = new DiplomatWriteableContext
+        DiplomatWriteContext ctx = new DiplomatWriteContext
         {
             flushFunc = flushFunc,
             growFunc = growFunc,
@@ -65,7 +65,7 @@ internal struct DiplomatWriteable : IDisposable
     {
         if (len > int.MaxValue)
         {
-            throw new IndexOutOfRangeException("DiplomatWriteable buffer is too big");
+            throw new IndexOutOfRangeException("DiplomatWrite buffer is too big");
         }
         byte[] managedArray = new byte[(int)len];
         Marshal.Copy(buf, managedArray, 0, (int)len);
@@ -76,7 +76,7 @@ internal struct DiplomatWriteable : IDisposable
     {
         if (len > int.MaxValue)
         {
-            throw new IndexOutOfRangeException("DiplomatWriteable buffer is too big");
+            throw new IndexOutOfRangeException("DiplomatWrite buffer is too big");
         }
 #if NET6_0_OR_GREATER
         return Marshal.PtrToStringUTF8(buf, (int)len) ?? string.Empty;
@@ -123,7 +123,7 @@ internal struct DiplomatWriteable : IDisposable
         {
             return false;
         }
-        DiplomatWriteable* self = (DiplomatWriteable*)writeable;
+        DiplomatWrite* self = (DiplomatWrite*)writeable;
 
         nuint newCap = capacity;
         if (newCap > int.MaxValue)
@@ -159,7 +159,7 @@ internal struct DiplomatWriteable : IDisposable
     }
 }
 
-internal struct DiplomatWriteableContext
+internal struct DiplomatWriteContext
 {
     internal WriteableFlush flushFunc;
     internal WriteableGrow growFunc;

--- a/feature_tests/dotnet/Generated/Float64Vec.cs
+++ b/feature_tests/dotnet/Generated/Float64Vec.cs
@@ -80,7 +80,7 @@ public partial class Float64Vec: IDisposable
             {
                 throw new ObjectDisposedException("Float64Vec");
             }
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 Raw.Float64Vec.ToString(AsFFI(), &writeable);

--- a/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
@@ -76,7 +76,7 @@ public partial class MyOpaqueEnum: IDisposable
             {
                 throw new ObjectDisposedException("MyOpaqueEnum");
             }
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 Raw.MyOpaqueEnum.ToString(AsFFI(), &writeable);

--- a/feature_tests/dotnet/Generated/MyString.cs
+++ b/feature_tests/dotnet/Generated/MyString.cs
@@ -114,7 +114,7 @@ public partial class MyString: IDisposable
             {
                 throw new ObjectDisposedException("MyString");
             }
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 Raw.MyString.GetStr(AsFFI(), &writeable);
@@ -135,7 +135,7 @@ public partial class MyString: IDisposable
             byte[] fooBytes = System.Text.Encoding.UTF8.GetBytes(foo);
             fixed (byte* fooPtr = fooBytes)
             {
-                DiplomatWriteable writeable = new DiplomatWriteable();
+                DiplomatWrite writeable = new DiplomatWrite();
                 try
                 {
                     Raw.MyString.StringTransform(new DiplomatSliceU8 { Ptr = fooPtr, Len = (nuint)fooBytes.Length }, &writeable);

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -108,7 +108,7 @@ public partial class Opaque: IDisposable
             {
                 throw new ObjectDisposedException("Opaque");
             }
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 Raw.Opaque.GetDebugStr(AsFFI(), &writeable);

--- a/feature_tests/dotnet/Generated/OpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThin.cs
@@ -91,7 +91,7 @@ public partial class OpaqueThin: IDisposable
             {
                 throw new ObjectDisposedException("OpaqueThin");
             }
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 Raw.OpaqueThin.C(AsFFI(), &writeable);

--- a/feature_tests/dotnet/Generated/OptionString.cs
+++ b/feature_tests/dotnet/Generated/OptionString.cs
@@ -82,7 +82,7 @@ public partial class OptionString: IDisposable
             {
                 throw new ObjectDisposedException("OptionString");
             }
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 var result = Raw.OptionString.Write(AsFFI(), &writeable);

--- a/feature_tests/dotnet/Generated/RawFloat64Vec.cs
+++ b/feature_tests/dotnet/Generated/RawFloat64Vec.cs
@@ -13,7 +13,7 @@ internal partial struct Float64Vec
     internal static unsafe extern Float64Vec* NewF64BeBytes(DiplomatSliceU8 v);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Float64Vec_to_string", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void ToString(Float64Vec* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void ToString(Float64Vec* handle, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Float64Vec_get", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern DiplomatOptionDouble Get(Float64Vec* handle, nuint i);

--- a/feature_tests/dotnet/Generated/RawMyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/RawMyOpaqueEnum.cs
@@ -13,7 +13,7 @@ internal partial struct MyOpaqueEnum
     internal static unsafe extern MyOpaqueEnum* New();
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyOpaqueEnum_to_string", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void ToString(MyOpaqueEnum* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void ToString(MyOpaqueEnum* handle, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyOpaqueEnum_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(MyOpaqueEnum* handle);

--- a/feature_tests/dotnet/Generated/RawMyString.cs
+++ b/feature_tests/dotnet/Generated/RawMyString.cs
@@ -19,10 +19,10 @@ internal partial struct MyString
     internal static unsafe extern void SetStr(MyString* handle, DiplomatSliceU8 newStr);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_get_str", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void GetStr(MyString* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void GetStr(MyString* handle, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_string_transform", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void StringTransform(DiplomatSliceU8 foo, DiplomatWriteable* writeable);
+    internal static unsafe extern void StringTransform(DiplomatSliceU8 foo, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(MyString* handle);

--- a/feature_tests/dotnet/Generated/RawOpaque.cs
+++ b/feature_tests/dotnet/Generated/RawOpaque.cs
@@ -19,7 +19,7 @@ internal partial struct Opaque
     internal static unsafe extern Opaque* FromStr(DiplomatSliceU8 input);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_get_debug_str", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void GetDebugStr(Opaque* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void GetDebugStr(Opaque* handle, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_assert_struct", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void AssertStruct(Opaque* handle, MyStruct s);

--- a/feature_tests/dotnet/Generated/RawOpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueThin.cs
@@ -16,7 +16,7 @@ internal partial struct OpaqueThin
     internal static unsafe extern float B(OpaqueThin* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThin_c", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void C(OpaqueThin* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void C(OpaqueThin* handle, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueThin_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OpaqueThin* handle);

--- a/feature_tests/dotnet/Generated/RawOptionString.cs
+++ b/feature_tests/dotnet/Generated/RawOptionString.cs
@@ -13,7 +13,7 @@ internal partial struct OptionString
     internal static unsafe extern OptionString* New(DiplomatSliceU8 diplomatStr);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionString_write", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern DiplomatResultVoidUnit Write(OptionString* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern DiplomatResultVoidUnit Write(OptionString* handle, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OptionString_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(OptionString* handle);

--- a/feature_tests/dotnet/Generated/RawRenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RawRenamedMixinTest.cs
@@ -10,7 +10,7 @@ internal partial struct RenamedMixinTest
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_MixinTest_hello", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void Hello(DiplomatWriteable* writeable);
+    internal static unsafe extern void Hello(DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_MixinTest_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(RenamedMixinTest* handle);

--- a/feature_tests/dotnet/Generated/RawUtf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/RawUtf16Wrap.cs
@@ -10,7 +10,7 @@ internal partial struct Utf16Wrap
 {
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Utf16Wrap_get_debug_str", CallingConvention = CallingConvention.Cdecl)]
-    internal static unsafe extern void GetDebugStr(Utf16Wrap* handle, DiplomatWriteable* writeable);
+    internal static unsafe extern void GetDebugStr(Utf16Wrap* handle, DiplomatWrite* writeable);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Utf16Wrap_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Utf16Wrap* handle);

--- a/feature_tests/dotnet/Generated/RenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedMixinTest.cs
@@ -61,7 +61,7 @@ public partial class RenamedMixinTest: IDisposable
     {
         unsafe
         {
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 Raw.RenamedMixinTest.Hello(&writeable);

--- a/feature_tests/dotnet/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/Utf16Wrap.cs
@@ -65,7 +65,7 @@ public partial class Utf16Wrap: IDisposable
             {
                 throw new ObjectDisposedException("Utf16Wrap");
             }
-            DiplomatWriteable writeable = new DiplomatWriteable();
+            DiplomatWrite writeable = new DiplomatWrite();
             try
             {
                 Raw.Utf16Wrap.GetDebugStr(AsFFI(), &writeable);

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -213,7 +213,7 @@ impl Display for DotnetReturnType {
             // Both render as the C# keyword `void` in raw externs. The
             // idiomatic signature spells `Write` methods as `string`
             // instead (see `idiomatic_signature_return_type`) — the writer
-            // is allocated and consumed internally, so `DiplomatWriteable`
+            // is allocated and consumed internally, so `DiplomatWrite`
             // never appears on the public API.
             Self::Write | Self::Unit => write!(f, "void"),
         }
@@ -630,7 +630,7 @@ impl MethodInfo<'_> {
     /// Idiomatic return type as it appears in the generated method
     /// signature. `Write` methods surface as `string`: the writer is
     /// allocated, filled, and disposed inside the generated body, so the
-    /// low-level `DiplomatWriteable` is never exposed on the public API.
+    /// low-level `DiplomatWrite` is never exposed on the public API.
     /// Everything else defers to [`Self::idiomatic_return_type`].
     pub(super) fn idiomatic_signature_return_type(&self) -> String {
         if self.return_type.is_write() {
@@ -649,9 +649,9 @@ impl MethodInfo<'_> {
             return self.inputs.raw_params.clone();
         }
         if self.inputs.raw_params.is_empty() {
-            "DiplomatWriteable* writeable".to_string()
+            "DiplomatWrite* writeable".to_string()
         } else {
-            format!("{}, DiplomatWriteable* writeable", self.inputs.raw_params)
+            format!("{}, DiplomatWrite* writeable", self.inputs.raw_params)
         }
     }
 

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -80,13 +80,13 @@ struct DiplomatSliceMutU32Template<'a> {
     namespace: &'a str,
 }
 
-/// `DiplomatWriteable` — caller-provided buffer Rust appends UTF-8 bytes
+/// `DiplomatWrite` — caller-provided buffer Rust appends UTF-8 bytes
 /// into. Carries function pointers for `flush` and `grow` callbacks so
 /// Rust can ask C# to enlarge the buffer when it runs out. Used for
 /// every "return string" API on the Rust side (`fn foo(&self, write: &mut DiplomatWrite)`).
 #[derive(Template)]
-#[template(path = "dotnet/DiplomatWriteable.cs.jinja", escape = "none")]
-struct DiplomatWriteableTemplate<'a> {
+#[template(path = "dotnet/DiplomatWrite.cs.jinja", escape = "none")]
+struct DiplomatWriteTemplate<'a> {
     namespace: &'a str,
 }
 
@@ -392,12 +392,12 @@ pub(crate) fn run<'tcx>(
     );
     add_cs_file(
         &files,
-        "DiplomatWriteable.cs".to_string(),
-        DiplomatWriteableTemplate {
+        "DiplomatWrite.cs".to_string(),
+        DiplomatWriteTemplate {
             namespace: &namespace,
         }
         .render()
-        .expect("DiplomatWriteable template render failed"),
+        .expect("DiplomatWrite template render failed"),
     );
     add_cs_file(
         &files,

--- a/tool/templates/dotnet/DiplomatWrite.cs.jinja
+++ b/tool/templates/dotnet/DiplomatWrite.cs.jinja
@@ -24,7 +24,7 @@ internal delegate bool WriteableGrow(IntPtr self, nuint capacity);
 // field corresponds to Rust's `grow_failed: bool`; Sequential layout pads
 // it to the next 8-byte boundary so `flush`/`grow` land at offsets 40/48.
 [StructLayout(LayoutKind.Sequential)]
-internal struct DiplomatWriteable : IDisposable
+internal struct DiplomatWrite : IDisposable
 {
     IntPtr context;
     IntPtr buf;
@@ -34,7 +34,7 @@ internal struct DiplomatWriteable : IDisposable
     readonly IntPtr flush;
     readonly IntPtr grow;
 
-    public DiplomatWriteable()
+    public DiplomatWrite()
     {
         WriteableFlush flushFunc = Flush;
         WriteableGrow growFunc = Grow;
@@ -45,7 +45,7 @@ internal struct DiplomatWriteable : IDisposable
         // Hold the delegate objects alive for as long as the function-pointer
         // form is in use. Without this, the GC could free the thunks and
         // Rust's callback into them would crash.
-        DiplomatWriteableContext ctx = new DiplomatWriteableContext
+        DiplomatWriteContext ctx = new DiplomatWriteContext
         {
             flushFunc = flushFunc,
             growFunc = growFunc,
@@ -65,7 +65,7 @@ internal struct DiplomatWriteable : IDisposable
     {
         if (len > int.MaxValue)
         {
-            throw new IndexOutOfRangeException("DiplomatWriteable buffer is too big");
+            throw new IndexOutOfRangeException("DiplomatWrite buffer is too big");
         }
         byte[] managedArray = new byte[(int)len];
         Marshal.Copy(buf, managedArray, 0, (int)len);
@@ -76,7 +76,7 @@ internal struct DiplomatWriteable : IDisposable
     {
         if (len > int.MaxValue)
         {
-            throw new IndexOutOfRangeException("DiplomatWriteable buffer is too big");
+            throw new IndexOutOfRangeException("DiplomatWrite buffer is too big");
         }
 #if NET6_0_OR_GREATER
         return Marshal.PtrToStringUTF8(buf, (int)len) ?? string.Empty;
@@ -123,7 +123,7 @@ internal struct DiplomatWriteable : IDisposable
         {
             return false;
         }
-        DiplomatWriteable* self = (DiplomatWriteable*)writeable;
+        DiplomatWrite* self = (DiplomatWrite*)writeable;
 
         nuint newCap = capacity;
         if (newCap > int.MaxValue)
@@ -159,7 +159,7 @@ internal struct DiplomatWriteable : IDisposable
     }
 }
 
-internal struct DiplomatWriteableContext
+internal struct DiplomatWriteContext
 {
     internal WriteableFlush flushFunc;
     internal WriteableGrow growFunc;

--- a/tool/templates/dotnet/method_body.cs.jinja
+++ b/tool/templates/dotnet/method_body.cs.jinja
@@ -56,11 +56,11 @@
 {%- if method.return_type.is_write() %}
     {#- Write methods return `string`. Allocate the writer in this frame,
         pass its address to Rust, read the buffer back, dispose. The
-        low-level DiplomatWriteable never appears on the public API.
+        low-level DiplomatWrite never appears on the public API.
         try/finally guarantees the unmanaged buffer is freed even if the
         raw call or ToUnicode() throws (the error-arm throw sits inside
         the try; finally still runs). #}
-{{ bi }}DiplomatWriteable writeable = new DiplomatWriteable();
+{{ bi }}DiplomatWrite writeable = new DiplomatWrite();
 {{ bi }}try
 {{ bi }}{
     {%- if method.error_info.is_some() %}

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -84,7 +84,7 @@ public partial class {{ name }}: IDisposable
     {#- One idiomatic method per HIR method. `DiplomatWrite`-returning
         methods surface as `string` — the writer is allocated, filled, and
         disposed inside the generated body (see method_body.cs.jinja), so
-        the low-level DiplomatWriteable never appears on the public API. #}
+        the low-level DiplomatWrite never appears on the public API. #}
     {%- for method in methods %}
 {%- if let Some(info) = method.error_info %}
     /// <exception cref="{{ info.exception_name }}"></exception>

--- a/tool/templates/dotnet/raw_extern.cs.jinja
+++ b/tool/templates/dotnet/raw_extern.cs.jinja
@@ -1,5 +1,5 @@
 {#- Shared raw [DllImport] extern declaration. Four return-type cases:
-    - Write:              void return + trailing DiplomatWriteable* param
+    - Write:              void return + trailing DiplomatWrite* param
     - Fallible:           DiplomatResult struct
     - Option<value-type>: DiplomatOption struct (tagged)
     - Option<Box<T>> / plain: just method.return_type.raw() (pointer


### PR DESCRIPTION
## Summary

The Rust-side `diplomat-runtime` writer type was renamed from `DiplomatWriteable` to `DiplomatWrite`, but the .NET backend's generated C# counterpart was never updated to match — it still emits an internal struct called `DiplomatWriteable` (file `DiplomatWriteable.cs.jinja` / `DiplomatWriteable.cs`). This is purely an internal/harmless naming inconsistency (the type isn't part of the public API), but it's a backend-template leftover from the old name that's worth fixing for consistency with the Rust type it mirrors.

Renames, no behavior change:
- `tool/templates/dotnet/DiplomatWriteable.cs.jinja` → `DiplomatWrite.cs.jinja` (and its internal struct/context type names, error messages, casts)
- `tool/src/dotnet/mod.rs`: `DiplomatWriteableTemplate` → `DiplomatWriteTemplate`, template path, output filename `DiplomatWrite.cs`
- `tool/src/dotnet/gen/method.rs`: doc comments + raw param strings
- `method_body.cs.jinja`, `opaque.impl.cs.jinja`, `raw_extern.cs.jinja`: doc comments
- Regenerated checked-in fixtures (`example/dotnet/Generated`, `feature_tests/dotnet/Generated`)

## Test plan
- [x] `cargo test -p diplomat-tool dotnet` — 21 passed
- [x] `cargo build -p diplomat-feature-tests` + `dotnet test feature_tests/dotnet/Somelib.FeatureTests.csproj` — 64 passed
- [x] Verified only rename-related lines changed in regenerated fixtures (no EOL/CRLF churn beyond intended diff)