### PR TITLE
hir: resolve callback optional-opaque returns in the enclosing module

### DIFF
--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -2243,7 +2243,7 @@ impl<'ast> LoweringContext<'ast> {
                 ast::TypeName::Box(t) | ast::TypeName::Reference(_, _, t) => {
                     match &**t {
                         ast::TypeName::Named(t) | ast::TypeName::SelfType(t) => {
-                            let ty = t.resolve(&t.path, self.env);
+                            let ty = t.resolve(in_path, self.env);
                             if let ast::CustomType::Opaque(..) = ty {
                                 if *stdlib == ast::StdlibOrDiplomat::Diplomat {
                                     self.errors.push(LoweringError::Other("found DiplomatOption<T>, where T is opaque. Please use Option<&T> (DiplomatOption is for primitives, structs, and enums)".to_string()));

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_diplomat_option_opaque_return_fails.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__callback_diplomat_option_opaque_return_fails.snap
@@ -1,0 +1,6 @@
+---
+source: core/src/hir/type_context.rs
+expression: output
+---
+Diplomat error: Lowering error in Foo::apply_callback
+> found DiplomatOption<T>, where T is opaque. Please use Option<&T> (DiplomatOption is for primitives, structs, and enums)

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -1659,6 +1659,101 @@ mod tests {
         insta::with_settings!({}, { insta::assert_snapshot!(output) });
     }
 
+    /// Callbacks and trait methods may return an optional borrowed opaque.
+    /// Lowering used to abort with "Could not resolve symbol" instead, because
+    /// the opaque check resolved the returned type against its own path rather
+    /// than against the module the method is declared in.
+    #[test]
+    fn test_callback_optional_opaque_return() {
+        let parsed: syn::File = syn::parse_quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Foo(u8);
+
+                pub trait Getter {
+                    fn get(&self) -> Option<&Foo>;
+                }
+
+                impl Foo {
+                    pub fn apply_callback(&self, cb: impl FnMut(&Foo) -> Option<&Foo>) {}
+
+                    pub fn apply_self_callback(&self, cb: impl FnMut(&Foo) -> Option<&Self>) {}
+
+                    pub fn apply_trait(&self, g: impl Getter) {}
+                }
+            }
+        };
+
+        let mut output = String::new();
+
+        let mut attr_validator = hir::BasicAttributeValidator::new("tests");
+        attr_validator.support.callbacks = true;
+        attr_validator.support.traits = true;
+        let config = super::LoweringConfig {
+            unsafe_references_in_callbacks: true,
+        };
+        match hir::TypeContext::from_syn(&parsed, config, attr_validator, None, &SpanLocation::None)
+        {
+            Ok(_context) => (),
+            Err(e) => {
+                for err in e {
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
+                }
+            }
+        };
+        assert!(
+            output.is_empty(),
+            "expected lowering to succeed, got:\n{output}"
+        );
+    }
+
+    /// The companion diagnostic to [`test_callback_optional_opaque_return`]:
+    /// spelling the same return type `DiplomatOption<&T>` is still rejected,
+    /// and now reaches its intended error instead of aborting lowering.
+    #[test]
+    fn test_callback_diplomat_option_opaque_return_fails() {
+        let parsed: syn::File = syn::parse_quote! {
+            #[diplomat::bridge]
+            mod ffi {
+                #[diplomat::opaque]
+                pub struct Foo(u8);
+
+                impl Foo {
+                    pub fn apply_callback(&self, cb: impl FnMut(&Foo) -> DiplomatOption<&Foo>) {}
+                }
+            }
+        };
+
+        let mut output = String::new();
+
+        let mut attr_validator = hir::BasicAttributeValidator::new("tests");
+        attr_validator.support.callbacks = true;
+        let config = super::LoweringConfig {
+            unsafe_references_in_callbacks: true,
+        };
+        match hir::TypeContext::from_syn(&parsed, config, attr_validator, None, &SpanLocation::None)
+        {
+            Ok(_context) => (),
+            Err(e) => {
+                for err in e {
+                    write_report(
+                        &err.ast_report(),
+                        &mut output,
+                        crate::ast::logging::PrettyPrint::ForceUgly,
+                    )
+                    .unwrap();
+                }
+            }
+        };
+        insta::with_settings!({}, { insta::assert_snapshot!(output) });
+    }
+
     #[test]
     fn test_unsupported_mut_slice() {
         uitest_lowering! {


### PR DESCRIPTION
A callback or trait method that returns `Option<&T>` or `Option<Box<T>>` aborts the tool with `Diplomat error: Could not resolve symbol` before any backend runs. This reproduces on `main`:

```rust
#[diplomat::bridge]
mod ffi {
    #[diplomat::opaque]
    pub struct Foo(u8);

    impl Foo {
        pub fn apply_callback(&self, cb: impl FnMut(&Foo) -> Option<&Foo>) {}
    }
}
```

The cause is one argument, at core/src/hir/lowering.rs:2246. `lower_callback_return_type` resolves the returned type so it can reject the `DiplomatOption` spelling for opaques, and it called `t.resolve(&t.path, self.env)`. `PathType::resolve_with_path` treats that argument as the module to resolve *from*, and walks `self.path` starting there, so for `Option<&Foo>` it went looking for `Foo` inside a module named `Foo`, found nothing, and landed in the `None` arm's `create_simple_report`, which panics. Every other `resolve` call in the file passes `in_path`, the module the method is declared in.

Passing `in_path` is the whole fix. The rest of the diff is tests.

Two things fall out of it. `Option<&T>` and `Option<&Self>` now lower the same way they do in every other position, and the `DiplomatOption<&T>` error this branch was written to emit becomes reachable for the first time, so I snapshotted it.

Both tests are in core/src/hir/type_context.rs and both panic without the change. `test_callback_optional_opaque_return` covers a closure returning `Option<&Foo>`, a closure returning `Option<&Self>`, and a trait method returning `Option<&Foo>`, and asserts lowering reports nothing. `test_callback_diplomat_option_opaque_return_fails` snapshots the `DiplomatOption<&Foo>` rejection. That snapshot is the only new one; no existing snapshot changed.

Verified on macOS with rustc 1.95:

```
cargo fmt --all -- --check                                            clean
cargo clippy -p diplomat_core --all-targets --all-features -- -D warnings   clean
cargo test -p diplomat_core --all-features    77 passed, 0 failed (+ 4 doctests)
cargo test -p diplomat_core -- ast::logging    1 passed, 0 failed
cargo test -p diplomat-tool                   99 passed, 0 failed
cargo test -p diplomat                        16 passed, 0 failed
```

I also ran every generator into a scratch directory (`cargo run -p diplomat-tool -- <backend> <out>` for c, cpp, js, demo_gen, dart, dotnet, kotlin and nanobind, over both feature_tests and example) and diffed against the checked-in bindings. Byte identical, so the `gen` job stays clean. The change is confined to a path that previously always panicked, so no existing fixture could have been reaching it.

Not run here: the Dart, Kotlin, .NET and nanobind suites, and `cargo +1.88 check`, for want of those toolchains on this machine. The diff adds no syntax newer than the declared MSRV.

Happy to file an issue for this if you want one on record. It looked small enough to just send the fix.
