### PR TITLE
dotnet: add blank-line separator between generated properties/methods

### DIFF
--- a/example/dotnet/Generated/DataProvider.cs
+++ b/example/dotnet/Generated/DataProvider.cs
@@ -57,6 +57,7 @@ public partial class DataProvider: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>DataProvider</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class DataProvider: IDisposable
             return new DataProvider(result);
         }
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     public static void ReturnsResult()
     {

--- a/example/dotnet/Generated/FixedDecimal.cs
+++ b/example/dotnet/Generated/FixedDecimal.cs
@@ -57,6 +57,7 @@ public partial class FixedDecimal: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>FixedDecimal</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class FixedDecimal: IDisposable
             return new FixedDecimal(result);
         }
     }
+
     public void MultiplyPow10(short power)
     {
         unsafe
@@ -80,6 +82,7 @@ public partial class FixedDecimal: IDisposable
             GC.KeepAlive(this);
         }
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     public override string ToString()
     {

--- a/example/dotnet/Generated/FixedDecimalFormatter.cs
+++ b/example/dotnet/Generated/FixedDecimalFormatter.cs
@@ -57,6 +57,7 @@ public partial class FixedDecimalFormatter: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     /// <returns>
     /// A <c>FixedDecimalFormatter</c> allocated on Rust side.
@@ -81,6 +82,7 @@ public partial class FixedDecimalFormatter: IDisposable
             return new FixedDecimalFormatter(result.Ok);
         }
     }
+
     public string FormatWrite(FixedDecimal value)
     {
         unsafe

--- a/example/dotnet/Generated/FixedDecimalFormatterOptions.cs
+++ b/example/dotnet/Generated/FixedDecimalFormatterOptions.cs
@@ -24,6 +24,7 @@ public partial struct FixedDecimalFormatterOptions
         SomeOtherConfig = raw.SomeOtherConfig,
     };
 
+
     public static FixedDecimalFormatterOptions Default()
     {
         unsafe

--- a/example/dotnet/Generated/Locale.cs
+++ b/example/dotnet/Generated/Locale.cs
@@ -57,6 +57,7 @@ public partial class Locale: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>Locale</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
+++ b/feature_tests/dotnet/Generated/AttrOpaque1Renamed.cs
@@ -57,6 +57,7 @@ public partial class AttrOpaque1Renamed: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>AttrOpaque1Renamed</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class AttrOpaque1Renamed: IDisposable
             return new AttrOpaque1Renamed(result);
         }
     }
+
     /// <returns>
     /// A <c>AttrOpaque1Renamed</c> allocated on Rust side.
     /// </returns>
@@ -79,6 +81,7 @@ public partial class AttrOpaque1Renamed: IDisposable
             return new AttrOpaque1Renamed(result);
         }
     }
+
     public static int MacTest()
     {
         unsafe
@@ -86,6 +89,7 @@ public partial class AttrOpaque1Renamed: IDisposable
             return Raw.AttrOpaque1Renamed.MacTest();
         }
     }
+
     public static int Hello()
     {
         unsafe
@@ -93,6 +97,7 @@ public partial class AttrOpaque1Renamed: IDisposable
             return Raw.AttrOpaque1Renamed.Hello();
         }
     }
+
     public byte method_renamed()
     {
         unsafe
@@ -106,6 +111,7 @@ public partial class AttrOpaque1Renamed: IDisposable
             return result;
         }
     }
+
     public byte Abirenamed()
     {
         unsafe
@@ -119,6 +125,7 @@ public partial class AttrOpaque1Renamed: IDisposable
             return result;
         }
     }
+
     public void UseUnnamespaced(Unnamespaced un)
     {
         unsafe
@@ -135,6 +142,7 @@ public partial class AttrOpaque1Renamed: IDisposable
             GC.KeepAlive(un);
         }
     }
+
     public void UseNamespaced(RenamedAttrEnum n)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/Bar.cs
