### PR TITLE
Always coerce enums in Demo Gen

### DIFF
--- a/example/demo_gen/demo/index.mjs
+++ b/example/demo_gen/demo/index.mjs
@@ -11,12 +11,12 @@ const displayOptionalEnum = (out) => out?.value || 'None';
 let termini = Object.assign({
     "FixedDecimalFormatter.formatWrite": {
         func: (selfLocaleName, selfOptionsGroupingStrategy, selfOptionsSomeOtherConfig, valueV) => somelib.FixedDecimalFormatter.tryNew(new somelib.Locale(selfLocaleName), somelib.DataProvider.newStatic(), somelib.FixedDecimalFormatterOptions.fromFields({
-            groupingStrategy: selfOptionsGroupingStrategy,
+            groupingStrategy: new somelib.FixedDecimalGroupingStrategy(selfOptionsGroupingStrategy),
             someOtherConfig: selfOptionsSomeOtherConfig
         })).formatWrite(new somelib.FixedDecimal(valueV)),
         // For avoiding webpacking minifying issues:
         funcName: "FixedDecimalFormatter.formatWrite",
-        expr: (selfLocaleName, selfOptionsGroupingStrategy, selfOptionsSomeOtherConfig, valueV) => "somelib.FixedDecimalFormatter.tryNew(new somelib.Locale(selfLocaleName), somelib.DataProvider.newStatic(), somelib.FixedDecimalFormatterOptions.fromFields({\n    groupingStrategy: selfOptionsGroupingStrategy,\n    someOtherConfig: selfOptionsSomeOtherConfig\n})).formatWrite(new somelib.FixedDecimal(valueV))".replace(/([\( ])selfLocaleName([,\) \n])/, '$1' + selfLocaleName + '$2').replace(/([\( ])selfOptionsGroupingStrategy([,\) \n])/, '$1' + selfOptionsGroupingStrategy + '$2').replace(/([\( ])selfOptionsSomeOtherConfig([,\) \n])/, '$1' + selfOptionsSomeOtherConfig + '$2').replace(/([\( ])valueV([,\) \n])/, '$1' + valueV + '$2'),
+        expr: (selfLocaleName, selfOptionsGroupingStrategy, selfOptionsSomeOtherConfig, valueV) => "somelib.FixedDecimalFormatter.tryNew(new somelib.Locale(selfLocaleName), somelib.DataProvider.newStatic(), somelib.FixedDecimalFormatterOptions.fromFields({\n    groupingStrategy: new somelib.FixedDecimalGroupingStrategy(selfOptionsGroupingStrategy),\n    someOtherConfig: selfOptionsSomeOtherConfig\n})).formatWrite(new somelib.FixedDecimal(valueV))".replace(/([\( ])selfLocaleName([,\) \n])/, '$1' + selfLocaleName + '$2').replace(/([\( ])selfOptionsGroupingStrategy([,\) \n])/, '$1' + selfOptionsGroupingStrategy + '$2').replace(/([\( ])selfOptionsSomeOtherConfig([,\) \n])/, '$1' + selfOptionsSomeOtherConfig + '$2').replace(/([\( ])valueV([,\) \n])/, '$1' + valueV + '$2'),
         parameters: [
             
             {

--- a/feature_tests/demo_gen/demo/index.mjs
+++ b/feature_tests/demo_gen/demo/index.mjs
@@ -143,11 +143,11 @@ let termini = Object.assign({
             d: selfD,
             e: selfE,
             f: selfF,
-            g: selfG
+            g: new somelib.MyEnum(selfG)
         }).intoA(),
         // For avoiding webpacking minifying issues:
         funcName: "MyStruct.intoA",
-        expr: (selfA, selfB, selfC, selfD, selfE, selfF, selfG) => "somelib.MyStruct.fromFields({\n    a: selfA,\n    b: selfB,\n    c: selfC,\n    d: selfD,\n    e: selfE,\n    f: selfF,\n    g: selfG\n}).intoA()".replace(/([\( ])selfA([,\) \n])/, '$1' + selfA + '$2').replace(/([\( ])selfB([,\) \n])/, '$1' + selfB + '$2').replace(/([\( ])selfC([,\) \n])/, '$1' + selfC + '$2').replace(/([\( ])selfD([,\) \n])/, '$1' + selfD + '$2').replace(/([\( ])selfE([,\) \n])/, '$1' + selfE + '$2').replace(/([\( ])selfF([,\) \n])/, '$1' + selfF + '$2').replace(/([\( ])selfG([,\) \n])/, '$1' + selfG + '$2'),
+        expr: (selfA, selfB, selfC, selfD, selfE, selfF, selfG) => "somelib.MyStruct.fromFields({\n    a: selfA,\n    b: selfB,\n    c: selfC,\n    d: selfD,\n    e: selfE,\n    f: selfF,\n    g: new somelib.MyEnum(selfG)\n}).intoA()".replace(/([\( ])selfA([,\) \n])/, '$1' + selfA + '$2').replace(/([\( ])selfB([,\) \n])/, '$1' + selfB + '$2').replace(/([\( ])selfC([,\) \n])/, '$1' + selfC + '$2').replace(/([\( ])selfD([,\) \n])/, '$1' + selfD + '$2').replace(/([\( ])selfE([,\) \n])/, '$1' + selfE + '$2').replace(/([\( ])selfF([,\) \n])/, '$1' + selfF + '$2').replace(/([\( ])selfG([,\) \n])/, '$1' + selfG + '$2'),
         parameters: [
             
             {
@@ -429,10 +429,10 @@ let termini = Object.assign({
     },
 
     "OptionOpaque.acceptsOptionEnum": {
-        func: (arg, sentinel) => somelib.OptionOpaque.acceptsOptionEnum(arg, sentinel),
+        func: (arg, sentinel) => somelib.OptionOpaque.acceptsOptionEnum(new somelib.OptionEnum(arg), sentinel),
         // For avoiding webpacking minifying issues:
         funcName: "OptionOpaque.acceptsOptionEnum",
-        expr: (arg, sentinel) => "somelib.OptionOpaque.acceptsOptionEnum(arg, sentinel)".replace(/([\( ])arg([,\) \n])/, '$1' + arg + '$2').replace(/([\( ])sentinel([,\) \n])/, '$1' + sentinel + '$2'),
+        expr: (arg, sentinel) => "somelib.OptionOpaque.acceptsOptionEnum(new somelib.OptionEnum(arg), sentinel)".replace(/([\( ])arg([,\) \n])/, '$1' + arg + '$2').replace(/([\( ])sentinel([,\) \n])/, '$1' + sentinel + '$2'),
         display: displayOptionalEnum,
         parameters: [
             
@@ -453,10 +453,10 @@ let termini = Object.assign({
     },
 
     "OptionOpaque.acceptsMultipleOptionEnum": {
-        func: (sentinel1, arg1, arg2, arg3, sentinel2) => somelib.OptionOpaque.acceptsMultipleOptionEnum(sentinel1, arg1, arg2, arg3, sentinel2),
+        func: (sentinel1, arg1, arg2, arg3, sentinel2) => somelib.OptionOpaque.acceptsMultipleOptionEnum(sentinel1, new somelib.OptionEnum(arg1), new somelib.OptionEnum(arg2), new somelib.OptionEnum(arg3), sentinel2),
         // For avoiding webpacking minifying issues:
         funcName: "OptionOpaque.acceptsMultipleOptionEnum",
-        expr: (sentinel1, arg1, arg2, arg3, sentinel2) => "somelib.OptionOpaque.acceptsMultipleOptionEnum(sentinel1, arg1, arg2, arg3, sentinel2)".replace(/([\( ])sentinel1([,\) \n])/, '$1' + sentinel1 + '$2').replace(/([\( ])arg1([,\) \n])/, '$1' + arg1 + '$2').replace(/([\( ])arg2([,\) \n])/, '$1' + arg2 + '$2').replace(/([\( ])arg3([,\) \n])/, '$1' + arg3 + '$2').replace(/([\( ])sentinel2([,\) \n])/, '$1' + sentinel2 + '$2'),
+        expr: (sentinel1, arg1, arg2, arg3, sentinel2) => "somelib.OptionOpaque.acceptsMultipleOptionEnum(sentinel1, new somelib.OptionEnum(arg1), new somelib.OptionEnum(arg2), new somelib.OptionEnum(arg3), sentinel2)".replace(/([\( ])sentinel1([,\) \n])/, '$1' + sentinel1 + '$2').replace(/([\( ])arg1([,\) \n])/, '$1' + arg1 + '$2').replace(/([\( ])arg2([,\) \n])/, '$1' + arg2 + '$2').replace(/([\( ])arg3([,\) \n])/, '$1' + arg3 + '$2').replace(/([\( ])sentinel2([,\) \n])/, '$1' + sentinel2 + '$2'),
         display: displayOptionalEnum,
         parameters: [
             

--- a/tool/src/demo_gen/terminus.rs
+++ b/tool/src/demo_gen/terminus.rs
@@ -295,7 +295,7 @@ impl RenderTerminusContext<'_, '_> {
             Type::Primitive(..) => {
                 self.append_out_param(param_name.clone(), param_type, node, Some(param_attrs))
             }
-            Type::Enum(e) if param_name == "self" => {
+            Type::Enum(e) => {
                 let type_name = self.formatter.fmt_type_name(e.tcx_id.into()).to_string();
 
                 if e.resolve(self.tcx).attrs.disable {
@@ -305,18 +305,8 @@ impl RenderTerminusContext<'_, '_> {
 
                 let param =
                     self.append_out_param(param_name.clone(), param_type, node, Some(param_attrs));
-                // Enum coercion only works for arguments, we need to construct self manually
+                // Coerce enum to the correct type:
                 format!("new {}.{type_name}({param})", self.lib_name,)
-            }
-            Type::Enum(e) => {
-                let type_name = self.formatter.fmt_type_name(e.tcx_id.into()).to_string();
-
-                if e.resolve(self.tcx).attrs.disable {
-                    self.errors
-                        .push_error(format!("Found usage of disabled type {type_name}"))
-                }
-
-                self.append_out_param(param_name.clone(), param_type, node, Some(param_attrs))
             }
             Type::Slice(..) => {
                 self.append_out_param(param_name.clone(), param_type, node, Some(param_attrs))


### PR DESCRIPTION
Fixes https://github.com/rust-diplomat/diplomat/issues/1255 

This just forces enums to always use the constructor in methods, since they're always strings within demo_gen.

Need to test within ICU4X, but I believe this should work.
