### PR TITLE
fix(lint): remove redundant borrows flagged by clippy 1.97

### DIFF
--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -90,7 +90,7 @@ pub mod ffi {
         }
 
         pub fn get_debug_str(&self, write: &mut DiplomatWrite) {
-            let _infallible = write!(write, "{:?}", &self.0);
+            let _infallible = write!(write, "{:?}", self.0);
         }
 
         #[diplomat::rust_link(Something::something, FnInStruct)]
@@ -180,7 +180,7 @@ pub mod ffi {
         }
 
         pub fn get_debug_str(&self, write: &mut DiplomatWrite) {
-            let _infallible = write!(write, "{:?}", &self.0);
+            let _infallible = write!(write, "{:?}", self.0);
         }
 
         #[diplomat::attr(dotnet, disable)]
@@ -352,11 +352,8 @@ pub mod ffi {
 
         // For demo gen: tests having the same variables in the namespace
         pub fn double_cyclic_out(self, cyclic_struct_a: Self, out: &mut DiplomatWrite) {
-            out.write_fmt(format_args!(
-                "{} {}",
-                &self.a.field, cyclic_struct_a.a.field
-            ))
-            .unwrap();
+            out.write_fmt(format_args!("{} {}", self.a.field, cyclic_struct_a.a.field))
+                .unwrap();
         }
 
         #[diplomat::attr(auto, getter)]

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -1360,11 +1360,9 @@ impl<'cx> ItemGenContext<'_, 'cx> {
     ) -> String {
         let name = format!(
             "_Result{}{}",
-            &self
-                .formatter
+            self.formatter
                 .fmt_type_as_ident(ok.map(|o| self.gen_type_name_ffi(o, false)).as_deref()),
-            &self
-                .formatter
+            self.formatter
                 .fmt_type_as_ident(err.map(|o| self.gen_type_name_ffi(o, false)).as_deref())
         );
 


### PR DESCRIPTION
Clippy's `useless_borrows_in_formatting` started firing on `tool/src/dart/mod.rs` and `feature_tests/src/structs.rs` under the CI-pinned toolchain (1.97.0), blocking the `lint` job on every other open PR. Removes the redundant `&` in each — no behavior change.