### PR TITLE
dotnet: support both UTF-8 and UTF-16 strings, zero-copy

### DIFF
--- a/book/src/backends/dotnet.md
+++ b/book/src/backends/dotnet.md
@@ -43,6 +43,38 @@ Consumers are not required to call `Dispose()`; a finalizer is the documented la
 cleanup path for owned handles. Native calls are followed by `GC.KeepAlive(this)` to
 prevent the finalizer from running mid-call and freeing memory a P/Invoke is still using.
 
+## String encoding
+
+The backend supports both UTF-8 and UTF-16 strings, zero-copy wherever the C# and Rust
+representations line up:
+
+* `&DiplomatStr16` params and returns: a C# `string` is already a flat UTF-16 buffer, so
+  these are always zero-copy — pinned directly with `fixed` (or, if the return value
+  borrows it, via `ReadOnlyMemory<char>` + the same pinning holder slices use).
+* `&DiplomatStr` params and returns (unvalidated UTF-8 — Rust places no validity
+  requirement on the caller): treated exactly like `&[u8]`, so these are also zero-copy —
+  `byte[]` / `ReadOnlyMemory<byte>` pinned directly, no transcoding.
+* `&str` params (validated UTF-8 — Rust requires the caller to guarantee well-formed
+  UTF-8, undefined behavior otherwise): a transcode from the UTF-16 `string` is
+  unavoidable here. That copy is always routed through the explicitly-named
+  `Diplomat.Utf8.Clone(...)` helper rather than inlined, so it stays visible in the
+  generated source instead of hiding inside generic marshalling.
+
+A borrowed string or slice return (`&'a str` / `&'a DiplomatStr` / `&'a DiplomatStr16` /
+`&'a [u8]` / `&'a [u32]`) surfaces as `DiplomatBorrowedSpan<T>` — a zero-copy view over
+memory Rust still owns, rooted with the same keep-alive-edge mechanism as a borrowed
+opaque return. It intentionally does not expose a `Span`-returning property (nothing
+would keep the view rooted once the span escaped it); call `WithSpan(...)` for scoped,
+zero-copy, read-only access instead — the same pattern `RustVec` uses for owned returns
+(see below). Producing an independent `T[]` is a separate, explicit step: call `Clone()`.
+
+An owned `Box<[u8]>` return surfaces as `RustVec` — it owns the native allocation, is
+`IDisposable`, and offers the same `WithSpan(...)` / `Clone()` shape as
+`DiplomatBorrowedSpan<T>` (it deliberately avoids `MemoryManager<T>` for the same reason:
+`GetSpan()`'s result wouldn't keep the owner alive). Other owned string/slice returns
+(`Box<str>`, `Box<[T]>` for `T` other than `u8`) and `&[&str]` (`&[DiplomatStrSlice]`)
+parameters aren't supported yet.
+
 ## Examples
 The best way to learn to use the .NET backend is to first understand Diplomat generally
 by reading this [book](../SUMMARY.md). Then look at the `example` and `feature_tests`

--- a/example/dotnet/Generated/DiplomatSliceU16.cs
+++ b/example/dotnet/Generated/DiplomatSliceU16.cs
@@ -1,0 +1,10 @@
+using System.Runtime.InteropServices;
+
+namespace Somelib.Diplomat;
+
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct DiplomatSliceU16
+{
+    public char* Ptr;
+    public nuint Len;
+}

--- a/example/dotnet/Generated/Locale.cs
+++ b/example/dotnet/Generated/Locale.cs
@@ -61,15 +61,14 @@ public partial class Locale: IDisposable
     /// <returns>
     /// A <c>Locale</c> allocated on Rust side.
     /// </returns>
-    public static Locale New(string name)
+    public static Locale New(byte[] name)
     {
         unsafe
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
-            byte[] nameBytes = System.Text.Encoding.UTF8.GetBytes(name);
-            fixed (byte* namePtr = nameBytes)
+            fixed (byte* namePtr = name)
             {
-                Raw.Locale* result = Raw.Locale.New(new DiplomatSliceU8 { Ptr = namePtr, Len = (nuint)nameBytes.Length });
+                Raw.Locale* result = Raw.Locale.New(new DiplomatSliceU8 { Ptr = namePtr, Len = (nuint)name.Length });
                 return new Locale(result);
             }
         }

--- a/example/dotnet/Generated/Utf8.cs
+++ b/example/dotnet/Generated/Utf8.cs
@@ -1,0 +1,14 @@
+namespace Somelib.Diplomat;
+
+/// <summary>
+/// Explicit conversions between a C# <c>string</c> (always UTF-16 internally)
+/// and raw UTF-8 bytes. Handing a <c>string</c> to a Rust <c>&amp;str</c>
+/// parameter always requires transcoding — there's no way around that
+/// allocation. This class exists so the copy is a visible, separately-named
+/// step in generated code (<c>Utf8.Clone(...)</c>) instead of being buried
+/// inside marshalling.
+/// </summary>
+internal static class Utf8
+{
+    public static byte[] Clone(string value) => System.Text.Encoding.UTF8.GetBytes(value);
+}

--- a/feature_tests/dotnet/Generated/DiplomatBorrowedSpan.cs
+++ b/feature_tests/dotnet/Generated/DiplomatBorrowedSpan.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace Somelib.Diplomat;
+
+#nullable enable
+
+public delegate void DiplomatBorrowedSpanAction<T>(ReadOnlySpan<T> span) where T : unmanaged;
+
+/// <summary>
+/// A zero-copy view over memory Rust still owns (a borrowed <c>&amp;str</c> /
+/// <c>&amp;[T]</c> return). Unlike <c>RustVec</c>, there's nothing to free
+/// here — Rust still owns this memory, so there's no <c>IDisposable</c> and
+/// no ownership race to guard against. <c>edges</c> roots whatever this was
+/// borrowed from (the receiver or an input parameter) so the GC can't
+/// collect it while this view is alive.
+/// </summary>
+/// <remarks>
+/// This intentionally does not expose a public <c>Span</c>-returning
+/// property. A caller could extract it, let this value go, and be left
+/// holding a span with nothing keeping <c>edges</c> (and the parent it
+/// roots) alive — exactly the trap <c>RustVec</c> avoids by not implementing
+/// <c>MemoryManager&lt;T&gt;</c>. <see cref="WithSpan"/> gives synchronous,
+/// zero-copy, read-only access instead: the callback receives the span
+/// directly, so it can never outlive this value's own lifetime. This is a
+/// plain struct, not a <c>ref struct</c>, so it can be stored in a field, a
+/// collection, or held across an <c>await</c> — unlike a bare
+/// <see cref="ReadOnlySpan{T}"/>. <see cref="Clone"/> is the explicit,
+/// independent copy — never something this type does on its own.
+/// </remarks>
+public readonly unsafe struct DiplomatBorrowedSpan<T> where T : unmanaged
+{
+    private readonly T* _ptr;
+    private readonly int _len;
+    private readonly object[] _edges;
+
+    internal DiplomatBorrowedSpan(T* ptr, nuint len, object[] edges)
+    {
+        _ptr = ptr;
+        _len = (int)len;
+        _edges = edges;
+    }
+
+    public int Length => _len;
+
+    /// <summary>
+    /// Synchronous, zero-copy, read-only access. The span is valid only for
+    /// the duration of this callback.
+    /// </summary>
+    public void WithSpan(DiplomatBorrowedSpanAction<T> action)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+        action(new ReadOnlySpan<T>(_ptr, _len));
+        GC.KeepAlive(_edges);
+    }
+
+    /// <summary>An explicit, independent copy — never implicit.</summary>
+    public T[] Clone() => new ReadOnlySpan<T>(_ptr, _len).ToArray();
+}

--- a/feature_tests/dotnet/Generated/DiplomatSliceU16.cs
+++ b/feature_tests/dotnet/Generated/DiplomatSliceU16.cs
@@ -1,0 +1,10 @@
+using System.Runtime.InteropServices;
+
+namespace Somelib.Diplomat;
+
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct DiplomatSliceU16
+{
+    public char* Ptr;
+    public nuint Len;
+}

--- a/feature_tests/dotnet/Generated/MyString.cs
+++ b/feature_tests/dotnet/Generated/MyString.cs
@@ -61,15 +61,14 @@ public partial class MyString: IDisposable
     /// <returns>
     /// A <c>MyString</c> allocated on Rust side.
     /// </returns>
-    public static MyString New(string v)
+    public static MyString New(byte[] v)
     {
         unsafe
         {
             if (v == null) throw new ArgumentNullException(nameof(v));
-            byte[] vBytes = System.Text.Encoding.UTF8.GetBytes(v);
-            fixed (byte* vPtr = vBytes)
+            fixed (byte* vPtr = v)
             {
-                Raw.MyString* result = Raw.MyString.New(new DiplomatSliceU8 { Ptr = vPtr, Len = (nuint)vBytes.Length });
+                Raw.MyString* result = Raw.MyString.New(new DiplomatSliceU8 { Ptr = vPtr, Len = (nuint)v.Length });
                 return new MyString(result);
             }
         }
@@ -83,7 +82,7 @@ public partial class MyString: IDisposable
         unsafe
         {
             if (v == null) throw new ArgumentNullException(nameof(v));
-            byte[] vBytes = System.Text.Encoding.UTF8.GetBytes(v);
+            byte[] vBytes = Diplomat.Utf8.Clone(v);
             fixed (byte* vPtr = vBytes)
             {
                 Raw.MyString* result = Raw.MyString.NewUnsafe(new DiplomatSliceU8 { Ptr = vPtr, Len = (nuint)vBytes.Length });
@@ -92,7 +91,7 @@ public partial class MyString: IDisposable
         }
     }
 
-    public void SetStr(string newStr)
+    public void SetStr(byte[] newStr)
     {
         unsafe
         {
@@ -101,10 +100,9 @@ public partial class MyString: IDisposable
                 throw new ObjectDisposedException("MyString");
             }
             if (newStr == null) throw new ArgumentNullException(nameof(newStr));
-            byte[] newStrBytes = System.Text.Encoding.UTF8.GetBytes(newStr);
-            fixed (byte* newStrPtr = newStrBytes)
+            fixed (byte* newStrPtr = newStr)
             {
-                Raw.MyString.SetStr(AsFFI(), new DiplomatSliceU8 { Ptr = newStrPtr, Len = (nuint)newStrBytes.Length });
+                Raw.MyString.SetStr(AsFFI(), new DiplomatSliceU8 { Ptr = newStrPtr, Len = (nuint)newStr.Length });
                 GC.KeepAlive(this);
             }
         }
@@ -137,7 +135,7 @@ public partial class MyString: IDisposable
         unsafe
         {
             if (foo == null) throw new ArgumentNullException(nameof(foo));
-            byte[] fooBytes = System.Text.Encoding.UTF8.GetBytes(foo);
+            byte[] fooBytes = Diplomat.Utf8.Clone(foo);
             fixed (byte* fooPtr = fooBytes)
             {
                 DiplomatWrite writeable = new DiplomatWrite();
@@ -151,6 +149,24 @@ public partial class MyString: IDisposable
                     writeable.Dispose();
                 }
             }
+        }
+    }
+
+    /// <remarks>
+    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
+    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// </remarks>
+    public DiplomatBorrowedSpan<byte> Borrow()
+    {
+        unsafe
+        {
+            if (_inner.IsNull)
+            {
+                throw new ObjectDisposedException("MyString");
+            }
+            var result = Raw.MyString.Borrow(AsFFI());
+            GC.KeepAlive(this);
+            return new DiplomatBorrowedSpan<byte>(result.Ptr, result.Len, new object[] { this });
         }
     }
 

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -73,15 +73,14 @@ public partial class Opaque: IDisposable
     /// <returns>
     /// A <c>Opaque</c> allocated on Rust side.
     /// </returns>
-    public static Opaque? TryFromUtf8(string input)
+    public static Opaque? TryFromUtf8(byte[] input)
     {
         unsafe
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
-            byte[] inputBytes = System.Text.Encoding.UTF8.GetBytes(input);
-            fixed (byte* inputPtr = inputBytes)
+            fixed (byte* inputPtr = input)
             {
-                Raw.Opaque* result = Raw.Opaque.TryFromUtf8(new DiplomatSliceU8 { Ptr = inputPtr, Len = (nuint)inputBytes.Length });
+                Raw.Opaque* result = Raw.Opaque.TryFromUtf8(new DiplomatSliceU8 { Ptr = inputPtr, Len = (nuint)input.Length });
                 return result == null ? null : new Opaque(result);
             }
         }
@@ -95,7 +94,7 @@ public partial class Opaque: IDisposable
         unsafe
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
-            byte[] inputBytes = System.Text.Encoding.UTF8.GetBytes(input);
+            byte[] inputBytes = Diplomat.Utf8.Clone(input);
             fixed (byte* inputPtr = inputBytes)
             {
                 Raw.Opaque* result = Raw.Opaque.FromStr(new DiplomatSliceU8 { Ptr = inputPtr, Len = (nuint)inputBytes.Length });

--- a/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/OpaqueMutexedString.cs
@@ -97,6 +97,24 @@ public partial class OpaqueMutexedString: IDisposable
         }
     }
 
+    /// <remarks>
+    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
+    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// </remarks>
+    public DiplomatBorrowedSpan<byte> DummyStr()
+    {
+        unsafe
+        {
+            if (_inner.IsNull)
+            {
+                throw new ObjectDisposedException("OpaqueMutexedString");
+            }
+            var result = Raw.OpaqueMutexedString.DummyStr(AsFFI());
+            GC.KeepAlive(this);
+            return new DiplomatBorrowedSpan<byte>(result.Ptr, result.Len, new object[] { this });
+        }
+    }
+
     /// <returns>
     /// A <c>Utf16Wrap</c> allocated on Rust side.
     /// </returns>

