### PR TITLE
Reproduce unstable annotation in bindings

### DIFF
--- a/core/src/ast/attrs.rs
+++ b/core/src/ast/attrs.rs
@@ -32,8 +32,7 @@ use crate::ast::SpanLocation;
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
 #[non_exhaustive]
 pub struct Attrs {
-    /// The regular #[cfg()] attributes. Inherited, though the inheritance onto methods is the
-    /// only relevant one here.
+    /// The regular #[cfg()] attributes. Inherited.
     pub cfg: Vec<Attribute>,
 
     /// The #[deprecated(note = 'foo')] attribute.

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1734,6 +1734,7 @@ impl AttributeValidator for BasicAttributeValidator {
     }
     fn is_unstable(&self, cfg: &syn::Attribute) -> bool {
         self.semver_unstable_features.iter().any(|f| {
+            // TODO(#1274): Improve this heuristic
             cfg.to_token_stream()
                 .to_string()
                 .contains(&format!("feature = {f:?}"))

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -463,11 +463,7 @@ impl Attrs {
 
         this.deprecated = ast.deprecated.clone();
 
-        this.unstable |= ast.cfg.iter().any(|x| {
-            x.to_token_stream()
-                .to_string()
-                .contains("feature = \"unstable\"")
-        });
+        this.unstable |= ast.cfg.iter().any(|x| validator.is_unstable(x));
 
         let support = validator.attrs_supported();
         let backend = validator.primary_name();
@@ -1591,6 +1587,8 @@ pub trait AttributeValidator {
     fn validate(&self, attrs: &Attrs, context: AttributeContext, errors: &mut ErrorStore) {
         attrs.validate(self, context, errors)
     }
+
+    fn is_unstable(&self, feature: &syn::Attribute) -> bool;
 }
 
 /// A basic attribute validator
@@ -1608,6 +1606,8 @@ pub struct BasicAttributeValidator {
     pub is_name_value: Option<Box<dyn Fn(&str, &str) -> bool>>,
     /// The features enabled.
     pub features_enabled: HashSet<String>,
+    /// The unstable features.
+    pub semver_unstable_features: HashSet<String>,
 }
 
 impl BasicAttributeValidator {
@@ -1731,6 +1731,13 @@ impl AttributeValidator for BasicAttributeValidator {
     }
     fn attrs_supported(&self) -> BackendAttrSupport {
         self.support
+    }
+    fn is_unstable(&self, cfg: &syn::Attribute) -> bool {
+        self.semver_unstable_features.iter().any(|f| {
+            cfg.to_token_stream()
+                .to_string()
+                .contains(&format!("feature = {f:?}"))
+        })
     }
 }
 

--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -27,6 +27,8 @@ pub struct Attrs {
     ///
     /// This attribute is always inherited except to variants
     pub disable: bool,
+    /// Whether this item is `cfg(feature = "unstable")`
+    pub unstable: bool,
     /// Mark this item deprecated in FFI.
     pub deprecated: Option<String>,
     /// An optional namespace. None is equivalent to the root namespace.
@@ -451,15 +453,21 @@ impl Attrs {
     pub fn from_ast(
         ast: &ast::Attrs,
         validator: &(impl AttributeValidator + ?Sized),
-        parent_attrs: &Attrs,
+        parent_attrs: Attrs,
         errors: &mut ErrorStore,
     ) -> Self {
-        let mut this = parent_attrs.clone();
+        let mut this = parent_attrs;
         // Backends must support this since it applies to the macro/C code.
         // No special inheritance, was already appropriately inherited in AST
         this.abi_rename = ast.abi_rename.clone();
 
         this.deprecated = ast.deprecated.clone();
+
+        this.unstable |= ast.cfg.iter().any(|x| {
+            x.to_token_stream()
+                .to_string()
+                .contains("feature = \"unstable\"")
+        });
 
         let support = validator.attrs_supported();
         let backend = validator.primary_name();
@@ -772,6 +780,7 @@ impl Attrs {
         // use an exhaustive destructure so new attributes are handled
         let Attrs {
             disable,
+            unstable: _unstable,
             deprecated: _deprecated,
             namespace,
             rename,
@@ -1270,6 +1279,7 @@ impl Attrs {
         Attrs {
             disable,
             deprecated: None,
+            unstable: self.unstable,
             rename,
             namespace,
             // Should not inherit from enums to their variants
@@ -1571,7 +1581,7 @@ pub trait AttributeValidator {
     fn attr_from_ast(
         &self,
         ast: &ast::Attrs,
-        parent_attrs: &Attrs,
+        parent_attrs: Attrs,
         errors: &mut ErrorStore,
     ) -> Attrs {
         Attrs::from_ast(ast, self, parent_attrs, errors)

--- a/core/src/hir/lowering.rs
+++ b/core/src/hir/lowering.rs
@@ -288,7 +288,7 @@ impl<'ast> LoweringContext<'ast> {
         let name = self.lower_ident(&ast_enum.name, "enum name");
         let attrs = self.attr_validator.attr_from_ast(
             &ast_enum.attrs,
-            &item.ty_parent_attrs,
+            item.ty_parent_attrs.clone(),
             &mut self.errors,
         );
 
@@ -296,9 +296,11 @@ impl<'ast> LoweringContext<'ast> {
         let variant_parent_attrs = attrs.for_inheritance(AttrInheritContext::Variant);
         for (ident, discriminant, docs, attrs) in ast_enum.variants.iter() {
             let name = self.lower_ident(ident, "enum variant");
-            let attrs =
-                self.attr_validator
-                    .attr_from_ast(attrs, &variant_parent_attrs, &mut self.errors);
+            let attrs = self.attr_validator.attr_from_ast(
+                attrs,
+                variant_parent_attrs.clone(),
+                &mut self.errors,
+            );
             match (name, &mut variants) {
                 (Ok(name), Ok(variants)) => {
                     let variant = EnumVariant {
@@ -361,7 +363,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let attrs = self.attr_validator.attr_from_ast(
             &ast_opaque.attrs,
-            &item.ty_parent_attrs,
+            item.ty_parent_attrs.clone(),
             &mut self.errors,
         );
         let mut special_method_presence = SpecialMethodPresence::default();
@@ -408,7 +410,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let attrs = self.attr_validator.attr_from_ast(
             &ast_struct.attrs,
-            &item.ty_parent_attrs,
+            item.ty_parent_attrs.clone(),
             &mut self.errors,
         );
         // Only compute fields if the type isn't disabled, otherwise we may encounter forbidden types
@@ -430,7 +432,7 @@ impl<'ast> LoweringContext<'ast> {
 
                 let field_attrs =
                     self.attr_validator
-                        .attr_from_ast(attrs, &Attrs::default(), &mut self.errors);
+                        .attr_from_ast(attrs, Attrs::default(), &mut self.errors);
 
                 self.attr_validator.validate(
                     &field_attrs,
@@ -502,7 +504,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let attrs = self.attr_validator.attr_from_ast(
             &ast_trait.attrs,
-            &item.ty_parent_attrs,
+            item.ty_parent_attrs.clone(),
             &mut self.errors,
         );
 
@@ -524,7 +526,7 @@ impl<'ast> LoweringContext<'ast> {
             for ast_trait_method in ast_trait.methods.iter() {
                 let trait_method_attrs = self.attr_validator.attr_from_ast(
                     &ast_trait_method.attrs,
-                    &attrs,
+                    attrs.clone(),
                     &mut self.errors,
                 );
 
@@ -584,7 +586,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let attrs = self.attr_validator.attr_from_ast(
             &ast_trait_method.attrs,
-            parent_trait_attrs,
+            parent_trait_attrs.clone(),
             &mut self.errors,
         );
 
@@ -624,7 +626,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let attrs = self.attr_validator.attr_from_ast(
             &ast_function.item.attrs,
-            &ast_function.ty_parent_attrs,
+            ast_function.ty_parent_attrs.clone(),
             &mut self.errors,
         );
 
@@ -689,7 +691,7 @@ impl<'ast> LoweringContext<'ast> {
 
         let attrs = self.attr_validator.attr_from_ast(
             &ast_out_struct.attrs,
-            &item.ty_parent_attrs,
+            item.ty_parent_attrs.clone(),
             &mut self.errors,
         );
         let fields = {
@@ -717,7 +719,7 @@ impl<'ast> LoweringContext<'ast> {
                             ty,
                             attrs: self.attr_validator.attr_from_ast(
                                 attrs,
-                                &Attrs::default(),
+                                Attrs::default(),
                                 &mut self.errors,
                             ),
                         }),
@@ -901,7 +903,7 @@ impl<'ast> LoweringContext<'ast> {
             self.errors.set_subitem(method.name.as_str(), &method.name);
             let attrs = self.attr_validator.attr_from_ast(
                 &method.attrs,
-                method_parent_attrs,
+                method_parent_attrs.clone(),
                 &mut self.errors,
             );
             if attrs.disable {
@@ -1785,7 +1787,7 @@ impl<'ast> LoweringContext<'ast> {
 
                     let attrs = self.attr_validator.attr_from_ast(
                         &self_param.attrs,
-                        &Attrs::default(),
+                        Attrs::default(),
                         &mut self.errors,
                     );
 
@@ -1848,7 +1850,7 @@ impl<'ast> LoweringContext<'ast> {
 
                     let attrs = self.attr_validator.attr_from_ast(
                         &self_param.attrs,
-                        &Attrs::default(),
+                        Attrs::default(),
                         &mut self.errors,
                     );
 
@@ -1880,7 +1882,7 @@ impl<'ast> LoweringContext<'ast> {
 
                 let attrs = self.attr_validator.attr_from_ast(
                     &self_param.attrs,
-                    &Attrs::default(),
+                    Attrs::default(),
                     &mut self.errors,
                 );
 
@@ -1956,7 +1958,7 @@ impl<'ast> LoweringContext<'ast> {
         // No parent attrs because parameters do not have a strictly clear parent.
         let attrs =
             self.attr_validator
-                .attr_from_ast(&param.attrs, &Attrs::default(), &mut self.errors);
+                .attr_from_ast(&param.attrs, Attrs::default(), &mut self.errors);
 
         self.attr_validator
             .validate(&attrs, AttributeContext::Param, &mut self.errors);

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__elision_in_struct.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__elision_in_struct.snap
@@ -52,6 +52,7 @@ Method {
             ),
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -117,6 +118,7 @@ Method {
             ),
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -155,6 +157,7 @@ Method {
     ),
     attrs: Attrs {
         disable: false,
+        unstable: false,
         deprecated: None,
         namespace: None,
         rename: RenameAttr {

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -55,6 +55,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -140,6 +141,7 @@ TypeContext {
                             ),
                             attrs: Attrs {
                                 disable: false,
+                                unstable: false,
                                 deprecated: None,
                                 namespace: None,
                                 rename: RenameAttr {
@@ -198,6 +200,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -233,6 +236,7 @@ TypeContext {
             ],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -331,6 +335,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -419,6 +424,7 @@ TypeContext {
                             ),
                             attrs: Attrs {
                                 disable: false,
+                                unstable: false,
                                 deprecated: None,
                                 namespace: None,
                                 rename: RenameAttr {
@@ -469,6 +475,7 @@ TypeContext {
                             ),
                             attrs: Attrs {
                                 disable: false,
+                                unstable: false,
                                 deprecated: None,
                                 namespace: None,
                                 rename: RenameAttr {
@@ -520,6 +527,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -555,6 +563,7 @@ TypeContext {
             ],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -635,6 +644,7 @@ TypeContext {
             methods: [],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {

--- a/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__type_context__tests__usage.snap
@@ -41,6 +41,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -77,6 +78,7 @@ TypeContext {
             methods: [],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -160,6 +162,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -196,6 +199,7 @@ TypeContext {
             methods: [],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -424,6 +428,7 @@ TypeContext {
                             ),
                             attrs: Attrs {
                                 disable: false,
+                                unstable: false,
                                 deprecated: None,
                                 namespace: None,
                                 rename: RenameAttr {
@@ -477,6 +482,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -581,6 +587,7 @@ TypeContext {
                             ),
                             attrs: Attrs {
                                 disable: false,
+                                unstable: false,
                                 deprecated: None,
                                 namespace: None,
                                 rename: RenameAttr {
@@ -645,6 +652,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -725,6 +733,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -812,6 +821,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -908,6 +918,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -1020,6 +1031,7 @@ TypeContext {
                             ),
                             attrs: Attrs {
                                 disable: false,
+                                unstable: false,
                                 deprecated: None,
                                 namespace: None,
                                 rename: RenameAttr {
@@ -1058,6 +1070,7 @@ TypeContext {
                     ),
                     attrs: Attrs {
                         disable: false,
+                        unstable: false,
                         deprecated: None,
                         namespace: None,
                         rename: RenameAttr {
@@ -1093,6 +1106,7 @@ TypeContext {
             ],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -1166,6 +1180,7 @@ TypeContext {
             methods: [],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -1239,6 +1254,7 @@ TypeContext {
             methods: [],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {
@@ -1388,6 +1404,7 @@ TypeContext {
             methods: [],
             attrs: Attrs {
                 disable: false,
+                unstable: false,
                 deprecated: None,
                 namespace: None,
                 rename: RenameAttr {

--- a/core/src/hir/type_context.rs
+++ b/core/src/hir/type_context.rs
@@ -247,6 +247,12 @@ impl TypeContext {
 
         let mut errors = ErrorStore::default();
 
+        // Sort modules such that children come after their parents in the list
+        let mut modules = env.iter_modules().collect::<Vec<_>>();
+        modules.sort_by_key(|(p, ..)| p.elements.len());
+
+        let mut module_attrs: HashMap<&[ast::Ident], Attrs> = HashMap::new();
+
         for (path, mod_env) in env.iter_modules() {
             let opt = path.elements.last().and_then(|m| m.span());
             errors.set_item(
@@ -259,12 +265,23 @@ impl TypeContext {
             let mod_attrs = Attrs::from_ast(
                 &mod_env.attrs,
                 &attr_validator,
-                &Default::default(),
+                module_attrs
+                    .get(
+                        &path
+                            .elements
+                            .split_last()
+                            .map(|(_, r)| r)
+                            .unwrap_or_default(),
+                    )
+                    .cloned()
+                    .unwrap_or_default(),
                 &mut errors,
             );
             let ty_attrs = mod_attrs.for_inheritance(AttrInheritContext::Type);
             let method_attrs =
                 mod_attrs.for_inheritance(AttrInheritContext::MethodOrImplFromModule);
+
+            module_attrs.insert(&path.elements, mod_attrs);
 
             for sym in mod_env.items() {
                 match sym {

--- a/tool/src/config.rs
+++ b/tool/src/config.rs
@@ -27,6 +27,8 @@ pub struct SharedConfig {
     pub custom_extra_code_location: PathBuf,
     /// List of features to enable/disable generation for.
     pub features_enabled: HashSet<String>,
+    /// List of unstable features.
+    pub semver_unstable_features: HashSet<String>,
     /// Where the manifest for this library is located.
     /// Used to detect relative include locations for `#[diplomat::include()]`.
     /// By default, is set to the parent of the parent of the given entry file.
@@ -44,6 +46,7 @@ impl SharedConfig {
                 | "unsafe_references_in_callbacks"
                 | "custom_extra_code_location"
                 | "features_enabled"
+                | "semver_unstable_features"
         )
     }
 
@@ -96,6 +99,35 @@ impl SharedConfig {
                     _ => panic!("Config key `features_enabled` must be an array or string."),
                 };
                 self.features_enabled = hash_set;
+            }
+            "semver_unstable_features" => {
+                let hash_set = match &value {
+                    Value::Array(arr) => {
+                        let str_arr : HashSet<String> = arr.iter().map(|v| {
+                            let st = v.as_str().unwrap_or_else(|| panic!("Expected semver_unstable_features=[] to be an array of strings. Got {v:?}"));
+                            st.to_string()
+                        }).collect();
+                        str_arr
+                    }
+                    Value::Table(t) if t.len() == 1 => t.keys().cloned().collect(),
+                    Value::String(st) => {
+                        // Serde Toml has screwed up reading an array:
+                        if st.starts_with("[") && st.ends_with("]") {
+                            let slice = &st[1..st.len() - 1];
+                            let hash = slice
+                                .split(",")
+                                .map(|s| s.replace("\"", "").trim().to_string())
+                                .collect();
+                            hash
+                        } else {
+                            HashSet::from([st.clone()])
+                        }
+                    }
+                    _ => {
+                        panic!("Config key `semver_unstable_features` must be an array or string.")
+                    }
+                };
+                self.semver_unstable_features = hash_set;
             }
             _ => (),
         }

--- a/tool/src/cpp/formatter.rs
+++ b/tool/src/cpp/formatter.rs
@@ -287,6 +287,14 @@ impl<'tcx> Cpp2Formatter<'tcx> {
             }
             let _ = writeln!(&mut docs, "\\deprecated {deprecated}");
         }
+        if attrs.unstable {
+            if !docs.is_empty() {
+                docs.push('\n');
+                docs.push('\n');
+            }
+            docs.push_str("🚧 This API is unstable and may experience breaking changes outside major releases.");
+            docs.push('\n');
+        }
         docs
     }
 

--- a/tool/src/dart/mod.rs
+++ b/tool/src/dart/mod.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 
 use crate::{filters, ErrorStore, FileMap};
-use diplomat_core::hir::OutputOnly;
 use diplomat_core::hir::{
     self,
     borrowing_param::{
@@ -13,6 +12,7 @@ use diplomat_core::hir::{
     ReturnType, SelfType, SpecialMethod, SpecialMethodPresence, StructPathLike, SuccessType,
     TyPosition, Type, TypeContext, TypeDef, TypeId,
 };
+use diplomat_core::hir::{Attrs, OutputOnly};
 
 use askama::Template;
 use itertools::Itertools;
@@ -238,7 +238,7 @@ impl<'cx> ItemGenContext<'_, 'cx> {
             type_name: &'a str,
             methods: &'a [MethodInfo<'a>],
             docs: String,
-            deprecated: Option<&'a str>,
+            attrs: &'a Attrs,
             destructor: &'a str,
             lifetimes: &'a LifetimeEnv,
             special: SpecialMethodGenInfo<'a>,
@@ -248,7 +248,7 @@ impl<'cx> ItemGenContext<'_, 'cx> {
             type_name,
             methods: methods.as_slice(),
             destructor: destructor.as_str(),
-            deprecated: ty.attrs.deprecated.as_deref(),
+            attrs: &ty.attrs,
             docs: self.formatter.fmt_docs(&ty.docs),
             lifetimes: &ty.lifetimes,
             special,
@@ -367,7 +367,7 @@ impl<'cx> ItemGenContext<'_, 'cx> {
             mutable: bool,
             fields: Vec<FieldInfo<'a, P>>,
             methods: Vec<MethodInfo<'a>>,
-            deprecated: Option<&'a str>,
+            attrs: &'a Attrs,
             docs: String,
             lifetimes: &'a LifetimeEnv,
             special: SpecialMethodGenInfo<'a>,
@@ -379,7 +379,7 @@ impl<'cx> ItemGenContext<'_, 'cx> {
             mutable,
             fields,
             methods,
-            deprecated: ty.attrs.deprecated.as_deref(),
+            attrs: &ty.attrs,
             docs: self.formatter.fmt_docs(&ty.docs),
             lifetimes: &ty.lifetimes,
             special,
@@ -679,7 +679,6 @@ impl<'cx> ItemGenContext<'_, 'cx> {
 
         Some(MethodInfo {
             method,
-            deprecated: method.attrs.deprecated.as_deref(),
             docs,
             declaration,
             abi_name,
@@ -1470,7 +1469,6 @@ fn is_contiguous_enum(ty: &hir::EnumDef) -> bool {
 struct MethodInfo<'a> {
     /// HIR of the method being rendered
     method: &'a hir::Method,
-    deprecated: Option<&'a str>,
     /// Docs
     docs: String,
     /// The declaration (everything before the parameter list)

--- a/tool/src/js/formatter.rs
+++ b/tool/src/js/formatter.rs
@@ -112,6 +112,14 @@ impl<'tcx> JSFormatter<'tcx> {
             }
             let _ = writeln!(&mut docs, "@deprecated {deprecated}");
         }
+        if attrs.unstable {
+            if !docs.is_empty() {
+                docs.push('\n');
+                docs.push('\n');
+            }
+            docs.push_str("@experimental");
+            docs.push('\n');
+        }
         docs
     }
 

--- a/tool/src/kotlin/formatter.rs
+++ b/tool/src/kotlin/formatter.rs
@@ -1,9 +1,9 @@
 use diplomat_core::hir::{
     self,
     borrowing_param::{LifetimeEdge, LifetimeEdgeKind},
-    Docs, DocsTypeReferenceSyntax, DocsUrlGenerator, EnumVariant, FloatType, IntSizeType, IntType,
-    LifetimeEnv, MaybeStatic, PrimitiveType, Slice, StringEncoding, StructPathLike, TraitId,
-    TyPosition, Type, TypeContext, TypeId,
+    Attrs, Docs, DocsTypeReferenceSyntax, DocsUrlGenerator, EnumVariant, FloatType, IntSizeType,
+    IntType, LifetimeEnv, MaybeStatic, PrimitiveType, Slice, StringEncoding, StructPathLike,
+    TraitId, TyPosition, Type, TypeContext, TypeId,
 };
 use heck::ToLowerCamelCase;
 use std::collections::HashSet;
@@ -105,10 +105,20 @@ impl<'tcx> KotlinFormatter<'tcx> {
         "String"
     }
 
-    pub fn fmt_docs(&self, docs: &Docs) -> String {
-        docs.to_markdown(DocsTypeReferenceSyntax::SquareBrackets, self.docs_url_gen)
+    pub fn fmt_docs(&self, docs: &Docs, attrs: &Attrs) -> String {
+        let mut docs = docs
+            .to_markdown(DocsTypeReferenceSyntax::SquareBrackets, self.docs_url_gen)
             .trim()
-            .to_string()
+            .to_string();
+        if attrs.unstable {
+            if !docs.is_empty() {
+                docs.push('\n');
+                docs.push('\n');
+            }
+            docs.push_str("🚧 This API is unstable and may experience breaking changes outside major releases.");
+            docs.push('\n');
+        }
+        docs
     }
 
     pub fn fmt_primitive_slice(&self, ty: PrimitiveType) -> String {

--- a/tool/src/kotlin/mod.rs
+++ b/tool/src/kotlin/mod.rs
@@ -1359,7 +1359,7 @@ returnVal.option() ?: return null
             write_return,
             slice_conversions,
             cleanups: &cleanups,
-            docs: self.formatter.fmt_docs(&method.docs),
+            docs: self.formatter.fmt_docs(&method.docs, &method.attrs),
             add_override_specifier_for_opaque_self_methods,
             lifetimes: &method.lifetime_env,
             method_lifetimes_map,
@@ -1526,7 +1526,7 @@ returnVal.option() ?: return null
                 special_methods: SpecialMethodsImpl::new(special_methods),
                 callback_params: self.callback_params.as_ref(),
                 use_finalizers_not_cleaners: self.use_finalizers_not_cleaners,
-                docs: self.formatter.fmt_docs(&ty.docs),
+                docs: self.formatter.fmt_docs(&ty.docs, &ty.attrs),
                 is_custom_error: ty.attrs.custom_errors,
                 generate_mocking_interface: (ty.attrs.generate_mocking_interface
                     && !self_methods.is_empty()),
@@ -1673,7 +1673,7 @@ returnVal.option() ?: return null
                         &field.ty,
                     ),
                     kt_to_native,
-                    docs: self.formatter.fmt_docs(&field.docs),
+                    docs: self.formatter.fmt_docs(&field.docs, &field.attrs),
                 }
             })
             .collect();
@@ -1695,7 +1695,7 @@ returnVal.option() ?: return null
                 native_methods: native_methods.as_ref(),
                 callback_params: self.callback_params.as_ref(),
                 lifetimes,
-                docs: self.formatter.fmt_docs(&ty.docs),
+                docs: self.formatter.fmt_docs(&ty.docs, &ty.attrs),
                 is_custom_error: ty.attrs.custom_errors,
                 is_out_struct: non_out_struct.is_none(),
             }
@@ -1813,7 +1813,9 @@ returnVal.option() ?: return null
             non_native_params_and_types,
             input_params: native_input_names.join(", "),
             docs: match &method.docs {
-                Some(method_docs) => self.formatter.fmt_docs(method_docs),
+                Some(method_docs) => self
+                    .formatter
+                    .fmt_docs(method_docs, &method.attrs.clone().unwrap_or_default()),
                 None => "".to_string(),
             },
         }
@@ -1862,7 +1864,7 @@ returnVal.option() ?: return null
                 trait_methods: trait_methods.as_ref(),
                 callback_params: self.callback_params.as_ref(),
                 trait_method_names: &trait_method_names.join(", "),
-                docs: self.formatter.fmt_docs(&trt.docs),
+                docs: self.formatter.fmt_docs(&trt.docs, &trt.attrs),
             }
             .render()
             .expect("Failed to render trait template"),
@@ -1997,7 +1999,7 @@ returnVal.option() ?: return null
             companion_methods: companion_methods.as_ref(),
             native_methods: native_methods.as_ref(),
             callback_params: self.callback_params.as_ref(),
-            docs: self.formatter.fmt_docs(&ty.docs),
+            docs: self.formatter.fmt_docs(&ty.docs, &ty.attrs),
             is_custom_error: ty.attrs.custom_errors,
         }
         .render()

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -112,6 +112,7 @@ pub fn gen(
     let lowering_config = config.shared_config.lowering_config();
 
     attr_validator.features_enabled = config.shared_config.features_enabled.clone();
+    attr_validator.semver_unstable_features = config.shared_config.semver_unstable_features.clone();
 
     let manifest_path = config
         .shared_config

--- a/tool/templates/dart/enum.dart.jinja
+++ b/tool/templates/dart/enum.dart.jinja
@@ -4,6 +4,9 @@
 {% if let Some(deprecated) = ty.attrs.deprecated -%}
 @core.Deprecated('{{ deprecated }}')
 {% endif -%}
+{% if ty.attrs.unstable -%}
+@meta.experimental
+{% endif -%}
 enum {{type_name}}
   {%- if !special.mixins.is_empty() %} with {{ special.mixins.iter().join(", ") }} {%- endif %}
   {%- if !special.implements.is_empty() %} implements {{ special.implements.iter().join(", ") }}{% endif %} {

--- a/tool/templates/dart/method.dart.jinja
+++ b/tool/templates/dart/method.dart.jinja
@@ -1,8 +1,11 @@
   {%- if !m.docs.is_empty() %}
   {{~ m.docs|prefix_trimmed("  /// ")}}
   {%- endif %}
-  {% if let Some(deprecated) = m.deprecated -%}
+  {% if let Some(deprecated) = m.method.attrs.deprecated -%}
   @core.Deprecated('{{ deprecated }}')
+  {% endif -%}
+  {% if m.method.attrs.unstable -%}
+  @meta.experimental
   {% endif -%}
   {{ m.declaration }} {
     {%- for arena in m.arenas %}

--- a/tool/templates/dart/opaque.dart.jinja
+++ b/tool/templates/dart/opaque.dart.jinja
@@ -1,8 +1,11 @@
 {% if !docs.is_empty() -%}
 {{docs|prefix_trimmed("/// ")}}
 {% endif -%}
-{% if let Some(deprecated) = deprecated -%}
+{% if let Some(deprecated) = attrs.deprecated -%}
 @core.Deprecated('{{ deprecated }}')
+{% endif -%}
+{% if attrs.unstable -%}
+@meta.experimental
 {% endif -%}
 final class {{type_name}}
   {%- if let Some(ext) = special.extends %} extends {{ext}}{% endif %}

--- a/tool/templates/dart/struct.dart.jinja
+++ b/tool/templates/dart/struct.dart.jinja
@@ -14,8 +14,11 @@ final class _{{type_name}}Ffi extends ffi.Struct {
 {% if !docs.is_empty() -%}
 {{ docs|prefix_trimmed("/// ")}}
 {% endif -%}
-{% if let Some(deprecated) = deprecated -%}
+{% if let Some(deprecated) = attrs.deprecated -%}
 @core.Deprecated('{{ deprecated }}')
+{% endif -%}
+{% if attrs.unstable -%}
+@meta.experimental
 {% endif -%}
 final class {{type_name}}
   {%- if let Some(ext) = special.extends %} extends {{ext}}{% endif %}


### PR DESCRIPTION
Avoids things like https://github.com/unicode-org/icu4x/pull/8461 in the future.