+++ b/feature_tests/dotnet/Generated/Bar.cs
@@ -57,6 +57,7 @@ public partial class Bar: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>Foo</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/BorrowingError.cs
+++ b/feature_tests/dotnet/Generated/BorrowingError.cs
@@ -57,6 +57,7 @@ public partial class BorrowingError: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>OpaqueThin</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/Float64Vec.cs
+++ b/feature_tests/dotnet/Generated/Float64Vec.cs
@@ -57,6 +57,7 @@ public partial class Float64Vec: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>Float64Vec</c> allocated on Rust side.
     /// </returns>
@@ -72,6 +73,7 @@ public partial class Float64Vec: IDisposable
             }
         }
     }
+
     public override string ToString()
     {
         unsafe
@@ -93,6 +95,7 @@ public partial class Float64Vec: IDisposable
             }
         }
     }
+
     public double? Get(nuint i)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/Foo.cs
+++ b/feature_tests/dotnet/Generated/Foo.cs
@@ -57,6 +57,7 @@ public partial class Foo: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>Bar</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/GcRaceProbe.cs
+++ b/feature_tests/dotnet/Generated/GcRaceProbe.cs
@@ -57,6 +57,7 @@ public partial class GcRaceProbe: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>GcRaceProbe</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class GcRaceProbe: IDisposable
             return new GcRaceProbe(result);
         }
     }
+
     public ulong DropsDuringSpin(ulong millis)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/MethodOverloading.cs
+++ b/feature_tests/dotnet/Generated/MethodOverloading.cs
@@ -57,6 +57,7 @@ public partial class MethodOverloading: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>MethodOverloading</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class MethodOverloading: IDisposable
             return new MethodOverloading(result);
         }
     }
+
     /// <returns>
     /// A <c>MethodOverloading</c> allocated on Rust side.
     /// </returns>
@@ -79,6 +81,7 @@ public partial class MethodOverloading: IDisposable
             return new MethodOverloading(result);
         }
     }
+
     /// <returns>
     /// A <c>MethodOverloading</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
+++ b/feature_tests/dotnet/Generated/MyOpaqueEnum.cs
@@ -57,6 +57,7 @@ public partial class MyOpaqueEnum: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>MyOpaqueEnum</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class MyOpaqueEnum: IDisposable
             return new MyOpaqueEnum(result);
         }
     }
+
     public override string ToString()
     {
         unsafe

--- a/feature_tests/dotnet/Generated/MyString.cs
+++ b/feature_tests/dotnet/Generated/MyString.cs
@@ -57,6 +57,7 @@ public partial class MyString: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>MyString</c> allocated on Rust side.
     /// </returns>
@@ -73,6 +74,7 @@ public partial class MyString: IDisposable
             }
         }
     }
+
     /// <returns>
     /// A <c>MyString</c> allocated on Rust side.
     /// </returns>
@@ -89,6 +91,7 @@ public partial class MyString: IDisposable
             }
         }
     }
+
     public void SetStr(string newStr)
     {
         unsafe
@@ -106,6 +109,7 @@ public partial class MyString: IDisposable
             }
         }
     }
+
     public string GetStr()
     {
         unsafe
@@ -127,6 +131,7 @@ public partial class MyString: IDisposable
             }
         }
     }
+
     public static string StringTransform(string foo)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/MyStruct.cs
+++ b/feature_tests/dotnet/Generated/MyStruct.cs
@@ -39,6 +39,7 @@ public partial struct MyStruct
         G = raw.G,
     };
 
+
     public static MyStruct New()
     {
         unsafe
@@ -47,6 +48,7 @@ public partial struct MyStruct
             return MyStruct.FromFFI(result);
         }
     }
+
 
     public static MyStruct NewOverload(int i)
     {
@@ -57,6 +59,7 @@ public partial struct MyStruct
         }
     }
 
+
     public byte IntoA()
     {
         unsafe
@@ -64,6 +67,7 @@ public partial struct MyStruct
             return Raw.MyStruct.IntoA(this.AsFFI());
         }
     }
