### PR TITLE
ci: pin Dart SDK to 3.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,10 @@ jobs:
 
     - name: Install Dart
       uses: dart-lang/setup-dart@4e3affd8e7047e1cd1ec18b666954637c96fd70b
+      with:
+        # Pin so `dart format --set-exit-if-changed` does not break on every
+        # stable release that tweaks formatting (3.13.0 reformats slice_test.dart).
+        sdk: 3.12.2
 
     - name: Test Dart
       run: cargo make test-dart


### PR DESCRIPTION
## What

Pin `dart-lang/setup-dart` to **3.12.2** in the `test-dart` job.

## Why

`setup-dart` was unpinned, so CI floated to stable **3.13.0**. That formatter rewrites `feature_tests/dart/test/slice_test.dart`, and `dart format --set-exit-if-changed` fails `test-dart` on every PR (including pure .NET ones). Main has been red since [#1251](https://github.com/rust-diplomat/diplomat/pull/1251) for this reason.

3.12.2 is the last stable that leaves the tree format-clean as-is.

## Test

- local: `dart format --set-exit-if-changed feature_tests/dart` clean under 3.12.2; dirty under 3.13.0