--- a/feature_tests/dotnet/Generated/OpaqueThinVec.cs
+++ b/feature_tests/dotnet/Generated/OpaqueThinVec.cs
@@ -61,21 +61,20 @@ public partial class OpaqueThinVec: IDisposable
     /// <returns>
     /// A <c>OpaqueThinVec</c> allocated on Rust side.
     /// </returns>
-    public static OpaqueThinVec CreateSingle(int a, float b, string c)
+    public static OpaqueThinVec CreateSingle(int a, float b, byte[] c)
     {
         unsafe
         {
             if (c == null) throw new ArgumentNullException(nameof(c));
-            byte[] cBytes = System.Text.Encoding.UTF8.GetBytes(c);
-            fixed (byte* cPtr = cBytes)
+            fixed (byte* cPtr = c)
             {
-                Raw.OpaqueThinVec* result = Raw.OpaqueThinVec.CreateSingle(a, b, new DiplomatSliceU8 { Ptr = cPtr, Len = (nuint)cBytes.Length });
+                Raw.OpaqueThinVec* result = Raw.OpaqueThinVec.CreateSingle(a, b, new DiplomatSliceU8 { Ptr = cPtr, Len = (nuint)c.Length });
                 return new OpaqueThinVec(result);
             }
         }
     }
 
-    public void SetFirstC(string value)
+    public void SetFirstC(byte[] value)
     {
         unsafe
         {
@@ -84,10 +83,9 @@ public partial class OpaqueThinVec: IDisposable
                 throw new ObjectDisposedException("OpaqueThinVec");
             }
             if (value == null) throw new ArgumentNullException(nameof(value));
-            byte[] valueBytes = System.Text.Encoding.UTF8.GetBytes(value);
-            fixed (byte* valuePtr = valueBytes)
+            fixed (byte* valuePtr = value)
             {
-                Raw.OpaqueThinVec.SetFirstC(AsFFI(), new DiplomatSliceU8 { Ptr = valuePtr, Len = (nuint)valueBytes.Length });
+                Raw.OpaqueThinVec.SetFirstC(AsFFI(), new DiplomatSliceU8 { Ptr = valuePtr, Len = (nuint)value.Length });
                 GC.KeepAlive(this);
             }
         }

--- a/feature_tests/dotnet/Generated/OptionString.cs
+++ b/feature_tests/dotnet/Generated/OptionString.cs
@@ -61,15 +61,14 @@ public partial class OptionString: IDisposable
     /// <returns>
     /// A <c>OptionString</c> allocated on Rust side.
     /// </returns>
-    public static OptionString? New(string diplomatStr)
+    public static OptionString? New(byte[] diplomatStr)
     {
         unsafe
         {
             if (diplomatStr == null) throw new ArgumentNullException(nameof(diplomatStr));
-            byte[] diplomatStrBytes = System.Text.Encoding.UTF8.GetBytes(diplomatStr);
-            fixed (byte* diplomatStrPtr = diplomatStrBytes)
+            fixed (byte* diplomatStrPtr = diplomatStr)
             {
-                Raw.OptionString* result = Raw.OptionString.New(new DiplomatSliceU8 { Ptr = diplomatStrPtr, Len = (nuint)diplomatStrBytes.Length });
+                Raw.OptionString* result = Raw.OptionString.New(new DiplomatSliceU8 { Ptr = diplomatStrPtr, Len = (nuint)diplomatStr.Length });
                 return result == null ? null : new OptionString(result);
             }
         }

--- a/feature_tests/dotnet/Generated/RawMyString.cs
+++ b/feature_tests/dotnet/Generated/RawMyString.cs
@@ -24,6 +24,9 @@ internal partial struct MyString
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_string_transform", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void StringTransform(DiplomatSliceU8 foo, DiplomatWrite* writeable);
 
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_borrow", CallingConvention = CallingConvention.Cdecl)]
+    internal static unsafe extern DiplomatSliceU8 Borrow(MyString* handle);
+
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "MyString_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(MyString* handle);
 }

--- a/feature_tests/dotnet/Generated/RawOpaqueMutexedString.cs
+++ b/feature_tests/dotnet/Generated/RawOpaqueMutexedString.cs
@@ -18,6 +18,9 @@ internal partial struct OpaqueMutexedString
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_get_len_and_add", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern nuint GetLenAndAdd(OpaqueMutexedString* handle, nuint other);
 
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_dummy_str", CallingConvention = CallingConvention.Cdecl)]
+    internal static unsafe extern DiplomatSliceU8 DummyStr(OpaqueMutexedString* handle);
+
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "OpaqueMutexedString_wrapper", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern Utf16Wrap* Wrapper(OpaqueMutexedString* handle);
 

--- a/feature_tests/dotnet/Generated/RawUtf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/RawUtf16Wrap.cs
@@ -9,8 +9,14 @@ namespace Somelib.Raw;
 internal partial struct Utf16Wrap
 {
 
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "Utf16Wrap_from_utf16", CallingConvention = CallingConvention.Cdecl)]
+    internal static unsafe extern Utf16Wrap* FromUtf16(DiplomatSliceU16 input);
+
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Utf16Wrap_get_debug_str", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void GetDebugStr(Utf16Wrap* handle, DiplomatWrite* writeable);
+
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "Utf16Wrap_borrow_cont", CallingConvention = CallingConvention.Cdecl)]
+    internal static unsafe extern DiplomatSliceU16 BorrowCont(Utf16Wrap* handle);
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Utf16Wrap_destroy", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern void Destroy(Utf16Wrap* handle);

--- a/feature_tests/dotnet/Generated/Utf16Wrap.cs
+++ b/feature_tests/dotnet/Generated/Utf16Wrap.cs
@@ -58,6 +58,22 @@ public partial class Utf16Wrap: IDisposable
         _edges = edges;
     }
 
+    /// <returns>
+    /// A <c>Utf16Wrap</c> allocated on Rust side.
+    /// </returns>
+    public static Utf16Wrap FromUtf16(string input)
+    {
+        unsafe
+        {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+            fixed (char* inputPtr = input)
+            {
+                Raw.Utf16Wrap* result = Raw.Utf16Wrap.FromUtf16(new DiplomatSliceU16 { Ptr = inputPtr, Len = (nuint)input.Length });
+                return new Utf16Wrap(result);
+            }
+        }
+    }
+
     public string GetDebugStr()
     {
         unsafe
@@ -77,6 +93,24 @@ public partial class Utf16Wrap: IDisposable
             {
                 writeable.Dispose();
             }
+        }
+    }
+
+    /// <remarks>
+    /// Lifetime: the returned native-backed value may borrow from the receiver or one or more inputs.
+    /// The caller is responsible for keeping any borrowed backing storage alive and undisposed while the returned value is in use.
+    /// </remarks>
+    public DiplomatBorrowedSpan<char> BorrowCont()
+    {
+        unsafe
+        {
+            if (_inner.IsNull)
+            {
+                throw new ObjectDisposedException("Utf16Wrap");
+            }
+            var result = Raw.Utf16Wrap.BorrowCont(AsFFI());
+            GC.KeepAlive(this);
+            return new DiplomatBorrowedSpan<char>(result.Ptr, result.Len, new object[] { this });
         }
     }
 

--- a/feature_tests/dotnet/Generated/Utf8.cs
+++ b/feature_tests/dotnet/Generated/Utf8.cs
@@ -1,0 +1,14 @@
+namespace Somelib.Diplomat;
+
+/// <summary>
+/// Explicit conversions between a C# <c>string</c> (always UTF-16 internally)
+/// and raw UTF-8 bytes. Handing a <c>string</c> to a Rust <c>&amp;str</c>
+/// parameter always requires transcoding — there's no way around that
+/// allocation. This class exists so the copy is a visible, separately-named
+/// step in generated code (<c>Utf8.Clone(...)</c>) instead of being buried
+/// inside marshalling.
+/// </summary>
+internal static class Utf8
+{
+    public static byte[] Clone(string value) => System.Text.Encoding.UTF8.GetBytes(value);
+}

--- a/feature_tests/dotnet/Tests/BorrowedReturnTests.cs
+++ b/feature_tests/dotnet/Tests/BorrowedReturnTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Somelib;
 using Xunit;
 
@@ -9,10 +10,14 @@ namespace Somelib.FeatureTests;
 // if `_edges` doesn't root it — these tests verify that can't happen.
 public class BorrowedReturnTests
 {
+    // `CreateSingle`/`SetFirstC`'s string param is `&DiplomatStr` (unvalidated
+    // UTF-8), lowered to a zero-copy `byte[]`.
+    private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
     [Fact]
     public void First_ReturnsReadableBorrowedView()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hello");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("hello"));
         Assert.Equal((nuint)1, vec.Len());
 
         using OpaqueThin first = vec.First()!;
@@ -25,7 +30,7 @@ public class BorrowedReturnTests
     [Fact]
     public void Get_InRangeBorrows_OutOfRangeReturnsNull()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("hi"));
 
         // The indexer `get` is a borrowed return just like `First()`: an
         // in-range index hands back a non-owning view into the Vec slot.
@@ -39,7 +44,7 @@ public class BorrowedReturnTests
     [Fact]
     public void First_AliasesOwnerStorage_StringField()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "before");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("before"));
 
         // The borrow is taken BEFORE the mutation and never refreshed.
         using OpaqueThin borrow = vec.First()!;
@@ -50,14 +55,14 @@ public class BorrowedReturnTests
         // re-reads the field. If `First()` had handed back a copy, the borrow
         // would still read "before"; seeing "after" proves it is an interior
         // reference into the same Vec slot the owner just wrote.
-        vec.SetFirstC("after");
+        vec.SetFirstC(Utf8("after"));
         Assert.Equal("after", borrow.C());
     }
 
     [Fact]
     public void DisposingBorrowedView_DoesNotFreeOwnersMemory()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("hi"));
 
         // A borrowed handle owns nothing, so Dispose must be a no-op on Rust's
         // pointer — even called twice, it must not double-free.
@@ -81,7 +86,7 @@ public class BorrowedReturnTests
     )]
     private static OpaqueThin BorrowAndDropOwner()
     {
-        return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").First()!;
+        return OpaqueThinVec.CreateSingle(42, 2.5f, Utf8("rooted")).First()!;
     }
 
     [Fact]
@@ -113,7 +118,7 @@ public class BorrowedReturnTests
     )]
     private static OpaqueThin TryFirstAndDropOwner()
     {
-        return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").TryFirst(false);
+        return OpaqueThinVec.CreateSingle(42, 2.5f, Utf8("rooted")).TryFirst(false);
     }
 
     [Fact]
@@ -138,7 +143,7 @@ public class BorrowedReturnTests
     [Fact]
     public void FallibleBorrowedReturn_Err_Throws()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("hi"));
         // The `Err(())` arm throws — and must not hand back a wrapper at all.
         Assert.Throws<InvalidOperationException>(() => vec.TryFirst(true));
     }
@@ -146,7 +151,7 @@ public class BorrowedReturnTests
     [Fact]
     public void FallibleOptionalBorrowedReturn_Composes()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("hi"));
 
         // Result + Option + borrowing view: Ok(Some(_)) reads through the borrow.
         using OpaqueThin at0 = vec.TryGet(0, false)!;
@@ -166,7 +171,7 @@ public class BorrowedReturnTests
     )]
     private static OpaqueThin TryGetAndDropOwner()
     {
-        return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").TryGet(0, false)!;
+        return OpaqueThinVec.CreateSingle(42, 2.5f, Utf8("rooted")).TryGet(0, false)!;
     }
 
     [Fact]
@@ -196,7 +201,7 @@ public class BorrowedReturnTests
     )]
     private static OpaqueThinIter TryIterAndDropOwner()
     {
-        return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").TryIter(false);
+        return OpaqueThinVec.CreateSingle(42, 2.5f, Utf8("rooted")).TryIter(false);
     }
 
     [Fact]
@@ -245,7 +250,7 @@ public class BorrowedReturnTests
     [Fact]
     public void FallibleOwnedBorrowingBoxReturn_Err_Throws()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("hi"));
         Assert.Throws<InvalidOperationException>(() => vec.TryIter(true));
     }
 
@@ -256,7 +261,7 @@ public class BorrowedReturnTests
     )]
     private static OpaqueThinIter OptionalIterAndDropOwner()
     {
-        return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").OptionalIter(true)!;
+        return OpaqueThinVec.CreateSingle(42, 2.5f, Utf8("rooted")).OptionalIter(true)!;
     }
 
     [Fact]
@@ -281,14 +286,14 @@ public class BorrowedReturnTests
     [Fact]
     public void OptionalOwnedBorrowingBoxReturn_None_ReturnsNull()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("hi"));
         Assert.Null(vec.OptionalIter(false));
     }
 
     [Fact]
     public void FallibleCustomBorrowingError_Throws_AndInnerExposesOwnerView()
     {
-        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, "hi");
+        using OpaqueThinVec vec = OpaqueThinVec.CreateSingle(7, 1.5f, Utf8("hi"));
 
         // The error is a custom opaque (`Box<BorrowingError<'a>>`) borrowing the
         // Vec, not a `()` mapped to InvalidOperationException. It surfaces as a