+
     /// <exception cref="MyZstException"></exception>
 
     public static void ReturnsZstResult()
@@ -78,6 +82,7 @@ public partial struct MyStruct
             return;
         }
     }
+
     /// <exception cref="MyZstException"></exception>
 
     public static void FailsZstResult()

--- a/feature_tests/dotnet/Generated/One.cs
+++ b/feature_tests/dotnet/Generated/One.cs
@@ -57,6 +57,7 @@ public partial class One: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -80,6 +81,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { hold });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -103,6 +105,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { hold });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -138,6 +141,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { a, b, c, d });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -161,6 +165,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { hold });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -192,6 +197,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { top, left, right, bottom });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -223,6 +229,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { left, bottom });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -254,6 +261,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { right, bottom });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -285,6 +293,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { bottom });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -320,6 +329,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { a, b, c, d });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>
@@ -347,6 +357,7 @@ public partial class One: IDisposable
             return new One(result, new object[] { explicitHold, implicitHold });
         }
     }
+
     /// <returns>
     /// A <c>One</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -57,6 +57,7 @@ public partial class Opaque: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>Opaque</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class Opaque: IDisposable
             return new Opaque(result);
         }
     }
+
     /// <returns>
     /// A <c>Opaque</c> allocated on Rust side.
     /// </returns>
@@ -84,6 +86,7 @@ public partial class Opaque: IDisposable
             }
         }
     }
+
     /// <returns>
     /// A <c>Opaque</c> allocated on Rust side.
     /// </returns>
@@ -100,6 +103,7 @@ public partial class Opaque: IDisposable
             }
         }
     }
+
     public string GetDebugStr()
     {
         unsafe
@@ -121,6 +125,7 @@ public partial class Opaque: IDisposable
             }
         }
     }
+
     public void AssertStruct(MyStruct s)
     {
         unsafe
@@ -133,6 +138,7 @@ public partial class Opaque: IDisposable
             GC.KeepAlive(this);
         }
     }
+
     public static nuint ReturnsUsize()
     {
         unsafe
@@ -140,6 +146,7 @@ public partial class Opaque: IDisposable
             return Raw.Opaque.ReturnsUsize();
         }
     }
+
     public static ImportedStruct ReturnsImported()
     {
         unsafe

--- a/feature_tests/dotnet/Generated/OpaqueMut.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMut.cs
@@ -57,6 +57,7 @@ public partial class OpaqueMut: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>OpaqueMut</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
@@ -57,6 +57,7 @@ public partial class OpaqueMutexedString: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>OpaqueMutexedString</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class OpaqueMutexedString: IDisposable
             return new OpaqueMutexedString(result);
         }
     }
+
     public void Change(nuint number)
     {
         unsafe
@@ -80,6 +82,7 @@ public partial class OpaqueMutexedString: IDisposable
             GC.KeepAlive(this);
         }
     }
+
     public nuint GetLenAndAdd(nuint other)
     {
         unsafe
@@ -93,6 +96,7 @@ public partial class OpaqueMutexedString: IDisposable
             return result;
         }
     }
+
     /// <returns>
     /// A <c>Utf16Wrap</c> allocated on Rust side.
     /// </returns>
@@ -109,6 +113,7 @@ public partial class OpaqueMutexedString: IDisposable
             return new Utf16Wrap(result);
         }
     }
+
     public ushort ToUnsignedFromUnsigned(ushort input)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/OpaqueSliceView.cs
+++ b/feature_tests/dotnet/Generated/OpaqueSliceView.cs
@@ -57,6 +57,7 @@ public partial class OpaqueSliceView: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <exception cref="SliceParseErrorException"></exception>
     /// <returns>
     /// A <c>OpaqueSliceView</c> allocated on Rust side.
@@ -89,6 +90,7 @@ public partial class OpaqueSliceView: IDisposable
             }
         }
     }
