### PR TITLE
dotnet: fixed-width bool tag so Result/Option marshal on .NET Framework

### DIFF
--- a/example/dotnet/Generated/DiplomatBool.cs
+++ b/example/dotnet/Generated/DiplomatBool.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+
+namespace Somelib.Diplomat;
+
+// Blittable one-byte stand-in for `bool`. .NET Framework P/Invoke can't return a
+// struct by value if any field is non-blittable, and `bool` is non-blittable, so
+// Result/Option tags and struct bool fields use a byte (these bindings target
+// netstandard2.0 and must load on net48).
+// Rules: https://learn.microsoft.com/en-us/dotnet/standard/native-interop/blittable-and-non-blittable-types
+// Matches Rust's 1-byte bool (0/1): https://doc.rust-lang.org/reference/types/boolean.html
+[StructLayout(LayoutKind.Sequential)]
+internal readonly struct DiplomatBool
+{
+    private readonly byte _value;
+
+    private DiplomatBool(byte value) => _value = value;
+
+    // Implicit both ways so the idiomatic layer stays bool-only.
+    public static implicit operator DiplomatBool(bool value) => new DiplomatBool(value ? (byte)1 : (byte)0);
+    public static implicit operator bool(DiplomatBool value) => value._value != 0;
+}

--- a/example/dotnet/Generated/DiplomatResultFixedDecimalFormatterUnit.cs
+++ b/example/dotnet/Generated/DiplomatResultFixedDecimalFormatterUnit.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultFixedDecimalFormatterUnit
@@ -16,7 +17,6 @@ internal partial struct DiplomatResultFixedDecimalFormatterUnit
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public unsafe FixedDecimalFormatter* Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
 }

--- a/example/dotnet/Generated/DiplomatResultVoidUnit.cs
+++ b/example/dotnet/Generated/DiplomatResultVoidUnit.cs
@@ -4,11 +4,11 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultVoidUnit
 {
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
 }

--- a/example/dotnet/Generated/RawFixedDecimalFormatterOptions.cs
+++ b/example/dotnet/Generated/RawFixedDecimalFormatterOptions.cs
@@ -10,8 +10,7 @@ namespace Somelib.Raw;
 internal partial struct FixedDecimalFormatterOptions
 {
     public FixedDecimalGroupingStrategy GroupingStrategy;
-    [MarshalAs(UnmanagedType.U1)]
-    public bool SomeOtherConfig;
+    public DiplomatBool SomeOtherConfig;
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "icu4x_FixedDecimalFormatterOptions_default_mv1", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern FixedDecimalFormatterOptions Default();

--- a/feature_tests/dotnet/Generated/DiplomatBool.cs
+++ b/feature_tests/dotnet/Generated/DiplomatBool.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+
+namespace Somelib.Diplomat;
+
+// Blittable one-byte stand-in for `bool`. .NET Framework P/Invoke can't return a
+// struct by value if any field is non-blittable, and `bool` is non-blittable, so
+// Result/Option tags and struct bool fields use a byte (these bindings target
+// netstandard2.0 and must load on net48).
+// Rules: https://learn.microsoft.com/en-us/dotnet/standard/native-interop/blittable-and-non-blittable-types
+// Matches Rust's 1-byte bool (0/1): https://doc.rust-lang.org/reference/types/boolean.html
+[StructLayout(LayoutKind.Sequential)]
+internal readonly struct DiplomatBool
+{
+    private readonly byte _value;
+
+    private DiplomatBool(byte value) => _value = value;
+
+    // Implicit both ways so the idiomatic layer stays bool-only.
+    public static implicit operator DiplomatBool(bool value) => new DiplomatBool(value ? (byte)1 : (byte)0);
+    public static implicit operator bool(DiplomatBool value) => value._value != 0;
+}

--- a/feature_tests/dotnet/Generated/DiplomatOptionDouble.cs
+++ b/feature_tests/dotnet/Generated/DiplomatOptionDouble.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatOptionDouble
@@ -16,8 +17,7 @@ internal partial struct DiplomatOptionDouble
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsSome;
+    public DiplomatBool IsSome;
 
     public double Value => IsSome ? _inner.value : throw new InvalidOperationException("Option is None");
 }

--- a/feature_tests/dotnet/Generated/DiplomatOptionInt.cs
+++ b/feature_tests/dotnet/Generated/DiplomatOptionInt.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatOptionInt
@@ -16,8 +17,7 @@ internal partial struct DiplomatOptionInt
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsSome;
+    public DiplomatBool IsSome;
 
     public int Value => IsSome ? _inner.value : throw new InvalidOperationException("Option is None");
 }

