### PR TITLE
Switch diplomat-runtime to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.16.0"
+version = "0.15.1"
 dependencies = [
  "jni",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ keywords = ["ffi", "codegen"]
 [workspace.dependencies]
 diplomat = { version = "0.16.0", path = "macro", default-features = false }
 diplomat_core = { version = "0.16.0", path = "core", default-features = false }
-diplomat-runtime = { version = "0.16.0", path = "runtime", default-features = false }
+diplomat-runtime = { version = "0.15.1", path = "runtime", default-features = false }
 diplomat-tool = { version = "0.16.0", path = "tool", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "diplomat-runtime"
 description = "Common runtime utilities used by diplomat codegen"
-version.workspace = true
+# We are working on decoupling diplomat-runtime's version from the rest
+# https://github.com/rust-diplomat/diplomat/issues/958
+version = "0.15.1"
 rust-version.workspace = true
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
To improve the experience for users of multiple Diplomat libraries, this switches diplomat-runtime over to 0.15.1 to avoid multiple copies in a single binary. At some point we shall update everyone to 1.0. This would need to be done coordinated between ICU4X and Temporal.

https://github.com/rust-diplomat/diplomat/issues/958