+
     /// <exception cref="SliceParseErrorException"></exception>
     /// <returns>
     /// A <c>OpaqueSliceView</c> allocated on Rust side.
@@ -121,6 +123,7 @@ public partial class OpaqueSliceView: IDisposable
             }
         }
     }
+
     /// <returns>
     /// A <c>OpaqueSliceView</c> allocated on Rust side.
     /// </returns>
@@ -148,6 +151,7 @@ public partial class OpaqueSliceView: IDisposable
             }
         }
     }
+
     public uint Length()
     {
         unsafe
@@ -161,6 +165,7 @@ public partial class OpaqueSliceView: IDisposable
             return result;
         }
     }
+
     public byte Get(uint index)
     {
         unsafe
@@ -174,6 +179,7 @@ public partial class OpaqueSliceView: IDisposable
             return result;
         }
     }
+
     public uint Sum()
     {
         unsafe

--- a/feature_tests/dotnet/Generated/OpaqueThin.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThin.cs
@@ -57,6 +57,7 @@ public partial class OpaqueThin: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     public int A()
     {
         unsafe
@@ -70,6 +71,7 @@ public partial class OpaqueThin: IDisposable
             return result;
         }
     }
+
     public float B()
     {
         unsafe
@@ -83,6 +85,7 @@ public partial class OpaqueThin: IDisposable
             return result;
         }
     }
+
     public string C()
     {
         unsafe

--- a/feature_tests/dotnet/Generated/OpaqueThinIter.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinIter.cs
@@ -57,6 +57,7 @@ public partial class OpaqueThinIter: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>OpaqueThin</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -57,6 +57,7 @@ public partial class OpaqueThinVec: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>OpaqueThinVec</c> allocated on Rust side.
     /// </returns>
@@ -73,6 +74,7 @@ public partial class OpaqueThinVec: IDisposable
             }
         }
     }
+
     public void SetFirstC(string value)
     {
         unsafe
@@ -90,6 +92,7 @@ public partial class OpaqueThinVec: IDisposable
             }
         }
     }
+
     /// <returns>
     /// A <c>OpaqueThinIter</c> allocated on Rust side.
     /// </returns>
@@ -110,6 +113,7 @@ public partial class OpaqueThinVec: IDisposable
             return new OpaqueThinIter(result, new object[] { this });
         }
     }
+
     public nuint Len()
     {
         unsafe
@@ -123,6 +127,7 @@ public partial class OpaqueThinVec: IDisposable
             return result;
         }
     }
+
     /// <returns>
     /// A <c>OpaqueThin</c> allocated on Rust side.
     /// </returns>
@@ -143,6 +148,7 @@ public partial class OpaqueThinVec: IDisposable
             return result == null ? null : new OpaqueThin(RustHandle<Raw.OpaqueThin>.Borrowed(result), new object[] { this });
         }
     }
+
     /// <returns>
     /// A <c>OpaqueThin</c> allocated on Rust side.
     /// </returns>
@@ -163,6 +169,7 @@ public partial class OpaqueThinVec: IDisposable
             return result == null ? null : new OpaqueThin(RustHandle<Raw.OpaqueThin>.Borrowed(result), new object[] { this });
         }
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     /// <returns>
     /// A <c>OpaqueThin</c> allocated on Rust side.
@@ -188,6 +195,7 @@ public partial class OpaqueThinVec: IDisposable
             return new OpaqueThin(RustHandle<Raw.OpaqueThin>.Borrowed(result.Ok), new object[] { this });
         }
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     /// <returns>
     /// A <c>OpaqueThin</c> allocated on Rust side.
@@ -213,6 +221,7 @@ public partial class OpaqueThinVec: IDisposable
             return result.Ok == null ? null : new OpaqueThin(RustHandle<Raw.OpaqueThin>.Borrowed(result.Ok), new object[] { this });
         }
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     /// <returns>
     /// A <c>OpaqueThinIter</c> allocated on Rust side.