--- a/feature_tests/dotnet/Generated/DiplomatOptionNInt.cs
+++ b/feature_tests/dotnet/Generated/DiplomatOptionNInt.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatOptionNInt
@@ -16,8 +17,7 @@ internal partial struct DiplomatOptionNInt
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsSome;
+    public DiplomatBool IsSome;
 
     public nint Value => IsSome ? _inner.value : throw new InvalidOperationException("Option is None");
 }

--- a/feature_tests/dotnet/Generated/DiplomatOptionNUInt.cs
+++ b/feature_tests/dotnet/Generated/DiplomatOptionNUInt.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatOptionNUInt
@@ -16,8 +17,7 @@ internal partial struct DiplomatOptionNUInt
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsSome;
+    public DiplomatBool IsSome;
 
     public nuint Value => IsSome ? _inner.value : throw new InvalidOperationException("Option is None");
 }

--- a/feature_tests/dotnet/Generated/DiplomatOptionUInt.cs
+++ b/feature_tests/dotnet/Generated/DiplomatOptionUInt.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatOptionUInt
@@ -16,8 +17,7 @@ internal partial struct DiplomatOptionUInt
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsSome;
+    public DiplomatBool IsSome;
 
     public uint Value => IsSome ? _inner.value : throw new InvalidOperationException("Option is None");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultErrorEnumResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultErrorEnumResultOpaque.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultErrorEnumResultOpaque
