### PR TITLE
book: add .NET backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Diplomat supports generating bindings from Rust to:
 - C++
 - Dart
 - Javascript/Typescript
+- .NET (C#)
 - Kotlin (using JNA)
 - Python (using [nanobind](https://nanobind.readthedocs.io/en/latest/index.html))
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -47,6 +47,7 @@
   - [C](backends/c.md)
   - [C++](backends/cpp.md)
   - [Dart](backends/dart.md)
+  - [.NET](backends/dotnet.md)
   - [demo_gen](backends/demo_gen.md)
   - [Javascript](backends/js.md)
   - [Kotlin](backends/kotlin.md)

--- a/book/src/backends/dotnet.md
+++ b/book/src/backends/dotnet.md
@@ -1,0 +1,53 @@
+# .NET Backend
+
+The .NET backend wraps Diplomat's C ABI in a C# library, generating two layers per type:
+a `Raw` layer of `[LibraryImport]` P/Invoke declarations and unsafe pointer types, and an
+idiomatic layer of safe, GC-friendly classes built on top of it. Consumers only interact
+with the idiomatic layer.
+
+To run the .NET backend you need to provide some configuration:
+```sh
+diplomat-tool -e {PATH_TO_LIB.RS} -c {CONFIG_FILE} --config {CONFIG_OVERRIDE_1} dotnet {OUTPUT_PATH}
+```
+The configuration consists of these options:
+* `namespace` - the root .NET namespace for the generated bindings (e.g. `Icu4x`). Defaults
+  to the crate's `lib_name`, upper-camel-cased.
+* `dylib_name` (or `native_lib`) - the native library name passed to `LibraryImport`.
+  Defaults to the crate's `lib_name`.
+* `exception_trim_suffix` (or `exceptions.trim_suffix`) - suffix trimmed when deriving
+  exception class names from error types, e.g. trimming `Error` so `FooError` becomes
+  `FooException`.
+* `exception_message_method` (or `exceptions.error_message_method`) - the method on an
+  error type used to populate the generated exception's message, e.g. `ToDisplay`.
+* `getters_prefix` (or `properties.getters_prefix`) - prefix identifying property getters,
+  e.g. `get_`.
+* `setters_prefix` (or `properties.setters_prefix`) - prefix identifying property setters,
+  e.g. `set_`.
+* `scaffold` - an optional binary value. If set to `true`, `diplomat-tool` will emit a
+  `.csproj` scaffold next to the generated sources.
+
+## Ownership and memory safety
+
+Every opaque type is backed by a `RustHandle<T>` rather than a bare pointer. A handle
+remembers who owns the underlying memory: an **owned** handle carries the Rust destructor
+and runs it on release; a **borrowed** handle carries none, so releasing it is a no-op
+because Rust still owns (and will free) that memory. This means methods returning `&T` or
+`Option<&T>` are safe to wrap without risking a double-free.
+
+Borrowed returns also carry a `_edges` array on the object rooting whatever it borrowed
+from, so the GC can't collect the source object out from under a still-live borrowed
+reference. `object[] _edges` is `Array.Empty<object>()` (no allocation) when a type has
+no lifetime-carrying returns.
+
+Consumers are not required to call `Dispose()`; a finalizer is the documented last-resort
+cleanup path for owned handles. Native calls are followed by `GC.KeepAlive(this)` to
+prevent the finalizer from running mid-call and freeing memory a P/Invoke is still using.
+
+## Examples
+The best way to learn to use the .NET backend is to first understand Diplomat generally
+by reading this [book](../SUMMARY.md). Then look at the `example` and `feature_tests`
+directories in the Diplomat project.
+* Feature tests: [rust source](https://github.com/rust-diplomat/diplomat/tree/main/feature_tests/src/), [.NET usage](https://github.com/rust-diplomat/diplomat/tree/main/feature_tests/dotnet/Tests)
+* Example: [rust source](https://github.com/rust-diplomat/diplomat/tree/main/example/src/), [.NET generated bindings](https://github.com/rust-diplomat/diplomat/tree/main/example/dotnet/Generated)
+
+{{supports("dotnet")}}

--- a/book/src/backends/intro.md
+++ b/book/src/backends/intro.md
@@ -1,4 +1,5 @@
 The different backends have specific considerations or configurations. Check below 
 to see what is necessary. Documentation for more backends will be added in the future.
+* [.NET](dotnet.md)
 * [Kotlin](kotlin.md)
 * [Nanobind](nanobind.md)

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -25,10 +25,11 @@ Diplomat currently supports the following backends:
  - JavaScript/TypeScript (using WASM)
    - [demo_gen](./demo_gen/intro.md)
  - Dart
+ - [.NET (C#)](./backends/dotnet.md)
  - [Kotlin (using JNA)](./backends/kotlin.md)
  - Python via [Nanobind](https://github.com/wjakob/nanobind) (maintained by [Zeromatter](https://www.zeromatter.com/))
  
-There is work in progress for a [Java backend] (using Panama). We used to have a .NET backend but it was removed in a refactor, it may get added again.
+There is work in progress for a [Java backend] (using Panama).
 
 We're happy to fix bugs or add configurability in the current backends if their produced output does not match what you need in your language. Details on how to write new backends is documented [later in this book](developer.html): you can do so as a third party library depending on `diplomat_core`, but we are also happy to accept these into Diplomat with the understanding that we'll only do minimal work to keep them working over time.
 


### PR DESCRIPTION
## Summary
- Adds `book/src/backends/dotnet.md`, documenting the .NET backend's config options (`namespace`, `dylib_name`, `exception_trim_suffix`, `exception_message_method`, `getters_prefix`, `setters_prefix`, `scaffold`) and its `RustHandle<T>`-based ownership/keep-alive-edges memory model.
- Wires the new page into `SUMMARY.md` and `backends/intro.md`, matching how the other backends (C, C++, Dart, Kotlin, Nanobind) are listed.

The .NET backend has been on `main` since #1164 with several follow-up PRs (#1180, #1186, #1189, #1191, #1193, #1194, #1195, #1201, #1214, #1216), but had no corresponding book page.

## Test plan
- [ ] `mdbook build book` (or equivalent) to confirm the new page renders and links resolve