@@ -238,6 +247,7 @@ public partial class OpaqueThinVec: IDisposable
             return new OpaqueThinIter(result.Ok, new object[] { this });
         }
     }
+
     /// <returns>
     /// A <c>OpaqueThinIter</c> allocated on Rust side.
     /// </returns>
@@ -258,6 +268,7 @@ public partial class OpaqueThinVec: IDisposable
             return result == null ? null : new OpaqueThinIter(result, new object[] { this });
         }
     }
+
     /// <exception cref="BorrowingErrorException"></exception>
     public int TryBorrow(bool fail)
     {

--- a/feature_tests/dotnet/Generated/OptionOpaque.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaque.cs
@@ -57,6 +57,7 @@ public partial class OptionOpaque: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>OptionOpaque</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class OptionOpaque: IDisposable
             return result == null ? null : new OptionOpaque(result);
         }
     }
+
     /// <returns>
     /// A <c>OptionOpaque</c> allocated on Rust side.
     /// </returns>
@@ -79,6 +81,7 @@ public partial class OptionOpaque: IDisposable
             return result == null ? null : new OptionOpaque(result);
         }
     }
+
     public nint? OptionIsize()
     {
         unsafe
@@ -92,6 +95,7 @@ public partial class OptionOpaque: IDisposable
             return result.IsSome ? result.Value : (nint?)null;
         }
     }
+
     public nuint? OptionUsize()
     {
         unsafe
@@ -105,6 +109,7 @@ public partial class OptionOpaque: IDisposable
             return result.IsSome ? result.Value : (nuint?)null;
         }
     }
+
     public int? OptionI32()
     {
         unsafe
@@ -118,6 +123,7 @@ public partial class OptionOpaque: IDisposable
             return result.IsSome ? result.Value : (int?)null;
         }
     }
+
     public uint? OptionU32()
     {
         unsafe
@@ -131,6 +137,7 @@ public partial class OptionOpaque: IDisposable
             return result.IsSome ? result.Value : (uint?)null;
         }
     }
+
     public void AssertInteger(int i)
     {
         unsafe
@@ -143,6 +150,7 @@ public partial class OptionOpaque: IDisposable
             GC.KeepAlive(this);
         }
     }
+
     public static bool OptionOpaqueArgument(OptionOpaque? arg)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
+++ b/feature_tests/dotnet/Generated/OptionOpaqueChar.cs
@@ -57,6 +57,7 @@ public partial class OptionOpaqueChar: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     public void AssertChar(uint ch)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/OptionString.cs
+++ b/feature_tests/dotnet/Generated/OptionString.cs
@@ -57,6 +57,7 @@ public partial class OptionString: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>OptionString</c> allocated on Rust side.
     /// </returns>
@@ -73,6 +74,7 @@ public partial class OptionString: IDisposable
             }
         }
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     public string Write()
     {

--- a/feature_tests/dotnet/Generated/RefList.cs
+++ b/feature_tests/dotnet/Generated/RefList.cs
@@ -57,6 +57,7 @@ public partial class RefList: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>RefList</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/RenamedMixinTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedMixinTest.cs
@@ -57,6 +57,7 @@ public partial class RenamedMixinTest: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     public static string Hello()
     {
         unsafe

--- a/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
+++ b/feature_tests/dotnet/Generated/RenamedOpaqueZSTIndexer.cs
@@ -57,6 +57,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>RenamedOpaqueZSTIndexer</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class RenamedOpaqueZSTIndexer: IDisposable
             return new RenamedOpaqueZSTIndexer(result);
         }
     }
+
     /// <returns>
     /// A <c>RenamedOpaqueZSTIndexer</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/RenamedStructWithAttrs.cs
+++ b/feature_tests/dotnet/Generated/RenamedStructWithAttrs.cs
@@ -23,6 +23,7 @@ public partial struct RenamedStructWithAttrs
         A = raw.A,
         B = raw.B,
     };
