### PR TITLE
nanobind: support None for char32_t

### DIFF
--- a/feature_tests/nanobind/src/include/diplomat_nanobind_common.hpp
+++ b/feature_tests/nanobind/src/include/diplomat_nanobind_common.hpp
@@ -32,15 +32,26 @@ namespace nanobind::detail
         template <typename T>
         using Cast = char32_t;
 
-        bool from_python(handle src, uint8_t, cleanup_list *) noexcept
+        bool from_python(handle src, uint8_t flags, cleanup_list *) noexcept
         {
-            value = PyUnicode_ReadChar(src.ptr(), 0);
-            if (!value)
+            if (src.is_none())
             {
-                PyErr_Clear();
-                return false;
+                if (!(flags & (uint8_t) cast_flags::accepts_none))
+                    return false;
+
+                value = U'\0';
+                size = 1;
+                return true;
             }
+
+            if (!PyUnicode_Check(src.ptr()))
+                return false;
+
             size = PyUnicode_GetLength(src.ptr());
+            if (size != 1)
+                return false;
+
+            value = PyUnicode_ReadChar(src.ptr(), 0);
             return true;
         }
 
@@ -71,7 +82,7 @@ namespace nanobind::detail
         template <typename T_>
         NB_INLINE bool can_cast() const noexcept
         {
-            return (value && size == 1);
+            return size == 1;
         }
 
         explicit operator char32_t()

--- a/feature_tests/nanobind/test/test_structs.py
+++ b/feature_tests/nanobind/test/test_structs.py
@@ -26,6 +26,8 @@ def test_structs():
     sl.append(somelib.PrimitiveStruct(1, True, 'c', 0, 0, 0))
     sl.append(somelib.PrimitiveStruct(2, False, ' ', 0, 0, 0))
     sl.append(somelib.PrimitiveStruct(-1, False, ' ', 0, 0, 0))
+    none_char = somelib.PrimitiveStruct(0, False, None, 0, 0, 0)
+    assert none_char.b == U'\0'
     sl = sl.asSlice
     assert sl[0].x == 1
     assert sl[1].x == 2

--- a/tool/templates/nanobind/common.h.jinja
+++ b/tool/templates/nanobind/common.h.jinja
@@ -32,15 +32,26 @@ namespace nanobind::detail
         template <typename T>
         using Cast = char32_t;
 
-        bool from_python(handle src, uint8_t, cleanup_list *) noexcept
+        bool from_python(handle src, uint8_t flags, cleanup_list *) noexcept
         {
-            value = PyUnicode_ReadChar(src.ptr(), 0);
-            if (!value)
+            if (src.is_none())
             {
-                PyErr_Clear();
-                return false;
+                if (!(flags & (uint8_t) cast_flags::accepts_none))
+                    return false;
+
+                value = U'\0';
+                size = 1;
+                return true;
             }
+
+            if (!PyUnicode_Check(src.ptr()))
+                return false;
+
             size = PyUnicode_GetLength(src.ptr());
+            if (size != 1)
+                return false;
+
+            value = PyUnicode_ReadChar(src.ptr(), 0);
             return true;
         }
 
@@ -71,7 +82,7 @@ namespace nanobind::detail
         template <typename T_>
         NB_INLINE bool can_cast() const noexcept
         {
-            return (value && size == 1);
+            return size == 1;
         }
 
         explicit operator char32_t()


### PR DESCRIPTION
Closes #1126.

## Summary

- honor nanobind's `accepts_none` flag in the custom `char32_t` caster
- convert an allowed `None` value to the default null character (`U+0000`)
- reject non-string and multi-code-point inputs before reading the character
- cover the struct-constructor path with a regression test

## Tests

- `uvx --with ./feature_tests/nanobind --refresh-package somelib pytest feature_tests/nanobind/test/ -q` (36 passed, clean wheel rebuild)
- `cargo test -p diplomat-tool nanobind` (4 passed)
- `cargo fmt --all -- --check`
