### PR TITLE
Publish core/macro/tool 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "diplomat"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "diplomat_core",
  "insta",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-example"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "criterion",
  "diplomat",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-feature-tests"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "jni",
  "log",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat-tool"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "askama",
  "clap",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "diplomat_core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "annotate-snippets",
  "either",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-diplomat"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "askama",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = ["core", "macro", "runtime", "tool", "example", "feature_tests", "book
 [workspace.package]
 
 # Individual subcrates may choose to temporarily switch to a different version
-version = "0.16.0"
+# diplomat-runtime will stick to 0.16 as long as it can.
+version = "0.16.1"
 # Applies to diplomat-core, diplomat, and diplomat-runtime
 # Diplomat-tool has no MSRV for now
 rust-version = "1.88"
@@ -23,5 +24,5 @@ keywords = ["ffi", "codegen"]
 [workspace.dependencies]
 diplomat = { version = "0.16.0", path = "macro", default-features = false }
 diplomat_core = { version = "0.16.0", path = "core", default-features = false }
-diplomat-runtime = { version = "0.15.1", path = "runtime", default-features = false }
+diplomat-runtime = { version = "0.16.0", path = "runtime", default-features = false }
 diplomat-tool = { version = "0.16.0", path = "tool", default-features = false }

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -702,19 +702,17 @@ impl Attrs {
                             } else if meta.path.is_ident("default_value") {
                                 let value = meta.value()?;
 
-                                let str_val: String;
-
                                 let ahead = value.lookahead1();
-                                if ahead.peek(syn::LitFloat) {
+                                let str_val = if ahead.peek(syn::LitFloat) {
                                     let s: syn::LitFloat = value.parse()?;
-                                    str_val = s.base10_parse::<f64>()?.to_string();
+                                    s.base10_parse::<f64>()?.to_string()
                                 } else if ahead.peek(syn::LitInt) {
                                     let s: syn::LitInt = value.parse()?;
-                                    str_val = s.base10_parse::<i64>()?.to_string();
+                                    s.base10_parse::<i64>()?.to_string()
                                 } else {
                                     let s: syn::LitStr = value.parse()?;
-                                    str_val = s.value();
-                                }
+                                    s.value()
+                                };
                                 this.demo_attrs.input_cfg.default_value = str_val;
                                 Ok(())
                             } else {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -3,7 +3,7 @@ name = "diplomat-runtime"
 description = "Common runtime utilities used by diplomat codegen"
 # We are working on decoupling diplomat-runtime's version from the rest
 # https://github.com/rust-diplomat/diplomat/issues/958
-version = "0.15.2"
+version = "0.16.0"
 rust-version.workspace = true
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION

Changes since 0.16.1:

 - 8e2b7a3a Publish core/macro/tool 0.16.1
 - 4cc68edd  CONTRIBUTING.md (#1258)
 - e75e0643 C++ traits (#1248)
 - 60cd7b91 dotnet: dispose borrowed-span edges on oversize construction (#1253)
 - 3738d61e ci: pin Dart SDK to 3.12.2 (#1254)
 - 6610ee15 dotnet: retain native borrow dependencies (#1251)
 - 48fa3f3a dotnet: make IDisposable opt-in for opaques (#1244)
 - 08e1f64d Upgrade Clippy MSRV to 1.88 (#1249)
 - e7d95fe8 Add `Error` and `Exception` to enums/classes which are errors/exceptions in Dart (#1220)
 - 242e3cb3 Validate JS arguments (#902)
 - 7b6ac1c5 Improve some diplomat-runtime docs (#1242)
 - 702b1b22 runtime should be 0.15.2 (#1237)
 - 5655be79 Switch diplomat-runtime to 0.15.1 (#1236)
 - 7de34935 Expose tuples entry in book (#1233)



The goal here is to get https://github.com/rust-diplomat/diplomat/pull/1220 and  #902 into the release. There are also dotnet fixes that are nice to get out.

This does include one larger feature: C++ trait support. I think that's okay.


Verified that there are no semver-checks issues in core/tool.

This also moves diplomat-runtime to 0.16.0 (already published) but adds a note that we plan to keep it there. As @tyler-zeromatter and I have been discussing, we're going to treat 0.16.x as the frozen stream. This is just to keep the repo state less confusing for the future.