+
     /// <exception cref="InvalidOperationException"></exception>
 
     public static RenamedStructWithAttrs NewFallible(bool a, uint b)
@@ -38,6 +39,7 @@ public partial struct RenamedStructWithAttrs
         }
     }
 
+
     public uint C()
     {
         unsafe
@@ -45,6 +47,7 @@ public partial struct RenamedStructWithAttrs
             return Raw.RenamedStructWithAttrs.C(this.AsFFI());
         }
     }
+
 
     public void Deprecated()
     {

--- a/feature_tests/dotnet/Generated/RenamedTestMacroStruct.cs
+++ b/feature_tests/dotnet/Generated/RenamedTestMacroStruct.cs
@@ -21,6 +21,7 @@ public partial struct RenamedTestMacroStruct
         A = raw.A,
     };
 
+
     public static nuint TestFunc()
     {
         unsafe
@@ -28,6 +29,7 @@ public partial struct RenamedTestMacroStruct
             return Raw.RenamedTestMacroStruct.TestFunc();
         }
     }
+
 
     public static RenamedTestMacroStruct TestMeta()
     {

--- a/feature_tests/dotnet/Generated/RenamedVectorTest.cs
+++ b/feature_tests/dotnet/Generated/RenamedVectorTest.cs
@@ -57,6 +57,7 @@ public partial class RenamedVectorTest: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>RenamedVectorTest</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class RenamedVectorTest: IDisposable
             return new RenamedVectorTest(result);
         }
     }
+
     public nuint Len()
     {
         unsafe
@@ -81,6 +83,7 @@ public partial class RenamedVectorTest: IDisposable
             return result;
         }
     }
+
     public double? Get(nuint idx)
     {
         unsafe
@@ -94,6 +97,7 @@ public partial class RenamedVectorTest: IDisposable
             return result.IsSome ? result.Value : (double?)null;
         }
     }
+
     public void Push(double value)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/ResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/ResultOpaque.cs
@@ -57,6 +57,7 @@ public partial class ResultOpaque: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <exception cref="ErrorEnumException"></exception>
     /// <returns>
     /// A <c>ResultOpaque</c> allocated on Rust side.
@@ -73,6 +74,7 @@ public partial class ResultOpaque: IDisposable
             return new ResultOpaque(result.Ok);
         }
     }
+
     /// <exception cref="ErrorEnumException"></exception>
     /// <returns>
     /// A <c>ResultOpaque</c> allocated on Rust side.
@@ -89,6 +91,7 @@ public partial class ResultOpaque: IDisposable
             return new ResultOpaque(result.Ok);
         }
     }
+
     /// <exception cref="ErrorEnumException"></exception>
     /// <returns>
     /// A <c>ResultOpaque</c> allocated on Rust side.
@@ -105,6 +108,7 @@ public partial class ResultOpaque: IDisposable
             return new ResultOpaque(result.Ok);
         }
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     /// <returns>
     /// A <c>ResultOpaque</c> allocated on Rust side.
@@ -121,6 +125,7 @@ public partial class ResultOpaque: IDisposable
             return new ResultOpaque(result.Ok);
         }
     }
+
     /// <exception cref="ErrorStructException"></exception>
     /// <returns>
     /// A <c>ResultOpaque</c> allocated on Rust side.
@@ -137,6 +142,7 @@ public partial class ResultOpaque: IDisposable
             return new ResultOpaque(result.Ok);
         }
     }
+
     /// <exception cref="ResultOpaqueException"></exception>
     public static void NewInErr(int i)
     {
@@ -150,6 +156,7 @@ public partial class ResultOpaque: IDisposable
             return;
         }
     }
+
     /// <exception cref="InvalidOperationException"></exception>
     public static int NewInt(int i)
     {
@@ -163,6 +170,7 @@ public partial class ResultOpaque: IDisposable
             return result.Ok;
         }
     }
+
     /// <exception cref="ResultOpaqueException"></exception>
     public static ErrorEnum NewInEnumErr(int i)
     {
@@ -176,6 +184,7 @@ public partial class ResultOpaque: IDisposable
             return result.Ok;
         }
     }
