### PR TITLE
Improve some diplomat-runtime docs

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,11 +6,22 @@
 //! Include this in any crate that also depends on `diplomat`, since `#[diplomat::bridge]`
 //! will generate code that relies on types from here.
 //!
-//! This crate contains a fair number of `DiplomatFoo` types. Some, like
-//! [`DiplomatOption`], are FFI-safe versions of Rust types that can be put in
-//! a struct and passed safely over FFI. Others, like [`DiplomatChar`], are simple
-//! type aliases that signal to the Diplomat tool that particular semantics are desired
-//! on the C++ side.
+//! # Type Overview
+//!
+//! - **Option and Result**: [`DiplomatResult<T, E>`] (FFI-safe `Result`) and [`DiplomatOption<T>`] (type alias for [`DiplomatResult<T, ()>`]).
+//! - **Slices**: [`DiplomatSlice<'a, T>`] (`&'a [T]`), [`DiplomatSliceMut<'a, T>`] (`&'a mut [T]`), and [`DiplomatOwnedSlice<T>`] (`Box<[T]>`).
+//! - **String input**: These all map to appropriate string types across FFI.
+//!    - Unvalidated UTF-8: [`DiplomatStrSlice<'a>`] (`&'a [u8]`), [`DiplomatOwnedStrSlice`] (`Box<[u8]>`)
+//!    - Unvalidated UTF-16: [`DiplomatStr16Slice<'a>`] (`&'a [u16]`), [`DiplomatOwnedStr16Slice`]  (`Box<[u16]>`)
+//!    - Validated UTF-8: [`DiplomatUtf8StrSlice<'a>`] (`&'a str`), [`DiplomatOwnedUTF8StrSlice`] (`Box<str>`)
+//!    - Unvalidated stringy DSTs: [`DiplomatStr`] (`[u8]`), [`DiplomatStr16`] (`[u16]`), for convenient use with `&` and `Box` as function parameters.
+//! - **String output**: [`DiplomatWrite`]
+//! - **Callbacks**: [`DiplomatCallback<ReturnType>`] (FFI-safe callback handle).
+//! - **Scalars**: [`DiplomatChar`] (`u32`) and [`DiplomatByte`] (`u8`).
+//!
+//! Note that many of these are type aliases; using these types instead of the type alias signals that Diplomat is expected to
+//! generate the equivalent type on the other side. For example, using `DiplomatChar` will signal that a language's `char` type is
+//! to be used, even if the actual type seen by rust is an unvalidated `u32`.
 //!
 //! # Features
 //!
@@ -18,6 +29,7 @@
 //!
 //! The `jvm-callback-support` feature should be enabled if building Diplomat for use in the JVM, for
 //! a Diplomat-based library that uses callbacks.
+
 extern crate alloc;
 
 use alloc::alloc::Layout;
@@ -27,7 +39,9 @@ mod wasm_glue;
 
 mod write;
 pub use write::DiplomatWrite;
-pub use write::{diplomat_buffer_write_create, diplomat_buffer_write_destroy};
+pub use write::{
+    diplomat_buffer_write_create, diplomat_buffer_write_destroy, diplomat_simple_write,
+};
 mod slices;
 pub use slices::{
     DiplomatOwnedSlice, DiplomatOwnedStr16Slice, DiplomatOwnedStrSlice, DiplomatOwnedUTF8StrSlice,
@@ -54,6 +68,11 @@ pub type DiplomatChar = u32;
 ///
 /// This type will usually map to some string type in the target language, and
 /// you will not need to worry about the safety of mismatched string invariants.
+///
+/// [`DiplomatStrSlice`] is equivalent to `&DiplomatStr`: both are provided since
+/// `&DiplomatStr` is more convenient but not allowed in Diplomat structs (since it
+/// is not directly FFI safe). Instead, this type can be conveniently used in function
+/// parameter lists.
 pub type DiplomatStr = [u8];
 
 /// Like `Wstr`, but unvalidated.
@@ -62,6 +81,11 @@ pub type DiplomatStr = [u8];
 ///
 /// This type will usually map to some string type in the target language, and
 /// you will not need to worry about the safety of mismatched string invariants.
+///
+/// [`DiplomatStr16Slice`] is equivalent to `&DiplomatStr16`: both are provided since
+/// `&DiplomatStr16` is more convenient but not allowed in Diplomat structs (since it
+/// is not directly FFI safe). Instead, this type can be conveniently used in function
+/// parameter lists.
 pub type DiplomatStr16 = [u16];
 
 /// Like [`u8`], but interpreted explicitly as a raw byte as opposed to a numerical value.

--- a/runtime/src/result.rs
+++ b/runtime/src/result.rs
@@ -16,7 +16,7 @@ pub struct DiplomatResult<T, E> {
     pub is_ok: bool,
 }
 
-/// A type to represent Option<T> over FFI.
+/// A type to represent `Option<T>` over FFI.
 ///
 /// Used internally to handle `Option<T>` arguments and return types, and needs to be
 /// used explicitly for optional struct fields.

--- a/runtime/src/slices.rs
+++ b/runtime/src/slices.rs
@@ -269,23 +269,35 @@ impl Deref for DiplomatOwnedUTF8StrSlice {
     }
 }
 
