### PR TITLE
HIR Location Errors

### DIFF
--- a/core/src/ast/idents.rs
+++ b/core/src/ast/idents.rs
@@ -17,6 +17,7 @@ pub struct LineColumn {
 
 /// Equivalent to `proc_macro2::Span`.
 #[derive(Hash, Eq, PartialEq, Serialize, Clone, Debug)]
+#[non_exhaustive]
 pub struct Span {
     pub start: LineColumn,
     pub end: LineColumn,

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -87,11 +87,33 @@ fn evaluate_bytes(sp: &super::idents::Span, src: &str) -> std::ops::Range<usize>
     }
 }
 
-pub(crate) fn create_report(report: AstReport) -> ! {
-    use std::io::Write;
-    let mut out = WRITER.read().unwrap()();
+pub trait WriteReport {
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), String>;
+    fn flush(&mut self) -> Result<(), String>;
+}
 
-    let span = report.primary_loc;
+impl WriteReport for Box<dyn std::io::Write> {
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), String> {
+        std::io::Write::write_fmt(self, args).map_err(|e| e.to_string())
+    }
+
+    fn flush(&mut self) -> Result<(), String> {
+        std::io::Write::flush(self).map_err(|e| e.to_string())
+    }
+}
+
+impl WriteReport for &mut std::fmt::Formatter<'_> {
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), String> {
+        std::fmt::Write::write_fmt(self, args).map_err(|e| e.to_string())
+    }
+
+    fn flush(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+pub fn write_report(report : &AstReport, mut out : impl WriteReport) -> Result<(), String> {
+    let span = report.primary_loc.as_ref();
     let src = if let Some(sp) = &span {
         match &sp.span_location {
             SpanLocation::FilePath(f) => {
@@ -140,27 +162,28 @@ pub(crate) fn create_report(report: AstReport) -> ! {
 
             &[Level::ERROR.primary_title(&report.title).element(
                 Snippet::<Annotation>::source(&src)
-                    .path(match sp.span_location {
+                    .path(match &sp.span_location {
                         SpanLocation::FilePath(f) => Some(f),
                         _ => None,
                     })
                     .annotation(
                         AnnotationKind::Primary
                             .span(bytes_range.unwrap())
-                            .label(report.primary_label),
+                            .label(&report.primary_label),
                     )
                     .annotations(annotations),
             )]
         } else {
             &[Level::ERROR
                 .primary_title(&report.title)
-                .element(Level::ERROR.message(report.primary_label))]
+                .element(Level::ERROR.message(&report.primary_label))]
         };
         let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
-        writeln!(out, "{}", renderer.render(report)).expect("Could not write report.");
+        writeln!(out, "{}", renderer.render(report))?;
     }
     #[cfg(not(feature = "pretty-print"))]
     {
+        let mut valid_excerpt = true;
         let (location, excerpt_pre, excerpt, excerpt_post) = if let Some(sp) = span {
             let range = bytes_range.unwrap();
             let start = sp.start.line;
@@ -174,7 +197,9 @@ pub(crate) fn create_report(report: AstReport) -> ! {
             let range_pre = range.start.saturating_sub(5);
             let range_post = std::cmp::min(range.end.saturating_add(5), src.len());
             match sp.span_location {
-                SpanLocation::None => (span_location, "", "<Excerpt not available>", ""),
+                SpanLocation::None => {
+                    valid_excerpt = false;
+                    (span_location, "", "<Excerpt not available>", "")},
                 _ => (
                     format!("{span_location}:{start}:{col}"),
                     &src[range_pre..range.start],
@@ -183,6 +208,7 @@ pub(crate) fn create_report(report: AstReport) -> ! {
                 ),
             }
         } else {
+            valid_excerpt = false;
             (
                 "<No associated span>".into(),
                 "",
@@ -190,20 +216,27 @@ pub(crate) fn create_report(report: AstReport) -> ! {
                 "",
             )
         };
-        write!(out, "Diplomat error: ").expect("Could not write to report.");
-        writeln!(out, "{}", report.title).expect("Could not write to report.");
-        writeln!(out, "In {location}:").expect("Could not write to report.");
+        write!(out, "Diplomat error: ")?;
+        writeln!(out, "{}", report.title)?;
+        if !valid_excerpt {
+            if !report.primary_label.is_empty() {
+                writeln!(out, "> {}", report.primary_label)?;
+            }
+            out.flush()?;
+            return Ok(());
+        }
+        writeln!(out, "In {location}:")?;
 
         let excerpt_pre_trimmed = excerpt_pre.trim_start();
 
         if !excerpt_pre.is_empty() {
-            write!(out, "...{}", excerpt_pre_trimmed).expect("Could not write to report.");
+            write!(out, "...{}", excerpt_pre_trimmed)?;
         }
 
-        write!(out, "{excerpt}").expect("Could not write to report.");
+        write!(out, "{excerpt}")?;
 
         if !excerpt_post.is_empty() {
-            writeln!(out, "{}...", excerpt_post.trim_end()).expect("Could not write to report.");
+            writeln!(out, "{}...", excerpt_post.trim_end())?;
         }
 
         // Add visible separation between the label and the excerpt.
@@ -215,13 +248,18 @@ pub(crate) fn create_report(report: AstReport) -> ! {
                 "{}{}",
                 " ".repeat(3 + excerpt_pre_trimmed.len()),
                 "^".repeat(excerpt.len())
-            )
-            .expect("Could not write to report.");
+            )?;
         }
 
-        write!(out, "{}", report.primary_label).expect("Could not write to report.");
+        write!(out, "{}", report.primary_label)?;
     }
-    out.flush().expect("Could not write to output.");
+    out.flush()?;
+    Ok(())
+}
+
+pub(crate) fn create_report(report: AstReport) -> ! {
+    let out = WRITER.read().unwrap()();
+    write_report(&report, out).expect("Could not write report");
     // Rust-analyzer will not show error messages unless we panic,
     // This just tells rust-analyzer users to check stderr:
     panic!("Diplomat error: {} (check stderr for more)", report.title);

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -21,7 +21,7 @@ impl ContextLocation {
     }
 }
 
-pub(crate) struct AstReport {
+pub struct AstReport {
     title: String,
     primary_loc: Option<Span>,
     primary_label: String,
@@ -31,7 +31,7 @@ pub(crate) struct AstReport {
 }
 
 impl AstReport {
-    pub fn new(
+    pub(crate) fn new(
         title: String,
         primary_loc: Option<Span>,
         primary_label: String,
@@ -112,7 +112,19 @@ impl WriteReport for &mut std::fmt::Formatter<'_> {
     }
 }
 
-pub fn write_report(report : &AstReport, mut out : impl WriteReport) -> Result<(), String> {
+impl WriteReport for &mut String {
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), String> {
+        std::fmt::Write::write_fmt(self, args).map_err(|e| e.to_string())
+    }
+    fn flush(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+pub fn write_report(report : &AstReport, mut out : impl WriteReport, 
+    // Only used when pretty-print feature is enabled:
+    #[allow(unused)]
+    force_ugly : bool) -> Result<(), String> {
     let span = report.primary_loc.as_ref();
     let src = if let Some(sp) = &span {
         match &sp.span_location {
@@ -149,8 +161,13 @@ pub fn write_report(report : &AstReport, mut out : impl WriteReport) -> Result<(
             );
         }
     }
+
+    #[allow(unused)]
+    let mut print_ugly = true;
+
     #[cfg(feature = "pretty-print")]
-    {
+    if !force_ugly {
+        print_ugly = false;
         use annotate_snippets::{renderer::DecorStyle, Level, Renderer, Snippet};
         let report = if let Some(sp) = span {
             use annotate_snippets::{Annotation, AnnotationKind};
@@ -168,7 +185,7 @@ pub fn write_report(report : &AstReport, mut out : impl WriteReport) -> Result<(
                     })
                     .annotation(
                         AnnotationKind::Primary
-                            .span(bytes_range.unwrap())
+                            .span(bytes_range.clone().unwrap())
                             .label(&report.primary_label),
                     )
                     .annotations(annotations),
@@ -181,8 +198,8 @@ pub fn write_report(report : &AstReport, mut out : impl WriteReport) -> Result<(
         let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
         writeln!(out, "{}", renderer.render(report))?;
     }
-    #[cfg(not(feature = "pretty-print"))]
-    {
+    
+    if print_ugly {
         let mut valid_excerpt = true;
         let (location, excerpt_pre, excerpt, excerpt_post) = if let Some(sp) = span {
             let range = bytes_range.unwrap();
@@ -259,7 +276,7 @@ pub fn write_report(report : &AstReport, mut out : impl WriteReport) -> Result<(
 
 pub(crate) fn create_report(report: AstReport) -> ! {
     let out = WRITER.read().unwrap()();
-    write_report(&report, out).expect("Could not write report");
+    write_report(&report, out, false).expect("Could not write report");
     // Rust-analyzer will not show error messages unless we panic,
     // This just tells rust-analyzer users to check stderr:
     panic!("Diplomat error: {} (check stderr for more)", report.title);

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -121,11 +121,18 @@ impl WriteReport for &mut String {
     }
 }
 
+pub enum PrettyPrint {
+    /// Attempt to use pretty printer first if feature enabled, fall back to ugly printer.
+    Default,
+    /// Even if pretty-printing is enabled, use the ugly printer (mostly for testing)
+    ForceUgly
+}
+
 pub fn write_report(
     report: &AstReport,
     mut out: impl WriteReport,
     // Only used when pretty-print feature is enabled:
-    #[allow(unused)] force_ugly: bool,
+    #[allow(unused)] force_ugly: PrettyPrint,
 ) -> Result<(), String> {
     let span = report.primary_loc.as_ref();
     let src = if let Some(sp) = &span {
@@ -164,12 +171,8 @@ pub fn write_report(
         }
     }
 
-    #[allow(unused)]
-    let mut print_ugly = true;
-
     #[cfg(feature = "pretty-print")]
-    if !force_ugly {
-        print_ugly = false;
+    if matches!(force_ugly, PrettyPrint::Default) {
         use annotate_snippets::{renderer::DecorStyle, Level, Renderer, Snippet};
         let report = if let Some(sp) = span {
             use annotate_snippets::{Annotation, AnnotationKind};
@@ -201,7 +204,8 @@ pub fn write_report(
         writeln!(out, "{}", renderer.render(report))?;
     }
 
-    if print_ugly {
+    // Either the pretty printer is disabled, or we're forced to use the ugly printer:
+    if !cfg!(feature = "pretty-print") || matches!(force_ugly, PrettyPrint::ForceUgly) {
         let mut valid_excerpt = true;
         let (location, excerpt_pre, excerpt, excerpt_post) = if let Some(sp) = span {
             let range = bytes_range.unwrap();
@@ -279,7 +283,7 @@ pub fn write_report(
 
 pub(crate) fn create_report(report: AstReport) -> ! {
     let out = WRITER.read().unwrap()();
-    write_report(&report, out, false).expect("Could not write report");
+    write_report(&report, out, PrettyPrint::ForceUgly).expect("Could not write report");
     // Rust-analyzer will not show error messages unless we panic,
     // This just tells rust-analyzer users to check stderr:
     panic!("Diplomat error: {} (check stderr for more)", report.title);

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -125,7 +125,7 @@ pub enum PrettyPrint {
     /// Attempt to use pretty printer first if feature enabled, fall back to ugly printer.
     Default,
     /// Even if pretty-printing is enabled, use the ugly printer (mostly for testing)
-    ForceUgly
+    ForceUgly,
 }
 
 pub fn write_report(

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -121,6 +121,7 @@ impl WriteReport for &mut String {
     }
 }
 
+#[non_exhaustive]
 pub enum PrettyPrint {
     /// Attempt to use pretty printer first if feature enabled, fall back to ugly printer.
     Default,

--- a/core/src/ast/logging.rs
+++ b/core/src/ast/logging.rs
@@ -121,10 +121,12 @@ impl WriteReport for &mut String {
     }
 }
 
-pub fn write_report(report : &AstReport, mut out : impl WriteReport, 
+pub fn write_report(
+    report: &AstReport,
+    mut out: impl WriteReport,
     // Only used when pretty-print feature is enabled:
-    #[allow(unused)]
-    force_ugly : bool) -> Result<(), String> {
+    #[allow(unused)] force_ugly: bool,
+) -> Result<(), String> {
     let span = report.primary_loc.as_ref();
     let src = if let Some(sp) = &span {
         match &sp.span_location {
@@ -198,7 +200,7 @@ pub fn write_report(report : &AstReport, mut out : impl WriteReport,
         let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
         writeln!(out, "{}", renderer.render(report))?;
     }
-    
+
     if print_ugly {
         let mut valid_excerpt = true;
         let (location, excerpt_pre, excerpt, excerpt_post) = if let Some(sp) = span {
@@ -216,7 +218,8 @@ pub fn write_report(report : &AstReport, mut out : impl WriteReport,
             match sp.span_location {
                 SpanLocation::None => {
                     valid_excerpt = false;
-                    (span_location, "", "<Excerpt not available>", "")},
+                    (span_location, "", "<Excerpt not available>", "")
+                }
                 _ => (
                     format!("{span_location}:{start}:{col}"),
                     &src[range_pre..range.start],

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -40,7 +40,7 @@ mod paths;
 pub use paths::Path;
 
 mod idents;
-pub use idents::{Ident, SpanLocation, Span};
+pub use idents::{Ident, Span, SpanLocation};
 
 mod docs;
 pub use docs::{DocType, Docs, RustLink, RustLinkDisplay};
@@ -49,4 +49,4 @@ mod macros;
 pub use macros::{MacroDef, MacroUse, Macros};
 
 pub(crate) mod logging;
-pub use logging::{AstReport, write_report};
+pub use logging::{write_report, AstReport};

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -49,4 +49,4 @@ mod macros;
 pub use macros::{MacroDef, MacroUse, Macros};
 
 pub(crate) mod logging;
-pub use logging::{write_report, AstReport};
+pub use logging::{write_report, AstReport, PrettyPrint};

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -49,3 +49,4 @@ mod macros;
 pub use macros::{MacroDef, MacroUse, Macros};
 
 pub(crate) mod logging;
+pub use logging::{AstReport, write_report};

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -40,7 +40,7 @@ mod paths;
 pub use paths::Path;
 
 mod idents;
-pub use idents::{Ident, SpanLocation};
+pub use idents::{Ident, SpanLocation, Span};
 
 mod docs;
 pub use docs::{DocType, Docs, RustLink, RustLinkDisplay};
@@ -48,4 +48,4 @@ pub use docs::{DocType, Docs, RustLink, RustLinkDisplay};
 mod macros;
 pub use macros::{MacroDef, MacroUse, Macros};
 
-mod logging;
+pub(crate) mod logging;

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1697,7 +1697,6 @@ impl AttributeValidator for BasicAttributeValidator {
 #[cfg(test)]
 mod tests {
     use crate::hir;
-    use std::fmt::Write;
 
     macro_rules! uitest_lowering_attr {
         ($attrs:expr, $($file:tt)*) => {

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1710,8 +1710,8 @@ mod tests {
             match hir::TypeContext::from_syn(&parsed, Default::default(), attr_validator, None, &crate::ast::SpanLocation::None) {
                 Ok(_context) => (),
                 Err(e) => {
-                    for (ctx, err) in e {
-                        writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                    for err in e {
+                        writeln!(&mut output, "{err}").unwrap();
                     }
                 }
             };

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1711,7 +1711,7 @@ mod tests {
                 Ok(_context) => (),
                 Err(e) => {
                     for err in e {
-                        writeln!(&mut output, "{err}").unwrap();
+                        crate::ast::write_report(&err.ast_report(), &mut output, true).unwrap();
                     }
                 }
             };

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1710,7 +1710,7 @@ mod tests {
                 Ok(_context) => (),
                 Err(e) => {
                     for err in e {
-                        crate::ast::write_report(&err.ast_report(), &mut output, true).unwrap();
+                        crate::ast::write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                     }
                 }
             };

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -26,10 +26,10 @@ impl std::fmt::Display for Ident {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
-} 
+}
 
 impl Ident {
-    pub(crate) fn new(name : IdentBuf, span : Option<crate::ast::Span>) -> Self {
+    pub(crate) fn new(name: IdentBuf, span: Option<crate::ast::Span>) -> Self {
         Self(name, span)
     }
 }

--- a/core/src/hir/defs.rs
+++ b/core/src/hir/defs.rs
@@ -13,6 +13,34 @@ pub enum ReturnableStructDef<'tcx> {
     OutStruct(&'tcx OutStructDef),
 }
 
+#[derive(Debug)]
+pub struct Ident(pub IdentBuf, pub(crate) Option<crate::ast::Span>);
+
+impl std::cmp::PartialEq<&'static str> for Ident {
+    fn eq(&self, other: &&'static str) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl std::fmt::Display for Ident {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+} 
+
+impl Ident {
+    pub(crate) fn new(name : IdentBuf, span : Option<crate::ast::Span>) -> Self {
+        Self(name, span)
+    }
+}
+
+impl std::ops::Deref for Ident {
+    type Target = IdentBuf;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum TypeDef<'tcx> {
@@ -27,7 +55,7 @@ pub enum TypeDef<'tcx> {
 pub struct TraitDef {
     // TyPosition: InputOnly
     pub docs: Docs,
-    pub name: IdentBuf,
+    pub name: Ident,
     pub methods: Vec<Callback>,
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
@@ -42,7 +70,7 @@ pub type OutStructDef = StructDef<OutputOnly>;
 #[non_exhaustive]
 pub struct StructDef<P: TyPosition = Everywhere> {
     pub docs: Docs,
-    pub name: IdentBuf,
+    pub name: Ident,
     pub fields: Vec<StructField<P>>,
     pub methods: Vec<Method>,
     pub attrs: Attrs,
@@ -63,7 +91,7 @@ pub struct StructDef<P: TyPosition = Everywhere> {
 #[non_exhaustive]
 pub struct OpaqueDef {
     pub docs: Docs,
-    pub name: IdentBuf,
+    pub name: Ident,
     pub methods: Vec<Method>,
     pub attrs: Attrs,
     pub lifetimes: LifetimeEnv,
@@ -79,7 +107,7 @@ pub struct OpaqueDef {
 #[non_exhaustive]
 pub struct EnumDef {
     pub docs: Docs,
-    pub name: IdentBuf,
+    pub name: Ident,
     pub variants: Vec<EnumVariant>,
     pub methods: Vec<Method>,
     pub attrs: Attrs,
@@ -179,7 +207,7 @@ pub struct EnumVariant {
 impl TraitDef {
     pub(super) fn new(
         docs: Docs,
-        name: IdentBuf,
+        name: Ident,
         methods: Vec<Callback>,
         attrs: Attrs,
         lifetimes: LifetimeEnv,
@@ -198,7 +226,7 @@ impl TraitDef {
 impl<P: TyPosition> StructDef<P> {
     pub(super) fn new(
         docs: Docs,
-        name: IdentBuf,
+        name: Ident,
         fields: Vec<StructField<P>>,
         methods: Vec<Method>,
         attrs: Attrs,
@@ -221,7 +249,7 @@ impl<P: TyPosition> StructDef<P> {
 impl OpaqueDef {
     pub(super) fn new(
         docs: Docs,
-        name: IdentBuf,
+        name: Ident,
         methods: Vec<Method>,
         attrs: Attrs,
         lifetimes: LifetimeEnv,
@@ -244,7 +272,7 @@ impl OpaqueDef {
 impl EnumDef {
     pub(super) fn new(
         docs: Docs,
-        name: IdentBuf,
+        name: Ident,
         variants: Vec<EnumVariant>,
         methods: Vec<Method>,
         attrs: Attrs,
@@ -287,6 +315,15 @@ impl<'tcx> TypeDef<'tcx> {
             Self::OutStruct(ty) => &ty.name,
             Self::Opaque(ty) => &ty.name,
             Self::Enum(ty) => &ty.name,
+        }
+    }
+
+    pub fn span(&self) -> &'tcx Option<crate::ast::Span> {
+        match *self {
+            Self::Struct(ty) => &ty.name.1,
+            Self::OutStruct(ty) => &ty.name.1,
+            Self::Opaque(ty) => &ty.name.1,
+            Self::Enum(ty) => &ty.name.1,
         }
     }
 

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -134,7 +134,7 @@ impl LoweringReport {
 impl fmt::Display for LoweringReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let report = self.ast_report();
-        write_report(&report, f, false).map_err(|e| {
+        write_report(&report, f, crate::ast::logging::PrettyPrint::Default).map_err(|e| {
             panic!(
                 "Could not write lowering report for {}: {e}",
                 self.get_location()

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -302,8 +302,7 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_enum(&mut self, item: ItemAndInfo<'ast, ast::Enum>) -> Result<EnumDef, ()> {
         let ast_enum = item.item;
-        self.errors
-            .set_item(ast_enum.name.as_str(), &ast_enum.name);
+        self.errors.set_item(ast_enum.name.as_str(), &ast_enum.name);
         let name = self.lower_ident(&ast_enum.name, "enum name");
         let attrs = self.attr_validator.attr_from_ast(
             &ast_enum.attrs,

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -9,7 +9,7 @@ use super::{
     TraitParamSelf, TraitPath, TyPosition, Type, TypeDef, TypeId,
 };
 use crate::ast::attrs::AttrInheritContext;
-use crate::ast::logging::{ContextLocation, write_report};
+use crate::ast::logging::{write_report, ContextLocation};
 use crate::hir::{Docs, StructPathLike, SymbolId, TypingUseInfo};
 use crate::{ast, Env};
 use core::fmt;
@@ -45,10 +45,10 @@ impl fmt::Display for LoweringError {
 
 #[derive(Clone, Default, Debug)]
 pub struct ErrorContext {
-    location : Option<crate::ast::Span>,
+    location: Option<crate::ast::Span>,
     // Old Lowering Error setup (since the span may not always be present):
     item: String,
-    subitem : Option<String>,
+    subitem: Option<String>,
 }
 
 /// An error store, which one can push errors to. It keeps track of the
@@ -59,21 +59,23 @@ pub struct ErrorStore<'tree> {
     /// The errors
     errors: Vec<ErrorAndContext>,
     /// The current context (types, modules)
-    item : &'tree str,
+    item: &'tree str,
     /// The current sub-item context (methods, etc)
-    subitem : Option<&'tree str>,
+    subitem: Option<&'tree str>,
     location: Option<crate::ast::Span>,
 }
 
 #[derive(Debug)]
 pub struct LoweringReport {
-    context : ErrorContext,
-    error : LoweringError
+    context: ErrorContext,
+    error: LoweringError,
 }
 
 impl LoweringReport {
     pub fn get_location(&self) -> String {
-        format!("{}{}", self.context.item,
+        format!(
+            "{}{}",
+            self.context.item,
             if let Some(s) = &self.context.subitem {
                 format!("::{}", s)
             } else {
@@ -91,11 +93,13 @@ impl LoweringReport {
                 } else {
                     vec![]
                 };
-                (format!("In field {field_ident}: {reason}"), field_ident.1.clone(), contexts)
+                (
+                    format!("In field {field_ident}: {reason}"),
+                    field_ident.1.clone(),
+                    contexts,
+                )
             }
-            LoweringError::Other(s) => {
-                (s.clone(), self.context.location.clone(), vec![])
-            }
+            LoweringError::Other(s) => (s.clone(), self.context.location.clone(), vec![]),
         };
         ast::logging::AstReport::new(
             format!("Lowering error in {location}"),
@@ -110,7 +114,10 @@ impl fmt::Display for LoweringReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let report = self.ast_report();
         write_report(&report, f, false).map_err(|e| {
-            panic!("Could not write lowering report for {}: {e}", self.get_location());
+            panic!(
+                "Could not write lowering report for {}: {e}",
+                self.get_location()
+            );
         })?;
         Ok(())
     }
@@ -156,10 +163,7 @@ impl<'tree> ErrorStore<'tree> {
             subitem: self.subitem.map(|s| s.into()),
             location: self.location.clone(),
         };
-        self.errors.push(LoweringReport {
-            context,
-            error
-        });
+        self.errors.push(LoweringReport { context, error });
     }
 
     pub(super) fn take_errors(&mut self) -> Vec<ErrorAndContext> {
@@ -170,13 +174,13 @@ impl<'tree> ErrorStore<'tree> {
         self.errors.is_empty()
     }
 
-    pub(super) fn set_item(&mut self, item: &'tree str, ctx : &dyn ReportContext) {
+    pub(super) fn set_item(&mut self, item: &'tree str, ctx: &dyn ReportContext) {
         self.item = item;
         self.subitem = None;
         self.location = ctx.to_span();
     }
 
-    pub(super) fn set_subitem(&mut self, subitem: &'tree str, ctx : &dyn ReportContext) {
+    pub(super) fn set_subitem(&mut self, subitem: &'tree str, ctx: &dyn ReportContext) {
         self.subitem = Some(subitem);
         self.location = ctx.to_span();
     }
@@ -298,7 +302,8 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_enum(&mut self, item: ItemAndInfo<'ast, ast::Enum>) -> Result<EnumDef, ()> {
         let ast_enum = item.item;
-        self.errors.set_item(&ast_enum.name.as_str(), &ast_enum.name);
+        self.errors
+            .set_item(&ast_enum.name.as_str(), &ast_enum.name);
         let name = self.lower_ident(&ast_enum.name, "enum name");
         let attrs = self.attr_validator.attr_from_ast(
             &ast_enum.attrs,
@@ -368,7 +373,8 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_opaque(&mut self, item: ItemAndInfo<'ast, ast::OpaqueType>) -> Result<OpaqueDef, ()> {
         let ast_opaque = item.item;
-        self.errors.set_item(&ast_opaque.name.as_str(), &ast_opaque.name);
+        self.errors
+            .set_item(&ast_opaque.name.as_str(), &ast_opaque.name);
         let name = self.lower_ident(&ast_opaque.name, "opaque name");
         let dtor_abi_name = self.lower_ident(&ast_opaque.dtor_abi_name, "opaque dtor abi name");
 
@@ -413,7 +419,8 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_struct(&mut self, item: ItemAndInfo<'ast, ast::Struct>) -> Result<StructDef, ()> {
         let ast_struct = item.item;
-        self.errors.set_item(&ast_struct.name.as_str(), &ast_struct.name);
+        self.errors
+            .set_item(&ast_struct.name.as_str(), &ast_struct.name);
         let struct_name = self.lower_ident(&ast_struct.name, "struct name")?;
 
         let mut fields = Ok(Vec::with_capacity(ast_struct.fields.len()));
@@ -429,11 +436,12 @@ impl<'ast> LoweringContext<'ast> {
                 let name = self.lower_ident(field_name, "struct field name")?;
                 if !ty.is_ffi_safe() {
                     let ffisafe = ty.ffi_safe_version();
-                    self.errors.push(LoweringError::InvalidField(super::defs::Ident::new(name.clone(), field_name.span()),
+                    self.errors.push(LoweringError::InvalidField(
+                        super::defs::Ident::new(name.clone(), field_name.span()),
                         Box::new(LoweringError::Other(format!(
                             "{ty} is FFI-unsafe, consider using {ffisafe}",
-                        ))
-                    )));
+                        ))),
+                    ));
                 }
                 let ty = self.lower_type::<Everywhere>(
                     ty,
@@ -510,7 +518,8 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_trait(&mut self, item: ItemAndInfo<'ast, ast::Trait>) -> Result<TraitDef, ()> {
         let ast_trait = item.item;
-        self.errors.set_item(&ast_trait.name.as_str(), &ast_trait.name);
+        self.errors
+            .set_item(&ast_trait.name.as_str(), &ast_trait.name);
         let trait_name = self.lower_ident(&ast_trait.name, "trait name")?;
 
         let attrs = self.attr_validator.attr_from_ast(
@@ -573,7 +582,8 @@ impl<'ast> LoweringContext<'ast> {
         in_path: &ast::Path,
         parent_trait_attrs: &Attrs,
     ) -> Result<Callback, ()> {
-        self.errors.set_subitem(&ast_trait_method.name.as_str(), &ast_trait_method.name);
+        self.errors
+            .set_subitem(&ast_trait_method.name.as_str(), &ast_trait_method.name);
         let name = ast_trait_method.name.clone();
         let self_param_ltl = SelfParamLifetimeLowerer::new(&ast_trait_method.lifetimes, self)?;
         let (param_self, mut param_ltl) =
@@ -618,7 +628,8 @@ impl<'ast> LoweringContext<'ast> {
         &mut self,
         ast_function: ItemAndInfo<'ast, ast::Function>,
     ) -> Result<Method, ()> {
-        self.errors.set_item(&ast_function.item.name.as_str(), &ast_function.item.name);
+        self.errors
+            .set_item(&ast_function.item.name.as_str(), &ast_function.item.name);
         let name = ast_function.item.name.clone();
         let param_ltl = SelfParamLifetimeLowerer::no_self_ref(SelfParamLifetimeLowerer::new(
             &ast_function.item.lifetimes,
@@ -668,7 +679,10 @@ impl<'ast> LoweringContext<'ast> {
                 self.attr_validator.as_ref(),
                 &mut self.errors,
             ),
-            name: super::defs::Ident::new(self.lower_ident(&name, "function name")?, ast_function.item.name.span()),
+            name: super::defs::Ident::new(
+                self.lower_ident(&name, "function name")?,
+                ast_function.item.name.span(),
+            ),
             abi_name: self.lower_ident(&ast_function.item.abi_name, "function abi name")?,
             lifetime_env,
             param_self: None,
@@ -688,7 +702,8 @@ impl<'ast> LoweringContext<'ast> {
         item: ItemAndInfo<'ast, ast::Struct>,
     ) -> Result<OutStructDef, ()> {
         let ast_out_struct = item.item;
-        self.errors.set_item(&ast_out_struct.name.as_str(), &ast_out_struct.name);
+        self.errors
+            .set_item(&ast_out_struct.name.as_str(), &ast_out_struct.name);
         let name = self.lower_ident(&ast_out_struct.name, "out-struct name");
 
         let attrs = self.attr_validator.attr_from_ast(

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -9,40 +9,18 @@ use super::{
     TraitParamSelf, TraitPath, TyPosition, Type, TypeDef, TypeId,
 };
 use crate::ast::attrs::AttrInheritContext;
-use crate::ast::logging::{write_report, ContextLocation};
+use crate::ast::logging::write_report;
 use crate::hir::{Docs, StructPathLike, SymbolId, TypingUseInfo};
 use crate::{ast, Env};
 use core::fmt;
 use std::collections::HashMap;
 use strck::IntoCk;
 
-#[derive(Debug)]
-#[non_exhaustive]
-/// String holder to provide additional context to the LoweringError.
-pub enum LoweringErrorReason {
-    /// The HIR has read something that could be unsafe when executed.
-    Unsafe(String),
-    /// Anything not caught above.
-    Other(String),
-}
-
-impl fmt::Display for LoweringErrorReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LoweringErrorReason::Unsafe(s) => write!(f, "Safety issue: {s}"),
-            LoweringErrorReason::Other(s) => s.fmt(f),
-        }
-    }
-}
-
 /// An error from lowering the AST to the HIR.
 /// This provides location information.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum LoweringError {
-    /// A field type is invalid in some way. The contained [`LoweringError`] has more specifics,
-    /// this is to just demarcate where the field is for the error.
-    InvalidField(Box<super::defs::Ident>, LoweringErrorReason),
     /// The purpose of having this is that translating to the HIR has enormous
     /// potential for really detailed error handling and giving suggestions.
     ///
@@ -51,14 +29,12 @@ pub enum LoweringError {
     /// written, we ctrl+F for `"LoweringError::Other"` in the lowering code, and turn every
     /// instance into an specialized enum variant, generalizing where possible
     /// without losing any information.
-    /// Currently in the process of being phased out (will be replaced with LoweringError::Generic(LoweringErrorReason))
     Other(String),
 }
 
 impl fmt::Display for LoweringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Self::InvalidField(_, ref reason) => reason.fmt(f),
             Self::Other(ref s) => s.fmt(f),
         }
     }
@@ -107,26 +83,11 @@ impl LoweringReport {
     pub fn ast_report(&self) -> crate::ast::logging::AstReport {
         let location = self.get_location();
 
-        let (primary_label, primary_loc, contexts) = match &self.error {
-            LoweringError::InvalidField(field_ident, reason) => {
-                let contexts = if let Some(sp) = &self.context.location {
-                    vec![ContextLocation::new(sp.clone(), "".into())]
-                } else {
-                    vec![]
-                };
-                (
-                    format!("In field {field_ident}: {reason}"),
-                    field_ident.1.clone(),
-                    contexts,
-                )
-            }
-            LoweringError::Other(s) => (s.clone(), self.context.location.clone(), vec![]),
-        };
         ast::logging::AstReport::new(
             format!("Lowering error in {location}"),
-            primary_loc,
-            primary_label,
-            contexts,
+            self.context.location.clone(),
+            format!("{}", self.error),
+            vec![],
         )
     }
 }
@@ -456,12 +417,9 @@ impl<'ast> LoweringContext<'ast> {
                 let name = self.lower_ident(field_name, "struct field name")?;
                 if !ty.is_ffi_safe() {
                     let ffisafe = ty.ffi_safe_version();
-                    self.errors.push(LoweringError::InvalidField(
-                        Box::new(super::defs::Ident::new(name.clone(), field_name.span())),
-                        LoweringErrorReason::Unsafe(format!(
-                            "{ty} is FFI-unsafe, consider using {ffisafe}"
-                        )),
-                    ));
+                    self.errors.push(LoweringError::Other(format!(
+                        "{ty} is FFI-unsafe, consider using {ffisafe}"
+                    )));
                 }
                 let ty = self.lower_type::<Everywhere>(
                     ty,

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -30,7 +30,7 @@ impl fmt::Display for LoweringErrorReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LoweringErrorReason::Unsafe(s) => write!(f, "Safety issue: {s}"),
-            LoweringErrorReason::Other(s) => s.fmt(f)
+            LoweringErrorReason::Other(s) => s.fmt(f),
         }
     }
 }
@@ -458,7 +458,9 @@ impl<'ast> LoweringContext<'ast> {
                     let ffisafe = ty.ffi_safe_version();
                     self.errors.push(LoweringError::InvalidField(
                         super::defs::Ident::new(name.clone(), field_name.span()),
-                        LoweringErrorReason::Unsafe(format!("{ty} is FFI-unsafe, consider using {ffisafe}")),
+                        LoweringErrorReason::Unsafe(format!(
+                            "{ty} is FFI-unsafe, consider using {ffisafe}"
+                        )),
                     ));
                 }
                 let ty = self.lower_type::<Everywhere>(

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -9,6 +9,7 @@ use super::{
     TraitParamSelf, TraitPath, TyPosition, Type, TypeDef, TypeId,
 };
 use crate::ast::attrs::AttrInheritContext;
+use crate::ast::logging::write_report;
 use crate::hir::{Docs, StructPathLike, SymbolId, TypingUseInfo};
 use crate::{ast, Env};
 use core::fmt;
@@ -38,26 +39,12 @@ impl fmt::Display for LoweringError {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone, Default, Debug)]
 pub struct ErrorContext {
+    location : Option<crate::ast::Span>,
+    // Old Lowering Error setup (since the span may not always be present):
     item: String,
-    subitem: Option<String>,
-}
-
-impl fmt::Display for ErrorContext {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref subitem) = self.subitem {
-            write!(f, "{}::{subitem}", self.item)
-        } else {
-            self.item.fmt(f)
-        }
-    }
-}
-
-impl fmt::Debug for ErrorContext {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
+    subitem : Option<String>,
 }
 
 /// An error store, which one can push errors to. It keeps track of the
@@ -68,12 +55,43 @@ pub struct ErrorStore<'tree> {
     /// The errors
     errors: Vec<ErrorAndContext>,
     /// The current context (types, modules)
-    item: &'tree str,
+    item : &'tree str,
     /// The current sub-item context (methods, etc)
-    subitem: Option<&'tree str>,
+    subitem : Option<&'tree str>,
+    location: Option<crate::ast::Span>,
 }
 
-pub type ErrorAndContext = (ErrorContext, LoweringError);
+#[derive(Debug)]
+pub struct LoweringReport {
+    context : ErrorContext,
+    error : LoweringError
+}
+
+impl fmt::Display for LoweringReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let location = format!("{}{}", self.context.item,
+            if let Some(s) = &self.context.subitem {
+                format!("::{}", s)
+            } else {
+                "".into()
+            }
+        );
+        let report = ast::logging::AstReport::new(
+            format!("Lowering error in {location}"),
+            self.context.location.clone(),
+            format!("{}", self.error),
+            // Add context locations based on the error type:
+        match self.error {
+            LoweringError::Other(..) => vec![]
+        });
+        write_report(&report, f).map_err(|e| {
+            panic!("Could not write lowering report for {location}: {e}");
+        })?;
+        Ok(())
+    }
+}
+
+pub type ErrorAndContext = LoweringReport;
 
 /// Where a type was found
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -83,14 +101,40 @@ enum TypeLoweringContext {
     Method,
 }
 
+pub(crate) trait ReportContext {
+    fn to_span(&self) -> Option<crate::ast::Span>;
+}
+
+impl ReportContext for ast::Ident {
+    fn to_span(&self) -> Option<crate::ast::Span> {
+        self.span()
+    }
+}
+
+impl ReportContext for super::defs::Ident {
+    fn to_span(&self) -> Option<crate::ast::Span> {
+        self.1.clone()
+    }
+}
+
+impl ReportContext for Option<crate::ast::Span> {
+    fn to_span(&self) -> Option<crate::ast::Span> {
+        self.clone()
+    }
+}
+
 impl<'tree> ErrorStore<'tree> {
     /// Push an error to the error store
     pub fn push(&mut self, error: LoweringError) {
         let context = ErrorContext {
             item: self.item.into(),
             subitem: self.subitem.map(|s| s.into()),
+            location: self.location.clone(),
         };
-        self.errors.push((context, error));
+        self.errors.push(LoweringReport {
+            context,
+            error
+        });
     }
 
     pub(super) fn take_errors(&mut self) -> Vec<ErrorAndContext> {
@@ -101,12 +145,15 @@ impl<'tree> ErrorStore<'tree> {
         self.errors.is_empty()
     }
 
-    pub(super) fn set_item(&mut self, item: &'tree str) {
+    pub(super) fn set_item(&mut self, item: &'tree str, ctx : &dyn ReportContext) {
         self.item = item;
         self.subitem = None;
+        self.location = ctx.to_span();
     }
-    pub(super) fn set_subitem(&mut self, subitem: &'tree str) {
+
+    pub(super) fn set_subitem(&mut self, subitem: &'tree str, ctx : &dyn ReportContext) {
         self.subitem = Some(subitem);
+        self.location = ctx.to_span();
     }
 }
 
@@ -226,7 +273,7 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_enum(&mut self, item: ItemAndInfo<'ast, ast::Enum>) -> Result<EnumDef, ()> {
         let ast_enum = item.item;
-        self.errors.set_item(ast_enum.name.as_str());
+        self.errors.set_item(&ast_enum.name.as_str(), &ast_enum.name);
         let name = self.lower_ident(&ast_enum.name, "enum name");
         let attrs = self.attr_validator.attr_from_ast(
             &ast_enum.attrs,
@@ -278,7 +325,7 @@ impl<'ast> LoweringContext<'ast> {
                 self.attr_validator.as_ref(),
                 &mut self.errors,
             ),
-            name?,
+            super::defs::Ident::new(name?, ast_enum.name.span()),
             variants?,
             methods,
             attrs,
@@ -296,7 +343,7 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_opaque(&mut self, item: ItemAndInfo<'ast, ast::OpaqueType>) -> Result<OpaqueDef, ()> {
         let ast_opaque = item.item;
-        self.errors.set_item(ast_opaque.name.as_str());
+        self.errors.set_item(&ast_opaque.name.as_str(), &ast_opaque.name);
         let name = self.lower_ident(&ast_opaque.name, "opaque name");
         let dtor_abi_name = self.lower_ident(&ast_opaque.dtor_abi_name, "opaque dtor abi name");
 
@@ -324,7 +371,7 @@ impl<'ast> LoweringContext<'ast> {
                 self.attr_validator.as_ref(),
                 &mut self.errors,
             ),
-            name?,
+            super::defs::Ident::new(name?, ast_opaque.name.span()),
             methods,
             attrs,
             lifetimes?,
@@ -341,7 +388,7 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_struct(&mut self, item: ItemAndInfo<'ast, ast::Struct>) -> Result<StructDef, ()> {
         let ast_struct = item.item;
-        self.errors.set_item(ast_struct.name.as_str());
+        self.errors.set_item(&ast_struct.name.as_str(), &ast_struct.name);
         let struct_name = self.lower_ident(&ast_struct.name, "struct name")?;
 
         let mut fields = Ok(Vec::with_capacity(ast_struct.fields.len()));
@@ -418,7 +465,7 @@ impl<'ast> LoweringContext<'ast> {
                 self.attr_validator.as_ref(),
                 &mut self.errors,
             ),
-            struct_name,
+            super::defs::Ident::new(struct_name, ast_struct.name.span()),
             fields?,
             methods,
             attrs,
@@ -436,7 +483,7 @@ impl<'ast> LoweringContext<'ast> {
 
     fn lower_trait(&mut self, item: ItemAndInfo<'ast, ast::Trait>) -> Result<TraitDef, ()> {
         let ast_trait = item.item;
-        self.errors.set_item(ast_trait.name.as_str());
+        self.errors.set_item(&ast_trait.name.as_str(), &ast_trait.name);
         let trait_name = self.lower_ident(&ast_trait.name, "trait name")?;
 
         let attrs = self.attr_validator.attr_from_ast(
@@ -482,7 +529,7 @@ impl<'ast> LoweringContext<'ast> {
                 self.attr_validator.as_ref(),
                 &mut self.errors,
             ),
-            trait_name,
+            super::defs::Ident::new(trait_name, ast_trait.name.span()),
             fcts,
             attrs,
             lifetimes?,
@@ -499,7 +546,7 @@ impl<'ast> LoweringContext<'ast> {
         in_path: &ast::Path,
         parent_trait_attrs: &Attrs,
     ) -> Result<Callback, ()> {
-        self.errors.set_subitem(ast_trait_method.name.as_str());
+        self.errors.set_subitem(&ast_trait_method.name.as_str(), &ast_trait_method.name);
         let name = ast_trait_method.name.clone();
         let self_param_ltl = SelfParamLifetimeLowerer::new(&ast_trait_method.lifetimes, self)?;
         let (param_self, mut param_ltl) =
@@ -544,7 +591,7 @@ impl<'ast> LoweringContext<'ast> {
         &mut self,
         ast_function: ItemAndInfo<'ast, ast::Function>,
     ) -> Result<Method, ()> {
-        self.errors.set_item(ast_function.item.name.as_str());
+        self.errors.set_item(&ast_function.item.name.as_str(), &ast_function.item.name);
         let name = ast_function.item.name.clone();
         let param_ltl = SelfParamLifetimeLowerer::no_self_ref(SelfParamLifetimeLowerer::new(
             &ast_function.item.lifetimes,
@@ -594,7 +641,7 @@ impl<'ast> LoweringContext<'ast> {
                 self.attr_validator.as_ref(),
                 &mut self.errors,
             ),
-            name: self.lower_ident(&name, "function name")?,
+            name: super::defs::Ident::new(self.lower_ident(&name, "function name")?, ast_function.item.name.span()),
             abi_name: self.lower_ident(&ast_function.item.abi_name, "function abi name")?,
             lifetime_env,
             param_self: None,
@@ -614,7 +661,7 @@ impl<'ast> LoweringContext<'ast> {
         item: ItemAndInfo<'ast, ast::Struct>,
     ) -> Result<OutStructDef, ()> {
         let ast_out_struct = item.item;
-        self.errors.set_item(ast_out_struct.name.as_str());
+        self.errors.set_item(&ast_out_struct.name.as_str(), &ast_out_struct.name);
         let name = self.lower_ident(&ast_out_struct.name, "out-struct name");
 
         let attrs = self.attr_validator.attr_from_ast(
@@ -677,7 +724,7 @@ impl<'ast> LoweringContext<'ast> {
                 self.attr_validator.as_ref(),
                 &mut self.errors,
             ),
-            name?,
+            super::defs::Ident::new(name?, ast_out_struct.name.span()),
             fields?,
             methods,
             attrs,
@@ -733,7 +780,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let mut hir_method = Method {
             docs: Docs::from_ast(&method.docs, self.attr_validator.as_ref(), &mut self.errors),
-            name: name?,
+            name: super::defs::Ident::new(name?, method.name.span()),
             abi_name,
             lifetime_env,
             param_self,
@@ -828,7 +875,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let mut has_unnamed_constructor = false;
         for method in ast_methods {
-            self.errors.set_subitem(method.name.as_str());
+            self.errors.set_subitem(&method.name.as_str(), &method.name);
             let attrs = self.attr_validator.attr_from_ast(
                 &method.attrs,
                 method_parent_attrs,

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -303,7 +303,7 @@ impl<'ast> LoweringContext<'ast> {
     fn lower_enum(&mut self, item: ItemAndInfo<'ast, ast::Enum>) -> Result<EnumDef, ()> {
         let ast_enum = item.item;
         self.errors
-            .set_item(&ast_enum.name.as_str(), &ast_enum.name);
+            .set_item(ast_enum.name.as_str(), &ast_enum.name);
         let name = self.lower_ident(&ast_enum.name, "enum name");
         let attrs = self.attr_validator.attr_from_ast(
             &ast_enum.attrs,
@@ -374,7 +374,7 @@ impl<'ast> LoweringContext<'ast> {
     fn lower_opaque(&mut self, item: ItemAndInfo<'ast, ast::OpaqueType>) -> Result<OpaqueDef, ()> {
         let ast_opaque = item.item;
         self.errors
-            .set_item(&ast_opaque.name.as_str(), &ast_opaque.name);
+            .set_item(ast_opaque.name.as_str(), &ast_opaque.name);
         let name = self.lower_ident(&ast_opaque.name, "opaque name");
         let dtor_abi_name = self.lower_ident(&ast_opaque.dtor_abi_name, "opaque dtor abi name");
 
@@ -420,7 +420,7 @@ impl<'ast> LoweringContext<'ast> {
     fn lower_struct(&mut self, item: ItemAndInfo<'ast, ast::Struct>) -> Result<StructDef, ()> {
         let ast_struct = item.item;
         self.errors
-            .set_item(&ast_struct.name.as_str(), &ast_struct.name);
+            .set_item(ast_struct.name.as_str(), &ast_struct.name);
         let struct_name = self.lower_ident(&ast_struct.name, "struct name")?;
 
         let mut fields = Ok(Vec::with_capacity(ast_struct.fields.len()));
@@ -519,7 +519,7 @@ impl<'ast> LoweringContext<'ast> {
     fn lower_trait(&mut self, item: ItemAndInfo<'ast, ast::Trait>) -> Result<TraitDef, ()> {
         let ast_trait = item.item;
         self.errors
-            .set_item(&ast_trait.name.as_str(), &ast_trait.name);
+            .set_item(ast_trait.name.as_str(), &ast_trait.name);
         let trait_name = self.lower_ident(&ast_trait.name, "trait name")?;
 
         let attrs = self.attr_validator.attr_from_ast(
@@ -583,7 +583,7 @@ impl<'ast> LoweringContext<'ast> {
         parent_trait_attrs: &Attrs,
     ) -> Result<Callback, ()> {
         self.errors
-            .set_subitem(&ast_trait_method.name.as_str(), &ast_trait_method.name);
+            .set_subitem(ast_trait_method.name.as_str(), &ast_trait_method.name);
         let name = ast_trait_method.name.clone();
         let self_param_ltl = SelfParamLifetimeLowerer::new(&ast_trait_method.lifetimes, self)?;
         let (param_self, mut param_ltl) =
@@ -629,7 +629,7 @@ impl<'ast> LoweringContext<'ast> {
         ast_function: ItemAndInfo<'ast, ast::Function>,
     ) -> Result<Method, ()> {
         self.errors
-            .set_item(&ast_function.item.name.as_str(), &ast_function.item.name);
+            .set_item(ast_function.item.name.as_str(), &ast_function.item.name);
         let name = ast_function.item.name.clone();
         let param_ltl = SelfParamLifetimeLowerer::no_self_ref(SelfParamLifetimeLowerer::new(
             &ast_function.item.lifetimes,
@@ -703,7 +703,7 @@ impl<'ast> LoweringContext<'ast> {
     ) -> Result<OutStructDef, ()> {
         let ast_out_struct = item.item;
         self.errors
-            .set_item(&ast_out_struct.name.as_str(), &ast_out_struct.name);
+            .set_item(ast_out_struct.name.as_str(), &ast_out_struct.name);
         let name = self.lower_ident(&ast_out_struct.name, "out-struct name");
 
         let attrs = self.attr_validator.attr_from_ast(
@@ -917,7 +917,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let mut has_unnamed_constructor = false;
         for method in ast_methods {
-            self.errors.set_subitem(&method.name.as_str(), &method.name);
+            self.errors.set_subitem(method.name.as_str(), &method.name);
             let attrs = self.attr_validator.attr_from_ast(
                 &method.attrs,
                 method_parent_attrs,

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -16,13 +16,33 @@ use core::fmt;
 use std::collections::HashMap;
 use strck::IntoCk;
 
+#[derive(Debug)]
+#[non_exhaustive]
+/// String holder to provide additional context to the LoweringError.
+pub enum LoweringErrorReason {
+    /// The HIR has read something that could be unsafe when executed.
+    Unsafe(String),
+    /// Anything not caught above.
+    Other(String),
+}
+
+impl fmt::Display for LoweringErrorReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoweringErrorReason::Unsafe(s) => write!(f, "Safety issue: {s}"),
+            LoweringErrorReason::Other(s) => s.fmt(f)
+        }
+    }
+}
+
 /// An error from lowering the AST to the HIR.
+/// This provides location information.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum LoweringError {
     /// A field type is invalid in some way. The contained [`LoweringError`] has more specifics,
     /// this is to just demarcate where the field is for the error.
-    InvalidField(super::defs::Ident, Box<LoweringError>),
+    InvalidField(super::defs::Ident, LoweringErrorReason),
     /// The purpose of having this is that translating to the HIR has enormous
     /// potential for really detailed error handling and giving suggestions.
     ///
@@ -31,6 +51,7 @@ pub enum LoweringError {
     /// written, we ctrl+F for `"LoweringError::Other"` in the lowering code, and turn every
     /// instance into an specialized enum variant, generalizing where possible
     /// without losing any information.
+    /// Currently in the process of being phased out (will be replaced with LoweringError::Generic(LoweringErrorReason))
     Other(String),
 }
 
@@ -437,9 +458,7 @@ impl<'ast> LoweringContext<'ast> {
                     let ffisafe = ty.ffi_safe_version();
                     self.errors.push(LoweringError::InvalidField(
                         super::defs::Ident::new(name.clone(), field_name.span()),
-                        Box::new(LoweringError::Other(format!(
-                            "{ty} is FFI-unsafe, consider using {ffisafe}",
-                        ))),
+                        LoweringErrorReason::Unsafe(format!("{ty} is FFI-unsafe, consider using {ffisafe}")),
                     ));
                 }
                 let ty = self.lower_type::<Everywhere>(

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -9,7 +9,7 @@ use super::{
     TraitParamSelf, TraitPath, TyPosition, Type, TypeDef, TypeId,
 };
 use crate::ast::attrs::AttrInheritContext;
-use crate::ast::logging::write_report;
+use crate::ast::logging::{ContextLocation, write_report};
 use crate::hir::{Docs, StructPathLike, SymbolId, TypingUseInfo};
 use crate::{ast, Env};
 use core::fmt;
@@ -20,6 +20,9 @@ use strck::IntoCk;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum LoweringError {
+    /// A field type is invalid in some way. The contained [`LoweringError`] has more specifics,
+    /// this is to just demarcate where the field is for the error.
+    InvalidField(super::defs::Ident, Box<LoweringError>),
     /// The purpose of having this is that translating to the HIR has enormous
     /// potential for really detailed error handling and giving suggestions.
     ///
@@ -34,6 +37,7 @@ pub enum LoweringError {
 impl fmt::Display for LoweringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Self::InvalidField(_, ref reason) => reason.fmt(f),
             Self::Other(ref s) => s.fmt(f),
         }
     }
@@ -76,14 +80,26 @@ impl fmt::Display for LoweringReport {
                 "".into()
             }
         );
+
+        let (primary_label, primary_loc, contexts) = match &self.error {
+            LoweringError::InvalidField(field_ident, reason) => {
+                let contexts = if let Some(sp) = &self.context.location {
+                    vec![ContextLocation::new(sp.clone(), "".into())]
+                } else {
+                    vec![]
+                };
+                (format!("In field {field_ident}: {reason}"), field_ident.1.clone(), contexts)
+            }
+            LoweringError::Other(s) => {
+                (s.clone(), self.context.location.clone(), vec![])
+            }
+        };
         let report = ast::logging::AstReport::new(
             format!("Lowering error in {location}"),
-            self.context.location.clone(),
-            format!("{}", self.error),
-            // Add context locations based on the error type:
-        match self.error {
-            LoweringError::Other(..) => vec![]
-        });
+            primary_loc,
+            primary_label,
+            contexts,
+        );
         write_report(&report, f).map_err(|e| {
             panic!("Could not write lowering report for {location}: {e}");
         })?;
@@ -400,12 +416,14 @@ impl<'ast> LoweringContext<'ast> {
         );
         // Only compute fields if the type isn't disabled, otherwise we may encounter forbidden types
         if !attrs.disable {
-            for (name, ty, docs, attrs) in ast_struct.fields.iter() {
-                let name = self.lower_ident(name, "struct field name")?;
+            for (field_name, ty, docs, attrs) in ast_struct.fields.iter() {
+                let name = self.lower_ident(field_name, "struct field name")?;
                 if !ty.is_ffi_safe() {
                     let ffisafe = ty.ffi_safe_version();
-                    self.errors.push(LoweringError::Other(format!(
-                        "Found FFI-unsafe type {ty} in struct field {struct_name}.{name}, consider using {ffisafe}",
+                    self.errors.push(LoweringError::InvalidField(super::defs::Ident::new(name.clone(), field_name.span()),
+                        Box::new(LoweringError::Other(format!(
+                            "{ty} is FFI-unsafe, consider using {ffisafe}",
+                        ))
                     )));
                 }
                 let ty = self.lower_type::<Everywhere>(

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -71,15 +71,18 @@ pub struct LoweringReport {
     error : LoweringError
 }
 
-impl fmt::Display for LoweringReport {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let location = format!("{}{}", self.context.item,
+impl LoweringReport {
+    pub fn get_location(&self) -> String {
+        format!("{}{}", self.context.item,
             if let Some(s) = &self.context.subitem {
                 format!("::{}", s)
             } else {
                 "".into()
             }
-        );
+        )
+    }
+    pub fn ast_report(&self) -> crate::ast::logging::AstReport {
+        let location = self.get_location();
 
         let (primary_label, primary_loc, contexts) = match &self.error {
             LoweringError::InvalidField(field_ident, reason) => {
@@ -94,14 +97,20 @@ impl fmt::Display for LoweringReport {
                 (s.clone(), self.context.location.clone(), vec![])
             }
         };
-        let report = ast::logging::AstReport::new(
+        ast::logging::AstReport::new(
             format!("Lowering error in {location}"),
             primary_loc,
             primary_label,
             contexts,
-        );
-        write_report(&report, f).map_err(|e| {
-            panic!("Could not write lowering report for {location}: {e}");
+        )
+    }
+}
+
+impl fmt::Display for LoweringReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let report = self.ast_report();
+        write_report(&report, f, false).map_err(|e| {
+            panic!("Could not write lowering report for {}: {e}", self.get_location());
         })?;
         Ok(())
     }

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -42,7 +42,7 @@ impl fmt::Display for LoweringErrorReason {
 pub enum LoweringError {
     /// A field type is invalid in some way. The contained [`LoweringError`] has more specifics,
     /// this is to just demarcate where the field is for the error.
-    InvalidField(super::defs::Ident, LoweringErrorReason),
+    InvalidField(Box<super::defs::Ident>, LoweringErrorReason),
     /// The purpose of having this is that translating to the HIR has enormous
     /// potential for really detailed error handling and giving suggestions.
     ///
@@ -457,7 +457,7 @@ impl<'ast> LoweringContext<'ast> {
                 if !ty.is_ffi_safe() {
                     let ffisafe = ty.ffi_safe_version();
                     self.errors.push(LoweringError::InvalidField(
-                        super::defs::Ident::new(name.clone(), field_name.span()),
+                        Box::new(super::defs::Ident::new(name.clone(), field_name.span())),
                         LoweringErrorReason::Unsafe(format!(
                             "{ty} is FFI-unsafe, consider using {ffisafe}"
                         )),

--- a/core/src/hir/methods.rs
+++ b/core/src/hir/methods.rs
@@ -26,7 +26,7 @@ pub struct Method {
     /// Documentation specified on the method
     pub docs: Docs,
     /// The name of the method as initially declared.
-    pub name: IdentBuf,
+    pub name: super::defs::Ident,
     /// The name of the generated `extern "C"` function
     pub abi_name: IdentBuf,
     /// The lifetimes introduced in this method and surrounding impl block.

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__auto.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__auto.snap
@@ -4,6 +4,5 @@ expression: output
 ---
 Diplomat error: Lowering error in Opaque::auto_doesnt_work_on_renames
 > Diplomat attribute "rename" gated on 'auto' but is not one that works with 'auto'
-
 Diplomat error: Lowering error in Opaque::auto_doesnt_work_on_disables
 > Diplomat attribute "disable" gated on 'auto' but is not one that works with 'auto'

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__auto.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__auto.snap
@@ -2,5 +2,8 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Opaque::auto_doesnt_work_on_renames: Diplomat attribute "rename" gated on 'auto' but is not one that works with 'auto'
-Lowering error in Opaque::auto_doesnt_work_on_disables: Diplomat attribute "disable" gated on 'auto' but is not one that works with 'auto'
+Diplomat error: Lowering error in Opaque::auto_doesnt_work_on_renames
+> Diplomat attribute "rename" gated on 'auto' but is not one that works with 'auto'
+
+Diplomat error: Lowering error in Opaque::auto_doesnt_work_on_disables
+> Diplomat attribute "disable" gated on 'auto' but is not one that works with 'auto'

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__comparator.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__comparator.snap
@@ -4,54 +4,37 @@ expression: output
 ---
 Diplomat error: Lowering error in Struct::comparison_other
 > Comparator's parameter must be identical to self
-
 Diplomat error: Lowering error in Struct::comparison_correct
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Struct::comparison_ref
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Struct::comparison_mut
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Struct::comparison_mut
 > comparators must accept immutable parameters
-
 Diplomat error: Lowering error in Opaque::comparator_static
 > Comparators must accept a self parameter
-
 Diplomat error: Lowering error in Opaque::comparator_none
 > Comparator must have exactly 1 parameter
-
 Diplomat error: Lowering error in Opaque::comparator_none
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Opaque::comparator_othertype
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Opaque::comparator_othertype
 > Comparators must accept a self parameter
-
 Diplomat error: Lowering error in Opaque::comparator_badreturn
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Opaque::comparator_badreturn
 > Found comparison method that does not return cmp::Ordering or Optional<cmp::Ordering>
-
 Diplomat error: Lowering error in Opaque::comparison_correct
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Opaque::ordering_wrong
 > Found cmp::Ordering in parameter or struct field, it is only allowed in return types
-
 Diplomat error: Lowering error in Opaque::comparison_mut
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Opaque::comparison_mut
 > comparators must accept immutable parameters
-
 Diplomat error: Lowering error in Opaque::comparison_opt
 > Cannot define two comparators on the same type
-
 Diplomat error: Lowering error in Opaque::comparison_opt
 > comparators must accept non-optional parameters

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__comparator.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__comparator.snap
@@ -2,21 +2,56 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Struct::comparison_other: Comparator's parameter must be identical to self
-Lowering error in Struct::comparison_correct: Cannot define two comparators on the same type
-Lowering error in Struct::comparison_ref: Cannot define two comparators on the same type
-Lowering error in Struct::comparison_mut: Cannot define two comparators on the same type
-Lowering error in Struct::comparison_mut: comparators must accept immutable parameters
-Lowering error in Opaque::comparator_static: Comparators must accept a self parameter
-Lowering error in Opaque::comparator_none: Comparator must have exactly 1 parameter
-Lowering error in Opaque::comparator_none: Cannot define two comparators on the same type
-Lowering error in Opaque::comparator_othertype: Cannot define two comparators on the same type
-Lowering error in Opaque::comparator_othertype: Comparators must accept a self parameter
-Lowering error in Opaque::comparator_badreturn: Cannot define two comparators on the same type
-Lowering error in Opaque::comparator_badreturn: Found comparison method that does not return cmp::Ordering or Optional<cmp::Ordering>
-Lowering error in Opaque::comparison_correct: Cannot define two comparators on the same type
-Lowering error in Opaque::ordering_wrong: Found cmp::Ordering in parameter or struct field, it is only allowed in return types
-Lowering error in Opaque::comparison_mut: Cannot define two comparators on the same type
-Lowering error in Opaque::comparison_mut: comparators must accept immutable parameters
-Lowering error in Opaque::comparison_opt: Cannot define two comparators on the same type
-Lowering error in Opaque::comparison_opt: comparators must accept non-optional parameters
+Diplomat error: Lowering error in Struct::comparison_other
+> Comparator's parameter must be identical to self
+
+Diplomat error: Lowering error in Struct::comparison_correct
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Struct::comparison_ref
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Struct::comparison_mut
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Struct::comparison_mut
+> comparators must accept immutable parameters
+
+Diplomat error: Lowering error in Opaque::comparator_static
+> Comparators must accept a self parameter
+
+Diplomat error: Lowering error in Opaque::comparator_none
+> Comparator must have exactly 1 parameter
+
+Diplomat error: Lowering error in Opaque::comparator_none
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Opaque::comparator_othertype
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Opaque::comparator_othertype
+> Comparators must accept a self parameter
+
+Diplomat error: Lowering error in Opaque::comparator_badreturn
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Opaque::comparator_badreturn
+> Found comparison method that does not return cmp::Ordering or Optional<cmp::Ordering>
+
+Diplomat error: Lowering error in Opaque::comparison_correct
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Opaque::ordering_wrong
+> Found cmp::Ordering in parameter or struct field, it is only allowed in return types
+
+Diplomat error: Lowering error in Opaque::comparison_mut
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Opaque::comparison_mut
+> comparators must accept immutable parameters
+
+Diplomat error: Lowering error in Opaque::comparison_opt
+> Cannot define two comparators on the same type
+
+Diplomat error: Lowering error in Opaque::comparison_opt
+> comparators must accept non-optional parameters

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__custom_extra_code_fail.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__custom_extra_code_fail.snap
@@ -2,7 +2,14 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in IncludeDef::test: Error parsing `custom_extra_code (a = "" , location = "unknown")`: Unrecognized include ident `a`
-Lowering error in IncludeDef::test: Expected `source=`, `file=`, `location=`. Got: Source: None Location: None
-Lowering error in IncludeDef::test: Include location `unknown` unsupported.
-Lowering error in IncludeDef::test: Expected `source=`, `file=`, `location=`. Got: Source: Some(Source("test")) Location: None
+Diplomat error: Lowering error in IncludeDef::test
+> Error parsing `custom_extra_code (a = "" , location = "unknown")`: Unrecognized include ident `a`
+
+Diplomat error: Lowering error in IncludeDef::test
+> Expected `source=`, `file=`, `location=`. Got: Source: None Location: None
+
+Diplomat error: Lowering error in IncludeDef::test
+> Include location `unknown` unsupported.
+
+Diplomat error: Lowering error in IncludeDef::test
+> Expected `source=`, `file=`, `location=`. Got: Source: Some(Source("test")) Location: None

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__custom_extra_code_fail.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__custom_extra_code_fail.snap
@@ -4,12 +4,9 @@ expression: output
 ---
 Diplomat error: Lowering error in IncludeDef::test
 > Error parsing `custom_extra_code (a = "" , location = "unknown")`: Unrecognized include ident `a`
-
 Diplomat error: Lowering error in IncludeDef::test
 > Expected `source=`, `file=`, `location=`. Got: Source: None Location: None
-
 Diplomat error: Lowering error in IncludeDef::test
 > Include location `unknown` unsupported.
-
 Diplomat error: Lowering error in IncludeDef::test
 > Expected `source=`, `file=`, `location=`. Got: Source: Some(Source("test")) Location: None

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__custom_extra_code_fail_unsupported.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__custom_extra_code_fail_unsupported.snap
@@ -4,6 +4,5 @@ expression: output
 ---
 Diplomat error: Lowering error in IncludeDef::test
 > Custom bindings not supported by this language.
-
 Diplomat error: Lowering error in IncludeDef::test
 > `custom_extra_code` only supported on type declarations or free functions.

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__custom_extra_code_fail_unsupported.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__custom_extra_code_fail_unsupported.snap
@@ -2,5 +2,8 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in IncludeDef::test: Custom bindings not supported by this language.
-Lowering error in IncludeDef::test: `custom_extra_code` only supported on type declarations or free functions.
+Diplomat error: Lowering error in IncludeDef::test
+> Custom bindings not supported by this language.
+
+Diplomat error: Lowering error in IncludeDef::test
+> `custom_extra_code` only supported on type declarations or free functions.

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__default_args_unsupport.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__default_args_unsupport.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Test::test: `default_value` not supported in backend tests
+Diplomat error: Lowering error in Test::test
+> `default_value` not supported in backend tests

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__iterator.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__iterator.snap
@@ -2,11 +2,26 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Broken::iterable_no_return: Iterables must return a custom type
-Lowering error in Broken::iterable_no_self: Iterables must accept a self parameter
-Lowering error in Broken::iterable_non_custom: Cannot mark type as iterable twice
-Lowering error in Broken::iterable_non_custom: Iterables must return a custom opaque type
-Lowering error in BrokenIterator::iterator_no_return: Iterator method must return nullable value
-Lowering error in BrokenIterator::iterator_no_self: Iterator must accept a self parameter
-Lowering error in BrokenIterator::iterator_no_option: Cannot mark type as iterator twice
-Lowering error in BrokenIterator::iterator_no_option: Iterator method must return nullable value
+Diplomat error: Lowering error in Broken::iterable_no_return
+> Iterables must return a custom type
+
+Diplomat error: Lowering error in Broken::iterable_no_self
+> Iterables must accept a self parameter
+
+Diplomat error: Lowering error in Broken::iterable_non_custom
+> Cannot mark type as iterable twice
+
+Diplomat error: Lowering error in Broken::iterable_non_custom
+> Iterables must return a custom opaque type
+
+Diplomat error: Lowering error in BrokenIterator::iterator_no_return
+> Iterator method must return nullable value
+
+Diplomat error: Lowering error in BrokenIterator::iterator_no_self
+> Iterator must accept a self parameter
+
+Diplomat error: Lowering error in BrokenIterator::iterator_no_option
+> Cannot mark type as iterator twice
+
+Diplomat error: Lowering error in BrokenIterator::iterator_no_option
+> Iterator method must return nullable value

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__iterator.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__iterator.snap
@@ -4,24 +4,17 @@ expression: output
 ---
 Diplomat error: Lowering error in Broken::iterable_no_return
 > Iterables must return a custom type
-
 Diplomat error: Lowering error in Broken::iterable_no_self
 > Iterables must accept a self parameter
-
 Diplomat error: Lowering error in Broken::iterable_non_custom
 > Cannot mark type as iterable twice
-
 Diplomat error: Lowering error in Broken::iterable_non_custom
 > Iterables must return a custom opaque type
-
 Diplomat error: Lowering error in BrokenIterator::iterator_no_return
 > Iterator method must return nullable value
-
 Diplomat error: Lowering error in BrokenIterator::iterator_no_self
 > Iterator must accept a self parameter
-
 Diplomat error: Lowering error in BrokenIterator::iterator_no_option
 > Cannot mark type as iterator twice
-
 Diplomat error: Lowering error in BrokenIterator::iterator_no_option
 > Iterator method must return nullable value

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__mocking_interface_for_non_opaque_type.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__mocking_interface_for_non_opaque_type.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Foo::get_y: `generate_mocking_interface` can only be used on opaque types
+Diplomat error: Lowering error in Foo::get_y
+> `generate_mocking_interface` can only be used on opaque types

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__mocking_interface_for_unsupported_backend.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__mocking_interface_for_unsupported_backend.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Foo: `generate_mocking_interface` not supported in backend tests
+Diplomat error: Lowering error in Foo
+> `generate_mocking_interface` not supported in backend tests

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__mut_struct_ref_for_unsupported_backend.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__mut_struct_ref_for_unsupported_backend.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Foo::takes_mut: Method `Foo_takes_mut` takes a mutable reference to a struct as a self parameter, which isn't allowed. Backend must support mut_struct_refs.
+Diplomat error: Lowering error in Foo::takes_mut
+> Method `Foo_takes_mut` takes a mutable reference to a struct as a self parameter, which isn't allowed. Backend must support mut_struct_refs.

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__primitive_struct_slices_for_unsupported_backend.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__primitive_struct_slices_for_unsupported_backend.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Foo: `abi_compatible` not supported in backend tests
+Diplomat error: Lowering error in Foo
+> `abi_compatible` not supported in backend tests

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__struct_ref_for_unsupported_backend.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__struct_ref_for_unsupported_backend.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in Foo::takes_mut: Method `Foo_takes_mut` takes a reference to a struct as a self parameter, which isn't allowed. Backend must support struct_refs.
+Diplomat error: Lowering error in Foo::takes_mut
+> Method `Foo_takes_mut` takes a reference to a struct as a self parameter, which isn't allowed. Backend must support struct_refs.

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__unsupported_features.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__unsupported_features.snap
@@ -4,12 +4,9 @@ expression: output
 ---
 Diplomat error: Lowering error in OutStruct
 > Options of structs/enums/primitives not supported by this backend
-
 Diplomat error: Lowering error in Struct
 > Options of structs/enums/primitives not supported by this backend
-
 Diplomat error: Lowering error in Struct2
 > Options of structs/enums/primitives not supported by this backend
-
 Diplomat error: Lowering error in Opaque::take_option
 > Options of structs/enums/primitives not supported by this backend

--- a/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__unsupported_features.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__attrs__tests__unsupported_features.snap
@@ -2,7 +2,14 @@
 source: core/src/hir/attrs.rs
 expression: output
 ---
-Lowering error in OutStruct: Options of structs/enums/primitives not supported by this backend
-Lowering error in Struct: Options of structs/enums/primitives not supported by this backend
-Lowering error in Struct2: Options of structs/enums/primitives not supported by this backend
-Lowering error in Opaque::take_option: Options of structs/enums/primitives not supported by this backend
+Diplomat error: Lowering error in OutStruct
+> Options of structs/enums/primitives not supported by this backend
+
+Diplomat error: Lowering error in Struct
+> Options of structs/enums/primitives not supported by this backend
+
+Diplomat error: Lowering error in Struct2
+> Options of structs/enums/primitives not supported by this backend
+
+Diplomat error: Lowering error in Opaque::take_option
+> Options of structs/enums/primitives not supported by this backend

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__elision_in_struct.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__elision_in_struct.snap
@@ -7,7 +7,23 @@ Method {
         lines: "",
         rust_links: [],
     },
-    name: "elided",
+    name: Ident(
+        "elided",
+        Some(
+            Span {
+                start: LineColumn {
+                    line: 1,
+                    col: 0,
+                },
+                end: LineColumn {
+                    line: 1,
+                    col: 0,
+                },
+                range: 0..0,
+                span_location: None,
+            },
+        ),
+    ),
     abi_name: "Opaque_elided",
     lifetime_env: LifetimeEnv {
         nodes: [],

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -9,7 +9,23 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "OutStruct",
+            name: Ident(
+                "OutStruct",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             fields: [
                 StructField {
                     docs: Docs {
@@ -77,7 +93,23 @@ TypeContext {
                         lines: "",
                         rust_links: [],
                     },
-                    name: "new",
+                    name: Ident(
+                        "new",
+                        Some(
+                            Span {
+                                start: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                end: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                range: 0..0,
+                                span_location: None,
+                            },
+                        ),
+                    ),
                     abi_name: "OutStruct_new",
                     lifetime_env: LifetimeEnv {
                         nodes: [
@@ -257,7 +289,23 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "Struct",
+            name: Ident(
+                "Struct",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             fields: [
                 StructField {
                     docs: Docs {
@@ -317,7 +365,23 @@ TypeContext {
                         lines: "",
                         rust_links: [],
                     },
-                    name: "rustc_elision",
+                    name: Ident(
+                        "rustc_elision",
+                        Some(
+                            Span {
+                                start: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                end: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                range: 0..0,
+                                span_location: None,
+                            },
+                        ),
+                    ),
                     abi_name: "Struct_rustc_elision",
                     lifetime_env: LifetimeEnv {
                         nodes: [
@@ -542,7 +606,23 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "Opaque",
+            name: Ident(
+                "Opaque",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             methods: [],
             attrs: Attrs {
                 disable: false,

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
@@ -2,17 +2,44 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in BadStructFields: Found FFI-unsafe type Option<u8> in struct field BadStructFields.field1, consider using DiplomatOption<u8>
-Lowering error in BadStructFields: Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
-Lowering error in BadStructFields: Found FFI-unsafe type Result<u8, u8> in struct field BadStructFields.field2, consider using Result<u8, u8>
-Lowering error in BadStructFields: Results can only appear as the top-level return type of methods
-Lowering error in InStructWithOutField: found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = OtherOpaque
-Lowering error in InStructWithOutField: found struct in input that is marked with #[diplomat::out]: OutStruct in OutStruct
-Lowering error in Opaque::use_foo_ref: found &T in input where T is a struct. The backend must support struct_refs.
-Lowering error in Opaque::return_foo_box: found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = Foo
-Lowering error in Opaque::use_self: Method `Opaque_use_self` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
-Lowering error in Opaque::return_self: Method `Opaque_return_self` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
-Lowering error in Opaque::use_opaque_owned: Opaque passed by value: OtherOpaque
-Lowering error in Opaque::return_opaque_owned: Opaque passed by value in input: OtherOpaque
-Lowering error in Opaque::use_out_as_in: found struct in input that is marked with #[diplomat::out]: OutStruct in OutStruct
-Lowering error in Opaque::wraps_result_option: Result<Option<OutStruct>, Option<OutStruct>> wraps Option<OutStruct>; OutStruct is not an opaque. Please use DiplomatOption<OutStruct> instead.
+Diplomat error: Lowering error in BadStructFields
+> Found FFI-unsafe type Option<u8> in struct field BadStructFields.field1, consider using DiplomatOption<u8>
+
+Diplomat error: Lowering error in BadStructFields
+> Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
+
+Diplomat error: Lowering error in BadStructFields
+> Found FFI-unsafe type Result<u8, u8> in struct field BadStructFields.field2, consider using Result<u8, u8>
+
+Diplomat error: Lowering error in BadStructFields
+> Results can only appear as the top-level return type of methods
+
+Diplomat error: Lowering error in InStructWithOutField
+> found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = OtherOpaque
+
+Diplomat error: Lowering error in InStructWithOutField
+> found struct in input that is marked with #[diplomat::out]: OutStruct in OutStruct
+
+Diplomat error: Lowering error in Opaque::use_foo_ref
+> found &T in input where T is a struct. The backend must support struct_refs.
+
+Diplomat error: Lowering error in Opaque::return_foo_box
+> found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = Foo
+
+Diplomat error: Lowering error in Opaque::use_self
+> Method `Opaque_use_self` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
+
+Diplomat error: Lowering error in Opaque::return_self
+> Method `Opaque_return_self` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
+
+Diplomat error: Lowering error in Opaque::use_opaque_owned
+> Opaque passed by value: OtherOpaque
+
+Diplomat error: Lowering error in Opaque::return_opaque_owned
+> Opaque passed by value in input: OtherOpaque
+
+Diplomat error: Lowering error in Opaque::use_out_as_in
+> found struct in input that is marked with #[diplomat::out]: OutStruct in OutStruct
+
+Diplomat error: Lowering error in Opaque::wraps_result_option
+> Result<Option<OutStruct>, Option<OutStruct>> wraps Option<OutStruct>; OutStruct is not an opaque. Please use DiplomatOption<OutStruct> instead.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
@@ -4,42 +4,29 @@ expression: output
 ---
 Diplomat error: Lowering error in BadStructFields
 > In field field1: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
-
 Diplomat error: Lowering error in BadStructFields
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
-
 Diplomat error: Lowering error in BadStructFields
 > In field field2: Result<u8, u8> is FFI-unsafe, consider using Result<u8, u8>
-
 Diplomat error: Lowering error in BadStructFields
 > Results can only appear as the top-level return type of methods
-
 Diplomat error: Lowering error in InStructWithOutField
 > found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = OtherOpaque
-
 Diplomat error: Lowering error in InStructWithOutField
 > found struct in input that is marked with #[diplomat::out]: OutStruct in OutStruct
-
 Diplomat error: Lowering error in Opaque::use_foo_ref
 > found &T in input where T is a struct. The backend must support struct_refs.
-
 Diplomat error: Lowering error in Opaque::return_foo_box
 > found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = Foo
-
 Diplomat error: Lowering error in Opaque::use_self
 > Method `Opaque_use_self` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
-
 Diplomat error: Lowering error in Opaque::return_self
 > Method `Opaque_return_self` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
-
 Diplomat error: Lowering error in Opaque::use_opaque_owned
 > Opaque passed by value: OtherOpaque
-
 Diplomat error: Lowering error in Opaque::return_opaque_owned
 > Opaque passed by value in input: OtherOpaque
-
 Diplomat error: Lowering error in Opaque::use_out_as_in
 > found struct in input that is marked with #[diplomat::out]: OutStruct in OutStruct
-
 Diplomat error: Lowering error in Opaque::wraps_result_option
 > Result<Option<OutStruct>, Option<OutStruct>> wraps Option<OutStruct>; OutStruct is not an opaque. Please use DiplomatOption<OutStruct> instead.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
@@ -3,13 +3,13 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in BadStructFields
-> Found FFI-unsafe type Option<u8> in struct field BadStructFields.field1, consider using DiplomatOption<u8>
+> In field field1: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 
 Diplomat error: Lowering error in BadStructFields
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 
 Diplomat error: Lowering error in BadStructFields
-> Found FFI-unsafe type Result<u8, u8> in struct field BadStructFields.field2, consider using Result<u8, u8>
+> In field field2: Result<u8, u8> is FFI-unsafe, consider using Result<u8, u8>
 
 Diplomat error: Lowering error in BadStructFields
 > Results can only appear as the top-level return type of methods

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
@@ -3,11 +3,11 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in BadStructFields
-> In field field1: Safety issue: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
+> Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 Diplomat error: Lowering error in BadStructFields
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 Diplomat error: Lowering error in BadStructFields
-> In field field2: Safety issue: Result<u8, u8> is FFI-unsafe, consider using Result<u8, u8>
+> Result<u8, u8> is FFI-unsafe, consider using Result<u8, u8>
 Diplomat error: Lowering error in BadStructFields
 > Results can only appear as the top-level return type of methods
 Diplomat error: Lowering error in InStructWithOutField

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__basic_lowering.snap
@@ -3,11 +3,11 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in BadStructFields
-> In field field1: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
+> In field field1: Safety issue: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 Diplomat error: Lowering error in BadStructFields
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 Diplomat error: Lowering error in BadStructFields
-> In field field2: Result<u8, u8> is FFI-unsafe, consider using Result<u8, u8>
+> In field field2: Safety issue: Result<u8, u8> is FFI-unsafe, consider using Result<u8, u8>
 Diplomat error: Lowering error in BadStructFields
 > Results can only appear as the top-level return type of methods
 Diplomat error: Lowering error in InStructWithOutField

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_borrowing_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_borrowing_fails.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo::apply_callback: Callbacks cannot take references since they can be unsafely persisted, set `unsafe_references_in_callbacks` config to override.
+Diplomat error: Lowering error in Foo::apply_callback
+> Callbacks cannot take references since they can be unsafely persisted, set `unsafe_references_in_callbacks` config to override.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_borrowing_fails_with_unsafe_borrows.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_borrowing_fails_with_unsafe_borrows.snap
@@ -2,5 +2,8 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo::apply_callback_owned_slice: Cannot return owned slices from callbacks
-Lowering error in Foo::apply_callback_borrowed_struct: Cannot return references to structs from callbacks
+Diplomat error: Lowering error in Foo::apply_callback_owned_slice
+> Cannot return owned slices from callbacks
+
+Diplomat error: Lowering error in Foo::apply_callback_borrowed_struct
+> Cannot return references to structs from callbacks

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_borrowing_fails_with_unsafe_borrows.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_borrowing_fails_with_unsafe_borrows.snap
@@ -4,6 +4,5 @@ expression: output
 ---
 Diplomat error: Lowering error in Foo::apply_callback_owned_slice
 > Cannot return owned slices from callbacks
-
 Diplomat error: Lowering error in Foo::apply_callback_borrowed_struct
 > Cannot return references to structs from callbacks

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_result_option_wrap_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_result_option_wrap_fails.snap
@@ -4,6 +4,5 @@ expression: output
 ---
 Diplomat error: Lowering error in MyStruct::takes_callback
 > Result<Option<MyStruct>, Option<MyStruct>> wraps Option<MyStruct>; MyStruct is not an opaque. Please use DiplomatOption<MyStruct> instead.
-
 Diplomat error: Lowering error in SomeTrait::xyz
 > Result<Option<MyStruct>, Option<MyStruct>> wraps Option<MyStruct>; MyStruct is not an opaque. Please use DiplomatOption<MyStruct> instead.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_result_option_wrap_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_result_option_wrap_fails.snap
@@ -2,5 +2,8 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in MyStruct::takes_callback: Result<Option<MyStruct>, Option<MyStruct>> wraps Option<MyStruct>; MyStruct is not an opaque. Please use DiplomatOption<MyStruct> instead.
-Lowering error in SomeTrait::xyz: Result<Option<MyStruct>, Option<MyStruct>> wraps Option<MyStruct>; MyStruct is not an opaque. Please use DiplomatOption<MyStruct> instead.
+Diplomat error: Lowering error in MyStruct::takes_callback
+> Result<Option<MyStruct>, Option<MyStruct>> wraps Option<MyStruct>; MyStruct is not an opaque. Please use DiplomatOption<MyStruct> instead.
+
+Diplomat error: Lowering error in SomeTrait::xyz
+> Result<Option<MyStruct>, Option<MyStruct>> wraps Option<MyStruct>; MyStruct is not an opaque. Please use DiplomatOption<MyStruct> instead.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__lifetime_in_return.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__lifetime_in_return.snap
@@ -1,6 +1,6 @@
 ---
 source: core/src/hir/type_context.rs
-assertion_line: 970
 expression: output
 ---
-Lowering error in Opaque::returns_foo_ref: found &T in output where T is a custom type, but not opaque. T = Foo
+Diplomat error: Lowering error in Opaque::returns_foo_ref
+> found &T in output where T is a custom type, but not opaque. T = Foo

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__mut_struct.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__mut_struct.snap
@@ -4,6 +4,5 @@ expression: output
 ---
 Diplomat error: Lowering error in Foo::takes_mut
 > Found a mutable struct ref &mut self. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
-
 Diplomat error: Lowering error in Foo::takes_mut
 > Found a mutable struct ref &mut Foo. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__mut_struct.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__mut_struct.snap
@@ -2,5 +2,8 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo::takes_mut: Found a mutable struct ref &mut self. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
-Lowering error in Foo::takes_mut: Found a mutable struct ref &mut Foo. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
+Diplomat error: Lowering error in Foo::takes_mut
+> Found a mutable struct ref &mut self. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
+
+Diplomat error: Lowering error in Foo::takes_mut
+> Found a mutable struct ref &mut Foo. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__mut_struct_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__mut_struct_fails.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo::takes_mut: found &T in output where T is a custom type, but not opaque. T = Foo
+Diplomat error: Lowering error in Foo::takes_mut
+> found &T in output where T is a custom type, but not opaque. T = Foo

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__non_opaque_move.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__non_opaque_move.snap
@@ -4,12 +4,9 @@ expression: output
 ---
 Diplomat error: Lowering error in NonOpaque::foo
 > Method `NonOpaque_foo` takes a reference to a struct as a self parameter, which isn't allowed. Backend must support struct_refs.
-
 Diplomat error: Lowering error in Opaque::bar
 > found &T in output where T is a custom type, but not opaque. T = NonOpaque
-
 Diplomat error: Lowering error in Opaque::baz
 > found &T in input where T is a struct. The backend must support struct_refs.
-
 Diplomat error: Lowering error in Opaque::quux
 > found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = NonOpaque

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__non_opaque_move.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__non_opaque_move.snap
@@ -2,7 +2,14 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in NonOpaque::foo: Method `NonOpaque_foo` takes a reference to a struct as a self parameter, which isn't allowed. Backend must support struct_refs.
-Lowering error in Opaque::bar: found &T in output where T is a custom type, but not opaque. T = NonOpaque
-Lowering error in Opaque::baz: found &T in input where T is a struct. The backend must support struct_refs.
-Lowering error in Opaque::quux: found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = NonOpaque
+Diplomat error: Lowering error in NonOpaque::foo
+> Method `NonOpaque_foo` takes a reference to a struct as a self parameter, which isn't allowed. Backend must support struct_refs.
+
+Diplomat error: Lowering error in Opaque::bar
+> found &T in output where T is a custom type, but not opaque. T = NonOpaque
+
+Diplomat error: Lowering error in Opaque::baz
+> found &T in input where T is a struct. The backend must support struct_refs.
+
+Diplomat error: Lowering error in Opaque::quux
+> found Box<T> in output where T is a custom type but not opaque. non-opaques can't be behind pointers. T = NonOpaque

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__non_primitive_struct_slices_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__non_primitive_struct_slices_fails.snap
@@ -4,6 +4,5 @@ expression: output
 ---
 Diplomat error: Lowering error in Foo
 > Struct Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None })) cannot have any lifetimes if it is marked as ABI compatible.
-
 Diplomat error: Lowering error in Foo
 > Cannot construct a slice of Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None })) with non-primitive, non-struct field "z"

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__non_primitive_struct_slices_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__non_primitive_struct_slices_fails.snap
@@ -2,5 +2,8 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo: Struct "Foo" cannot have any lifetimes if it is marked as ABI compatible.
-Lowering error in Foo: Cannot construct a slice of "Foo" with non-primitive, non-struct field "z"
+Diplomat error: Lowering error in Foo
+> Struct Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None })) cannot have any lifetimes if it is marked as ABI compatible.
+
+Diplomat error: Lowering error in Foo
+> Cannot construct a slice of Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None })) with non-primitive, non-struct field "z"

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_checks_with_error.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_checks_with_error.snap
@@ -2,6 +2,8 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in OpaqueStruct::new: Opaque passed by value in input: OpaqueStruct
-Lowering error in OpaqueStruct::get_i32: Method `OpaqueStruct_get_i32` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
+Diplomat error: Lowering error in OpaqueStruct::new
+> Opaque passed by value in input: OpaqueStruct
 
+Diplomat error: Lowering error in OpaqueStruct::get_i32
+> Method `OpaqueStruct_get_i32` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_checks_with_error.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_checks_with_error.snap
@@ -4,6 +4,5 @@ expression: output
 ---
 Diplomat error: Lowering error in OpaqueStruct::new
 > Opaque passed by value in input: OpaqueStruct
-
 Diplomat error: Lowering error in OpaqueStruct::get_i32
 > Method `OpaqueStruct_get_i32` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_checks_with_safe_use.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_checks_with_safe_use.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in NonOpaqueStruct: Methods on ZST structs are not yet implemented: NonOpaqueStruct
+Diplomat error: Lowering error in NonOpaqueStruct
+> Methods on ZST structs are not yet implemented: NonOpaqueStruct

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_ffi.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_ffi.snap
@@ -1,9 +1,15 @@
 ---
 source: core/src/hir/type_context.rs
-assertion_line: 691
 expression: output
 ---
-Lowering error in MyOpaqueEnum::new_broken: Opaque passed by value in input: MyOpaqueEnum
-Lowering error in MyOpaqueEnum::do_thing_broken: Method `MyOpaqueEnum_do_thing_broken` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
-Lowering error in MyOpaqueStruct::new_broken: Opaque passed by value in input: MyOpaqueStruct
-Lowering error in MyOpaqueStruct::do_thing_broken: Method `MyOpaqueStruct_do_thing_broken` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
+Diplomat error: Lowering error in MyOpaqueEnum::new_broken
+> Opaque passed by value in input: MyOpaqueEnum
+
+Diplomat error: Lowering error in MyOpaqueEnum::do_thing_broken
+> Method `MyOpaqueEnum_do_thing_broken` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
+
+Diplomat error: Lowering error in MyOpaqueStruct::new_broken
+> Opaque passed by value in input: MyOpaqueStruct
+
+Diplomat error: Lowering error in MyOpaqueStruct::do_thing_broken
+> Method `MyOpaqueStruct_do_thing_broken` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_ffi.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_ffi.snap
@@ -4,12 +4,9 @@ expression: output
 ---
 Diplomat error: Lowering error in MyOpaqueEnum::new_broken
 > Opaque passed by value in input: MyOpaqueEnum
-
 Diplomat error: Lowering error in MyOpaqueEnum::do_thing_broken
 > Method `MyOpaqueEnum_do_thing_broken` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs
-
 Diplomat error: Lowering error in MyOpaqueStruct::new_broken
 > Opaque passed by value in input: MyOpaqueStruct
-
 Diplomat error: Lowering error in MyOpaqueStruct::do_thing_broken
 > Method `MyOpaqueStruct_do_thing_broken` takes an opaque by value as the self parameter, but opaques as inputs must be behind refs

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_slice.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_slice.snap
@@ -4,57 +4,39 @@ expression: output
 ---
 Diplomat error: Lowering error in Foo::static_opaque_slice
 > 'static Reference(Static, Immutable, Named(PathType { path: Path { elements: [Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None }))] }, lifetimes: [] })) slice types not supported. Try #[diplomat::cfg(supports = static_slices)]
-
 Diplomat error: Lowering error in Foo::static_opaque_slice
 > &'static slices of opaques (&'static [&'static Foo]) are currently unsupported in Diplomat.
-
 Diplomat error: Lowering error in Foo::static_opaque_slice
 > Slices of &'static opaques (&[&'static Foo]) are currently unsupported in Diplomat.
-
 Diplomat error: Lowering error in Foo::static_opaque_slice
 > Slice of opaque &[&'static Foo] is unsupported by this backend.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > &mut [&Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > Mutable slices of opaques (&mut [&Foo]) are currently unsupported in Diplomat.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > Slice of opaque &[&Foo] is unsupported by this backend.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > found opaque type Foo being passed around as &mut without #[diplomat::opaque_mut] annotation
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > Slices of mutable opaques (&[&mut Foo]) are currently unsupported in Diplomat.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > Slice of opaque &[&mut Foo] is unsupported by this backend.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > &mut [&mut Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > found opaque type Foo being passed around as &mut without #[diplomat::opaque_mut] annotation
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > Mutable slices of opaques (&mut [&mut Foo]) are currently unsupported in Diplomat.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > Slices of mutable opaques (&[&mut Foo]) are currently unsupported in Diplomat.
-
 Diplomat error: Lowering error in Foo::takes_mut_slice
 > Slice of opaque &[&mut Foo] is unsupported by this backend.
-
 Diplomat error: Lowering error in Foo::returns_mut_slice
 > &mut [&'a mut Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-
 Diplomat error: Lowering error in Foo::returns_mut_slice
 > Opaque slices are currently disallowed as an output type.
-
 Diplomat error: Lowering error in Foo::takes_owned_slice
 > found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = Foo
-
 Diplomat error: Lowering error in Foo::returns_owned_slice
 > Opaque slices are currently disallowed as an output type.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_slice.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_slice.snap
@@ -2,22 +2,59 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo::static_opaque_slice: 'static Reference(Static, Immutable, Named(PathType { path: Path { elements: [Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None }))] }, lifetimes: [] })) slice types not supported. Try #[diplomat::cfg(supports = static_slices)]
-Lowering error in Foo::static_opaque_slice: &'static slices of opaques (&'static [&'static Foo]) are currently unsupported in Diplomat.
-Lowering error in Foo::static_opaque_slice: Slices of &'static opaques (&[&'static Foo]) are currently unsupported in Diplomat.
-Lowering error in Foo::static_opaque_slice: Slice of opaque &[&'static Foo] is unsupported by this backend.
-Lowering error in Foo::takes_mut_slice: &mut [&Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-Lowering error in Foo::takes_mut_slice: Mutable slices of opaques (&mut [&Foo]) are currently unsupported in Diplomat.
-Lowering error in Foo::takes_mut_slice: Slice of opaque &[&Foo] is unsupported by this backend.
-Lowering error in Foo::takes_mut_slice: found opaque type Foo being passed around as &mut without #[diplomat::opaque_mut] annotation
-Lowering error in Foo::takes_mut_slice: Slices of mutable opaques (&[&mut Foo]) are currently unsupported in Diplomat.
-Lowering error in Foo::takes_mut_slice: Slice of opaque &[&mut Foo] is unsupported by this backend.
-Lowering error in Foo::takes_mut_slice: &mut [&mut Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-Lowering error in Foo::takes_mut_slice: found opaque type Foo being passed around as &mut without #[diplomat::opaque_mut] annotation
-Lowering error in Foo::takes_mut_slice: Mutable slices of opaques (&mut [&mut Foo]) are currently unsupported in Diplomat.
-Lowering error in Foo::takes_mut_slice: Slices of mutable opaques (&[&mut Foo]) are currently unsupported in Diplomat.
-Lowering error in Foo::takes_mut_slice: Slice of opaque &[&mut Foo] is unsupported by this backend.
-Lowering error in Foo::returns_mut_slice: &mut [&'a mut Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-Lowering error in Foo::returns_mut_slice: Opaque slices are currently disallowed as an output type.
-Lowering error in Foo::takes_owned_slice: found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = Foo
-Lowering error in Foo::returns_owned_slice: Opaque slices are currently disallowed as an output type.
+Diplomat error: Lowering error in Foo::static_opaque_slice
+> 'static Reference(Static, Immutable, Named(PathType { path: Path { elements: [Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None }))] }, lifetimes: [] })) slice types not supported. Try #[diplomat::cfg(supports = static_slices)]
+
+Diplomat error: Lowering error in Foo::static_opaque_slice
+> &'static slices of opaques (&'static [&'static Foo]) are currently unsupported in Diplomat.
+
+Diplomat error: Lowering error in Foo::static_opaque_slice
+> Slices of &'static opaques (&[&'static Foo]) are currently unsupported in Diplomat.
+
+Diplomat error: Lowering error in Foo::static_opaque_slice
+> Slice of opaque &[&'static Foo] is unsupported by this backend.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> &mut [&Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> Mutable slices of opaques (&mut [&Foo]) are currently unsupported in Diplomat.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> Slice of opaque &[&Foo] is unsupported by this backend.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> found opaque type Foo being passed around as &mut without #[diplomat::opaque_mut] annotation
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> Slices of mutable opaques (&[&mut Foo]) are currently unsupported in Diplomat.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> Slice of opaque &[&mut Foo] is unsupported by this backend.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> &mut [&mut Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> found opaque type Foo being passed around as &mut without #[diplomat::opaque_mut] annotation
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> Mutable slices of opaques (&mut [&mut Foo]) are currently unsupported in Diplomat.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> Slices of mutable opaques (&[&mut Foo]) are currently unsupported in Diplomat.
+
+Diplomat error: Lowering error in Foo::takes_mut_slice
+> Slice of opaque &[&mut Foo] is unsupported by this backend.
+
+Diplomat error: Lowering error in Foo::returns_mut_slice
+> &mut [&'a mut Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
+
+Diplomat error: Lowering error in Foo::returns_mut_slice
+> Opaque slices are currently disallowed as an output type.
+
+Diplomat error: Lowering error in Foo::takes_owned_slice
+> found Box<T> in input where T is an opaque, but owned opaques aren't allowed in inputs. try &T instead? T = Foo
+
+Diplomat error: Lowering error in Foo::returns_owned_slice
+> Opaque slices are currently disallowed as an output type.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_slice_borrows.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__opaque_slice_borrows.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo::borrows_opaque_slice: Opaque slices (param op) cannot be borrowed from. Suggestion: remove &'a from method output.
+Diplomat error: Lowering error in Foo::borrows_opaque_slice
+> Opaque slices (param op) cannot be borrowed from. Suggestion: remove &'a from method output.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
@@ -3,13 +3,13 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in BrokenStruct
-> Found FFI-unsafe type Option<u8> in struct field BrokenStruct.regular_option, consider using DiplomatOption<u8>
+> In field regular_option: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 
 Diplomat error: Lowering error in BrokenStruct
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 
 Diplomat error: Lowering error in BrokenStruct
-> Found FFI-unsafe type Option<CustomStruct> in struct field BrokenStruct.regular_option, consider using DiplomatOption<CustomStruct>
+> In field regular_option: Option<CustomStruct> is FFI-unsafe, consider using DiplomatOption<CustomStruct>
 
 Diplomat error: Lowering error in BrokenStruct
 > Found Option<T> for struct/enum T in a struct field, please use DiplomatOption<T>

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
@@ -3,11 +3,11 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in BrokenStruct
-> In field regular_option: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
+> In field regular_option: Safety issue: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 Diplomat error: Lowering error in BrokenStruct
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 Diplomat error: Lowering error in BrokenStruct
-> In field regular_option: Option<CustomStruct> is FFI-unsafe, consider using DiplomatOption<CustomStruct>
+> In field regular_option: Safety issue: Option<CustomStruct> is FFI-unsafe, consider using DiplomatOption<CustomStruct>
 Diplomat error: Lowering error in BrokenStruct
 > Found Option<T> for struct/enum T in a struct field, please use DiplomatOption<T>
 Diplomat error: Lowering error in Foo::diplo_option_ref

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
@@ -3,11 +3,11 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in BrokenStruct
-> In field regular_option: Safety issue: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
+> Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 Diplomat error: Lowering error in BrokenStruct
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 Diplomat error: Lowering error in BrokenStruct
-> In field regular_option: Safety issue: Option<CustomStruct> is FFI-unsafe, consider using DiplomatOption<CustomStruct>
+> Option<CustomStruct> is FFI-unsafe, consider using DiplomatOption<CustomStruct>
 Diplomat error: Lowering error in BrokenStruct
 > Found Option<T> for struct/enum T in a struct field, please use DiplomatOption<T>
 Diplomat error: Lowering error in Foo::diplo_option_ref

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
@@ -1,11 +1,21 @@
 ---
 source: core/src/hir/type_context.rs
-assertion_line: 1060
 expression: output
 ---
-Lowering error in BrokenStruct: Found FFI-unsafe type Option<u8> in struct field BrokenStruct.regular_option, consider using DiplomatOption<u8>
-Lowering error in BrokenStruct: Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
-Lowering error in BrokenStruct: Found FFI-unsafe type Option<CustomStruct> in struct field BrokenStruct.regular_option, consider using DiplomatOption<CustomStruct>
-Lowering error in BrokenStruct: Found Option<T> for struct/enum T in a struct field, please use DiplomatOption<T>
-Lowering error in Foo::diplo_option_ref: found DiplomatOption<&T>, please use Option<&T> (DiplomatOption is for primitives, structs, and enums)
-Lowering error in Foo::diplo_option_box: found DiplomatOption<Box<T>>, please use Option<Box<T>> (DiplomatOption is for primitives, structs, and enums)
+Diplomat error: Lowering error in BrokenStruct
+> Found FFI-unsafe type Option<u8> in struct field BrokenStruct.regular_option, consider using DiplomatOption<u8>
+
+Diplomat error: Lowering error in BrokenStruct
+> Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
+
+Diplomat error: Lowering error in BrokenStruct
+> Found FFI-unsafe type Option<CustomStruct> in struct field BrokenStruct.regular_option, consider using DiplomatOption<CustomStruct>
+
+Diplomat error: Lowering error in BrokenStruct
+> Found Option<T> for struct/enum T in a struct field, please use DiplomatOption<T>
+
+Diplomat error: Lowering error in Foo::diplo_option_ref
+> found DiplomatOption<&T>, please use Option<&T> (DiplomatOption is for primitives, structs, and enums)
+
+Diplomat error: Lowering error in Foo::diplo_option_box
+> found DiplomatOption<Box<T>>, please use Option<Box<T>> (DiplomatOption is for primitives, structs, and enums)

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option.snap
@@ -4,18 +4,13 @@ expression: output
 ---
 Diplomat error: Lowering error in BrokenStruct
 > In field regular_option: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
-
 Diplomat error: Lowering error in BrokenStruct
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
-
 Diplomat error: Lowering error in BrokenStruct
 > In field regular_option: Option<CustomStruct> is FFI-unsafe, consider using DiplomatOption<CustomStruct>
-
 Diplomat error: Lowering error in BrokenStruct
 > Found Option<T> for struct/enum T in a struct field, please use DiplomatOption<T>
-
 Diplomat error: Lowering error in Foo::diplo_option_ref
 > found DiplomatOption<&T>, please use Option<&T> (DiplomatOption is for primitives, structs, and enums)
-
 Diplomat error: Lowering error in Foo::diplo_option_box
 > found DiplomatOption<Box<T>>, please use Option<Box<T>> (DiplomatOption is for primitives, structs, and enums)

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
@@ -3,7 +3,7 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in Foo
-> In field field: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
+> In field field: Safety issue: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 Diplomat error: Lowering error in Foo
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 Diplomat error: Lowering error in Foo::do_thing

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
@@ -3,7 +3,7 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in Foo
-> Found FFI-unsafe type Option<u8> in struct field Foo.field, consider using DiplomatOption<u8>
+> In field field: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 
 Diplomat error: Lowering error in Foo
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
@@ -4,12 +4,9 @@ expression: output
 ---
 Diplomat error: Lowering error in Foo
 > In field field: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
-
 Diplomat error: Lowering error in Foo
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
-
 Diplomat error: Lowering error in Foo::do_thing
 > found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = Option<u16>
-
 Diplomat error: Lowering error in Foo::do_thing2
 > Results can only appear as the top-level return type of methods

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
@@ -3,7 +3,7 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in Foo
-> In field field: Safety issue: Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
+> Option<u8> is FFI-unsafe, consider using DiplomatOption<u8>
 Diplomat error: Lowering error in Foo
 > Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
 Diplomat error: Lowering error in Foo::do_thing

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_invalid.snap
@@ -2,7 +2,14 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo: Found FFI-unsafe type Option<u8> in struct field Foo.field, consider using DiplomatOption<u8>
-Lowering error in Foo: Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
-Lowering error in Foo::do_thing: found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = Option<u16>
-Lowering error in Foo::do_thing2: Results can only appear as the top-level return type of methods
+Diplomat error: Lowering error in Foo
+> Found FFI-unsafe type Option<u8> in struct field Foo.field, consider using DiplomatOption<u8>
+
+Diplomat error: Lowering error in Foo
+> Found Option<T> for primitive T in a struct field, please use DiplomatOption<T>
+
+Diplomat error: Lowering error in Foo::do_thing
+> found Option<T> in input, where T isn't a reference but Option<T> in inputs requires that T is a reference to an opaque. T = Option<u16>
+
+Diplomat error: Lowering error in Foo::do_thing2
+> Results can only appear as the top-level return type of methods

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_valid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_valid.snap
@@ -4,9 +4,7 @@ expression: output
 ---
 Diplomat error: Lowering error in Foo
 > found Option<Box<T>> in input, but box isn't allowed in inputs. T = u8
-
 Diplomat error: Lowering error in Foo::do_thing
 > found Option<Box<T>> in input, but box isn't allowed in inputs. T = u32
-
 Diplomat error: Lowering error in Foo::do_thing2
 > found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = u32

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_valid.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__option_valid.snap
@@ -2,7 +2,11 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo: found Option<Box<T>> in input, but box isn't allowed in inputs. T = u8
-Lowering error in Foo::do_thing: found Option<Box<T>> in input, but box isn't allowed in inputs. T = u32
-Lowering error in Foo::do_thing2: found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = u32
+Diplomat error: Lowering error in Foo
+> found Option<Box<T>> in input, but box isn't allowed in inputs. T = u8
 
+Diplomat error: Lowering error in Foo::do_thing
+> found Option<Box<T>> in input, but box isn't allowed in inputs. T = u32
+
+Diplomat error: Lowering error in Foo::do_thing2
+> found Option<&T> in input, but T isn't a custom type and therefore not opaque. T = u32

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__partial_comparison_unsupported.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__partial_comparison_unsupported.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in PartialComparable::cmp: Comparators that return `Option` are not supported by this backend (Filter with #[diplomat::cfg(supports=partial_comparators)]).
+Diplomat error: Lowering error in PartialComparable::cmp
+> Comparators that return `Option` are not supported by this backend (Filter with #[diplomat::cfg(supports=partial_comparators)]).

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__required_implied_bounds.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__required_implied_bounds.snap
@@ -4,18 +4,13 @@ expression: output
 ---
 Diplomat error: Lowering error in Opaque::use_foo
 > Method should explicitly include this lifetime bound from param foo: 'y: 'x (comes from source type's 'b: 'a)
-
 Diplomat error: Lowering error in Opaque::use_foo
 > Method should explicitly include this lifetime bound from param foo: 'z: 'y (comes from source type's 'c: 'b)
-
 Diplomat error: Lowering error in Opaque::return_foo
 > Method should explicitly include this lifetime bound from return type: 'y: 'x (comes from source type's 'b: 'a)
-
 Diplomat error: Lowering error in Opaque::return_foo
 > Method should explicitly include this lifetime bound from return type: 'z: 'y (comes from source type's 'c: 'b)
-
 Diplomat error: Lowering error in Opaque::return_result_foo
 > Method should explicitly include this lifetime bound from return type: 'y: 'x (comes from source type's 'b: 'a)
-
 Diplomat error: Lowering error in Opaque::return_result_foo
 > Method should explicitly include this lifetime bound from return type: 'z: 'y (comes from source type's 'c: 'b)

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__required_implied_bounds.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__required_implied_bounds.snap
@@ -2,10 +2,20 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Opaque::use_foo: Method should explicitly include this lifetime bound from param foo: 'y: 'x (comes from source type's 'b: 'a)
-Lowering error in Opaque::use_foo: Method should explicitly include this lifetime bound from param foo: 'z: 'y (comes from source type's 'c: 'b)
-Lowering error in Opaque::return_foo: Method should explicitly include this lifetime bound from return type: 'y: 'x (comes from source type's 'b: 'a)
-Lowering error in Opaque::return_foo: Method should explicitly include this lifetime bound from return type: 'z: 'y (comes from source type's 'c: 'b)
-Lowering error in Opaque::return_result_foo: Method should explicitly include this lifetime bound from return type: 'y: 'x (comes from source type's 'b: 'a)
-Lowering error in Opaque::return_result_foo: Method should explicitly include this lifetime bound from return type: 'z: 'y (comes from source type's 'c: 'b)
+Diplomat error: Lowering error in Opaque::use_foo
+> Method should explicitly include this lifetime bound from param foo: 'y: 'x (comes from source type's 'b: 'a)
 
+Diplomat error: Lowering error in Opaque::use_foo
+> Method should explicitly include this lifetime bound from param foo: 'z: 'y (comes from source type's 'c: 'b)
+
+Diplomat error: Lowering error in Opaque::return_foo
+> Method should explicitly include this lifetime bound from return type: 'y: 'x (comes from source type's 'b: 'a)
+
+Diplomat error: Lowering error in Opaque::return_foo
+> Method should explicitly include this lifetime bound from return type: 'z: 'y (comes from source type's 'c: 'b)
+
+Diplomat error: Lowering error in Opaque::return_result_foo
+> Method should explicitly include this lifetime bound from return type: 'y: 'x (comes from source type's 'b: 'a)
+
+Diplomat error: Lowering error in Opaque::return_result_foo
+> Method should explicitly include this lifetime bound from return type: 'z: 'y (comes from source type's 'c: 'b)

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__return_struct_slice.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__return_struct_slice.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo::returns_slice: `abi_compatible` can only be used on non-output-only struct types.
+Diplomat error: Lowering error in Foo::returns_slice
+> `abi_compatible` can only be used on non-output-only struct types.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
@@ -3,28 +3,47 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in Crimes
-> Found FFI-unsafe type &'a str in struct field Crimes.slice1, consider using DiplomatUtf8Str<'a>
-
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:4:9:
+...slice1: &'a...
+   ^^^^^^
+In field slice1: &'a str is FFI-unsafe, consider using DiplomatUtf8Str<'a>
 Diplomat error: Lowering error in Crimes
-> Found FFI-unsafe type &'a DiplomatStr in struct field Crimes.slice1, consider using DiplomatStrSlice<'a>
-
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:5:9:
+...slice1: &'a...
+   ^^^^^^
+In field slice1: &'a DiplomatStr is FFI-unsafe, consider using DiplomatStrSlice<'a>
 Diplomat error: Lowering error in Crimes
-> Found FFI-unsafe type &'a [u8] in struct field Crimes.slice2, consider using DiplomatSlice<'a,u8>
-
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:6:9:
+...slice2: &'a...
+   ^^^^^^
+In field slice2: &'a [u8] is FFI-unsafe, consider using DiplomatSlice<'a,u8>
 Diplomat error: Lowering error in Crimes
-> Found FFI-unsafe type Box<str> in struct field Crimes.slice3, consider using DiplomatOwnedUtf8Str
-
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:7:9:
+...slice3: Box...
+   ^^^^^^
+In field slice3: Box<str> is FFI-unsafe, consider using DiplomatOwnedUtf8Str
 Diplomat error: Lowering error in Crimes
-> Owned slices are not supported in this backend.
-
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+Owned slices are not supported in this backend.
 Diplomat error: Lowering error in Crimes
-> Found FFI-unsafe type Box<DiplomatStr> in struct field Crimes.slice3, consider using DiplomatOwnedStrSlice
-
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:8:9:
+...slice3: Box...
+   ^^^^^^
+In field slice3: Box<DiplomatStr> is FFI-unsafe, consider using DiplomatOwnedStrSlice
 Diplomat error: Lowering error in Crimes
-> Owned slices are not supported in this backend.
-
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+Owned slices are not supported in this backend.
 Diplomat error: Lowering error in Crimes
-> Found FFI-unsafe type Box<[u8]> in struct field Crimes.slice4, consider using Box<[u8]>
-
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:9:9:
+...slice4: Box...
+   ^^^^^^
+In field slice4: Box<[u8]> is FFI-unsafe, consider using Box<[u8]>
 Diplomat error: Lowering error in Crimes
-> Owned slices are not supported in this backend.
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+Owned slices are not supported in this backend.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
@@ -3,45 +3,45 @@ source: core/src/hir/type_context.rs
 expression: output
 ---
 Diplomat error: Lowering error in Crimes
-In src/hir/snapshots/span_testing/test_struct_forbidden.rs:4:9:
-...slice1: &'a...
-   ^^^^^^
-In field slice1: Safety issue: &'a str is FFI-unsafe, consider using DiplomatUtf8Str<'a>
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+&'a str is FFI-unsafe, consider using DiplomatUtf8Str<'a>
 Diplomat error: Lowering error in Crimes
-In src/hir/snapshots/span_testing/test_struct_forbidden.rs:5:9:
-...slice1: &'a...
-   ^^^^^^
-In field slice1: Safety issue: &'a DiplomatStr is FFI-unsafe, consider using DiplomatStrSlice<'a>
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+&'a DiplomatStr is FFI-unsafe, consider using DiplomatStrSlice<'a>
 Diplomat error: Lowering error in Crimes
-In src/hir/snapshots/span_testing/test_struct_forbidden.rs:6:9:
-...slice2: &'a...
-   ^^^^^^
-In field slice2: Safety issue: &'a [u8] is FFI-unsafe, consider using DiplomatSlice<'a,u8>
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+&'a [u8] is FFI-unsafe, consider using DiplomatSlice<'a,u8>
 Diplomat error: Lowering error in Crimes
-In src/hir/snapshots/span_testing/test_struct_forbidden.rs:7:9:
-...slice3: Box...
-   ^^^^^^
-In field slice3: Safety issue: Box<str> is FFI-unsafe, consider using DiplomatOwnedUtf8Str
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+Box<str> is FFI-unsafe, consider using DiplomatOwnedUtf8Str
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
 ...ruct Crimes<'a>...
         ^^^^^^
 Owned slices are not supported in this backend.
 Diplomat error: Lowering error in Crimes
-In src/hir/snapshots/span_testing/test_struct_forbidden.rs:8:9:
-...slice3: Box...
-   ^^^^^^
-In field slice3: Safety issue: Box<DiplomatStr> is FFI-unsafe, consider using DiplomatOwnedStrSlice
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+Box<DiplomatStr> is FFI-unsafe, consider using DiplomatOwnedStrSlice
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
 ...ruct Crimes<'a>...
         ^^^^^^
 Owned slices are not supported in this backend.
 Diplomat error: Lowering error in Crimes
-In src/hir/snapshots/span_testing/test_struct_forbidden.rs:9:9:
-...slice4: Box...
-   ^^^^^^
-In field slice4: Safety issue: Box<[u8]> is FFI-unsafe, consider using Box<[u8]>
+In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
+...ruct Crimes<'a>...
+        ^^^^^^
+Box<[u8]> is FFI-unsafe, consider using Box<[u8]>
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
 ...ruct Crimes<'a>...

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
@@ -2,12 +2,29 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Crimes: Found FFI-unsafe type &'a str in struct field Crimes.slice1, consider using DiplomatUtf8Str<'a>
-Lowering error in Crimes: Found FFI-unsafe type &'a DiplomatStr in struct field Crimes.slice1, consider using DiplomatStrSlice<'a>
-Lowering error in Crimes: Found FFI-unsafe type &'a [u8] in struct field Crimes.slice2, consider using DiplomatSlice<'a,u8>
-Lowering error in Crimes: Found FFI-unsafe type Box<str> in struct field Crimes.slice3, consider using DiplomatOwnedUtf8Str
-Lowering error in Crimes: Owned slices are not supported in this backend.
-Lowering error in Crimes: Found FFI-unsafe type Box<DiplomatStr> in struct field Crimes.slice3, consider using DiplomatOwnedStrSlice
-Lowering error in Crimes: Owned slices are not supported in this backend.
-Lowering error in Crimes: Found FFI-unsafe type Box<[u8]> in struct field Crimes.slice4, consider using Box<[u8]>
-Lowering error in Crimes: Owned slices are not supported in this backend.
+Diplomat error: Lowering error in Crimes
+> Found FFI-unsafe type &'a str in struct field Crimes.slice1, consider using DiplomatUtf8Str<'a>
+
+Diplomat error: Lowering error in Crimes
+> Found FFI-unsafe type &'a DiplomatStr in struct field Crimes.slice1, consider using DiplomatStrSlice<'a>
+
+Diplomat error: Lowering error in Crimes
+> Found FFI-unsafe type &'a [u8] in struct field Crimes.slice2, consider using DiplomatSlice<'a,u8>
+
+Diplomat error: Lowering error in Crimes
+> Found FFI-unsafe type Box<str> in struct field Crimes.slice3, consider using DiplomatOwnedUtf8Str
+
+Diplomat error: Lowering error in Crimes
+> Owned slices are not supported in this backend.
+
+Diplomat error: Lowering error in Crimes
+> Found FFI-unsafe type Box<DiplomatStr> in struct field Crimes.slice3, consider using DiplomatOwnedStrSlice
+
+Diplomat error: Lowering error in Crimes
+> Owned slices are not supported in this backend.
+
+Diplomat error: Lowering error in Crimes
+> Found FFI-unsafe type Box<[u8]> in struct field Crimes.slice4, consider using Box<[u8]>
+
+Diplomat error: Lowering error in Crimes
+> Owned slices are not supported in this backend.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_forbidden.snap
@@ -6,22 +6,22 @@ Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:4:9:
 ...slice1: &'a...
    ^^^^^^
-In field slice1: &'a str is FFI-unsafe, consider using DiplomatUtf8Str<'a>
+In field slice1: Safety issue: &'a str is FFI-unsafe, consider using DiplomatUtf8Str<'a>
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:5:9:
 ...slice1: &'a...
    ^^^^^^
-In field slice1: &'a DiplomatStr is FFI-unsafe, consider using DiplomatStrSlice<'a>
+In field slice1: Safety issue: &'a DiplomatStr is FFI-unsafe, consider using DiplomatStrSlice<'a>
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:6:9:
 ...slice2: &'a...
    ^^^^^^
-In field slice2: &'a [u8] is FFI-unsafe, consider using DiplomatSlice<'a,u8>
+In field slice2: Safety issue: &'a [u8] is FFI-unsafe, consider using DiplomatSlice<'a,u8>
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:7:9:
 ...slice3: Box...
    ^^^^^^
-In field slice3: Box<str> is FFI-unsafe, consider using DiplomatOwnedUtf8Str
+In field slice3: Safety issue: Box<str> is FFI-unsafe, consider using DiplomatOwnedUtf8Str
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
 ...ruct Crimes<'a>...
@@ -31,7 +31,7 @@ Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:8:9:
 ...slice3: Box...
    ^^^^^^
-In field slice3: Box<DiplomatStr> is FFI-unsafe, consider using DiplomatOwnedStrSlice
+In field slice3: Safety issue: Box<DiplomatStr> is FFI-unsafe, consider using DiplomatOwnedStrSlice
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
 ...ruct Crimes<'a>...
@@ -41,7 +41,7 @@ Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:9:9:
 ...slice4: Box...
    ^^^^^^
-In field slice4: Box<[u8]> is FFI-unsafe, consider using Box<[u8]>
+In field slice4: Safety issue: Box<[u8]> is FFI-unsafe, consider using Box<[u8]>
 Diplomat error: Lowering error in Crimes
 In src/hir/snapshots/span_testing/test_struct_forbidden.rs:3:12:
 ...ruct Crimes<'a>...

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_ref_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_ref_fails.snap
@@ -2,5 +2,8 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo: Struct "Foo" field "foo" cannot be borrowed. Structs cannot be borrowed inside of other structs, try removing the borrow and storing the struct directly.
-Lowering error in Foo::out: Found lifetimes used in struct references also used in the return type: 'a
+Diplomat error: Lowering error in Foo
+> Struct Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None })) field "foo" cannot be borrowed. Structs cannot be borrowed inside of other structs, try removing the borrow and storing the struct directly.
+
+Diplomat error: Lowering error in Foo::out
+> Found lifetimes used in struct references also used in the return type: 'a

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_ref_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__struct_ref_fails.snap
@@ -4,6 +4,5 @@ expression: output
 ---
 Diplomat error: Lowering error in Foo
 > Struct Ident("Foo", Some(Span { start: LineColumn { line: 1, col: 0 }, end: LineColumn { line: 1, col: 0 }, range: 0..0, span_location: None })) field "foo" cannot be borrowed. Structs cannot be borrowed inside of other structs, try removing the borrow and storing the struct directly.
-
 Diplomat error: Lowering error in Foo::out
 > Found lifetimes used in struct references also used in the return type: 'a

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__tuple_inputs.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__tuple_inputs.snap
@@ -4,21 +4,15 @@ expression: output
 ---
 Diplomat error: Lowering error in TupleStruct::takes_self
 > Tuple structs cannot have non-static methods.
-
 Diplomat error: Lowering error in TupleStruct::takes_self_ref
 > Tuple structs cannot have non-static methods.
-
 Diplomat error: Lowering error in TupleStruct::takes_mut_self
 > Found a mutable struct ref &mut self. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
-
 Diplomat error: Lowering error in TupleStruct::takes_mut_self
 > Tuple structs cannot have non-static methods.
-
 Diplomat error: Lowering error in TupleStruct::takes_ref
 > Tuple structs cannot be passed by reference, this is currently unsupported in Diplomat. See https://github.com/rust-diplomat/diplomat/issues/1143
-
 Diplomat error: Lowering error in TupleStruct::takes_mut_ref
 > Found a mutable struct ref &mut TupleStruct. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
-
 Diplomat error: Lowering error in TupleStruct::takes_mut_ref
 > Tuple structs cannot be passed by reference, this is currently unsupported in Diplomat. See https://github.com/rust-diplomat/diplomat/issues/1143

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__tuple_inputs.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__tuple_inputs.snap
@@ -2,10 +2,23 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in TupleStruct::takes_self: Tuple structs cannot have non-static methods.
-Lowering error in TupleStruct::takes_self_ref: Tuple structs cannot have non-static methods.
-Lowering error in TupleStruct::takes_mut_self: Found a mutable struct ref &mut self. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
-Lowering error in TupleStruct::takes_mut_self: Tuple structs cannot have non-static methods.
-Lowering error in TupleStruct::takes_ref: Tuple structs cannot be passed by reference, this is currently unsupported in Diplomat. See https://github.com/rust-diplomat/diplomat/issues/1143
-Lowering error in TupleStruct::takes_mut_ref: Found a mutable struct ref &mut TupleStruct. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
-Lowering error in TupleStruct::takes_mut_ref: Tuple structs cannot be passed by reference, this is currently unsupported in Diplomat. See https://github.com/rust-diplomat/diplomat/issues/1143
+Diplomat error: Lowering error in TupleStruct::takes_self
+> Tuple structs cannot have non-static methods.
+
+Diplomat error: Lowering error in TupleStruct::takes_self_ref
+> Tuple structs cannot have non-static methods.
+
+Diplomat error: Lowering error in TupleStruct::takes_mut_self
+> Found a mutable struct ref &mut self. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
+
+Diplomat error: Lowering error in TupleStruct::takes_mut_self
+> Tuple structs cannot have non-static methods.
+
+Diplomat error: Lowering error in TupleStruct::takes_ref
+> Tuple structs cannot be passed by reference, this is currently unsupported in Diplomat. See https://github.com/rust-diplomat/diplomat/issues/1143
+
+Diplomat error: Lowering error in TupleStruct::takes_mut_ref
+> Found a mutable struct ref &mut TupleStruct. Try marking the struct def with `#[diplomat::attr(auto, mut_struct_ref)]`
+
+Diplomat error: Lowering error in TupleStruct::takes_mut_ref
+> Tuple structs cannot be passed by reference, this is currently unsupported in Diplomat. See https://github.com/rust-diplomat/diplomat/issues/1143

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__unsupported_mut_slice.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__unsupported_mut_slice.snap
@@ -4,12 +4,9 @@ expression: output
 ---
 Diplomat error: Lowering error in Foo::takes_slice
 > &mut [f32] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-
 Diplomat error: Lowering error in Foo::takes_slice
 > &mut [Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-
 Diplomat error: Lowering error in Foo::takes_slice
 > &mut [f32] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-
 Diplomat error: Lowering error in Foo::returns_abi_slice
 > &mut [Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__unsupported_mut_slice.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__unsupported_mut_slice.snap
@@ -2,7 +2,14 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in Foo::takes_slice: &mut [f32] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-Lowering error in Foo::takes_slice: &mut [Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-Lowering error in Foo::takes_slice: &mut [f32] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
-Lowering error in Foo::returns_abi_slice: &mut [Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
+Diplomat error: Lowering error in Foo::takes_slice
+> &mut [f32] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
+
+Diplomat error: Lowering error in Foo::takes_slice
+> &mut [Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
+
+Diplomat error: Lowering error in Foo::takes_slice
+> &mut [f32] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.
+
+Diplomat error: Lowering error in Foo::returns_abi_slice
+> &mut [Foo] not supported in this backend. Try #[diplomat::cfg(supports=mutable_slices)] to restrict this API only to backends which support mutable slices.

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
@@ -10,7 +10,23 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "StructOptionUsedInReturn",
+            name: Ident(
+                "StructOptionUsedInReturn",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             fields: [
                 StructField {
                     docs: Docs {
@@ -111,7 +127,23 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "UsedInSlice",
+            name: Ident(
+                "UsedInSlice",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             fields: [
                 StructField {
                     docs: Docs {
@@ -316,14 +348,46 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "Opaque",
+            name: Ident(
+                "Opaque",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             methods: [
                 Method {
                     docs: Docs {
                         lines: "",
                         rust_links: [],
                     },
-                    name: "used_in_option",
+                    name: Ident(
+                        "used_in_option",
+                        Some(
+                            Span {
+                                start: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                end: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                range: 0..0,
+                                span_location: None,
+                            },
+                        ),
+                    ),
                     abi_name: "Opaque_used_in_option",
                     lifetime_env: LifetimeEnv {
                         nodes: [],
@@ -444,7 +508,23 @@ TypeContext {
                         lines: "",
                         rust_links: [],
                     },
-                    name: "used_in_slice",
+                    name: Ident(
+                        "used_in_slice",
+                        Some(
+                            Span {
+                                start: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                end: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                range: 0..0,
+                                span_location: None,
+                            },
+                        ),
+                    ),
                     abi_name: "Opaque_used_in_slice",
                     lifetime_env: LifetimeEnv {
                         nodes: [
@@ -594,7 +674,23 @@ TypeContext {
                         lines: "",
                         rust_links: [],
                     },
-                    name: "struct_option_ret",
+                    name: Ident(
+                        "struct_option_ret",
+                        Some(
+                            Span {
+                                start: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                end: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                range: 0..0,
+                                span_location: None,
+                            },
+                        ),
+                    ),
                     abi_name: "Opaque_struct_option_ret",
                     lifetime_env: LifetimeEnv {
                         nodes: [],
@@ -657,7 +753,23 @@ TypeContext {
                         lines: "",
                         rust_links: [],
                     },
-                    name: "struct_result_ret",
+                    name: Ident(
+                        "struct_result_ret",
+                        Some(
+                            Span {
+                                start: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                end: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                range: 0..0,
+                                span_location: None,
+                            },
+                        ),
+                    ),
                     abi_name: "Opaque_struct_result_ret",
                     lifetime_env: LifetimeEnv {
                         nodes: [],
@@ -727,7 +839,23 @@ TypeContext {
                         lines: "",
                         rust_links: [],
                     },
-                    name: "option_result_ret",
+                    name: Ident(
+                        "option_result_ret",
+                        Some(
+                            Span {
+                                start: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                end: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                range: 0..0,
+                                span_location: None,
+                            },
+                        ),
+                    ),
                     abi_name: "Opaque_option_result_ret",
                     lifetime_env: LifetimeEnv {
                         nodes: [],
@@ -806,7 +934,23 @@ TypeContext {
                         lines: "",
                         rust_links: [],
                     },
-                    name: "callback_result",
+                    name: Ident(
+                        "callback_result",
+                        Some(
+                            Span {
+                                start: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                end: LineColumn {
+                                    line: 1,
+                                    col: 0,
+                                },
+                                range: 0..0,
+                                span_location: None,
+                            },
+                        ),
+                    ),
                     abi_name: "Opaque_callback_result",
                     lifetime_env: LifetimeEnv {
                         nodes: [],
@@ -988,7 +1132,23 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "OptionUsedInReturnOpaque",
+            name: Ident(
+                "OptionUsedInReturnOpaque",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             methods: [],
             attrs: Attrs {
                 disable: false,
@@ -1044,7 +1204,23 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "UsedInOptionOpaque",
+            name: Ident(
+                "UsedInOptionOpaque",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             methods: [],
             attrs: Attrs {
                 disable: false,
@@ -1176,7 +1352,23 @@ TypeContext {
                 lines: "",
                 rust_links: [],
             },
-            name: "UsedInSliceOpaque",
+            name: Ident(
+                "UsedInSliceOpaque",
+                Some(
+                    Span {
+                        start: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        end: LineColumn {
+                            line: 1,
+                            col: 0,
+                        },
+                        range: 0..0,
+                        span_location: None,
+                    },
+                ),
+            ),
             methods: [],
             attrs: Attrs {
                 disable: false,

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__zst_non_opaque.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__zst_non_opaque.snap
@@ -2,4 +2,5 @@
 source: core/src/hir/type_context.rs
 expression: output
 ---
-Lowering error in NonOpaque: Methods on ZST structs are not yet implemented: NonOpaque
+Diplomat error: Lowering error in NonOpaque
+> Methods on ZST structs are not yet implemented: NonOpaque

--- a/core/src/hir/snapshots/span_testing/test_struct_forbidden.rs
+++ b/core/src/hir/snapshots/span_testing/test_struct_forbidden.rs
@@ -1,0 +1,11 @@
+#[diplomat::bridge]
+mod ffi {
+    struct Crimes<'a> {
+        slice1: &'a str,
+        slice1: &'a DiplomatStr,
+        slice2: &'a [u8],
+        slice3: Box<str>,
+        slice3: Box<DiplomatStr>,
+        slice4: Box<[u8]>,
+    }
+}

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -224,7 +224,7 @@ impl TypeContext {
     ) -> Result<Self, Vec<ErrorAndContext>> {
         let types = ast::File::from_syn(s, include_info, entry_location).all_types();
         let (mut ctx, hir) = Self::from_ast_without_validation(&types, cfg, attr_validator)?;
-        ctx.errors.set_item("(validation)");
+        ctx.errors.set_item("(validation)", &None);
         hir.validate(&mut ctx.errors);
         if !ctx.errors.is_empty() {
             return Err(ctx.errors.take_errors());
@@ -248,11 +248,13 @@ impl TypeContext {
         let mut errors = ErrorStore::default();
 
         for (path, mod_env) in env.iter_modules() {
+            let opt = path.elements.last().and_then(|m| m.span());
             errors.set_item(
                 path.elements
                     .last()
                     .map(|m| m.as_str())
                     .unwrap_or("root module"),
+                    &opt,
             );
             let mod_attrs = Attrs::from_ast(
                 &mod_env.attrs,
@@ -419,12 +421,12 @@ impl TypeContext {
     fn validate<'hir>(&'hir self, errors: &mut ErrorStore<'hir>) {
         // Lifetime validity check
         for (_id, ty) in self.all_types() {
-            errors.set_item(ty.name().as_str());
+            errors.set_item(ty.name().as_str(), ty.span());
 
             self.validate_type_def(errors, ty);
 
             for method in ty.methods() {
-                errors.set_subitem(method.name.as_str());
+                errors.set_subitem(&method.name.as_str(), &method.name);
 
                 // This check must occur before validate_ty_in_method is called
                 // since validate_ty_in_method calls link_lifetimes which does not
@@ -497,7 +499,7 @@ impl TypeContext {
         }
 
         for (_id, def) in self.all_traits() {
-            errors.set_item(def.name.as_str());
+            errors.set_item(&def.name.as_str(), &def.name);
             self.validate_trait(errors, def);
         }
     }
@@ -926,8 +928,8 @@ mod tests {
             match hir::TypeContext::from_syn(&parsed, Default::default(), attr_validator, None, &SpanLocation::None) {
                 Ok(_context) => (),
                 Err(e) => {
-                    for (ctx, err) in e {
-                        writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                    for err in e {
+                        writeln!(&mut output, "{err}").unwrap();
                     }
                 }
             };
@@ -1365,8 +1367,8 @@ mod tests {
         ) {
             Ok(_context) => (),
             Err(e) => {
-                for (ctx, err) in e {
-                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                for err in e {
+                    writeln!(&mut output, "{err}").unwrap();
                 }
             }
         };
@@ -1405,8 +1407,8 @@ mod tests {
         ) {
             Ok(_context) => (),
             Err(e) => {
-                for (ctx, err) in e {
-                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                for err in e {
+                    writeln!(&mut output, "{err}").unwrap();
                 }
             }
         };
@@ -1447,8 +1449,8 @@ mod tests {
         ) {
             Ok(_context) => (),
             Err(e) => {
-                for (ctx, err) in e {
-                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                for err in e {
+                    writeln!(&mut output, "{err}").unwrap();
                 }
             }
         };
@@ -1485,8 +1487,8 @@ mod tests {
         ) {
             Ok(_context) => (),
             Err(e) => {
-                for (ctx, err) in e {
-                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                for err in e {
+                    writeln!(&mut output, "{err}").unwrap();
                 }
             }
         };
@@ -1530,8 +1532,8 @@ mod tests {
         {
             Ok(_context) => (),
             Err(e) => {
-                for (ctx, err) in e {
-                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                for err in e {
+                    writeln!(&mut output, "{err}").unwrap();
                 }
             }
         };
@@ -1570,8 +1572,8 @@ mod tests {
         {
             Ok(_context) => (),
             Err(e) => {
-                for (ctx, err) in e {
-                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                for err in e {
+                    writeln!(&mut output, "{err}").unwrap();
                 }
             }
         };
@@ -1700,8 +1702,8 @@ mod tests {
         {
             Ok(_context) => (),
             Err(e) => {
-                for (ctx, err) in e {
-                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                for err in e {
+                    writeln!(&mut output, "{err}").unwrap();
                 }
             }
         };
@@ -1737,8 +1739,8 @@ mod tests {
         {
             Ok(_context) => (),
             Err(e) => {
-                for (ctx, err) in e {
-                    writeln!(&mut output, "Lowering error in {ctx}: {err}").unwrap();
+                for err in e {
+                    writeln!(&mut output, "{err}").unwrap();
                 }
             }
         };

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -426,7 +426,7 @@ impl TypeContext {
             self.validate_type_def(errors, ty);
 
             for method in ty.methods() {
-                errors.set_subitem(&method.name.as_str(), &method.name);
+                errors.set_subitem(method.name.as_str(), &method.name);
 
                 // This check must occur before validate_ty_in_method is called
                 // since validate_ty_in_method calls link_lifetimes which does not
@@ -499,7 +499,7 @@ impl TypeContext {
         }
 
         for (_id, def) in self.all_traits() {
-            errors.set_item(&def.name.as_str(), &def.name);
+            errors.set_item(def.name.as_str(), &def.name);
             self.validate_trait(errors, def);
         }
     }

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -911,9 +911,8 @@ impl TryInto<TraitId> for SymbolId {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::SpanLocation;
+    use crate::ast::{SpanLocation, write_report};
     use crate::hir;
-    use std::fmt::Write;
 
     macro_rules! uitest_lowering {
         ($($file:tt)*) => {
@@ -929,7 +928,7 @@ mod tests {
                 Ok(_context) => (),
                 Err(e) => {
                     for err in e {
-                        writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                     }
                 }
             };
@@ -956,7 +955,9 @@ mod tests {
                 Ok(_context) => (),
                 Err(e) => {
                     for err in e {
-                        writeln!(&mut output, "{err}").unwrap();
+                        use std::fmt::Write;
+                        write_report(&err.ast_report(), &mut output, true).unwrap();
+                        writeln!(output, "");
                     }
                 }
             };
@@ -1384,7 +1385,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                 }
             }
         };
@@ -1424,7 +1425,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                 }
             }
         };
@@ -1466,7 +1467,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                 }
             }
         };
@@ -1504,7 +1505,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                 }
             }
         };
@@ -1549,7 +1550,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                 }
             }
         };
@@ -1589,7 +1590,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                 }
             }
         };
@@ -1719,7 +1720,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                 }
             }
         };
@@ -1756,7 +1757,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    writeln!(&mut output, "{err}").unwrap();
+                    write_report(&err.ast_report(), &mut output, true).unwrap();
                 }
             }
         };

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -928,7 +928,7 @@ mod tests {
                 Ok(_context) => (),
                 Err(e) => {
                     for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                     }
                 }
             };
@@ -962,7 +962,7 @@ mod tests {
                 Err(e) => {
                     for err in e {
                         use std::fmt::Write;
-                        write_report(&err.ast_report(), &mut output, true).unwrap();
+                        write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                         writeln!(output, "").unwrap();
                     }
                 }
@@ -1389,7 +1389,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                 }
             }
         };
@@ -1429,7 +1429,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                 }
             }
         };
@@ -1471,7 +1471,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                 }
             }
         };
@@ -1509,7 +1509,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                 }
             }
         };
@@ -1554,7 +1554,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                 }
             }
         };
@@ -1594,7 +1594,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                 }
             }
         };
@@ -1724,7 +1724,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                 }
             }
         };
@@ -1761,7 +1761,7 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, true).unwrap();
+                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
                 }
             }
         };

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -938,6 +938,33 @@ mod tests {
             });
         }
     }
+    
+    macro_rules! file_test_lowering {
+        ($file_name:expr) => {
+            let folder_pth_name = format!("src/hir/snapshots/span_testing");
+            let folder_pth = std::path::Path::new(&folder_pth_name);
+            let file_path = folder_pth.join($file_name);
+            
+            let st = std::fs::read_to_string(&file_path).expect("Could not read file.");
+            let parsed = syn::parse_str::<syn::File>(&st).expect("Could not read file");
+            
+            let mut attr_validator = hir::BasicAttributeValidator::new("tests");
+            attr_validator.support.option = true;
+            
+            let mut output = String::new();
+            match hir::TypeContext::from_syn(&parsed, Default::default(), attr_validator, None, &SpanLocation::FilePath(format!("{}/{}", folder_pth_name, $file_name))) {
+                Ok(_context) => (),
+                Err(e) => {
+                    for err in e {
+                        writeln!(&mut output, "{err}").unwrap();
+                    }
+                }
+            };
+            insta::with_settings!({}, {
+                insta::assert_snapshot!(output)
+            });  
+        };
+    }
 
     #[test]
     fn test_required_implied_bounds() {
@@ -1217,21 +1244,10 @@ mod tests {
             }
         };
     }
+
     #[test]
     fn test_struct_forbidden() {
-        uitest_lowering! {
-            #[diplomat::bridge]
-            mod ffi {
-                struct Crimes<'a> {
-                    slice1: &'a str,
-                    slice1: &'a DiplomatStr,
-                    slice2: &'a [u8],
-                    slice3: Box<str>,
-                    slice3: Box<DiplomatStr>,
-                    slice4: Box<[u8]>,
-                }
-            }
-        };
+        file_test_lowering!{"test_struct_forbidden.rs"};
     }
 
     #[test]

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -962,7 +962,12 @@ mod tests {
                 Err(e) => {
                     for err in e {
                         use std::fmt::Write;
-                        write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                        write_report(
+                            &err.ast_report(),
+                            &mut output,
+                            crate::ast::logging::PrettyPrint::ForceUgly,
+                        )
+                        .unwrap();
                         writeln!(output, "").unwrap();
                     }
                 }
@@ -1389,7 +1394,12 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
                 }
             }
         };
@@ -1429,7 +1439,12 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
                 }
             }
         };
@@ -1471,7 +1486,12 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
                 }
             }
         };
@@ -1509,7 +1529,12 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
                 }
             }
         };
@@ -1554,7 +1579,12 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
                 }
             }
         };
@@ -1594,7 +1624,12 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
                 }
             }
         };
@@ -1724,7 +1759,12 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
                 }
             }
         };
@@ -1761,7 +1801,12 @@ mod tests {
             Ok(_context) => (),
             Err(e) => {
                 for err in e {
-                    write_report(&err.ast_report(), &mut output, crate::ast::logging::PrettyPrint::ForceUgly).unwrap();
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
                 }
             }
         };

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -254,7 +254,7 @@ impl TypeContext {
                     .last()
                     .map(|m| m.as_str())
                     .unwrap_or("root module"),
-                    &opt,
+                &opt,
             );
             let mod_attrs = Attrs::from_ast(
                 &mod_env.attrs,
@@ -911,7 +911,7 @@ impl TryInto<TraitId> for SymbolId {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{SpanLocation, write_report};
+    use crate::ast::{write_report, SpanLocation};
     use crate::hir;
 
     macro_rules! uitest_lowering {
@@ -937,21 +937,27 @@ mod tests {
             });
         }
     }
-    
+
     macro_rules! file_test_lowering {
         ($file_name:expr) => {
             let folder_pth_name = format!("src/hir/snapshots/span_testing");
             let folder_pth = std::path::Path::new(&folder_pth_name);
             let file_path = folder_pth.join($file_name);
-            
+
             let st = std::fs::read_to_string(&file_path).expect("Could not read file.");
             let parsed = syn::parse_str::<syn::File>(&st).expect("Could not read file");
-            
+
             let mut attr_validator = hir::BasicAttributeValidator::new("tests");
             attr_validator.support.option = true;
-            
+
             let mut output = String::new();
-            match hir::TypeContext::from_syn(&parsed, Default::default(), attr_validator, None, &SpanLocation::FilePath(format!("{}/{}", folder_pth_name, $file_name))) {
+            match hir::TypeContext::from_syn(
+                &parsed,
+                Default::default(),
+                attr_validator,
+                None,
+                &SpanLocation::FilePath(format!("{}/{}", folder_pth_name, $file_name)),
+            ) {
                 Ok(_context) => (),
                 Err(e) => {
                     for err in e {
@@ -961,9 +967,7 @@ mod tests {
                     }
                 }
             };
-            insta::with_settings!({}, {
-                insta::assert_snapshot!(output)
-            });  
+            insta::with_settings!({}, { insta::assert_snapshot!(output) });
         };
     }
 
@@ -1248,7 +1252,7 @@ mod tests {
 
     #[test]
     fn test_struct_forbidden() {
-        file_test_lowering!{"test_struct_forbidden.rs"};
+        file_test_lowering! {"test_struct_forbidden.rs"};
     }
 
     #[test]

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -963,7 +963,7 @@ mod tests {
                     for err in e {
                         use std::fmt::Write;
                         write_report(&err.ast_report(), &mut output, true).unwrap();
-                        writeln!(output, "");
+                        writeln!(output, "").unwrap();
                     }
                 }
             };

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -387,8 +387,8 @@ pub mod test {
         ) {
             Ok(context) => context,
             Err(e) => {
-                for (_cx, err) in e {
-                    eprintln!("Lowering error: {err}");
+                for err in e {
+                    eprintln!("{err}");
                 }
                 panic!("Failed to create context")
             }

--- a/tool/src/dotnet/mod.rs
+++ b/tool/src/dotnet/mod.rs
@@ -676,8 +676,8 @@ mod test {
         ) {
             Ok(context) => context,
             Err(e) => {
-                for (_cx, err) in e {
-                    eprintln!("Lowering error: {err}");
+                for err in e {
+                    eprintln!("{err}");
                 }
                 panic!("Failed to create context")
             }
@@ -705,7 +705,7 @@ mod test {
             &diplomat_core::ast::SpanLocation::None,
         ) {
             Ok(_) => Vec::new(),
-            Err(e) => e.into_iter().map(|(_cx, err)| err.to_string()).collect(),
+            Err(e) => e.into_iter().map(|err| err.to_string()).collect(),
         }
     }
 

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -574,8 +574,8 @@ pub mod test {
         ) {
             Ok(context) => context,
             Err(e) => {
-                for (_cx, err) in e {
-                    eprintln!("Lowering error: {err}");
+                for err in e {
+                    eprintln!("{err}");
                 }
                 panic!("Failed to create context")
             }

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -134,8 +134,8 @@ pub fn gen(
         &diplomat_core::ast::SpanLocation::FilePath(entry_parent.to_string_lossy().into()),
     )
     .unwrap_or_else(|e| {
-        for (ctx, err) in e {
-            eprintln!("Lowering error in {ctx}: {err}");
+        for err in e {
+            eprintln!("{err}");
         }
         std::process::exit(1);
     });

--- a/tool/src/nanobind/mod.rs
+++ b/tool/src/nanobind/mod.rs
@@ -345,8 +345,8 @@ mod test {
             {
                 Ok(context) => context,
                 Err(e) => {
-                    for (_cx, err) in e {
-                        eprintln!("Lowering error: {err}");
+                    for err in e {
+                        eprintln!("{err}");
                     }
                     panic!("Failed to create context")
                 }


### PR DESCRIPTION
Handles https://github.com/rust-diplomat/diplomat/issues/111 in HIR lowering errors.

This adds a new LoweringError type: `InvalidField`, for testing the new printer. It also adds new `LoweringReport` and `hir::defs::Ident` structs for including location information when printing errors (but it functions without location information, as seen in the updated snapshots)

TODOs:
- [x] Document breaking API changes to core on approval (for the relnotes if this gets approved/merged)