### PR TITLE
Update rust version to 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
 
     - name: Install MSRV Rust
-      run: rustup install 1.81 --profile minimal
+      run: rustup install 1.88 --profile minimal
 
     - name: Check
-      run: cargo +1.81 check -p diplomat -p diplomat-runtime -p diplomat_core --verbose
+      run: cargo +1.88 check -p diplomat -p diplomat-runtime -p diplomat_core --verbose
 
   gen:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["core", "macro", "runtime", "tool", "example", "feature_tests", "book
 version = "0.15.0"
 # Applies to diplomat-core, diplomat, and diplomat-runtime
 # Diplomat-tool has no MSRV for now
-rust-version = "1.81"
+rust-version = "1.88"
 authors = [
   "Shadaj Laddad <shadaj@users.noreply.github.com>",
   "Manish Goregaokar <manishsmail@gmail.com>",


### PR DESCRIPTION
While going over release notes, I realized we never actually updated the minimum rust version for the runtime and core. This makes sure we have a minimum of 1.88, which supports [proc macro locations](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/).