### PR TITLE
Expose tuples entry in book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -33,6 +33,7 @@
     - [Comparators](attrs/comparators.md)
     - [Stringifiers](attrs/stringifiers.md)
     - [References](attrs/references.md)
+    - [Tuples](attrs/tuples.md)
     - [Custom Extra Code](attrs/custom_extra_code.md)
   - [Notes on Diplomat and safety](safety.md)
 - [Backend developer guide](developer.md)


### PR DESCRIPTION
Noticed this doing another pass of the release notes, but the tuples entry of the book is not included during builds.