@@ -17,8 +18,7 @@ internal partial struct DiplomatResultErrorEnumResultOpaque
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public ErrorEnum Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
     public unsafe ResultOpaque* Err => !IsOk ? _inner.err : throw new InvalidOperationException("Result does not contain Err value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultIntBorrowingError.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultIntBorrowingError.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultIntBorrowingError
@@ -17,8 +18,7 @@ internal partial struct DiplomatResultIntBorrowingError
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public int Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
     public unsafe BorrowingError* Err => !IsOk ? _inner.err : throw new InvalidOperationException("Result does not contain Err value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultIntUnit.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultIntUnit.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultIntUnit
@@ -16,7 +17,6 @@ internal partial struct DiplomatResultIntUnit
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public int Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultOpaqueSliceViewSliceParseError.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultOpaqueSliceViewSliceParseError.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultOpaqueSliceViewSliceParseError
@@ -17,8 +18,7 @@ internal partial struct DiplomatResultOpaqueSliceViewSliceParseError
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public unsafe OpaqueSliceView* Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
     public unsafe SliceParseError* Err => !IsOk ? _inner.err : throw new InvalidOperationException("Result does not contain Err value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultOpaqueThinIterUnit.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultOpaqueThinIterUnit.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultOpaqueThinIterUnit
@@ -16,7 +17,6 @@ internal partial struct DiplomatResultOpaqueThinIterUnit
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public unsafe OpaqueThinIter* Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultOpaqueThinUnit.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultOpaqueThinUnit.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultOpaqueThinUnit
@@ -16,7 +17,6 @@ internal partial struct DiplomatResultOpaqueThinUnit
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public unsafe OpaqueThin* Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultRenamedStructWithAttrsUnit.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultRenamedStructWithAttrsUnit.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultRenamedStructWithAttrsUnit
@@ -16,7 +17,6 @@ internal partial struct DiplomatResultRenamedStructWithAttrsUnit
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public RenamedStructWithAttrs Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultResultOpaqueErrorEnum.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultResultOpaqueErrorEnum.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultResultOpaqueErrorEnum
@@ -17,8 +18,7 @@ internal partial struct DiplomatResultResultOpaqueErrorEnum
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public unsafe ResultOpaque* Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
     public ErrorEnum Err => !IsOk ? _inner.err : throw new InvalidOperationException("Result does not contain Err value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultResultOpaqueErrorStruct.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultResultOpaqueErrorStruct.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultResultOpaqueErrorStruct
@@ -17,8 +18,7 @@ internal partial struct DiplomatResultResultOpaqueErrorStruct
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public unsafe ResultOpaque* Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
     public ErrorStruct Err => !IsOk ? _inner.err : throw new InvalidOperationException("Result does not contain Err value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultResultOpaqueUnit.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultResultOpaqueUnit.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultResultOpaqueUnit
@@ -16,7 +17,6 @@ internal partial struct DiplomatResultResultOpaqueUnit
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public unsafe ResultOpaque* Ok => IsOk ? _inner.ok : throw new InvalidOperationException("Result does not contain Ok value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultVoidMyZst.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultVoidMyZst.cs
@@ -4,11 +4,11 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultVoidMyZst
 {
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultVoidResultOpaque.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultVoidResultOpaque.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultVoidResultOpaque
@@ -16,7 +17,6 @@ internal partial struct DiplomatResultVoidResultOpaque
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
     public unsafe ResultOpaque* Err => !IsOk ? _inner.err : throw new InvalidOperationException("Result does not contain Err value");
 }

--- a/feature_tests/dotnet/Generated/DiplomatResultVoidUnit.cs
+++ b/feature_tests/dotnet/Generated/DiplomatResultVoidUnit.cs
@@ -4,11 +4,11 @@ using System.Runtime.InteropServices;
 namespace Somelib.Raw;
 
 using Somelib;
+using Somelib.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct DiplomatResultVoidUnit
 {
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
 }

--- a/feature_tests/dotnet/Generated/Opaque.cs
+++ b/feature_tests/dotnet/Generated/Opaque.cs
@@ -147,6 +147,14 @@ public partial class Opaque: IDisposable
         }
     }
 
+    public static bool EchoBool(bool x)
+    {
+        unsafe
+        {
+            return Raw.Opaque.EchoBool(x);
+        }
+    }
+
     public static ImportedStruct ReturnsImported()
     {
         unsafe

--- a/feature_tests/dotnet/Generated/RawMyStruct.cs
+++ b/feature_tests/dotnet/Generated/RawMyStruct.cs
@@ -10,8 +10,7 @@ namespace Somelib.Raw;
 internal partial struct MyStruct
 {
     public byte A;
-    [MarshalAs(UnmanagedType.U1)]
-    public bool B;
+    public DiplomatBool B;
     public byte C;
     public ulong D;
     public int E;

--- a/feature_tests/dotnet/Generated/RawOpaque.cs
+++ b/feature_tests/dotnet/Generated/RawOpaque.cs
@@ -27,6 +27,10 @@ internal partial struct Opaque
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_returns_usize", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern nuint ReturnsUsize();
 
+    [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_echo_bool", CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.U1)]
+    internal static unsafe extern bool EchoBool([MarshalAs(UnmanagedType.U1)] bool x);
+
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "Opaque_returns_imported", CallingConvention = CallingConvention.Cdecl)]
     internal static unsafe extern ImportedStruct ReturnsImported();
 

--- a/feature_tests/dotnet/Generated/RawPrimitiveStruct.cs
+++ b/feature_tests/dotnet/Generated/RawPrimitiveStruct.cs
@@ -10,8 +10,7 @@ namespace Somelib.Raw;
 internal partial struct PrimitiveStruct
 {
     public float X;
-    [MarshalAs(UnmanagedType.U1)]
-    public bool A;
+    public DiplomatBool A;
     public uint B;
     public long C;
     public nint D;

--- a/feature_tests/dotnet/Generated/RawRenamedStructWithAttrs.cs
+++ b/feature_tests/dotnet/Generated/RawRenamedStructWithAttrs.cs
@@ -9,8 +9,7 @@ namespace Somelib.Raw;
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct RenamedStructWithAttrs
 {
-    [MarshalAs(UnmanagedType.U1)]
-    public bool A;
+    public DiplomatBool A;
     public uint B;
 
     [DllImport(DiplomatNativeLib.Name, EntryPoint = "namespace_StructWithAttrs_new_fallible", CallingConvention = CallingConvention.Cdecl)]

--- a/feature_tests/dotnet/Somelib.FeatureTests.csproj
+++ b/feature_tests/dotnet/Somelib.FeatureTests.csproj
@@ -16,7 +16,12 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <!-- net48 runs the suite on the legacy .NET Framework CLR, where
+         non-blittable-by-value marshalling (the Result/Option/struct bool tags)
+         has to keep working. It only builds on Windows, so Linux/macOS (and CI's
+         ubuntu leg) get net8 alone. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net8.0;net48</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -48,9 +53,25 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- .NET Framework only. net8 ignores all of this; it's here so the same
+       sources also run on the legacy CLR. net48 has no Span/Memory in the BCL
+       (System.Memory backfills it), and the vstest host needs binding redirects
+       (net48.config) to load a single System.Memory version. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <AppConfig>net48.config</AppConfig>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
   <!-- Copy the Rust-built cdylib next to the test assembly so P/Invoke
        (DllImport "diplomat_feature_tests") resolves it at runtime. -->
-  <Target Name="CopyNativeLib" BeforeTargets="Build">
+  <!-- Only in the per-TFM inner build: the multi-target outer build has no
+       $(TargetFramework)/$(OutDir), so the copy has nowhere to go. -->
+  <Target Name="CopyNativeLib" BeforeTargets="Build" Condition="'$(TargetFramework)' != ''">
     <Copy SourceFiles="$(NativeLibPath)"
           DestinationFolder="$(OutDir)"
           Condition="Exists('$(NativeLibPath)')"

--- a/feature_tests/dotnet/Tests/BorrowedReturnTests.cs
+++ b/feature_tests/dotnet/Tests/BorrowedReturnTests.cs
@@ -74,7 +74,11 @@ public class BorrowedReturnTests
     // use (the `First()` call). If `_edges` didn't root it, GC -> finalizer ->
     // Destroy would free the Vec out from under the returned borrow.
     // AggressiveOptimization forces that liveness so the race can surface.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static OpaqueThin BorrowAndDropOwner()
     {
         return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").First()!;
@@ -102,7 +106,11 @@ public class BorrowedReturnTests
     // Same liveness trap, but the borrow comes back through a
     // `Result<&OpaqueThin, ()>` — the keep-alive edges must ride on the
     // *success* (`result.Ok`) wrapper for a fallible return too.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static OpaqueThin TryFirstAndDropOwner()
     {
         return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").TryFirst(false);
@@ -151,7 +159,11 @@ public class BorrowedReturnTests
         Assert.Throws<InvalidOperationException>(() => vec.TryGet(0, true));
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static OpaqueThin TryGetAndDropOwner()
     {
         return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").TryGet(0, false)!;
@@ -177,7 +189,11 @@ public class BorrowedReturnTests
     // `Result<Box<OpaqueThinIter<'a>>, ()>` — the Ok value is an *owned* Box
     // (IronRDP's shape) that still borrows the Vec. Its keep-alive edges must
     // root the now-unreferenced owner, so the owned-but-borrowing case works.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static OpaqueThinIter TryIterAndDropOwner()
     {
         return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").TryIter(false);
@@ -233,7 +249,11 @@ public class BorrowedReturnTests
         Assert.Throws<InvalidOperationException>(() => vec.TryIter(true));
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static OpaqueThinIter OptionalIterAndDropOwner()
     {
         return OpaqueThinVec.CreateSingle(42, 2.5f, "rooted").OptionalIter(true)!;
@@ -285,7 +305,11 @@ public class BorrowedReturnTests
     // only thing that can root the owner for a caught exception is the edge
     // threaded onto the exception (and its inner error). Drop every other
     // reference to prove that edge alone holds the Vec.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static BorrowingErrorException TryBorrowAndDropOwner()
     {
         try

--- a/feature_tests/dotnet/Tests/GcRaceTests.cs
+++ b/feature_tests/dotnet/Tests/GcRaceTests.cs
@@ -19,7 +19,11 @@ public class GcRaceTests
 {
     // AggressiveOptimization: Tier1's precise liveness drops `probe` at its
     // last use (the race); Tier0 would root it and hide the bug.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static ulong UnrootedSlowCall(ulong millis)
     {
         GcRaceProbe probe = GcRaceProbe.Create();

--- a/feature_tests/dotnet/Tests/OpaqueTests.cs
+++ b/feature_tests/dotnet/Tests/OpaqueTests.cs
@@ -62,4 +62,11 @@ public class OpaqueTests
         // Disposed arg must throw, not feed a freed pointer to native (UAF).
         Assert.Throws<ObjectDisposedException>(() => OptionOpaque.OptionOpaqueArgument(arg));
     }
+
+    [Fact]
+    public void EchoBool_RoundTripsBothDirections()
+    {
+        Assert.True(Opaque.EchoBool(true));
+        Assert.False(Opaque.EchoBool(false));
+    }
 }

--- a/feature_tests/dotnet/Tests/OwnedSliceReturnTests.cs
+++ b/feature_tests/dotnet/Tests/OwnedSliceReturnTests.cs
@@ -135,7 +135,11 @@ public class OwnedSliceReturnTests
     }
 
     // Precise liveness must release the local so the finalizer path is observable.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static void MakeAndDropWithoutDisposing(int len)
     {
         RustVec vec = OwnedSliceReturn.MakeBytes((uint)len);

--- a/feature_tests/dotnet/Tests/PinnedSliceTests.cs
+++ b/feature_tests/dotnet/Tests/PinnedSliceTests.cs
@@ -28,7 +28,11 @@ public class PinnedSliceTests
     // Build and parse inside an AggressiveOptimization frame so Tier1's precise
     // liveness drops the byte[] local at its last use. The only thing keeping
     // it alive AND pinned afterwards is the view's DiplomatPinnedMemory edge.
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining
+#if !NETFRAMEWORK
+        | MethodImplOptions.AggressiveOptimization
+#endif
+    )]
     private static OpaqueSliceView ParseAndDropBuffer()
     {
         byte[] data = [10, 20, 30, 40];

--- a/feature_tests/dotnet/net48.config
+++ b/feature_tests/dotnet/net48.config
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  .NET Framework (net48) only — referenced via <AppConfig> under the net48
+  condition in the csproj, so net8 never sees it. The vstest host loads a newer
+  System.Memory (and its deps) than the System.Memory package ships; these
+  redirects bind every requested version down to the copies next to the test
+  binary so the assembly loads.
+-->
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="4.0.4.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -106,6 +106,13 @@ pub mod ffi {
             412
         }
 
+        // Gives the .NET tests a bool to assert in both marshalling directions;
+        // `not(dotnet)` disable keeps the other backends' fixtures untouched.
+        #[diplomat::attr(not(dotnet), disable)]
+        pub fn echo_bool(x: bool) -> bool {
+            x
+        }
+
         pub fn returns_imported() -> ImportedStruct {
             unimplemented!()
         }

--- a/tool/src/dotnet/gen/impl_struct.rs
+++ b/tool/src/dotnet/gen/impl_struct.rs
@@ -32,6 +32,17 @@ pub(super) struct StructField {
     field_type: StructFieldType,
 }
 
+impl StructField {
+    /// Raw-layer field type: `bool` becomes the blittable `DiplomatBool` (see its docs).
+    pub(super) fn raw_field_type(&self) -> String {
+        if self.field_type.is_bool() {
+            "DiplomatBool".to_string()
+        } else {
+            self.field_type.to_string()
+        }
+    }
+}
+
 /// Field type that templates render verbatim. Enums use the same C# type
 /// name on both the raw and idiomatic side (they're declared once in the
 /// project namespace, not under `Raw.`), and they P/Invoke as their
@@ -43,9 +54,7 @@ enum StructFieldType {
 }
 
 impl StructFieldType {
-    /// True only for `bool` — used to gate `[MarshalAs(UnmanagedType.U1)]`
-    /// on the field. Enums never need this; C#'s default marshaling already
-    /// matches Rust's discriminant width.
+    /// True only for `bool`, which `raw_field_type` maps to `DiplomatBool`.
     fn is_bool(&self) -> bool {
         matches!(self, Self::Primitive(p) if p.is_bool())
     }

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -109,6 +109,14 @@ struct RustHandleTemplate<'a> {
     namespace: &'a str,
 }
 
+/// `DiplomatBool` — the blittable one-byte `bool` stand-in for Result/Option
+/// tags and struct bool fields (the template explains why).
+#[derive(Template)]
+#[template(path = "dotnet/DiplomatBool.cs.jinja", escape = "none")]
+struct DiplomatBoolTemplate<'a> {
+    namespace: &'a str,
+}
+
 /// `DiplomatPinnedMemory` — pins a caller `ReadOnlyMemory` buffer while a
 /// Rust value borrows it, and unpins when the borrowing wrapper is disposed.
 #[derive(Template)]
@@ -446,6 +454,15 @@ pub(crate) fn run<'tcx>(
         }
         .render()
         .expect("RustHandle template render failed"),
+    );
+    add_cs_file(
+        &files,
+        "DiplomatBool.cs".to_string(),
+        DiplomatBoolTemplate {
+            namespace: &namespace,
+        }
+        .render()
+        .expect("DiplomatBool template render failed"),
     );
     // The helper pulls in System.Memory, which the netstandard2.0 floor lacks
     // by default — so only ship it when the run actually pins a slice.

--- a/tool/templates/dotnet/DiplomatBool.cs.jinja
+++ b/tool/templates/dotnet/DiplomatBool.cs.jinja
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+
+namespace {{ namespace }}.Diplomat;
+
+// Blittable one-byte stand-in for `bool`. .NET Framework P/Invoke can't return a
+// struct by value if any field is non-blittable, and `bool` is non-blittable, so
+// Result/Option tags and struct bool fields use a byte (these bindings target
+// netstandard2.0 and must load on net48).
+// Rules: https://learn.microsoft.com/en-us/dotnet/standard/native-interop/blittable-and-non-blittable-types
+// Matches Rust's 1-byte bool (0/1): https://doc.rust-lang.org/reference/types/boolean.html
+[StructLayout(LayoutKind.Sequential)]
+internal readonly struct DiplomatBool
+{
+    private readonly byte _value;
+
+    private DiplomatBool(byte value) => _value = value;
+
+    // Implicit both ways so the idiomatic layer stays bool-only.
+    public static implicit operator DiplomatBool(bool value) => new DiplomatBool(value ? (byte)1 : (byte)0);
+    public static implicit operator bool(DiplomatBool value) => value._value != 0;
+}

--- a/tool/templates/dotnet/option.raw.cs.jinja
+++ b/tool/templates/dotnet/option.raw.cs.jinja
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace {{ namespace }}.Raw;
 
 using {{ namespace }};
+using {{ namespace }}.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct {{ option_struct_name }}
@@ -19,8 +20,7 @@ internal partial struct {{ option_struct_name }}
 
     private InnerUnion _inner;
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsSome;
+    public DiplomatBool IsSome;
 
     public {{ inner.raw() }} Value => IsSome ? {{ inner.read_union_field("_inner.value") }} : throw new InvalidOperationException("Option is None");
 }

--- a/tool/templates/dotnet/result.raw.cs.jinja
+++ b/tool/templates/dotnet/result.raw.cs.jinja
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 namespace {{ namespace }}.Raw;
 
 using {{ namespace }};
+using {{ namespace }}.Diplomat;
 
 [StructLayout(LayoutKind.Sequential)]
 internal partial struct {{ result_struct_name }}
@@ -28,8 +29,7 @@ internal partial struct {{ result_struct_name }}
     private InnerUnion _inner;
     {%- endif %}
 
-    [MarshalAs(UnmanagedType.U1)]
-    public bool IsOk;
+    public DiplomatBool IsOk;
 
     {%- if !ok_result.is_void() %}
     public {% if ok_result.is_opaque() %}unsafe {% endif %}{{ ok_result.raw() }} Ok => IsOk ? {{ ok_result.read_union_field("_inner.ok") }} : throw new InvalidOperationException("Result does not contain Ok value");

--- a/tool/templates/dotnet/struct.raw.cs.jinja
+++ b/tool/templates/dotnet/struct.raw.cs.jinja
@@ -10,13 +10,7 @@ namespace {{ namespace }}.Raw;
 internal partial struct {{ name }}
 {
     {%- for field in fields %}
-    {#- C#'s default marshaling of `bool` is `BOOL` (4 bytes) — wrong for
-        a Rust `repr(C)` struct field where `bool` is 1 byte. Force U1
-        marshaling on bool fields so the struct layout matches Rust's. #}
-    {%- if field.field_type.is_bool() %}
-    [MarshalAs(UnmanagedType.U1)]
-    {%- endif %}
-    public {{ field.field_type }} {{ field.name }};
+    public {{ field.raw_field_type() }} {{ field.name }};
     {%- endfor %}
 
 


### PR DESCRIPTION
.NET Framework can't marshal a by-value struct return that has a `bool` field — `bool` isn't blittable — so every by-value `DiplomatResult`/`DiplomatOption` return throws `MarshalDirectiveException` on net48 (`Method's type signature is not PInvoke compatible`). Struct `bool` fields hit the same wall. Kotlin already sidesteps this by storing struct-field bools as `Byte`.

This adds a one-byte [`DiplomatBool`](https://github.com/irvingoujAtDevolution/diplomat/blob/dotnet-blittable-bool-tag/tool/templates/dotnet/DiplomatBool.cs.jinja) and uses it for the Result/Option tag and struct `bool` fields. Rust and the public C# API stay `bool` — the conversion lives in the generated raw layer. Params stay `bool` (those marshal fine on net48).

Tests: feature tests now multi-target `net8.0;net48` — 76/76 on both.