-/// This like `&str`, but unvalidated and safe to use over FFI
+/// This is like `&str`, but unvalidated and safe to use over FFI
 ///
 /// This type will usually map to some string type in the target language, and
 /// you will not need to worry about the safety of mismatched string invariants.
+///
+/// Using this type on a function signature is equivalent to using `&DiplomatStr`,
+/// however this type is FFI-safe and therefore also allowed inside Diplomat structs.
 pub type DiplomatStrSlice<'a> = DiplomatSlice<'a, u8>;
-/// This like `Box<str>`, but unvalidated and safe to use over FFI
+/// This is like `Box<str>`, but unvalidated and safe to use over FFI
 ///
 /// This type will usually map to some string type in the target language, and
 /// you will not need to worry about the safety of mismatched string invariants.
+///
+/// Using this type on a function signature is equivalent to using `Box<DiplomatStr>`,
+/// however this type is FFI-safe and therefore also allowed inside Diplomat structs.
 pub type DiplomatOwnedStrSlice = DiplomatOwnedSlice<u8>;
 /// An unvalidated UTF-16 string that is safe to use over FFI
 ///
 /// This type will usually map to some string type in the target language, and
 /// you will not need to worry about the safety of mismatched string invariants.
+///
+/// Using this type on a function signature is equivalent to using `&DiplomatStr16`,
+/// however this type is FFI-safe and therefore also allowed inside Diplomat structs.
 pub type DiplomatStr16Slice<'a> = DiplomatSlice<'a, u16>;
 /// An unvalidated, owned UTF-16 string that is safe to use over FFI
 ///
 /// This type will usually map to some string type in the target language, and
 /// you will not need to worry about the safety of mismatched string invariants.
+///
+/// Using this type on a function signature is equivalent to using `Box<DiplomatStr16>`,
+/// however this type is FFI-safe and therefore also allowed inside Diplomat structs.
 pub type DiplomatOwnedStr16Slice<'a> = DiplomatOwnedSlice<u16>;

--- a/runtime/src/write.rs
+++ b/runtime/src/write.rs
@@ -30,7 +30,7 @@ use core::{fmt, ptr};
 ///
 /// 1. [`diplomat_simple_write()`] to write to a fixed-size buffer.
 /// 2. [`diplomat_buffer_write_create()`] to write to a Vec allocated by Rust.
-///    A wrapper is provided: [`RustWriteVec`](rust_interop::RustWriteVec).
+///    A wrapper is provided: [`RustWriteVec`](crate::rust_interop::RustWriteVec).
 ///
 /// Backends may have additional constructors for writing to various shapes of buffer.
 ///
@@ -49,10 +49,10 @@ use core::{fmt, ptr};
 /// ```
 ///
 /// As a result, any function that returns an owned `DiplomatWrite` or a `&mut DiplomatWrite`
-/// must be `unsafe`. For an example, see [`RustWriteVec::borrow_mut`].
+/// must be `unsafe`. For an example, see [`RustWriteVec::borrow_mut`](crate::rust_interop::RustWriteVec::borrow_mut).
 ///
 /// Diplomat backends guarantee they will only ever hand the same type of `DiplomatWrite` object to Rust
-/// code; this is only something you need to worry about if using [`RustWriteVec`](rust_interop::RustWriteVec),
+/// code; this is only something you need to worry about if using [`RustWriteVec`](crate::rust_interop::RustWriteVec),
 /// or `DiplomatWrite` objects manually created in Rust via APIs like `diplomat_simple_write`.
 ///
 /// # Safety invariants:
@@ -151,7 +151,7 @@ impl fmt::Write for DiplomatWrite {
 /// Once done, this will append a null terminator to the written string.
 ///
 /// This is largely used internally by Diplomat-generated FFI code, and should not need to be constructed
-/// manually outside of that context. See [`RustWriteVec`](rust_interop::RustWriteVec) if you need this in Rust.
+/// manually outside of that context. See [`RustWriteVec`](crate::rust_interop::RustWriteVec) if you need this in Rust.
 ///
 /// # Safety
 ///
@@ -186,7 +186,7 @@ pub unsafe extern "C" fn diplomat_simple_write(buf: *mut u8, buf_size: usize) ->
 /// The pointer is valid until that function is called.
 ///
 /// This is largely used internally by Diplomat-generated FFI code, and should not need to be constructed
-/// manually outside of that context. See [`RustWriteVec`](rust_interop::RustWriteVec) if you need this in Rust.
+/// manually outside of that context. See [`RustWriteVec`](crate::rust_interop::RustWriteVec) if you need this in Rust.
 ///
 /// The grow impl never sets `grow_failed`, although it is possible for it to panic.
 #[no_mangle]


### PR DESCRIPTION
Bunch of docs cleanups, added an overview section, and added some clarity on the slice types.

PR mostly made by getting gemini to do what improvements it saw, and then cherry picking. I ended up redoing the type overview section myself.