@@ -314,7 +319,7 @@ public class BorrowedReturnTests
     {
         try
         {
-            OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").TryBorrow(true);
+            OpaqueThinVec.CreateSingle(42, 2.5f, Utf8("rooted")).TryBorrow(true);
             throw new InvalidOperationException("TryBorrow(true) was expected to throw");
         }
         catch (BorrowingErrorException ex)

--- a/feature_tests/dotnet/Tests/MyStringTests.cs
+++ b/feature_tests/dotnet/Tests/MyStringTests.cs
@@ -1,15 +1,23 @@
 using System;
+using System.Runtime.CompilerServices;
+using System.Text;
 using Somelib;
+using Somelib.Diplomat;
 using Xunit;
 
 namespace Somelib.FeatureTests;
 
 public class MyStringTests
 {
+    // `New`/`SetStr` take `&DiplomatStr` (unvalidated UTF-8), lowered to a
+    // zero-copy `byte[]` param. `NewUnsafe` takes a validated `&str`, which
+    // stays `string` and transcodes internally via `Diplomat.Utf8.Clone`.
+    private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
     [Fact]
     public void New_GetStr_RoundTripsUtf8()
     {
-        using MyString value = MyString.New("hello 餐");
+        using MyString value = MyString.New(Utf8("hello 餐"));
 
         Assert.Equal("hello 餐", value.GetStr());
     }
@@ -25,9 +33,9 @@ public class MyStringTests
     [Fact]
     public void SetStr_ReplacesValue()
     {
-        using MyString value = MyString.New("old");
+        using MyString value = MyString.New(Utf8("old"));
 
-        value.SetStr("new 餐");
+        value.SetStr(Utf8("new 餐"));
 
         Assert.Equal("new 餐", value.GetStr());
     }
@@ -37,7 +45,52 @@ public class MyStringTests
     {
         Assert.Throws<ArgumentNullException>(() => MyString.New(null!));
 
-        using MyString value = MyString.New("value");
+        using MyString value = MyString.New(Utf8("value"));
         Assert.Throws<ArgumentNullException>(() => value.SetStr(null!));
+    }
+
+    // `borrow` returns `&'a str` — a zero-copy `DiplomatBorrowedSpan<byte>`
+    // view into the owner's Rust-side storage, not a copy. `WithSpan` scopes
+    // access to the callback, mirroring `RustVec`.
+    [Fact]
+    public void Borrow_WithSpan_MatchesGetStr()
+    {
+        using MyString value = MyString.New(Utf8("hello 餐"));
+
+        DiplomatBorrowedSpan<byte> view = value.Borrow();
+
+        string decoded = "";
+        view.WithSpan(span => decoded = Encoding.UTF8.GetString(span));
+        Assert.Equal("hello 餐", decoded);
+    }
+
+    // Tier1's precise liveness can drop the owning `MyString` local at its
+    // last use (the `Borrow()` call). If the view's `_edges` didn't root it,
+    // GC -> finalizer -> Destroy would free the owner out from under the
+    // borrowed view. AggressiveOptimization forces that liveness so the race
+    // can surface.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static DiplomatBorrowedSpan<byte> BorrowAndDropOwner()
+    {
+        return MyString.New(Utf8("rooted 餐")).Borrow();
+    }
+
+    [Fact]
+    public void Borrow_KeepsOwnerAliveAcrossGc()
+    {
+        DiplomatBorrowedSpan<byte> view = BorrowAndDropOwner();
+
+        for (int i = 0; i < 10; i++)
+        {
+            _ = new byte[256 * 1024];
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        // If the owner had been finalized, this reads freed memory (UAF).
+        string decoded = "";
+        view.WithSpan(span => decoded = Encoding.UTF8.GetString(span));
+        Assert.Equal("rooted 餐", decoded);
+        GC.KeepAlive(view);
     }
 }

--- a/feature_tests/dotnet/Tests/MyStringTests.cs
+++ b/feature_tests/dotnet/Tests/MyStringTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Somelib;
@@ -13,6 +13,15 @@ public class MyStringTests
     // zero-copy `byte[]` param. `NewUnsafe` takes a validated `&str`, which
     // stays `string` and transcodes internally via `Diplomat.Utf8.Clone`.
     private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    // .NET Framework's BCL has no span-taking GetString overload, so the
+    // legacy target copies out of the borrowed view first.
+    private static string Utf8String(ReadOnlySpan<byte> span) =>
+#if NETFRAMEWORK
+        Encoding.UTF8.GetString(span.ToArray());
+#else
+        Encoding.UTF8.GetString(span);
+#endif
 
     [Fact]
     public void New_GetStr_RoundTripsUtf8()
@@ -60,7 +69,7 @@ public class MyStringTests
         DiplomatBorrowedSpan<byte> view = value.Borrow();
 
         string decoded = "";
-        view.WithSpan(span => decoded = Encoding.UTF8.GetString(span));
+        view.WithSpan(span => decoded = Utf8String(span));
         Assert.Equal("hello 餐", decoded);
     }
 
@@ -69,7 +78,11 @@ public class MyStringTests
     // GC -> finalizer -> Destroy would free the owner out from under the
     // borrowed view. AggressiveOptimization forces that liveness so the race
     // can surface.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static DiplomatBorrowedSpan<byte> BorrowAndDropOwner()
     {
         return MyString.New(Utf8("rooted 餐")).Borrow();
@@ -89,7 +102,7 @@ public class MyStringTests
 
         // If the owner had been finalized, this reads freed memory (UAF).
         string decoded = "";
-        view.WithSpan(span => decoded = Encoding.UTF8.GetString(span));
+        view.WithSpan(span => decoded = Utf8String(span));
         Assert.Equal("rooted 餐", decoded);
         GC.KeepAlive(view);
     }

--- a/feature_tests/dotnet/Tests/OpaqueMutexedStringTests.cs
+++ b/feature_tests/dotnet/Tests/OpaqueMutexedStringTests.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using Somelib;
+using Somelib.Diplomat;
 using Xunit;
 
 namespace Somelib.FeatureTests;
@@ -35,5 +37,21 @@ public class OpaqueMutexedStringTests
         using OpaqueMutexedString value = OpaqueMutexedString.FromUsize(356);
 
         Assert.Equal((ushort)42, value.ToUnsignedFromUnsigned(42));
+    }
+
+    // `dummy_str` returns `&'a DiplomatStr` — a zero-copy view into Rust-owned
+    // memory. `WithSpan` scopes access to the callback (mirroring `RustVec`);
+    // decoding to a real `string` is a separate, explicit
+    // `Encoding.UTF8.GetString` call inside it.
+    [Fact]
+    public void DummyStr_WithSpan_DecodesToExpectedUtf8()
+    {
+        using OpaqueMutexedString value = OpaqueMutexedString.FromUsize(356);
+
+        DiplomatBorrowedSpan<byte> view = value.DummyStr();
+
+        string decoded = "";
+        view.WithSpan(span => decoded = Encoding.UTF8.GetString(span));
+        Assert.Equal("A const str with non byte char: 餐 which is a DiplomatChar,", decoded);
     }
 }

--- a/feature_tests/dotnet/Tests/OpaqueMutexedStringTests.cs
+++ b/feature_tests/dotnet/Tests/OpaqueMutexedStringTests.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Text;
 using Somelib;
 using Somelib.Diplomat;
@@ -7,6 +8,15 @@ namespace Somelib.FeatureTests;
 
 public class OpaqueMutexedStringTests
 {
+    // .NET Framework's BCL has no span-taking GetString overload, so the
+    // legacy target copies out of the borrowed view first.
+    private static string Utf8String(ReadOnlySpan<byte> span) =>
+#if NETFRAMEWORK
+        Encoding.UTF8.GetString(span.ToArray());
+#else
+        Encoding.UTF8.GetString(span);
+#endif
+
     [Fact]
     public void Change_UpdatesStoredStringLength()
     {
@@ -51,7 +61,7 @@ public class OpaqueMutexedStringTests
         DiplomatBorrowedSpan<byte> view = value.DummyStr();
 
         string decoded = "";
-        view.WithSpan(span => decoded = Encoding.UTF8.GetString(span));
+        view.WithSpan(span => decoded = Utf8String(span));
         Assert.Equal("A const str with non byte char: 餐 which is a DiplomatChar,", decoded);
     }
 }

--- a/feature_tests/dotnet/Tests/OpaqueTests.cs
+++ b/feature_tests/dotnet/Tests/OpaqueTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using Somelib;
 using Xunit;
 
@@ -33,7 +34,8 @@ public class OpaqueTests
     [Fact]
     public void TryFromUtf8_ValidInputReturnsNonNull()
     {
-        using Opaque? o = Opaque.TryFromUtf8("hi");
+        // `&DiplomatStr` (unvalidated UTF-8) lowers to a zero-copy `byte[]`.
+        using Opaque? o = Opaque.TryFromUtf8(Encoding.UTF8.GetBytes("hi"));
         Assert.NotNull(o);
     }
 

--- a/feature_tests/dotnet/Tests/OptionTests.cs
+++ b/feature_tests/dotnet/Tests/OptionTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Somelib;
 using Xunit;
 
@@ -42,7 +43,9 @@ public class OptionTests
     [Fact]
     public void OptionString_Write_RoundTripsUtf8()
     {
-        using OptionString value = Assert.IsType<OptionString>(OptionString.New("hello 餐"));
+        // `&DiplomatStr` (unvalidated UTF-8) lowers to a zero-copy `byte[]`.
+        using OptionString value =
+            Assert.IsType<OptionString>(OptionString.New(Encoding.UTF8.GetBytes("hello 餐")));
 
         Assert.Equal("hello 餐", value.Write());
     }

--- a/feature_tests/dotnet/Tests/Utf16WrapTests.cs
+++ b/feature_tests/dotnet/Tests/Utf16WrapTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Runtime.CompilerServices;
+using Somelib;
+using Somelib.Diplomat;
+using Xunit;
+
+namespace Somelib.FeatureTests;
+
+// `&DiplomatStr16` inputs and `&'a DiplomatStr16` returns: a C# `string` is
+// already a flat UTF-16 buffer, so both directions are zero-copy — no
+// transcoding, unlike the UTF-8 (`&DiplomatStr`/`&str`) path.
+public class Utf16WrapTests
+{
+    [Fact]
+    public void FromUtf16_GetDebugStr_ShowsUtf16CodeUnits()
+    {
+        using Utf16Wrap value = Utf16Wrap.FromUtf16("AB");
+
+        Assert.Equal("[65, 66]", value.GetDebugStr());
+    }
+
+    // `fixed` on a C# string — even `""` — pins a valid pointer to its null
+    // terminator; `Len = 0` means Rust never reads through it. This is the
+    // case the old UTF-8-only path couldn't offer: `fixed` over an empty
+    // `byte[]` binds a null pointer instead.
+    [Fact]
+    public void FromUtf16_EmptyString_Works()
+    {
+        using Utf16Wrap value = Utf16Wrap.FromUtf16("");
+
+        Assert.Equal("[]", value.GetDebugStr());
+    }
+
+    [Fact]
+    public void FromUtf16_RejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => Utf16Wrap.FromUtf16(null!));
+    }
+
+    // `borrow_cont` returns `&'a DiplomatStr16` — a zero-copy
+    // `DiplomatBorrowedSpan<char>` view into the owner's Rust-side storage.
+    // `WithSpan` scopes access to the callback, mirroring `RustVec`.
+    [Fact]
+    public void BorrowCont_WithSpan_MatchesSourceString()
+    {
+        using Utf16Wrap value = Utf16Wrap.FromUtf16("hello 𐐷");
+
+        DiplomatBorrowedSpan<char> view = value.BorrowCont();
+
+        string decoded = "";
+        view.WithSpan(span => decoded = new string(span));
+        Assert.Equal("hello 𐐷", decoded);
+    }
+
+    // Same liveness trap as MyStringTests.Borrow_KeepsOwnerAliveAcrossGc: if
+    // the borrowed view's `_edges` didn't root the owner, GC -> finalizer ->
+    // Destroy would free it out from under the view.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static DiplomatBorrowedSpan<char> BorrowContAndDropOwner()
+    {
+        return Utf16Wrap.FromUtf16("rooted 𐐷").BorrowCont();
+    }
+
+    [Fact]
+    public void BorrowCont_KeepsOwnerAliveAcrossGc()
+    {
+        DiplomatBorrowedSpan<char> view = BorrowContAndDropOwner();
+
+        for (int i = 0; i < 10; i++)
+        {
+            _ = new byte[256 * 1024];
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        string decoded = "";
+        view.WithSpan(span => decoded = new string(span));
+        Assert.Equal("rooted 𐐷", decoded);
+        GC.KeepAlive(view);
+    }
+}

--- a/feature_tests/dotnet/Tests/Utf16WrapTests.cs
+++ b/feature_tests/dotnet/Tests/Utf16WrapTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using Somelib;
 using Somelib.Diplomat;
@@ -11,6 +11,15 @@ namespace Somelib.FeatureTests;
 // transcoding, unlike the UTF-8 (`&DiplomatStr`/`&str`) path.
 public class Utf16WrapTests
 {
+    // .NET Framework's BCL has no span-taking string constructor, so the
+    // legacy target copies out of the borrowed view first.
+    private static string Utf16String(ReadOnlySpan<char> span) =>
+#if NETFRAMEWORK
+        new string(span.ToArray());
+#else
+        new string(span);
+#endif
+
     [Fact]
     public void FromUtf16_GetDebugStr_ShowsUtf16CodeUnits()
     {
@@ -48,14 +57,18 @@ public class Utf16WrapTests
         DiplomatBorrowedSpan<char> view = value.BorrowCont();
 
         string decoded = "";
-        view.WithSpan(span => decoded = new string(span));
+        view.WithSpan(span => decoded = Utf16String(span));
         Assert.Equal("hello 𐐷", decoded);
     }
 
     // Same liveness trap as MyStringTests.Borrow_KeepsOwnerAliveAcrossGc: if
     // the borrowed view's `_edges` didn't root the owner, GC -> finalizer ->
     // Destroy would free it out from under the view.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static DiplomatBorrowedSpan<char> BorrowContAndDropOwner()
     {
         return Utf16Wrap.FromUtf16("rooted 𐐷").BorrowCont();
@@ -74,7 +87,7 @@ public class Utf16WrapTests
         }
 
         string decoded = "";
-        view.WithSpan(span => decoded = new string(span));
+        view.WithSpan(span => decoded = Utf16String(span));
         Assert.Equal("rooted 𐐷", decoded);
         GC.KeepAlive(view);
     }

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -54,7 +54,6 @@ pub mod ffi {
             let _ = write;
         }
 
