### PR TITLE
feat: `diplomat-runtime` - Add `no_std` support for `wasm32`

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(any(target_arch = "wasm32")), no_std)]
+#![no_std]
 
 //! The [Diplomat](https://rust-diplomat.github.io/diplomat/) runtime crate.
 //!

--- a/runtime/src/wasm_glue.rs
+++ b/runtime/src/wasm_glue.rs
@@ -6,7 +6,7 @@
 #[cfg(debug_assertions)]
 extern crate std;
 #[cfg(debug_assertions)]
-use alloc::{ boxed::Box, string::String };
+use alloc::{boxed::Box, string::String};
 
 // https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/#what-is-going-to-break-and-how-to-fix
 #[link(wasm_import_module = "env")]

--- a/runtime/src/wasm_glue.rs
+++ b/runtime/src/wasm_glue.rs
@@ -1,11 +1,17 @@
 //! Wasm-specific glue code
 //!
 //! This is a private module
-use alloc::format;
+
+// `std` is only required to support a `panic_handler()` hook in debug builds:
+#[cfg(debug_assertions)]
+extern crate std;
+#[cfg(debug_assertions)]
+use alloc::{ boxed::Box, string::String };
 
 // https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/#what-is-going-to-break-and-how-to-fix
 #[link(wasm_import_module = "env")]
 extern "C" {
+    #[cfg(debug_assertions)]
     fn diplomat_throw_error_js(ptr: *const u8, len: usize);
 
     #[cfg(feature = "log")]
@@ -26,12 +32,14 @@ extern "C" {
 unsafe extern "C" fn diplomat_init() {
     #[cfg(debug_assertions)]
     std::panic::set_hook(Box::new(panic_handler));
+
     #[cfg(feature = "log")]
     log::set_logger(&ConsoleLogger)
         .map(|()| log::set_max_level(log::LevelFilter::Debug))
         .unwrap();
 }
 
+#[cfg(debug_assertions)]
 fn panic_handler(info: &std::panic::PanicHookInfo) {
     let msg = match info.payload().downcast_ref::<&'static str>() {
         Some(&s) => s,
@@ -42,13 +50,13 @@ fn panic_handler(info: &std::panic::PanicHookInfo) {
     };
 
     let msg = match info.location() {
-        Some(l) => format!(
+        Some(l) => alloc::format!(
             "wasm panicked at {}:{}:{}:\n{msg}",
             l.file(),
             l.line(),
             l.column(),
         ),
-        None => format!("wasm panicked at <unknown location>:\n{msg}"),
+        None => alloc::format!("wasm panicked at <unknown location>:\n{msg}"),
     };
 
     unsafe { diplomat_throw_error_js(msg.as_ptr(), msg.len()) }


### PR DESCRIPTION
Presently the `diplomat-runtime` crate is `no_std` for all targets other than `wasm32-unknown-unknown`. This PR should keep the existing functionality during debug builds, but enable support for building without `std` on release builds.

This is only required for the `wasm_glur.rs` module, which itself feature gates the module functionality behind a `log` feature (only requires `alloc`) and the remainder behind a `debug_assertions` constraint for a panic handler hook (that requires `std`).

Resolves: https://github.com/rust-diplomat/diplomat/issues/1212

