### PR TITLE
Nanobind: Keep Lifetime Annotations for Read-Only Properties

### DIFF
--- a/feature_tests/nanobind/src/sub_modules/somelib/Bar_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/Bar_binding.cpp
@@ -12,7 +12,7 @@ void add_Bar_binding(nb::module_ mod) {
     
     nb::class_<somelib::Bar> opaque(mod, "Bar", nb::type_slots(somelib_Bar_slots));
     opaque
-        .def_prop_ro("foo", &somelib::Bar::foo);
+        .def_prop_ro("foo", &somelib::Bar::foo, nb::rv_policy::reference_internal);
 }
 
 } 

--- a/feature_tests/nanobind/src/sub_modules/somelib/Foo_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/Foo_binding.cpp
@@ -16,7 +16,7 @@ void add_Foo_binding(nb::module_ mod) {
     opaque
         .def(nb::new_(std::move(maybe_op_unwrap(&somelib::Foo::new_))), "x"_a, nb::keep_alive<1, 2>())
         .def("as_returning", &somelib::Foo::as_returning, nb::keep_alive<0, 1>())
-        .def_prop_ro("bar", std::move(maybe_op_unwrap(&somelib::Foo::get_bar)))
+        .def_prop_ro("bar", std::move(maybe_op_unwrap(&somelib::Foo::get_bar)), nb::keep_alive<0, 1>())
         .def_static("extract_from_bounds", std::move(maybe_op_unwrap(&somelib::Foo::extract_from_bounds)), "bounds"_a, "another_string"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), "Test that the extraction logic correctly pins the right fields")
         .def_static("extract_from_fields", std::move(maybe_op_unwrap(&somelib::Foo::extract_from_fields)), "fields"_a, nb::keep_alive<0, 1>())
         .def_static("new_static", std::move(maybe_op_unwrap(&somelib::Foo::new_static)), "x"_a);

--- a/feature_tests/nanobind/src/sub_modules/somelib/OpaqueThinVec_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/OpaqueThinVec_binding.cpp
@@ -14,7 +14,7 @@ void add_OpaqueThinVec_binding(nb::module_ mod) {
     opaque
         .def("__len__", &somelib::OpaqueThinVec::__len__)
         .def(nb::new_(std::move(maybe_op_unwrap(&somelib::OpaqueThinVec::create))), "a"_a, "b"_a, "c"_a)
-        .def_prop_ro("first", &somelib::OpaqueThinVec::first)
+        .def_prop_ro("first", &somelib::OpaqueThinVec::first, nb::rv_policy::reference_internal)
         .def("__getitem__", [](somelib::OpaqueThinVec* self, size_t index) {
                 auto out = self->operator[] (index);
                 if (out == nullptr) {

--- a/feature_tests/nanobind/test/test_lifetimes.py
+++ b/feature_tests/nanobind/test/test_lifetimes.py
@@ -38,3 +38,16 @@ def test_fill_lifetimes():
     gc.collect()
 
     assert c.c == "This is a test"
+
+def test_getter_borrow():
+    f = somelib.Foo("test")
+    # Bar should be kept alive as long as foo:
+    b = f.bar
+    assert b.foo.as_returning().bytes == 'test'
+    del f
+    # Fool the garbage collector again:
+    for i in range(0, 10000):
+        f = somelib.OpaqueThinVec([120, 2], [.1, .2], "This is adifferent test")
+    gc.collect()
+    # The memory underlying Foo is kept alive, even after deletion:
+    assert b.foo.as_returning().bytes == 'test'

--- a/tool/templates/nanobind/method_impl.cpp.jinja
+++ b/tool/templates/nanobind/method_impl.cpp.jinja
@@ -58,12 +58,9 @@
                   { {{type_name}}::{{setter_name}}(
                     {%- for p in m.param_decls.params -%}{%- if !loop.first -%}, {% endif -%}{{p.name}}{%- endfor -%}); }
             {%- endif -%}
-            {{- method_params::params(m.method.params, m.lifetime_args) }}
-        {%- else -%}
-            {#- Read-only getters still need their keep_alive/rv_policy annotations: a getter
-                returning a borrowed view must keep self alive while the view exists. -#}
-            {%- if let Some(lifetime_args) = m.lifetime_args %}, {{lifetime_args}}{% endif %}
         {%- endif -%}
+        {#- Always render the parameters/lifetime annotations after a property definition. -#}
+        {{- method_params::params(m.method.params, m.lifetime_args) }}
         {%- if let Some(doc) = m.docstring %}, {{doc}}{% endif -%})
     {%- when crate::hir::SpecialMethod::Constructor -%}
         {{- gen_constructor_body(m.cpp_method_name, m.param_decls.params.clone(), m.docstring.clone()) -}}

--- a/tool/templates/nanobind/method_impl.cpp.jinja
+++ b/tool/templates/nanobind/method_impl.cpp.jinja
@@ -59,6 +59,10 @@
                     {%- for p in m.param_decls.params -%}{%- if !loop.first -%}, {% endif -%}{{p.name}}{%- endfor -%}); }
             {%- endif -%}
             {{- method_params::params(m.method.params, m.lifetime_args) }}
+        {%- else -%}
+            {#- Read-only getters still need their keep_alive/rv_policy annotations: a getter
+                returning a borrowed view must keep self alive while the view exists. -#}
+            {%- if let Some(lifetime_args) = m.lifetime_args %}, {{lifetime_args}}{% endif %}
         {%- endif -%}
         {%- if let Some(doc) = m.docstring %}, {{doc}}{% endif -%})
     {%- when crate::hir::SpecialMethod::Constructor -%}


### PR DESCRIPTION
Found by @Yazan-Reactor and Claude Fable 5, this fixes an issue where lifetime annotations are not rendered for read-only properties.