-        #[diplomat::attr(dotnet, disable)]
         pub fn borrow<'a>(&'a self) -> DiplomatStrSlice<'a> {
             AsRef::<[u8]>::as_ref(&self.0).into()
         }

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -162,7 +162,6 @@ pub mod ffi {
             guard.len() + other
         }
 
-        #[diplomat::attr(dotnet, disable)]
         pub fn dummy_str<'a>(&'a self) -> &'a DiplomatStr {
             "A const str with non byte char: 餐 which is a DiplomatChar,".as_bytes()
         }
@@ -181,7 +180,6 @@ pub mod ffi {
 
     impl Utf16Wrap {
         #[diplomat::attr(auto, constructor)]
-        #[diplomat::attr(dotnet, disable)]
         pub fn from_utf16(input: &DiplomatStr16) -> Box<Self> {
             Box::new(Self(input.into()))
         }
@@ -190,7 +188,6 @@ pub mod ffi {
             let _infallible = write!(write, "{:?}", self.0);
         }
 
-        #[diplomat::attr(dotnet, disable)]
         pub fn borrow_cont<'a>(&'a self) -> &'a DiplomatStr16 {
             &self.0
         }

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -393,7 +393,9 @@ impl DotnetReturnType {
     ) -> String {
         match ownership {
             Ownership::Owned if edges.is_empty() => format!("new {name}({raw_expr})"),
-            Ownership::Owned => format!("new {name}({raw_expr}, {})", Self::edges_array_expr(edges)),
+            Ownership::Owned => {
+                format!("new {name}({raw_expr}, {})", Self::edges_array_expr(edges))
+            }
             // `new {name}(...)` (not `{name}.Borrowed(...)`) so the type always
             // resolves even when the wrapper has a same-named method.
             Ownership::Borrowed => format!(
@@ -958,6 +960,19 @@ pub(super) fn collect_properties(methods: &[MethodInfo<'_>]) -> Vec<PropertyInfo
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-method builders
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// The bits that differ between element types lowered by
+/// [`ItemGenContext::lower_immutable_element_slice`] — bundled into one
+/// struct so that function stays under clippy's argument-count limit.
+/// `mutable_class` is only consulted for the plain (non-borrowed-by-return)
+/// case — the borrowed-by-return case always rejects mutable slices before
+/// it matters.
+struct ImmutableElementShape<'a> {
+    element_type: &'a str,
+    ptr_type: &'a str,
+    immutable_class: &'a str,
+    mutable_class: &'a str,
+}
 
 impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
     /// Build a method's render view, or `None` if the method uses an HIR
@@ -1644,19 +1659,20 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
     /// by `&[u8]`/`&[u32]` primitive slices and by `&DiplomatStr`
     /// (`StringEncoding::UnvalidatedUtf8`), which carries no caller-side
     /// validity contract and so is really just `&[u8]` tagged as
-    /// string-like. `mutable_class` is only consulted for the plain
-    /// (non-borrowed-by-return) case — the borrowed-by-return case always
-    /// rejects mutable slices before it matters.
+    /// string-like.
     fn lower_immutable_element_slice(
         &self,
         input_context: &MethodInputContext<'tcx>,
         borrow_info: ParamBorrowInfo<'tcx>,
-        element_type: &str,
-        ptr_type: &str,
-        immutable_class: &str,
-        mutable_class: &str,
+        shape: ImmutableElementShape<'_>,
         mutability: hir::Mutability,
     ) -> Option<InputLowering> {
+        let ImmutableElementShape {
+            element_type,
+            ptr_type,
+            immutable_class,
+            mutable_class,
+        } = shape;
         let arg_name = input_context.arg_name();
         let ptr = self.slice_local_name(input_context.param_ident(), "Ptr");
 
@@ -1848,10 +1864,12 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                                 .lower_immutable_element_slice(
                                     &input_context,
                                     borrow_info,
-                                    "byte",
-                                    "byte",
-                                    "DiplomatSliceU8",
-                                    "DiplomatSliceU8",
+                                    ImmutableElementShape {
+                                        element_type: "byte",
+                                        ptr_type: "byte",
+                                        immutable_class: "DiplomatSliceU8",
+                                        mutable_class: "DiplomatSliceU8",
+                                    },
                                     hir::Mutability::Immutable,
                                 )?,
                             hir::StringEncoding::UnvalidatedUtf16 => {
@@ -1946,10 +1964,12 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                         self.lower_immutable_element_slice(
                             &input_context,
                             borrow_info,
-                            element_type,
-                            ptr_type,
-                            immutable_class,
-                            mutable_class,
+                            ImmutableElementShape {
+                                element_type,
+                                ptr_type,
+                                immutable_class,
+                                mutable_class,
+                            },
                             borrow.mutability,
                         )?
                     }

--- a/tool/src/dotnet/gen/method.rs
+++ b/tool/src/dotnet/gen/method.rs
@@ -178,6 +178,46 @@ pub(crate) enum Ownership {
     Borrowed,
 }
 
+/// Element type carried by a borrowed slice/string return
+/// (`DiplomatBorrowedSpan<T>`). Distinct from [`DotnetPrimitives`] because
+/// `char` (a UTF-16 code unit) isn't a Rust primitive type being lowered —
+/// it's the C# wire element type a string encoding picks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BorrowedSpanElement {
+    Byte,
+    UInt32,
+    Char,
+}
+
+impl BorrowedSpanElement {
+    pub(super) fn element_type(self) -> &'static str {
+        match self {
+            Self::Byte => "byte",
+            Self::UInt32 => "uint",
+            Self::Char => "char",
+        }
+    }
+
+    /// The raw wire struct this element type is pinned onto — same structs
+    /// used for input slices (`DiplomatSliceU8`/`DiplomatSliceU32`/`DiplomatSliceU16`).
+    pub(super) fn wire_struct(self) -> &'static str {
+        match self {
+            Self::Byte => "DiplomatSliceU8",
+            Self::UInt32 => "DiplomatSliceU32",
+            Self::Char => "DiplomatSliceU16",
+        }
+    }
+
+    /// PascalCase token for embedding in generated *type names*.
+    pub(super) fn name_token(self) -> &'static str {
+        match self {
+            Self::Byte => "Byte",
+            Self::UInt32 => "UInt32",
+            Self::Char => "Char",
+        }
+    }
+}
+
 /// The return type of a method, expressed once. The variant names the
 /// *kind*; [`Display`] writes the bare C# name; templates branch on kind
 /// via `is_*` predicates and supply the kind-specific bits (the `*` for
@@ -194,6 +234,11 @@ pub(crate) enum DotnetReturnType {
     /// shape as a primitive at the C ABI (an integer discriminant) —
     /// neither raw extern nor idiomatic surface needs marshalling glue.
     Enum(String),
+    /// A borrowed slice/string return (`&'a str` / `&'a DiplomatStr` /
+    /// `&'a DiplomatStr16` / `&'a [u8]` / `&'a [u32]`) — a zero-copy view
+    /// over Rust-owned memory, wrapped in `DiplomatBorrowedSpan<T>` and
+    /// rooted with keep-alive edges the same way a borrowed opaque return is.
+    BorrowedSpan(BorrowedSpanElement),
     /// `DiplomatWrite` writer. Not yet emitted; preserves prior behavior.
     Write,
     Unit,
@@ -215,6 +260,9 @@ impl Display for DotnetReturnType {
         match self {
             Self::Primitive(p) => write!(f, "{p}"),
             Self::Opaque(name) | Self::Struct(name) | Self::Enum(name) => write!(f, "{name}"),
+            Self::BorrowedSpan(elem) => {
+                write!(f, "DiplomatBorrowedSpan<{}>", elem.element_type())
+            }
             // Both render as the C# keyword `void` in raw externs. The
             // idiomatic signature spells `Write` methods as `string`
             // instead (see `idiomatic_signature_return_type`) — the writer
@@ -240,10 +288,13 @@ impl DotnetReturnType {
     /// Templates avoid carrying the inline `{% if is_opaque() %}*{% endif %}`
     /// micro-conditional.
     pub(super) fn raw(&self) -> String {
-        if self.is_opaque() {
-            format!("{self}*")
-        } else {
-            self.to_string()
+        match self {
+            Self::Opaque(_) => format!("{self}*"),
+            // A borrowed span crosses the wire as the same struct-by-value
+            // shape used for input slices — not `DiplomatBorrowedSpan<T>`,
+            // which only exists on the idiomatic side.
+            Self::BorrowedSpan(elem) => elem.wire_struct().to_string(),
+            _ => self.to_string(),
         }
     }
 
@@ -313,7 +364,19 @@ impl DotnetReturnType {
         match self {
             Self::Unit | Self::Write => "Void".to_string(),
             Self::Primitive(p) => p.name_token().to_string(),
+            Self::BorrowedSpan(elem) => format!("BorrowedSpan{}", elem.name_token()),
             _ => self.to_string(),
+        }
+    }
+
+    /// `new object[] { ... }`, or the shared empty-array constant when there
+    /// are no edges to root — used by both opaque and borrowed-span
+    /// construction, which both carry keep-alive edges the same way.
+    fn edges_array_expr(edges: &[String]) -> String {
+        if edges.is_empty() {
+            "System.Array.Empty<object>()".to_string()
+        } else {
+            format!("new object[] {{ {} }}", edges.join(", "))
         }
     }
 
@@ -328,21 +391,14 @@ impl DotnetReturnType {
         edges: &[String],
         ownership: Ownership,
     ) -> String {
-        let edges_array = || {
-            if edges.is_empty() {
-                "System.Array.Empty<object>()".to_string()
-            } else {
-                format!("new object[] {{ {} }}", edges.join(", "))
-            }
-        };
         match ownership {
             Ownership::Owned if edges.is_empty() => format!("new {name}({raw_expr})"),
-            Ownership::Owned => format!("new {name}({raw_expr}, {})", edges_array()),
+            Ownership::Owned => format!("new {name}({raw_expr}, {})", Self::edges_array_expr(edges)),
             // `new {name}(...)` (not `{name}.Borrowed(...)`) so the type always
             // resolves even when the wrapper has a same-named method.
             Ownership::Borrowed => format!(
                 "new {name}(RustHandle<Raw.{name}>.Borrowed({raw_expr}), {})",
-                edges_array()
+                Self::edges_array_expr(edges)
             ),
         }
     }
@@ -358,6 +414,14 @@ impl DotnetReturnType {
         match self {
             Self::Opaque(name) => Self::opaque_construction(name, &raw_expr, edges, ownership),
             Self::Struct(name) => format!("{name}.FromFFI({raw_expr})"),
+            // Rust still owns this memory — no ownership decision needed,
+            // unlike opaque construction. Just wrap the pointer/length off
+            // the raw wire struct and root the keep-alive edges.
+            Self::BorrowedSpan(elem) => format!(
+                "new DiplomatBorrowedSpan<{}>({raw_expr}.Ptr, {raw_expr}.Len, {})",
+                elem.element_type(),
+                Self::edges_array_expr(edges)
+            ),
             Self::Unit | Self::Write => String::new(),
             Self::Primitive(_) | Self::Enum(_) => raw_expr.to_string(),
             // The raw struct's fields are named to match `DiplomatSliceU8`
@@ -372,6 +436,9 @@ impl DotnetReturnType {
             Self::Unit | Self::Write => unreachable!("unit/write options are rejected earlier"),
             Self::OwnedByteSlice => {
                 unreachable!("`Option<Box<[u8]>>` returns are rejected earlier")
+            }
+            Self::BorrowedSpan(_) => {
+                unreachable!("Option-wrapped borrowed-span returns are rejected earlier")
             }
             Self::Primitive(_) | Self::Struct(_) | Self::Enum(_) => format!("({self}?)null"),
         }
@@ -764,11 +831,25 @@ impl MethodInfo<'_> {
         !self.inputs.borrowed_slice_pins.is_empty()
     }
 
+    /// True if this method returns a `DiplomatBorrowedSpan<T>` — used to
+    /// gate emitting that helper type only when a run actually needs it
+    /// (mirrors `has_pinned_inputs` gating `DiplomatPinnedMemory`).
+    pub(super) fn returns_borrowed_span(&self) -> bool {
+        matches!(self.return_type, DotnetReturnType::BorrowedSpan(_))
+    }
+
     pub(super) fn can_return_raw_call_directly(&self) -> bool {
         self.option_info.is_none()
             && matches!(
                 self.return_type,
-                DotnetReturnType::Primitive(_) | DotnetReturnType::Enum(_)
+                // `BorrowedSpan`'s raw type is a run-level wire struct
+                // (`DiplomatSliceU8`/`DiplomatSliceU16`/`DiplomatSliceU32`)
+                // living in the `Diplomat` namespace, not nested under the
+                // `Raw` static class like Opaque/Struct/Enum mirrors are —
+                // same "no `Raw.` mirror" situation as Primitive/Enum.
+                DotnetReturnType::Primitive(_)
+                    | DotnetReturnType::Enum(_)
+                    | DotnetReturnType::BorrowedSpan(_)
             )
     }
 
@@ -949,14 +1030,39 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             self.borrowed_output_keep_alive_edges(method, &inputs, &borrow_map, ownership)?;
         let lifetime_warning = !keep_alive_edges.is_empty();
 
-        // A non-opaque success return drops edges silently in `idiomatic_value_expr`
-        // (no struct edge-plumbing yet) — would be a use-after-free.
-        if !keep_alive_edges.is_empty() && !matches!(return_type, DotnetReturnType::Opaque(_)) {
+        // A non-opaque, non-borrowed-span success return drops edges silently
+        // in `idiomatic_value_expr` (no struct edge-plumbing yet) — would be
+        // a use-after-free.
+        if !keep_alive_edges.is_empty()
+            && !matches!(
+                return_type,
+                DotnetReturnType::Opaque(_) | DotnetReturnType::BorrowedSpan(_)
+            )
+        {
             self.errors.push_error(format!(
                 "[.NET backend] return value of type `{return_type}` borrows from the receiver \
                  or an opaque parameter; keep-alive edges are only supported for opaque (`Box<T>`) \
-                 returns today. Return an opaque, or disable this API for .NET."
+                 and borrowed-span (`&str`/`&[T]`) returns today. Return an opaque or borrowed \
+                 span, or disable this API for .NET."
             ));
+            return None;
+        }
+
+        // `DiplomatBorrowedSpan<T>` carries its edges in its own constructor
+        // the same way an opaque wrapper does, but wrapping it in
+        // `Result`/`Option` hasn't been exercised end-to-end (the result/
+        // option helper structs' union-field and none-value plumbing was
+        // only ever built for opaque/primitive/struct/enum arms) — reject
+        // rather than risk generating broken bridging code.
+        if matches!(return_type, DotnetReturnType::BorrowedSpan(_))
+            && (option_info.is_some() || error_info.is_some())
+        {
+            self.errors.push_error(
+                "[.NET backend] wrapping a borrowed span return (`&str` / `&[T]`) in \
+                 `Result`/`Option` is not yet supported — return it bare, or disable this \
+                 API for .NET."
+                    .to_string(),
+            );
             return None;
         }
 
@@ -1241,43 +1347,92 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             hir::SuccessType::OutType(hir::Type::Enum(p)) => {
                 DotnetReturnType::Enum(self.enum_name(p))
             }
-            hir::SuccessType::OutType(hir::Type::Slice(hir::Slice::Primitive(
-                MaybeOwn::Own,
-                primitive_type,
-            ))) => {
-                if !matches!(
-                    primitive_type,
-                    hir::PrimitiveType::Byte | hir::PrimitiveType::Int(hir::IntType::U8)
-                ) {
-                    self.errors.push_error(format!(
-                        "[.NET backend] owned slice return not yet supported for element \
-                         type {primitive_type:?}; only owned `u8`/`DiplomatByte` slices \
-                         (`Box<[u8]>`) are supported today"
-                    ));
-                    return None;
+            hir::SuccessType::OutType(hir::Type::Slice(slice)) => match slice {
+                hir::Slice::Str(Some(_), encoding) => {
+                    let elem = match encoding {
+                        hir::StringEncoding::Utf8 | hir::StringEncoding::UnvalidatedUtf8 => {
+                            BorrowedSpanElement::Byte
+                        }
+                        hir::StringEncoding::UnvalidatedUtf16 => BorrowedSpanElement::Char,
+                        other => {
+                            self.errors.push_error(format!(
+                                "[.NET backend] borrowed string return encoding not yet \
+                                 supported: {other:?}"
+                            ));
+                            return None;
+                        }
+                    };
+                    DotnetReturnType::BorrowedSpan(elem)
                 }
-                // Both rejections are defense in depth — HIR lowering only
-                // accepts an owned byte slice as a plain top-level return
-                // (`!in_result_option`), because the macro leaves a `Result`'s
-                // ok arm as a raw `Box<[u8]>` fat pointer inside
-                // `DiplomatResult` instead of converting it to the repr(C)
-                // `DiplomatOwnedSlice<u8>`, so the union layout would not be
-                // FFI-stable.
-                if is_nullable_path {
+                // Owned string returns (`Box<str>`) need the separately-decided
+                // owned-slice-return design (see DECISIONS.md) — not
+                // implemented here, don't re-litigate it.
+                hir::Slice::Str(None, _) => {
                     self.errors.push_error(
-                        "[.NET backend] `Option<Box<[u8]>>` return is not supported.".to_string(),
-                    );
-                    return None;
-                }
-                if failed.is_some() {
-                    self.errors.push_error(
-                        "[.NET backend] `Result<Box<[u8]>, E>` return is not supported."
+                        "[.NET backend] owned string return (`Box<str>`) is not yet \
+                         supported."
                             .to_string(),
                     );
                     return None;
                 }
-                DotnetReturnType::OwnedByteSlice
-            }
+                hir::Slice::Primitive(MaybeOwn::Borrow(_), primitive_type) => {
+                    let elem = match primitive_type {
+                        hir::PrimitiveType::Byte | hir::PrimitiveType::Int(hir::IntType::U8) => {
+                            BorrowedSpanElement::Byte
+                        }
+                        hir::PrimitiveType::Int(hir::IntType::U32) => BorrowedSpanElement::UInt32,
+                        other => {
+                            self.errors.push_error(format!(
+                                "[.NET backend] borrowed slice return element type not yet \
+                                 supported: {other:?}"
+                            ));
+                            return None;
+                        }
+                    };
+                    DotnetReturnType::BorrowedSpan(elem)
+                }
+                hir::Slice::Primitive(MaybeOwn::Own, primitive_type) => {
+                    if !matches!(
+                        primitive_type,
+                        hir::PrimitiveType::Byte | hir::PrimitiveType::Int(hir::IntType::U8)
+                    ) {
+                        self.errors.push_error(format!(
+                            "[.NET backend] owned slice return not yet supported for element \
+                             type {primitive_type:?}; only owned `u8`/`DiplomatByte` slices \
+                             (`Box<[u8]>`) are supported today"
+                        ));
+                        return None;
+                    }
+                    // Both rejections are defense in depth — HIR lowering only
+                    // accepts an owned byte slice as a plain top-level return
+                    // (`!in_result_option`), because the macro leaves a `Result`'s
+                    // ok arm as a raw `Box<[u8]>` fat pointer inside
+                    // `DiplomatResult` instead of converting it to the repr(C)
+                    // `DiplomatOwnedSlice<u8>`, so the union layout would not be
+                    // FFI-stable.
+                    if is_nullable_path {
+                        self.errors.push_error(
+                            "[.NET backend] `Option<Box<[u8]>>` return is not supported."
+                                .to_string(),
+                        );
+                        return None;
+                    }
+                    if failed.is_some() {
+                        self.errors.push_error(
+                            "[.NET backend] `Result<Box<[u8]>, E>` return is not supported."
+                                .to_string(),
+                        );
+                        return None;
+                    }
+                    DotnetReturnType::OwnedByteSlice
+                }
+                other => {
+                    self.errors.push_error(format!(
+                        "[.NET backend] slice return type not yet supported: {other:?}"
+                    ));
+                    return None;
+                }
+            },
             other => {
                 self.errors.push_error(format!(
                     "[.NET backend] success return type not yet supported: {other:?}"
@@ -1483,6 +1638,77 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             .into_owned()
     }
 
+    /// Lowers a parameter that's always immutable and always borrowed, and
+    /// whose C# idiomatic surface is an array/`ReadOnlyMemory` of some
+    /// blittable element type pinned directly onto the wire struct — shared
+    /// by `&[u8]`/`&[u32]` primitive slices and by `&DiplomatStr`
+    /// (`StringEncoding::UnvalidatedUtf8`), which carries no caller-side
+    /// validity contract and so is really just `&[u8]` tagged as
+    /// string-like. `mutable_class` is only consulted for the plain
+    /// (non-borrowed-by-return) case — the borrowed-by-return case always
+    /// rejects mutable slices before it matters.
+    fn lower_immutable_element_slice(
+        &self,
+        input_context: &MethodInputContext<'tcx>,
+        borrow_info: ParamBorrowInfo<'tcx>,
+        element_type: &str,
+        ptr_type: &str,
+        immutable_class: &str,
+        mutable_class: &str,
+        mutability: hir::Mutability,
+    ) -> Option<InputLowering> {
+        let arg_name = input_context.arg_name();
+        let ptr = self.slice_local_name(input_context.param_ident(), "Ptr");
+
+        Some(if matches!(borrow_info, ParamBorrowInfo::BorrowedSlice) {
+            if matches!(mutability, hir::Mutability::Mutable) {
+                self.errors.push_error(format!(
+                    "[.NET backend] mutable slice parameter `{arg_name}` borrowed \
+                     by the output is not yet supported; ReadOnlyMemory cannot hand \
+                     Rust a mutable view"
+                ));
+                return None;
+            }
+            let pin = self.slice_local_name(input_context.param_ident(), "Pin");
+            InputLowering {
+                raw_param: format!("{immutable_class} {arg_name}"),
+                idiomatic_param: format!("ReadOnlyMemory<{element_type}> {arg_name}"),
+                raw_call_arg: format!(
+                    "new {immutable_class} {{ Ptr = ({ptr_type}*){pin}.Pointer, Len = (nuint){arg_name}.Length }}"
+                ),
+                borrowed_slice_pin: Some(SlicePin {
+                    arg_name: arg_name.to_string(),
+                    pin_local: pin,
+                }),
+                idiomatic_param_type: Some(format!("ReadOnlyMemory<{element_type}>")),
+                ..Default::default()
+            }
+        } else {
+            let slice_class = match mutability {
+                hir::Mutability::Mutable => mutable_class,
+                hir::Mutability::Immutable => immutable_class,
+            };
+
+            InputLowering {
+                raw_param: format!("{slice_class} {arg_name}"),
+                idiomatic_param: format!("{element_type}[] {arg_name}"),
+                raw_call_arg: format!(
+                    "new {slice_class} {{ Ptr = {ptr}, Len = (nuint){arg_name}.Length }}"
+                ),
+                // Non-optional slice param — null array is a contract
+                // violation. Without this check the `{arg_name}.Length` in
+                // the call arg throws a bare `NullReferenceException` with
+                // no parameter name.
+                validation_statement: Some(format!(
+                    "if ({arg_name} == null) throw new ArgumentNullException(nameof({arg_name}));"
+                )),
+                fix_statement: Some(format!("fixed ({ptr_type}* {ptr} = {arg_name})")),
+                idiomatic_param_type: Some(format!("{element_type}[]")),
+                ..Default::default()
+            }
+        })
+    }
+
     fn lower_input(
         &self,
         input_context: MethodInputContext<'tcx>,
@@ -1560,61 +1786,130 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                             );
                             return None;
                         }
-                        hir::MaybeStatic::NonStatic(_) => {
-                            // The marshaller below is hard-coded to UTF-8.
-                            // `attr_support.utf16_strings = false` keeps the
-                            // HIR validator from sending UTF-16 here, but be
-                            // explicit so any future encoding (e.g.
-                            // `UnvalidatedUtf8`) doesn't silently slip
-                            // through and get encoded incorrectly.
-                            match string_encoding {
-                                hir::StringEncoding::Utf8
-                                | hir::StringEncoding::UnvalidatedUtf8 => {}
-                                other => {
-                                    self.errors.push_error(format!(
-                                        "[.NET backend] string encoding not yet supported: {other:?}"
-                                    ));
-                                    return None;
+                        hir::MaybeStatic::NonStatic(_) => match string_encoding {
+                            // `&str` requires the caller to *guarantee*
+                            // valid UTF-8 (UB on the Rust side otherwise —
+                            // see the doc comment on `StringEncoding::Utf8`),
+                            // so this can't be reshaped to a raw `byte[]`
+                            // like `UnvalidatedUtf8` below: a careless
+                            // caller could then hand Rust invalid UTF-8.
+                            // `Encoding.UTF8.GetBytes` on a real C# `string`
+                            // is the only thing that can make that
+                            // guarantee, so the transcode-copy stays —
+                            // routed through the explicitly-named
+                            // `Diplomat.Utf8.Clone` instead of inlining the
+                            // BCL call, so the allocation is visible.
+                            hir::StringEncoding::Utf8 => {
+                                let base = input_context.param_ident();
+                                let ptr = self.slice_local_name(base, "Ptr");
+                                let bytes = self.slice_local_name(base, "Bytes");
+                                InputLowering {
+                                    raw_param: format!("DiplomatSliceU8 {arg_name}"),
+                                    idiomatic_param: format!("string {arg_name}"),
+                                    raw_call_arg: format!(
+                                        "new DiplomatSliceU8 {{ Ptr = {ptr}, Len = (nuint){bytes}.Length }}"
+                                    ),
+                                    // `&str` is non-optional on the Rust
+                                    // side, so a null string is a contract
+                                    // violation. Surface `ArgumentNullException`
+                                    // naming the actual parameter — without this,
+                                    // `Utf8.Clone(null)` throws with its own
+                                    // internal param name (`"value"`). The
+                                    // template emits validation before to-bytes.
+                                    validation_statement: Some(format!(
+                                        "if ({arg_name} == null) throw new ArgumentNullException(nameof({arg_name}));"
+                                    )),
+                                    to_bytes_statement: Some(format!(
+                                        "byte[] {bytes} = Diplomat.Utf8.Clone({arg_name});"
+                                    )),
+                                    // FIXME: an empty string yields a zero-length
+                                    // `byte[]`, and `fixed` on an empty array binds
+                                    // a null pointer — so Rust receives
+                                    // `{ Ptr = null, Len = 0 }`. Diplomat's C ABI
+                                    // tolerates `(null, 0)` today (it only reads the
+                                    // pointer when `Len > 0`), but a strictly-correct
+                                    // binding would hand over a non-null dangling
+                                    // pointer for the empty case.
+                                    fix_statement: Some(format!(
+                                        "fixed (byte* {ptr} = {bytes})"
+                                    )),
+                                    idiomatic_param_type: Some("string".to_string()),
+                                    keep_alive_target: None,
+                                    borrowed_slice_pin: None,
                                 }
                             }
-                            let base = input_context.param_ident();
-                            let ptr = self.slice_local_name(base, "Ptr");
-                            let bytes = self.slice_local_name(base, "Bytes");
-                            InputLowering {
-                                raw_param: format!("DiplomatSliceU8 {arg_name}"),
-                                idiomatic_param: format!("string {arg_name}"),
-                                raw_call_arg: format!(
-                                    "new DiplomatSliceU8 {{ Ptr = {ptr}, Len = (nuint){bytes}.Length }}"
-                                ),
-                                // `&DiplomatStr` is non-optional on the Rust
-                                // side, so a null string is a contract
-                                // violation. Surface `ArgumentNullException`
-                                // naming the actual parameter — without this,
-                                // `Encoding.UTF8.GetBytes(null)` throws with
-                                // its own internal param name (`"s"`). The
-                                // template emits validation before to-bytes.
-                                validation_statement: Some(format!(
-                                    "if ({arg_name} == null) throw new ArgumentNullException(nameof({arg_name}));"
-                                )),
-                                to_bytes_statement: Some(format!(
-                                    "byte[] {bytes} = System.Text.Encoding.UTF8.GetBytes({arg_name});"
-                                )),
-                                // FIXME: an empty string yields a zero-length
-                                // `byte[]`, and `fixed` on an empty array binds
-                                // a null pointer — so Rust receives
-                                // `{ Ptr = null, Len = 0 }`. Diplomat's C ABI
-                                // tolerates `(null, 0)` today (it only reads the
-                                // pointer when `Len > 0`), but a strictly-correct
-                                // binding would hand over a non-null dangling
-                                // pointer for the empty case.
-                                fix_statement: Some(format!(
-                                    "fixed (byte* {ptr} = {bytes})"
-                                )),
-                                idiomatic_param_type: Some("string".to_string()),
-                                keep_alive_target: None,
-                                borrowed_slice_pin: None,
+                            // `&DiplomatStr` carries no caller-side validity
+                            // contract — Rust treats it as opaque bytes — so
+                            // unlike `&str` above it's really just `&[u8]`
+                            // tagged as string-like, and gets the exact same
+                            // zero-copy treatment as an existing `&[u8]`
+                            // parameter (no transcode, ever).
+                            hir::StringEncoding::UnvalidatedUtf8 => self
+                                .lower_immutable_element_slice(
+                                    &input_context,
+                                    borrow_info,
+                                    "byte",
+                                    "byte",
+                                    "DiplomatSliceU8",
+                                    "DiplomatSliceU8",
+                                    hir::Mutability::Immutable,
+                                )?,
+                            hir::StringEncoding::UnvalidatedUtf16 => {
+                                // A C# `string` is already a flat UTF-16
+                                // buffer — `fixed` pins it directly with no
+                                // allocation, unlike the UTF-8 arm above
+                                // which must transcode first. Bonus: `fixed`
+                                // on a C# string (even `""`) always yields a
+                                // valid pointer to its null terminator, so
+                                // the empty-string dangling-pointer FIXME
+                                // above doesn't apply here.
+                                let base = input_context.param_ident();
+                                let ptr = self.slice_local_name(base, "Ptr");
+
+                                if matches!(borrow_info, ParamBorrowInfo::BorrowedSlice) {
+                                    let pin = self.slice_local_name(base, "Pin");
+                                    InputLowering {
+                                        raw_param: format!("DiplomatSliceU16 {arg_name}"),
+                                        idiomatic_param: format!(
+                                            "ReadOnlyMemory<char> {arg_name}"
+                                        ),
+                                        raw_call_arg: format!(
+                                            "new DiplomatSliceU16 {{ Ptr = (char*){pin}.Pointer, Len = (nuint){arg_name}.Length }}"
+                                        ),
+                                        borrowed_slice_pin: Some(SlicePin {
+                                            arg_name: arg_name.to_string(),
+                                            pin_local: pin,
+                                        }),
+                                        idiomatic_param_type: Some(
+                                            "ReadOnlyMemory<char>".to_string(),
+                                        ),
+                                        ..Default::default()
+                                    }
+                                } else {
+                                    InputLowering {
+                                        raw_param: format!("DiplomatSliceU16 {arg_name}"),
+                                        idiomatic_param: format!("string {arg_name}"),
+                                        raw_call_arg: format!(
+                                            "new DiplomatSliceU16 {{ Ptr = {ptr}, Len = (nuint){arg_name}.Length }}"
+                                        ),
+                                        validation_statement: Some(format!(
+                                            "if ({arg_name} == null) throw new ArgumentNullException(nameof({arg_name}));"
+                                        )),
+                                        fix_statement: Some(format!(
+                                            "fixed (char* {ptr} = {arg_name})"
+                                        )),
+                                        idiomatic_param_type: Some("string".to_string()),
+                                        ..Default::default()
+                                    }
+                                }
                             }
-                        }
+                            other => {
+                                self.errors.push_error(format!(
+                                    "[.NET backend] string encoding not yet supported: {other:?}"
+                                ));
+                                return None;
+                            }
+                        },
                     },
                     None => {
                         self.errors.push_error(
@@ -1628,7 +1923,6 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                 hir::Slice::Primitive(maybe_own, primitive_type) => match primitive_type {
                     hir::PrimitiveType::Byte
                     | hir::PrimitiveType::Int(hir::IntType::U8 | hir::IntType::U32) => {
-                        let ptr = self.slice_local_name(input_context.param_ident(), "Ptr");
                         let MaybeOwn::Borrow(borrow) = maybe_own else {
                             self.errors.push_error(format!(
                                 "[.NET backend] owned primitive slice not yet supported: \
@@ -1649,56 +1943,15 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                                 _ => unreachable!(),
                             };
 
-                        if matches!(borrow_info, ParamBorrowInfo::BorrowedSlice) {
-                            if matches!(borrow.mutability, hir::Mutability::Mutable) {
-                                self.errors.push_error(format!(
-                                    "[.NET backend] mutable slice parameter `{arg_name}` borrowed \
-                                     by the output is not yet supported; ReadOnlyMemory cannot hand \
-                                     Rust a mutable view"
-                                ));
-                                return None;
-                            }
-                            let pin = self.slice_local_name(input_context.param_ident(), "Pin");
-                            InputLowering {
-                                raw_param: format!("{immutable_class} {arg_name}"),
-                                idiomatic_param: format!("ReadOnlyMemory<{element_type}> {arg_name}"),
-                                raw_call_arg: format!(
-                                    "new {immutable_class} {{ Ptr = ({ptr_type}*){pin}.Pointer, Len = (nuint){arg_name}.Length }}"
-                                ),
-                                borrowed_slice_pin: Some(SlicePin {
-                                    arg_name: arg_name.to_string(),
-                                    pin_local: pin,
-                                }),
-                                idiomatic_param_type: Some(format!("ReadOnlyMemory<{element_type}>")),
-                                ..Default::default()
-                            }
-                        } else {
-                            let slice_class = match borrow.mutability {
-                                hir::Mutability::Mutable => mutable_class,
-                                hir::Mutability::Immutable => immutable_class,
-                            };
-
-                            InputLowering {
-                                raw_param: format!("{slice_class} {arg_name}"),
-                                idiomatic_param: format!("{element_type}[] {arg_name}"),
-                                raw_call_arg: format!(
-                                    "new {slice_class} {{ Ptr = {ptr}, Len = (nuint){arg_name}.Length }}"
-                                ),
-                                // Non-optional slice param — null array is a
-                                // contract violation. Without this check the
-                                // `{arg_name}.Length` in the call arg throws a
-                                // bare `NullReferenceException` with no
-                                // parameter name.
-                                validation_statement: Some(format!(
-                                    "if ({arg_name} == null) throw new ArgumentNullException(nameof({arg_name}));"
-                                )),
-                                fix_statement: Some(format!("fixed ({ptr_type}* {ptr} = {arg_name})")),
-                                to_bytes_statement: None,
-                                idiomatic_param_type: Some(format!("{element_type}[]")),
-                                keep_alive_target: None,
-                                borrowed_slice_pin: None,
-                            }
-                        }
+                        self.lower_immutable_element_slice(
+                            &input_context,
+                            borrow_info,
+                            element_type,
+                            ptr_type,
+                            immutable_class,
+                            mutable_class,
+                            borrow.mutability,
+                        )?
                     }
                     hir::PrimitiveType::Int(int_type) => {
                         self.errors.push_error(format!(

--- a/tool/src/dotnet/gen/mod.rs
+++ b/tool/src/dotnet/gen/mod.rs
@@ -143,6 +143,19 @@ impl PreparedType<'_> {
             }
         }
     }
+
+    /// True iff any of this type's methods returns a `DiplomatBorrowedSpan<T>`.
+    /// Gates emitting that helper type the same way `uses_pinned_memory` gates
+    /// `DiplomatPinnedMemory` — independent flag, since a method can return a
+    /// borrowed span without pinning any input (e.g. borrowing only from `self`).
+    fn uses_borrowed_span(&self) -> bool {
+        match self {
+            Self::Prerendered { .. } => false,
+            Self::Opaque { methods, .. } | Self::Struct { methods, .. } => {
+                methods.iter().any(|m| m.returns_borrowed_span())
+            }
+        }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -195,14 +208,16 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
     }
 
     /// Render every non-disabled type to `(display_name, raw, content)`,
-    /// alongside the run-level `uses_pinned_memory` flag. Types are BUILT
-    /// first (each method lowered exactly once) so the flag is known before
-    /// the first opaque Dispose sweep — a pin edge lands on the RETURNED
-    /// type's wrapper, which may render before the method that pins into it.
-    pub(super) fn render_all_types(&self) -> (bool, bool, Vec<RenderedType>) {
+    /// alongside the run-level `uses_pinned_memory`, `uses_owned_byte_slice_return`,
+    /// and `uses_borrowed_span` flags. Types are BUILT first (each method
+    /// lowered exactly once) so the flags are known before the first opaque
+    /// Dispose sweep — a pin edge lands on the RETURNED type's wrapper, which
+    /// may render before the method that pins into it.
+    pub(super) fn render_all_types(&self) -> (bool, bool, bool, Vec<RenderedType>) {
         let mut prepared_types = Vec::new();
         let mut uses_pinned_memory = false;
         let mut uses_owned_byte_slice_return = false;
+        let mut uses_borrowed_span = false;
         for (id, ty) in self.tcx.all_types() {
             if ty.attrs().disable {
                 continue;
@@ -217,6 +232,7 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
             };
             uses_pinned_memory |= prepared.uses_pinned_memory();
             uses_owned_byte_slice_return |= prepared.uses_owned_byte_slice_return();
+            uses_borrowed_span |= prepared.uses_borrowed_span();
             prepared_types.push(prepared);
         }
 
@@ -232,7 +248,12 @@ impl<'ctx, 'tcx> ItemGenContext<'ctx, 'tcx> {
                 }
             })
             .collect();
-        (uses_pinned_memory, uses_owned_byte_slice_return, rendered)
+        (
+            uses_pinned_memory,
+            uses_owned_byte_slice_return,
+            uses_borrowed_span,
+            rendered,
+        )
     }
 
     /// Build a type's render data without emitting any C#. `build_method_info`

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -3,8 +3,11 @@
 //! Generates C# bindings that call into the Diplomat-generated C ABI via
 //! P/Invoke (`[DllImport]` externs with the `Cdecl` calling convention).
 //! Opaque Rust handles map to `IDisposable` partial classes backed by
-//! `RustHandle<T>`, which records whether C# or Rust owns the pointer. Slices
-//! and strings copy across the boundary; callbacks are pinned via `GCHandle`.
+//! `RustHandle<T>`, which records whether C# or Rust owns the pointer.
+//! Slices, `&DiplomatStr` (unvalidated UTF-8) and `&DiplomatStr16` pin
+//! zero-copy; a validated `&str` still copies, since only a transcode from a
+//! real `System.String` can guarantee well-formed UTF-8. Callbacks are
+//! pinned via `GCHandle`.
 //!
 //! This file is the entry point that the Diplomat CLI dispatches to. Codegen
 //! itself lives in [`gen`] and naming/type-formatting concerns live in
@@ -16,20 +19,38 @@
 //! lifetime-edge analysis to root supported borrowed outputs and reject the
 //! unsafe cases:
 //!
-//! * `&[u8]` / `&[u32]` / `&DiplomatStr` params are pinned with `fixed (...)`
-//!   (or copied into a pinned `byte[]`) for the call and unpinned immediately
-//!   after. When an owned opaque success return borrows a `&[u8]` / `&[u32]`
-//!   param, that param instead surfaces as `ReadOnlyMemory` and is pinned via
-//!   `DiplomatPinnedMemory`, rooted as a keep-alive edge and unpinned after the
-//!   Rust destructor runs. String params and other borrow positions (borrowed
-//!   errors, Option-wrapped or non-opaque returns) are still rejected with a
-//!   diagnostic. Because `ReadOnlyMemory` / `MemoryHandle` need the
-//!   `System.Memory` package on the netstandard2.0 / .NET Framework floor, the
-//!   `DiplomatPinnedMemory` helper and its `Dispose` sweep are emitted only when
-//!   a run actually pins (see `uses_pinned_memory`), so runs that never borrow a
-//!   slice don't inherit the dependency.
+//! * `&[u8]` / `&[u32]` / `&DiplomatStr` (`byte[]`) and `&DiplomatStr16`
+//!   (`string`) params are pinned with `fixed (...)` for the call and
+//!   unpinned immediately after. A validated `&str` is transcoded first
+//!   (`Diplomat.Utf8.Clone`, an explicit, separately-named copy — see
+//!   `gen::method`'s `Slice::Str` lowering) and then pinned the same way.
+//!   When an owned opaque success return borrows a `&[u8]` / `&[u32]` /
+//!   `&DiplomatStr` / `&DiplomatStr16` param, that param instead surfaces as
+//!   `ReadOnlyMemory` and is pinned via `DiplomatPinnedMemory`, rooted as a
+//!   keep-alive edge and unpinned after the Rust destructor runs. A
+//!   validated `&str` can't take this path — the transcode-copy only lives
+//!   for the call, so this borrow position (and other borrow positions:
+//!   borrowed errors, Option-wrapped or non-opaque returns) are still
+//!   rejected with a diagnostic. Because `ReadOnlyMemory` / `MemoryHandle`
+//!   need the `System.Memory` package on the netstandard2.0 / .NET
+//!   Framework floor, the `DiplomatPinnedMemory` helper and its `Dispose`
+//!   sweep are emitted only when a run actually pins (see
+//!   `uses_pinned_memory`), so runs that never borrow a slice don't inherit
+//!   the dependency.
 //! * Borrowed opaque returns (`&T`, `&mut T`, `Option<&T>`) use non-owning
 //!   handles plus keep-alive edges.
+//! * Borrowed string/slice returns (`&'a str` / `&'a [u8]` / `&'a [u32]`) wrap
+//!   the same `(ptr, len)` shape as an input slice in `DiplomatBorrowedSpan<T>`,
+//!   rooted with keep-alive edges the same way a borrowed opaque return is.
+//!   It exposes `WithSpan(...)` (scoped, zero-copy, read-only access) and
+//!   `Clone()` (an explicit, independent `T[]`) — never a bare `Span`-returning
+//!   property, since nothing would keep the view's edges rooted once the span
+//!   escaped it. Wrapping one in `Result`/`Option` isn't supported yet.
+//! * An owned `Box<[u8]>` return wraps the `DiplomatOwnedSliceU8` `(ptr, len)`
+//!   struct in `RustVec`, which owns the native allocation and is
+//!   `IDisposable`. It offers the same `WithSpan(...)` / `Clone()` shape as
+//!   `DiplomatBorrowedSpan<T>`, for the same reason: `MemoryManager<T>` would
+//!   force a `GetSpan()` whose result doesn't keep the owner alive.
 //! * Borrowed opaque errors (`Result<_, &E>`) are rejected; without a success
 //!   arm to carry keep-alive edges, `Dispose` would call `Destroy` on a pointer
 //!   Rust still owns (double-free).
@@ -65,6 +86,16 @@ struct DiplomatSliceU8Template<'a> {
 #[derive(Template)]
 #[template(path = "dotnet/DiplomatSliceMutU8.cs.jinja", escape = "none")]
 struct DiplomatSliceMutU8Template<'a> {
+    namespace: &'a str,
+}
+
+/// `DiplomatSliceU16` — the `repr(C)` fat pointer that crosses the FFI
+/// boundary for every `&DiplomatStr16` param. A C# `char` is a UTF-16 code
+/// unit, the same width as Rust's `u16`, so a C# `string` pins directly into
+/// this shape with no transcoding.
+#[derive(Template)]
+#[template(path = "dotnet/DiplomatSliceU16.cs.jinja", escape = "none")]
+struct DiplomatSliceU16Template<'a> {
     namespace: &'a str,
 }
 
@@ -117,6 +148,25 @@ struct DiplomatBoolTemplate<'a> {
     namespace: &'a str,
 }
 
+/// `DiplomatBorrowedSpan<T>` — a zero-copy view over a borrowed slice/string
+/// return (Rust still owns the memory). Needs the `System.Memory` package on
+/// the netstandard2.0 / .NET Framework floor (`ReadOnlySpan<T>`), so it's
+/// emitted only when a run actually returns one (see `uses_borrowed_span`).
+#[derive(Template)]
+#[template(path = "dotnet/DiplomatBorrowedSpan.cs.jinja", escape = "none")]
+struct DiplomatBorrowedSpanTemplate<'a> {
+    namespace: &'a str,
+}
+
+/// `Diplomat.Utf8` — explicit, named UTF-16 `string` -> UTF-8 `byte[]`
+/// clone, used wherever a validated `&str` parameter forces a transcode
+/// that can't be avoided (see `gen::method`'s `Slice::Str` lowering).
+#[derive(Template)]
+#[template(path = "dotnet/Utf8.cs.jinja", escape = "none")]
+struct Utf8Template<'a> {
+    namespace: &'a str,
+}
+
 /// `DiplomatPinnedMemory` — pins a caller `ReadOnlyMemory` buffer while a
 /// Rust value borrows it, and unpins when the borrowing wrapper is disposed.
 #[derive(Template)]
@@ -164,15 +214,22 @@ pub(crate) fn attr_support() -> BackendAttrSupport {
     a.non_exhaustive_structs = true;
     a.method_overloading = true;
     a.utf8_strings = true;
-    a.utf16_strings = false;
-    // `option` and `mutable_slices` are advertised but coverage is
-    // narrower than the flag suggests:
+    a.utf16_strings = true;
+    // `option`, `mutable_slices`, and `utf16_strings` are advertised but
+    // coverage is narrower than the flag suggests:
     //   - `mutable_slices`: only `&mut [DiplomatByte]`, `&mut [u8]`, and
     //     `&mut [u32]` lower today; other primitive element types report a
     //     diagnostic in the slice-primitive arm of `gen::method::lower_input`.
     //   - `option`: works for primitive / enum / struct success values;
     //     unsupported non-primitive struct fields report a diagnostic during
     //     struct codegen.
+    //   - `utf16_strings`: `&DiplomatStr16` inputs are zero-copy (call-scoped
+    //     and borrowed-by-return); borrowed string *returns* (`&'a str` /
+    //     `&'a DiplomatStr` / `&'a DiplomatStr16`) work bare but not wrapped
+    //     in `Result`/`Option` yet; owned string returns (`Box<str>`) aren't
+    //     supported (see the separately-decided owned-slice-return design in
+    //     DECISIONS.md); `&[&str]` (`Slice::Strs`) is rejected regardless of
+    //     encoding.
     // The granularity needed to express this in `attr_support` doesn't
     // exist (no per-primitive flag), so we keep the broad flags `true`
     // and document the gaps here + via the diagnostics themselves.
@@ -335,7 +392,8 @@ pub(crate) fn run<'tcx>(
      * The content layer represents the safe, idiomatic C# API that end-users will interact with.
      * It may wrap or compose multiple raw items, and should prioritize usability and safety.
      */
-    let (uses_pinned_memory, uses_owned_byte_slice_return, rendered_types) = ctx.render_all_types();
+    let (uses_pinned_memory, uses_owned_byte_slice_return, uses_borrowed_span, rendered_types) =
+        ctx.render_all_types();
     for rendered in rendered_types {
         let file_name = format!("{}.cs", rendered.display_name);
         if let Some(raw) = rendered.raw {
@@ -411,6 +469,15 @@ pub(crate) fn run<'tcx>(
     );
     add_cs_file(
         &files,
+        "DiplomatSliceU16.cs".to_string(),
+        DiplomatSliceU16Template {
+            namespace: &namespace,
+        }
+        .render()
+        .expect("DiplomatSliceU16 template render failed"),
+    );
+    add_cs_file(
+        &files,
         "DiplomatSliceU32.cs".to_string(),
         DiplomatSliceU32Template {
             namespace: &namespace,
@@ -464,6 +531,15 @@ pub(crate) fn run<'tcx>(
         .render()
         .expect("DiplomatBool template render failed"),
     );
+    add_cs_file(
+        &files,
+        "Utf8.cs".to_string(),
+        Utf8Template {
+            namespace: &namespace,
+        }
+        .render()
+        .expect("Utf8 template render failed"),
+    );
     // The helper pulls in System.Memory, which the netstandard2.0 floor lacks
     // by default — so only ship it when the run actually pins a slice.
     if uses_pinned_memory {
@@ -475,6 +551,20 @@ pub(crate) fn run<'tcx>(
             }
             .render()
             .expect("DiplomatPinnedMemory template render failed"),
+        );
+    }
+    // Also needs System.Memory (`ReadOnlySpan<T>`) — same reasoning, gated
+    // independently since a method can return a borrowed span without
+    // pinning any input (e.g. borrowing only from `self`).
+    if uses_borrowed_span {
+        add_cs_file(
+            &files,
+            "DiplomatBorrowedSpan.cs".to_string(),
+            DiplomatBorrowedSpanTemplate {
+                namespace: &namespace,
+            }
+            .render()
+            .expect("DiplomatBorrowedSpan template render failed"),
         );
     }
 
@@ -701,8 +791,14 @@ mod test {
         );
     }
 
+    // `&DiplomatStr` (`UnvalidatedUtf8`) carries no caller-side validity
+    // contract, so it's lowered exactly like `&[u8]` (see
+    // `lower_immutable_element_slice`) — including this case, which used to
+    // be rejected before that reshape: an owned opaque return borrowing a
+    // `&DiplomatStr` parameter now pins it and roots the pin as a
+    // keep-alive edge, identical to `owned_return_borrowing_byte_slice_unpins_on_dispose`.
     #[test]
-    fn lifetime_carrying_owned_return_borrowing_slice_input_is_rejected() {
+    fn owned_return_borrowing_diplomat_str_input_pins_and_unpins_on_dispose() {
         let tk_stream = quote! {
             #[diplomat::bridge]
             mod ffi {
@@ -713,6 +809,53 @@ mod test {
 
                 impl<'a> Foo<'a> {
                     pub fn new(x: &'a DiplomatStr) -> Box<Self> {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let foo = files.get("Foo.cs").expect("expected Foo.cs output");
+        assert!(
+            foo.contains("public static Foo New(ReadOnlyMemory<byte> x)"),
+            "borrowed &DiplomatStr param should surface as ReadOnlyMemory<byte>:\n{foo}"
+        );
+        assert!(
+            foo.contains("new Foo(result, new object[] { xPin })"),
+            "infallible owned return should root the pin holder as an edge:\n{foo}"
+        );
+        let release_at = foo
+            .find("_inner.Release();")
+            .expect("Dispose should release the Rust handle");
+        let unpin_at = foo
+            .find("(edge as DiplomatPinnedMemory)?.Dispose();")
+            .expect("Dispose should unpin holder edges");
+        assert!(
+            release_at < unpin_at,
+            "unpin must run AFTER Release() so Rust's Drop can still read the buffer:\n{foo}"
+        );
+    }
+
+    // A validated `&'a str` still forces a transcode-copy (`Utf8.Clone`),
+    // so it can't be pinned past the call — this borrow position stays
+    // rejected, unlike the `&DiplomatStr` case above.
+    #[test]
+    fn lifetime_carrying_owned_return_borrowing_validated_str_input_is_rejected() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Foo<'a>(&'a str);
+
+                impl<'a> Foo<'a> {
+                    pub fn new(x: &'a str) -> Box<Self> {
                         unimplemented!()
                     }
                 }
@@ -1068,6 +1211,165 @@ mod test {
         assert!(
             !hasher.contains("DiplomatPinnedMemory.Pin("),
             "temporary slice method should not pin the input:\n{hasher}"
+        );
+    }
+
+    // `&DiplomatStr` carries no caller-side validity contract, so it's
+    // lowered exactly like `&[u8]` — zero-copy `byte[]` + `fixed`, no
+    // transcode, ever.
+    #[test]
+    fn temporary_diplomat_str_keeps_byte_array_fixed_pinning() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                use diplomat_runtime::DiplomatStr;
+
+                #[diplomat::opaque]
+                pub struct Hasher;
+
+                impl Hasher {
+                    pub fn hash(data: &DiplomatStr) -> u32 {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let hasher = files.get("Hasher.cs").expect("expected Hasher.cs output");
+        assert!(
+            hasher.contains("public static uint Hash(byte[] data)")
+                && hasher.contains("fixed (byte* dataPtr = data)"),
+            "&DiplomatStr should get the same byte[] + fixed lowering as &[u8]:\n{hasher}"
+        );
+        assert!(
+            !hasher.contains("Encoding.UTF8") && !hasher.contains("Utf8.Clone"),
+            "&DiplomatStr must never transcode — it's already raw bytes:\n{hasher}"
+        );
+    }
+
+    // A validated `&str` still needs the caller to guarantee well-formed
+    // UTF-8, so the idiomatic surface stays `string` and the unavoidable
+    // transcode is routed through the explicitly-named `Diplomat.Utf8.Clone`.
+    #[test]
+    fn validated_str_input_uses_utf8_clone() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Hasher;
+
+                impl Hasher {
+                    pub fn hash(data: &str) -> u32 {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let hasher = files.get("Hasher.cs").expect("expected Hasher.cs output");
+        assert!(
+            hasher.contains("public static uint Hash(string data)"),
+            "validated &str should keep the string idiomatic param:\n{hasher}"
+        );
+        assert!(
+            hasher.contains("byte[] dataBytes = Diplomat.Utf8.Clone(data);")
+                && hasher.contains("fixed (byte* dataPtr = dataBytes)"),
+            "the unavoidable transcode should be named Utf8.Clone, not inlined:\n{hasher}"
+        );
+    }
+
+    // A C# `string` is already a flat UTF-16 buffer — `&DiplomatStr16` pins
+    // it directly with no allocation.
+    #[test]
+    fn temporary_diplomat_str16_keeps_string_fixed_pinning() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                use diplomat_runtime::DiplomatStr16;
+
+                #[diplomat::opaque]
+                pub struct Hasher;
+
+                impl Hasher {
+                    pub fn hash(data: &DiplomatStr16) -> u32 {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let hasher = files.get("Hasher.cs").expect("expected Hasher.cs output");
+        assert!(
+            hasher.contains("public static uint Hash(string data)")
+                && hasher.contains("fixed (char* dataPtr = data)"),
+            "&DiplomatStr16 should pin the C# string directly, zero-copy:\n{hasher}"
+        );
+        assert!(
+            !hasher.contains("Encoding.UTF8") && !hasher.contains("Utf8.Clone"),
+            "&DiplomatStr16 must never transcode:\n{hasher}"
+        );
+    }
+
+    // A `&DiplomatStr16` borrowed by an owned opaque return pins via
+    // `ReadOnlyMemory<char>` — same keep-alive-edge mechanism as `&[u8]`.
+    #[test]
+    fn owned_return_borrowing_diplomat_str16_input_pins_via_readonly_memory_char() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                use diplomat_runtime::DiplomatStr16;
+
+                #[diplomat::opaque]
+                pub struct Foo<'a>(&'a DiplomatStr16);
+
+                impl<'a> Foo<'a> {
+                    pub fn new(x: &'a DiplomatStr16) -> Box<Self> {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let foo = files.get("Foo.cs").expect("expected Foo.cs output");
+        assert!(
+            foo.contains("public static Foo New(ReadOnlyMemory<char> x)"),
+            "borrowed &DiplomatStr16 param should surface as ReadOnlyMemory<char>:\n{foo}"
+        );
+        assert!(
+            foo.contains("DiplomatPinnedMemory.Pin(x)") && foo.contains("(char*)xPin.Pointer"),
+            "borrowed &DiplomatStr16 should be pinned via DiplomatPinnedMemory:\n{foo}"
+        );
+        assert!(
+            foo.contains("new Foo(result, new object[] { xPin })"),
+            "infallible owned return should root the pin holder as an edge:\n{foo}"
         );
     }
 
@@ -1630,6 +1932,173 @@ mod test {
             "an owned slice parameter must still be rejected now that \
              owned_byte_slice_returns is enabled for the return position; got: {}",
             errors[0]
+        );
+    }
+
+    // A borrowed string return (`&'a str` family) has no `IDisposable`
+    // wrapper of its own — Rust still owns the memory — so it's a
+    // zero-copy `DiplomatBorrowedSpan<byte>` rooting `this` as a keep-alive
+    // edge, the same mechanism a borrowed opaque return already uses.
+    #[test]
+    fn borrowed_string_return_generates_diplomat_borrowed_span() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                use diplomat_runtime::DiplomatStrSlice;
+
+                #[diplomat::opaque]
+                pub struct MyString;
+
+                impl MyString {
+                    pub fn borrow<'a>(&'a self) -> DiplomatStrSlice<'a> {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let my_string = files.get("MyString.cs").expect("expected MyString.cs output");
+        assert!(
+            my_string.contains("public DiplomatBorrowedSpan<byte> Borrow()"),
+            "borrowed string return should surface as DiplomatBorrowedSpan<byte>:\n{my_string}"
+        );
+        assert!(
+            my_string.contains(
+                "new DiplomatBorrowedSpan<byte>(result.Ptr, result.Len, new object[] { this })"
+            ),
+            "the returned view should root `this` as a keep-alive edge:\n{my_string}"
+        );
+
+        let span = files
+            .get("DiplomatBorrowedSpan.cs")
+            .expect("DiplomatBorrowedSpan.cs should be emitted when a run returns one");
+        assert!(
+            span.contains("public readonly unsafe struct DiplomatBorrowedSpan<T>"),
+            "the view must be a plain struct (not a ref struct, not a class) so it can be \
+             stored anywhere and keep `edges` reachable:\n{span}"
+        );
+        assert!(
+            span.contains("public void WithSpan(DiplomatBorrowedSpanAction<T> action)"),
+            "the view should expose zero-copy access scoped to a callback, mirroring \
+             RustVec's WithSpan — never a bare Span-returning property:\n{span}"
+        );
+        assert!(
+            span.contains("public T[] Clone()"),
+            "an independent copy should be a separate, explicitly-named operation:\n{span}"
+        );
+        assert!(
+            !span.contains("void Dispose()"),
+            "the view never owns the memory, so it shouldn't be IDisposable:\n{span}"
+        );
+    }
+
+    // The same view type covers a borrowed primitive slice return, not just
+    // strings — `lower_return` previously had no `Type::Slice` arm at all.
+    #[test]
+    fn borrowed_u32_slice_return_generates_diplomat_borrowed_span() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Buffer;
+
+                impl Buffer {
+                    pub fn borrow<'a>(&'a self) -> &'a [u32] {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+
+        let buffer = files.get("Buffer.cs").expect("expected Buffer.cs output");
+        assert!(
+            buffer.contains("public DiplomatBorrowedSpan<uint> Borrow()"),
+            "borrowed &[u32] return should surface as DiplomatBorrowedSpan<uint>:\n{buffer}"
+        );
+        assert!(
+            buffer.contains(
+                "new DiplomatBorrowedSpan<uint>(result.Ptr, result.Len, new object[] { this })"
+            ),
+            "the returned view should root `this` as a keep-alive edge:\n{buffer}"
+        );
+    }
+
+    // A run that never returns a borrowed span shouldn't pay for the
+    // System.Memory-dependent helper — mirrors
+    // `run_without_pinning_omits_pin_helper_and_sweep`.
+    #[test]
+    fn run_without_borrowed_span_omits_the_helper() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Foo;
+
+                impl Foo {
+                    pub fn value(&self) -> u32 {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (files, errors) = run_dotnet(tk_stream);
+        assert!(
+            errors.is_empty(),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
+        );
+        assert!(
+            !files.contains_key("DiplomatBorrowedSpan.cs"),
+            "a run that never returns a borrowed span shouldn't emit the helper"
+        );
+    }
+
+    // Wrapping a borrowed span return in Result/Option hasn't been exercised
+    // end-to-end (the result/option helper structs' bridging was only ever
+    // built for opaque/primitive/struct/enum arms) — reject rather than risk
+    // generating broken code, instead of silently mis-lowering it.
+    #[test]
+    fn fallible_borrowed_string_return_is_rejected() {
+        let tk_stream = quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                use diplomat_runtime::DiplomatStrSlice;
+
+                #[diplomat::opaque]
+                pub struct MyString;
+
+                #[diplomat::opaque]
+                pub struct MyError;
+
+                impl MyString {
+                    pub fn try_borrow<'a>(&'a self) -> Result<DiplomatStrSlice<'a>, Box<MyError>> {
+                        unimplemented!()
+                    }
+                }
+            }
+        };
+
+        let (_files, errors) = run_dotnet(tk_stream);
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains("wrapping a borrowed span return"),
+            "unexpected diagnostics: {}",
+            errors.join("\n")
         );
     }
 }

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -1964,7 +1964,9 @@ mod test {
             errors.join("\n")
         );
 
-        let my_string = files.get("MyString.cs").expect("expected MyString.cs output");
+        let my_string = files
+            .get("MyString.cs")
+            .expect("expected MyString.cs output");
         assert!(
             my_string.contains("public DiplomatBorrowedSpan<byte> Borrow()"),
             "borrowed string return should surface as DiplomatBorrowedSpan<byte>:\n{my_string}"

--- a/tool/templates/dotnet/DiplomatBorrowedSpan.cs.jinja
+++ b/tool/templates/dotnet/DiplomatBorrowedSpan.cs.jinja
@@ -1,0 +1,61 @@
+using System;
+
+namespace {{ namespace }}.Diplomat;
+
+#nullable enable
+
+public delegate void DiplomatBorrowedSpanAction<T>(ReadOnlySpan<T> span) where T : unmanaged;
+
+/// <summary>
+/// A zero-copy view over memory Rust still owns (a borrowed <c>&amp;str</c> /
+/// <c>&amp;[T]</c> return). Unlike <c>RustVec</c>, there's nothing to free
+/// here — Rust still owns this memory, so there's no <c>IDisposable</c> and
+/// no ownership race to guard against. <c>edges</c> roots whatever this was
+/// borrowed from (the receiver or an input parameter) so the GC can't
+/// collect it while this view is alive.
+/// </summary>
+/// <remarks>
+/// This intentionally does not expose a public <c>Span</c>-returning
+/// property. A caller could extract it, let this value go, and be left
+/// holding a span with nothing keeping <c>edges</c> (and the parent it
+/// roots) alive — exactly the trap <c>RustVec</c> avoids by not implementing
+/// <c>MemoryManager&lt;T&gt;</c>. <see cref="WithSpan"/> gives synchronous,
+/// zero-copy, read-only access instead: the callback receives the span
+/// directly, so it can never outlive this value's own lifetime. This is a
+/// plain struct, not a <c>ref struct</c>, so it can be stored in a field, a
+/// collection, or held across an <c>await</c> — unlike a bare
+/// <see cref="ReadOnlySpan{T}"/>. <see cref="Clone"/> is the explicit,
+/// independent copy — never something this type does on its own.
+/// </remarks>
+public readonly unsafe struct DiplomatBorrowedSpan<T> where T : unmanaged
+{
+    private readonly T* _ptr;
+    private readonly int _len;
+    private readonly object[] _edges;
+
+    internal DiplomatBorrowedSpan(T* ptr, nuint len, object[] edges)
+    {
+        _ptr = ptr;
+        _len = (int)len;
+        _edges = edges;
+    }
+
+    public int Length => _len;
+
+    /// <summary>
+    /// Synchronous, zero-copy, read-only access. The span is valid only for
+    /// the duration of this callback.
+    /// </summary>
+    public void WithSpan(DiplomatBorrowedSpanAction<T> action)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+        action(new ReadOnlySpan<T>(_ptr, _len));
+        GC.KeepAlive(_edges);
+    }
+
+    /// <summary>An explicit, independent copy — never implicit.</summary>
+    public T[] Clone() => new ReadOnlySpan<T>(_ptr, _len).ToArray();
+}

--- a/tool/templates/dotnet/DiplomatSliceU16.cs.jinja
+++ b/tool/templates/dotnet/DiplomatSliceU16.cs.jinja
@@ -1,0 +1,10 @@
+using System.Runtime.InteropServices;
+
+namespace {{ namespace }}.Diplomat;
+
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct DiplomatSliceU16
+{
+    public char* Ptr;
+    public nuint Len;
+}

--- a/tool/templates/dotnet/Utf8.cs.jinja
+++ b/tool/templates/dotnet/Utf8.cs.jinja
@@ -1,0 +1,14 @@
+namespace {{ namespace }}.Diplomat;
+
+/// <summary>
+/// Explicit conversions between a C# <c>string</c> (always UTF-16 internally)
+/// and raw UTF-8 bytes. Handing a <c>string</c> to a Rust <c>&amp;str</c>
+/// parameter always requires transcoding — there's no way around that
+/// allocation. This class exists so the copy is a visible, separately-named
+/// step in generated code (<c>Utf8.Clone(...)</c>) instead of being buried
+/// inside marshalling.
+/// </summary>
+internal static class Utf8
+{
+    public static byte[] Clone(string value) => System.Text.Encoding.UTF8.GetBytes(value);
+}


### PR DESCRIPTION
Adds UTF-16 string support to the .NET backend alongside the existing UTF-8 path, and closes a related gap: borrowed string/slice returns (`&'a str` / `&'a [u8]` / `&'a [u32]`), which `lower_return` had no `Type::Slice` arm for at all.

Inputs split three ways by what Rust's own safety contract actually requires. `&DiplomatStr16` and `&DiplomatStr` (unvalidated UTF-8, no caller-side validity requirement) both pin zero-copy — the latter is reshaped to `byte[]`/`ReadOnlyMemory<byte>` and reuses the exact `&[u8]` codegen path, since that's really all it is. A validated `&str` still copies (only a transcode from a real `System.String` can guarantee well-formed UTF-8), but the copy is routed through a named `Diplomat.Utf8.Clone(...)` helper instead of an inlined `Encoding.UTF8.GetBytes` call, so it's a visible, named step rather than something buried in marshalling.

Borrowed string/slice returns get a new `DiplomatBorrowedSpan<T>`, rooted with the same keep-alive edges a borrowed opaque return already uses. It deliberately doesn't expose a `Span`-returning property — a bare `Span<T>` carries no reference back to the edges keeping the borrow's owner alive, so a caller who only kept the span would be left holding a dangling pointer the moment the owner got collected. `WithSpan(...)` scopes access to a callback instead (same shape as `RustVec`'s), and `Clone()` is the explicit, separate copy. Wrapping a borrowed span in `Result`/`Option` isn't supported yet — the result/option bridging was never exercised for this shape, so it's rejected rather than risking broken codegen.

Regen: un-disabled the 4 feature-test methods that were `#[diplomat::attr(dotnet, disable)]`'d for this (`MyString::borrow`, `OpaqueMutexedString::dummy_str`, `Utf16Wrap::from_utf16`, `Utf16Wrap::borrow_cont`). Existing UTF-8 fixtures also changed: `&DiplomatStr` params flipped from `string` to `byte[]` wherever they appear.

Tests: 38 tool unit tests (dotnet), 84 xunit facts against the built native library — new coverage for empty-string zero-copy pinning, `Clone`, and GC-survival of borrowed views under stress.