+
     public void AssertInteger(int i)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/Unnamespaced.cs
+++ b/feature_tests/dotnet/Generated/Unnamespaced.cs
@@ -57,6 +57,7 @@ public partial class Unnamespaced: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     /// <returns>
     /// A <c>Unnamespaced</c> allocated on Rust side.
     /// </returns>
@@ -68,6 +69,7 @@ public partial class Unnamespaced: IDisposable
             return new Unnamespaced(result);
         }
     }
+
     public void UseNamespaced(AttrOpaque1Renamed n)
     {
         unsafe

--- a/feature_tests/dotnet/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/Utf16Wrap.cs
@@ -57,6 +57,7 @@ public partial class Utf16Wrap: IDisposable
         _inner = inner;
         _edges = edges;
     }
+
     public string GetDebugStr()
     {
         unsafe

--- a/tool/templates/dotnet/opaque.impl.cs.jinja
+++ b/tool/templates/dotnet/opaque.impl.cs.jinja
@@ -20,8 +20,7 @@ public partial class {{ name }}: IDisposable
 
     private static readonly unsafe RustDestructor<Raw.{{ name }}> _destroy = Raw.{{ name }}.Destroy;
     {%- for property in properties %}
-
-{%- if property.lifetime_warning %}
+{% if property.lifetime_warning %}
     /// <remarks>
     /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
     /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
@@ -86,7 +85,7 @@ public partial class {{ name }}: IDisposable
         disposed inside the generated body (see method_body.cs.jinja), so
         the low-level DiplomatWriteable never appears on the public API. #}
     {%- for method in methods %}
-{%- if let Some(info) = method.error_info %}
+{% if let Some(info) = method.error_info %}
     /// <exception cref="{{ info.exception_name }}"></exception>
 {%- endif %}
 {%- if method.return_type.is_opaque() %}

--- a/tool/templates/dotnet/struct.impl.cs.jinja
+++ b/tool/templates/dotnet/struct.impl.cs.jinja
@@ -28,8 +28,7 @@ public partial struct {{ name }}
     };
 
     {%- for property in properties %}
-
-{%- if property.lifetime_warning %}
+{% if property.lifetime_warning %}
     /// <remarks>
     /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
     /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
@@ -47,7 +46,7 @@ public partial struct {{ name }}
     {%- endfor %}
 
     {%- for method in methods %}
-{%- if let Some(info) = method.error_info %}
+{% if let Some(info) = method.error_info %}
     /// <exception cref="{{ info.exception_name }}"></exception>
 {%- endif %}
 {%- if method.return_type.is_opaque() %}


### PR DESCRIPTION
## Summary

The .NET backend's idiomatic opaque/struct templates (`opaque.impl.cs.jinja`, `struct.impl.cs.jinja`) put a blank line between hand-written constructors, but the `properties` and `methods` loops render every property/method flush against the next with no separator — the loop body's first tag was a left-trimming `{%- if %}`, which silently ate the blank line that was already there ahead of it.

Fix: drop the trim on that first conditional in both loops so the blank line survives, instead of being eaten. This makes property/method spacing consistent with how constructors are already spaced.

No semantic change — purely a formatting/readability fix to the generated C#. Regenerated the checked-in `example/dotnet/Generated` and `feature_tests/dotnet/Generated` fixtures; diff is blank-line insertions only (verified no unrelated changes and no EOL-only churn).

## Test plan
- [x] `cargo test -p diplomat-tool dotnet` — 21 passed
- [x] `cargo build -p diplomat-feature-tests` + `dotnet test feature_tests/dotnet/Somelib.FeatureTests.csproj` — 64 passed
- [x] `cargo clippy -p diplomat-tool --all-targets` — clean
- [x] Manually diffed several regenerated files to confirm exactly one blank line is inserted per property/method boundary, with no unrelated changes